### PR TITLE
Add translation comments

### DIFF
--- a/src/components/field-key/list.vue
+++ b/src/components/field-key/list.vue
@@ -238,8 +238,10 @@ export default {
     "header": {
       "nickname": "Nickname",
       "lastUsed": "Last Used",
+      // Header for the table column that shows QR codes to configure data collection clients such as ODK Collect.
       "configureClient": "Configure Client"
     },
+    // Linked to a help file about QR codes to configure data collection clients.
     "qrCodeHelp": "What’s this?",
     "emptyTable": "There are no App Users yet. You will need to create some to download Forms and submit data from your device.",
     "alert": {

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -300,6 +300,7 @@ $popup-width: 300px;
     },
     "duringUpload": {
       "total": "Please wait, uploading your {count} file: | Please wait, uploading your {count} files:",
+      // Displayed in a pop-up to indicate a Media File that is currently being uploaded to be attached to a Form.
       "current": "Sending {filename}",
       "remaining": {
         "beforeLast": "{count} file remains. | {count} files remain.",

--- a/src/components/form-draft/checklist.vue
+++ b/src/components/form-draft/checklist.vue
@@ -133,8 +133,10 @@ export default {
         "title": "Upload revised Form definition (optional)",
         "body": [
           {
+            // This refers to changes to the form definition as opposed to just the media associated with the Form.
             "status": "If you have made changes to the Form itself, including question text or logic rules, now is the time to upload the new XML or XLSForm using the button to the right.",
             "link": {
+              // This refers to changes to the form definition as opposed to just the media associated with the Form.
               "full": "If you have made changes to the Form itself, including question text or logic rules, now is the time to {upload} the new XML or XLSForm.",
               "upload": "upload"
             }

--- a/src/components/form/checklist.vue
+++ b/src/components/form/checklist.vue
@@ -193,7 +193,7 @@ export default {
         ]
       },
       {
-        // This is the title of a checklist item.
+        // This is the title of a checklist item. "Retirement" refers to reducing access to the form. For example, removing the ability to download the form or to submit to it.
         "title": "Manage Form retirement",
         "body": [
           {

--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -279,6 +279,7 @@ body {
         "submissions": "Submissions",
         "settings": "Settings"
       },
+      // Tooltip text that will be shown when hovering over tabs for Form Overview, Submissions, etc.
       "tabTitle": "These functions will become available once you publish your Draft Form"
     },
     "draftNav": {

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -180,6 +180,7 @@ $shadow-color: #dedede;
 {
   "en": {
     "action": {
+      // Used by screen readers to describe the button used to show or hide the navigation bar on small screens ("hamburger menu").
       "toggle": "Toggle navigation"
     }
   }

--- a/src/components/navbar/links.vue
+++ b/src/components/navbar/links.vue
@@ -80,7 +80,8 @@ export default {
     // This is the text of a link shown in the navigation bar at the top of the
     // page.
     "system": "System",
-    "current": "(current)"
+    // Used by screen readers to identify the currently-selected navigation tab
+    "current": "current"
   }
 }
 </i18n>

--- a/src/components/system/home.vue
+++ b/src/components/system/home.vue
@@ -52,7 +52,7 @@ export default {
 <i18n lang="json5">
 {
   "en": {
-    // This is shown as the title at the top of the page.
+    // This is the title of the page for managing backups, audit logs, and other system-level functions.
     "title": "System Management",
     "tab": {
       "backups": "Backups",


### PR DESCRIPTION
I went through every string at https://www.transifex.com/matthew-white/odk-central-frontend and considered whether more context was needed. I only felt the need to add context for a few strings.

I was surprised to find a couple of places with text for screen readers. I wrote comments accordingly. One of the screen reader strings was `(current)` and I removed the parentheses.

I made a few other notes while going through and those are captured [in this public Google Doc](https://docs.google.com/document/d/1XRI3VjXgk1Xt5eS_phdoJs8SXg_WeRwbVvXeF5uWB8I/edit?usp=sharing).