### PR TITLE
Add missing space in FormAttachmentPopups

### DIFF
--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -105,7 +105,7 @@ some point. -->
           </p>
           <p id="form-attachment-popups-current">
             <strong>Sending {{ uploadStatus.current }}</strong>
-            <span v-if="hasProgress">({{ percentLoaded }})</span>
+            <span v-if="hasProgress"> ({{ percentLoaded }})</span>
           </p>
           <p v-if="uploadStatus.total !== 1">
             <template v-if="uploadStatus.remaining > 1">


### PR DESCRIPTION
Originally, a space was shown between the text within the `<strong>` element and the percentage. However, I think the space has been missing since we switched to Vue CLI, which usually removes the white space between elements.