### PR TITLE
Add submission download options

### DIFF
--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -39,6 +39,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 import FormGroup from '../form-group.vue';
 import Modal from '../modal.vue';
 import callWait from '../../mixins/call-wait';
@@ -54,11 +56,7 @@ export default {
       type: Boolean,
       default: false
     },
-    managedKey: Object, // eslint-disable-line vue/require-default-prop
-    formAction: {
-      type: String,
-      required: true
-    },
+    formAction: String, // eslint-disable-line vue/require-default-prop
     delayBetweenChecks: {
       type: Number,
       default: 1000
@@ -70,9 +68,10 @@ export default {
       passphrase: ''
     };
   },
-  // The component assumes that this data will exist when the component is
-  // created.
-  computed: requestData(['session']),
+  computed: {
+    ...requestData(['session']),
+    ...mapGetters(['managedKey'])
+  },
   watch: {
     state() {
       if (!this.state) {

--- a/src/components/submission/download-dropdown.vue
+++ b/src/components/submission/download-dropdown.vue
@@ -20,12 +20,12 @@ except according to the terms contained in the LICENSE file.
     </button>
     <ul class="dropdown-menu"
       aria-labelledby="submission-download-dropdown-toggle" @click="download">
-      <li>
+      <li :class="{ disabled: disablesDownloadWithMedia }">
         <a :href="`${baseUrl}/submissions.csv.zip`" :target="target">
           {{ $t('action.download.withMedia') }}
         </a>
       </li>
-      <li :class="{ disabled: disablesDownloadWithoutMedia }">
+      <li>
         <a :href="`${baseUrl}/submissions.csv.zip?media=false`"
           :target="target">
           {{ $t('action.download.withoutMedia') }}
@@ -62,19 +62,17 @@ export default {
     ...requestData(['fields']),
     ...mapGetters(['managedKey']),
     buttonText() {
-      if (this.formVersion.submissions <= 1)
-        return this.$t('action.download.allRecords.withoutCount');
       return this.$tcn(
-        'action.download.allRecords.withCount',
+        'action.download.unfiltered',
         this.formVersion.submissions
       );
     },
-    target() {
-      return this.managedKey == null ? '_blank' : null;
-    },
-    disablesDownloadWithoutMedia() {
+    disablesDownloadWithMedia() {
       // The link will be enabled while this.fields is loading.
       return this.fields != null && !this.fields.some(field => field.binary);
+    },
+    target() {
+      return this.managedKey == null ? '_blank' : null;
     }
   },
   methods: {
@@ -98,10 +96,7 @@ export default {
   "en": {
     "action": {
       "download": {
-        "allRecords": {
-          "withCount": "Download all {count} record | Download all {count} records",
-          "withoutCount": "Download all records"
-        },
+        "unfiltered": "Download {count} record | Download {count} records",
         "withMedia": "All data and media files (.zip)",
         "withoutMedia": "All data without media files (.zip)",
         "primaryDataTable": "Primary data table (.csv)"

--- a/src/components/submission/download-dropdown.vue
+++ b/src/components/submission/download-dropdown.vue
@@ -1,0 +1,112 @@
+<!--
+Copyright 2020 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div id="submission-download-dropdown" class="btn-group">
+    <button id="submission-download-dropdown-toggle" type="button"
+      class="btn btn-primary dropdown-toggle" data-toggle="dropdown"
+      aria-haspopup="true" aria-expanded="false">
+      <span class="icon-arrow-circle-down"></span>
+      <span>{{ buttonText }}</span>
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu"
+      aria-labelledby="submission-download-dropdown-toggle" @click="download">
+      <li>
+        <a :href="`${baseUrl}/submissions.csv.zip`" :target="target">
+          {{ $t('action.download.withMedia') }}
+        </a>
+      </li>
+      <li :class="{ disabled: disablesDownloadWithoutMedia }">
+        <a :href="`${baseUrl}/submissions.csv.zip?media=false`"
+          :target="target">
+          {{ $t('action.download.withoutMedia') }}
+        </a>
+      </li>
+      <li>
+        <a :href="`${baseUrl}/submissions.csv`" :target="target">
+          {{ $t('action.download.primaryDataTable') }}
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+import Form from '../../presenters/form';
+import { requestData } from '../../store/modules/request';
+
+export default {
+  name: 'SubmissionDownloadDropdown',
+  props: {
+    baseUrl: {
+      type: String,
+      required: true
+    },
+    formVersion: {
+      type: Form,
+      required: true
+    }
+  },
+  computed: {
+    ...requestData(['fields']),
+    ...mapGetters(['managedKey']),
+    buttonText() {
+      if (this.formVersion.submissions <= 1)
+        return this.$t('action.download.allRecords.withoutCount');
+      return this.$tcn(
+        'action.download.allRecords.withCount',
+        this.formVersion.submissions
+      );
+    },
+    target() {
+      return this.managedKey == null ? '_blank' : null;
+    },
+    disablesDownloadWithoutMedia() {
+      // The link will be enabled while this.fields is loading.
+      return this.fields != null && !this.fields.some(field => field.binary);
+    }
+  },
+  methods: {
+    download(event) {
+      const { target } = event;
+      if (target.tagName !== 'A') return;
+      const disabled = target.parentNode.classList.contains('disabled');
+      if (this.managedKey == null) {
+        if (disabled) event.preventDefault();
+      } else {
+        event.preventDefault();
+        if (!disabled) this.$emit('decrypt', target.getAttribute('href'));
+      }
+    }
+  }
+};
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    "action": {
+      "download": {
+        "allRecords": {
+          "withCount": "Download all {count} record | Download all {count} records",
+          "withoutCount": "Download all records"
+        },
+        "withMedia": "All data and media files (.zip)",
+        "withoutMedia": "All data without media files (.zip)",
+        "primaryDataTable": "Primary data table (.csv)"
+      }
+    }
+  }
+}
+</i18n>

--- a/src/store/modules/request/keys.js
+++ b/src/store/modules/request/keys.js
@@ -123,6 +123,12 @@ const dataGetters = {
       0
     );
   },
+  // Returns a managed key if there is one among `keys`. Returns `null` if there
+  // is no managed key or if `keys` is `null`.
+  managedKey: ({ data }) => {
+    const ks = data.keys;
+    return ks != null ? ks.find(k => k.managed) : null;
+  },
   fieldKeysWithToken: ({ data: { fieldKeys } }) => (fieldKeys != null
     ? fieldKeys.filter(fieldKey => fieldKey.token != null)
     : null),

--- a/test/components/submission/download-dropdown.spec.js
+++ b/test/components/submission/download-dropdown.spec.js
@@ -22,22 +22,10 @@ const mountComponent = () => {
 
 describe('SubmissionDownloadDropdown', () => {
   describe('button text', () => {
-    it('shows the correct text if there are no submissions', () => {
-      testData.extendedForms.createPast(1, { submissions: 0 });
-      const text = mountComponent().first('button').text().trim();
-      text.should.equal('Download all records');
-    });
-
-    it('shows the correct text if there is 1 submission', () => {
-      testData.extendedForms.createPast(1, { submissions: 1 });
-      const text = mountComponent().first('button').text().trim();
-      text.should.equal('Download all records');
-    });
-
-    it('shows the correct text if there are 2 submissions', () => {
+    it('shows the correct text if the submissions are not filtered', () => {
       testData.extendedForms.createPast(1, { submissions: 2 });
       const text = mountComponent().first('button').text().trim();
-      text.should.equal('Download all 2 records');
+      text.should.equal('Download 2 records');
     });
   });
 
@@ -68,12 +56,12 @@ describe('SubmissionDownloadDropdown', () => {
         });
       });
 
-      it('disables the "without media" link', () => {
-        mountComponent().find('li')[1].hasClass('disabled').should.be.true();
+      it('disables the "with media" link', () => {
+        mountComponent().first('li').hasClass('disabled').should.be.true();
       });
 
       it('prevents default', () => {
-        const a = mountComponent().find('a')[1];
+        const a = mountComponent().first('a');
         const event = new MouseEvent('click', {
           bubbles: true,
           cancelable: true
@@ -90,7 +78,9 @@ describe('SubmissionDownloadDropdown', () => {
     });
 
     it('emits a decrypt event for the "with media" link', () => {
-      testData.extendedForms.createPast(1);
+      testData.extendedForms.createPast(1, {
+        fields: [{ path: '/b', type: 'binary', binary: true }]
+      });
       const dropdown = mountComponent();
       const $emit = sinon.fake();
       sinon.replace(dropdown.vm, '$emit', $emit);
@@ -102,9 +92,7 @@ describe('SubmissionDownloadDropdown', () => {
     });
 
     it('emits a decrypt event for the "without media" link', () => {
-      testData.extendedForms.createPast(1, {
-        fields: [{ path: '/b', type: 'binary', binary: true }]
-      });
+      testData.extendedForms.createPast(1);
       const dropdown = mountComponent();
       const $emit = sinon.fake();
       sinon.replace(dropdown.vm, '$emit', $emit);
@@ -129,7 +117,7 @@ describe('SubmissionDownloadDropdown', () => {
 
     it('prevents default', () => {
       testData.extendedForms.createPast(1);
-      const a = mountComponent().first('a');
+      const a = mountComponent().find('a')[1];
       const event = new MouseEvent('click', {
         bubbles: true,
         cancelable: true
@@ -150,15 +138,15 @@ describe('SubmissionDownloadDropdown', () => {
         });
       });
 
-      it('disables the "without media" link', () => {
-        mountComponent().find('li')[1].hasClass('disabled').should.be.true();
+      it('disables the "with media" link', () => {
+        mountComponent().first('li').hasClass('disabled').should.be.true();
       });
 
       it('does not emit a decrypt event', () => {
         const dropdown = mountComponent();
         const $emit = sinon.fake();
         sinon.replace(dropdown.vm, '$emit', $emit);
-        trigger.click(dropdown.find('a')[1]);
+        trigger.click(dropdown, 'a');
         $emit.called.should.be.false();
       });
     });

--- a/test/components/submission/download-dropdown.spec.js
+++ b/test/components/submission/download-dropdown.spec.js
@@ -1,0 +1,166 @@
+import sinon from 'sinon';
+
+import Form from '../../../src/presenters/form';
+import SubmissionDownloadDropdown from '../../../src/components/submission/download-dropdown.vue';
+import testData from '../../data';
+import { mount } from '../../util/lifecycle';
+import { trigger } from '../../util/event';
+
+const mountComponent = () => {
+  const formVersion = testData.extendedForms.last();
+  return mount(SubmissionDownloadDropdown, {
+    propsData: {
+      baseUrl: '/v1/projects/1/forms/f',
+      formVersion: new Form(formVersion)
+    },
+    requestData: {
+      fields: formVersion._fields,
+      keys: testData.standardKeys.sorted()
+    }
+  });
+};
+
+describe('SubmissionDownloadDropdown', () => {
+  describe('button text', () => {
+    it('shows the correct text if there are no submissions', () => {
+      testData.extendedForms.createPast(1, { submissions: 0 });
+      const text = mountComponent().first('button').text().trim();
+      text.should.equal('Download all records');
+    });
+
+    it('shows the correct text if there is 1 submission', () => {
+      testData.extendedForms.createPast(1, { submissions: 1 });
+      const text = mountComponent().first('button').text().trim();
+      text.should.equal('Download all records');
+    });
+
+    it('shows the correct text if there are 2 submissions', () => {
+      testData.extendedForms.createPast(1, { submissions: 2 });
+      const text = mountComponent().first('button').text().trim();
+      text.should.equal('Download all 2 records');
+    });
+  });
+
+  describe('form does not have a managed key', () => {
+    beforeEach(() => {
+      testData.extendedProjects.createPast(1, { key: null });
+    });
+
+    it('sets the correct href attributes', () => {
+      testData.extendedForms.createPast(1);
+      mountComponent().find('a').map(a => a.getAttribute('href')).should.eql([
+        '/v1/projects/1/forms/f/submissions.csv.zip',
+        '/v1/projects/1/forms/f/submissions.csv.zip?media=false',
+        '/v1/projects/1/forms/f/submissions.csv'
+      ]);
+    });
+
+    it('sets the target attribute to _blank', () => {
+      testData.extendedForms.createPast(1);
+      mountComponent().find('a').should.matchEach(a =>
+        a.getAttribute('target') === '_blank');
+    });
+
+    describe('form does not have a binary field', () => {
+      beforeEach(() => {
+        testData.extendedForms.createPast(1, {
+          fields: [{ path: '/i', type: 'int' }]
+        });
+      });
+
+      it('disables the "without media" link', () => {
+        mountComponent().find('li')[1].hasClass('disabled').should.be.true();
+      });
+
+      it('prevents default', () => {
+        const a = mountComponent().find('a')[1];
+        const event = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true
+        });
+        a.element.dispatchEvent(event).should.be.false();
+      });
+    });
+  });
+
+  describe('form has a managed key', () => {
+    beforeEach(() => {
+      const key = testData.standardKeys.createPast(1, { managed: true }).last();
+      testData.extendedProjects.createPast(1, { key });
+    });
+
+    it('emits a decrypt event for the "with media" link', () => {
+      testData.extendedForms.createPast(1);
+      const dropdown = mountComponent();
+      const $emit = sinon.fake();
+      sinon.replace(dropdown.vm, '$emit', $emit);
+      trigger.click(dropdown, 'a');
+      $emit.getCall(0).args.should.eql([
+        'decrypt',
+        '/v1/projects/1/forms/f/submissions.csv.zip'
+      ]);
+    });
+
+    it('emits a decrypt event for the "without media" link', () => {
+      testData.extendedForms.createPast(1, {
+        fields: [{ path: '/b', type: 'binary', binary: true }]
+      });
+      const dropdown = mountComponent();
+      const $emit = sinon.fake();
+      sinon.replace(dropdown.vm, '$emit', $emit);
+      trigger.click(dropdown.find('a')[1]);
+      $emit.getCall(0).args.should.eql([
+        'decrypt',
+        '/v1/projects/1/forms/f/submissions.csv.zip?media=false'
+      ]);
+    });
+
+    it('emits a decrypt event for the "primary data table" link', () => {
+      testData.extendedForms.createPast(1);
+      const dropdown = mountComponent();
+      const $emit = sinon.fake();
+      sinon.replace(dropdown.vm, '$emit', $emit);
+      trigger.click(dropdown.find('a')[2]);
+      $emit.getCall(0).args.should.eql([
+        'decrypt',
+        '/v1/projects/1/forms/f/submissions.csv'
+      ]);
+    });
+
+    it('prevents default', () => {
+      testData.extendedForms.createPast(1);
+      const a = mountComponent().first('a');
+      const event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      });
+      a.element.dispatchEvent(event).should.be.false();
+    });
+
+    it('does not set the target attribute', () => {
+      testData.extendedForms.createPast(1);
+      mountComponent().find('a').should.matchEach(a =>
+        !a.hasAttribute('target'));
+    });
+
+    describe('form does not have a binary field', () => {
+      beforeEach(() => {
+        testData.extendedForms.createPast(1, {
+          fields: [{ path: '/i', type: 'int' }]
+        });
+      });
+
+      it('disables the "without media" link', () => {
+        mountComponent().find('li')[1].hasClass('disabled').should.be.true();
+      });
+
+      it('does not emit a decrypt event', () => {
+        const dropdown = mountComponent();
+        const $emit = sinon.fake();
+        sinon.replace(dropdown.vm, '$emit', $emit);
+        trigger.click(dropdown.find('a')[1]);
+        $emit.called.should.be.false();
+      });
+    });
+  });
+});

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -368,30 +368,6 @@ describe('SubmissionList', () => {
       }
     });
 
-    describe('download button', () => {
-      it('shows the number of submissions', () => {
-        createSubmissions(2);
-        return loadSubmissionList()
-          .afterResponses(page => {
-            const button = page.first('#submission-list-download-button');
-            const text = button.text().trim().replace(/\s+/g, ' ');
-            const count = testData.extendedSubmissions.size;
-            text.should.equal(`Download all ${count} records`);
-          });
-      });
-
-      it('has the correct href', () => {
-        createSubmissions(1);
-        return loadSubmissionList()
-          .afterResponses(page => {
-            const button = page.first('#submission-list-download-button');
-            const $button = $(button.element);
-            $button.prop('tagName').should.equal('A');
-            $button.attr('href').should.equal('/v1/projects/1/forms/f/submissions.csv.zip');
-          });
-      });
-    });
-
     describe('load by chunk', () => {
       const checkTopSkip = ({ url }, top, skip) => {
         url.should.match(new RegExp(`[?&]%24top=${top}(&|$)`));
@@ -460,14 +436,6 @@ describe('SubmissionList', () => {
             tested.should.be.true();
             checkIds(component, 2);
           });
-      });
-
-      it('shows the total in the download button even if there are multiple chunks', () => {
-        createSubmissions(10);
-        return loadSubmissionList([2]).afterResponses(component => {
-          const button = component.first('#submission-list-download-button');
-          button.text().trim().iTrim().should.equal('Download all 10 records');
-        });
       });
 
       it('clicking refresh button loads only first chunk of submissions', () => {
@@ -734,9 +702,8 @@ describe('SubmissionList', () => {
               attachments: false
             })
             .afterResponses(app => {
-              const button = app.first('#submission-list-download-button');
-              const text = button.text().trim().iTrim();
-              text.should.equal('Download all 10 records');
+              const button = app.first('#submission-download-dropdown-toggle');
+              button.text().trim().should.equal('Download all 10 records');
             })
             .request(app => trigger.click(app, '.btn-refresh'))
             .respondWithData(() => {
@@ -744,9 +711,8 @@ describe('SubmissionList', () => {
               return testData.submissionOData();
             })
             .afterResponses(app => {
-              const button = app.first('#submission-list-download-button');
-              const text = button.text().trim().iTrim();
-              text.should.equal('Download all 11 records');
+              const button = app.first('#submission-download-dropdown-toggle');
+              button.text().trim().should.equal('Download all 11 records');
             });
         });
 

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -703,7 +703,7 @@ describe('SubmissionList', () => {
             })
             .afterResponses(app => {
               const button = app.first('#submission-download-dropdown-toggle');
-              button.text().trim().should.equal('Download all 10 records');
+              button.text().trim().should.equal('Download 10 records');
             })
             .request(app => trigger.click(app, '.btn-refresh'))
             .respondWithData(() => {
@@ -712,7 +712,7 @@ describe('SubmissionList', () => {
             })
             .afterResponses(app => {
               const button = app.first('#submission-download-dropdown-toggle');
-              button.text().trim().should.equal('Download all 11 records');
+              button.text().trim().should.equal('Download 11 records');
             });
         });
 

--- a/test/util/event.js
+++ b/test/util/event.js
@@ -44,7 +44,9 @@ trigger.click = (...args) => {
     return (wrapper) => trigger.click(wrapper, ...args);
   const [wrapper, selector] = args;
   const target = selector == null ? wrapper : wrapper.first(selector);
-  target.trigger('click');
+  // The avoriaz trigger() method triggers an event that does not bubble, so we
+  // trigger our own event.
+  unwrapElement(target).click();
   return Promise.resolve(wrapper);
 };
 

--- a/test/util/event.js
+++ b/test/util/event.js
@@ -1,5 +1,3 @@
-import Vue from 'vue';
-
 import { unwrapElement } from './util';
 
 
@@ -26,8 +24,8 @@ export const dataTransfer = (files) => {
 export const trigger = {};
 
 /*
-trigger.click() triggers a click event, then waits a tick for the DOM to update.
-For example:
+trigger.click() triggers a click event, then waits a tick for Vue to react. For
+example:
 
   // Specify an Avoriaz wrapper.
   trigger.click(wrapper);
@@ -38,7 +36,7 @@ For example:
   // If the wrapper is omitted, trigger.click() returns a function that expects
   // the wrapper.
   const clickButton = trigger.click('button');
-  return clickButton(wrapper);
+  clickButton(wrapper);
 */
 trigger.click = (...args) => {
   if (args.length === 0) throw new Error('invalid arguments');
@@ -47,7 +45,7 @@ trigger.click = (...args) => {
   const [wrapper, selector] = args;
   const target = selector == null ? wrapper : wrapper.first(selector);
   target.trigger('click');
-  return Vue.nextTick().then(() => wrapper);
+  return Promise.resolve(wrapper);
 };
 
 // Define methods for events that change the value of an <input> or <select>
@@ -63,7 +61,7 @@ for (const [name, event] of [['changeValue', 'change'], ['input', 'input']]) {
     if (target.element.value === value) throw new Error('no change');
     target.element.value = value;
     target.trigger(event);
-    return Vue.nextTick().then(() => wrapper);
+    return Promise.resolve(wrapper);
   };
 }
 
@@ -73,7 +71,7 @@ trigger.check = (wrapper, selector = null) => {
   if (target.element.checked) throw new Error('already checked');
   target.element.checked = true;
   target.trigger('change');
-  return Vue.nextTick().then(() => wrapper);
+  return Promise.resolve(wrapper);
 };
 
 // Unchecks a checkbox or radio input, triggering a change event.
@@ -82,7 +80,7 @@ trigger.uncheck = (wrapper, selector = null) => {
   if (!target.element.checked) throw new Error('already unchecked');
   target.element.checked = false;
   target.trigger('change');
-  return Vue.nextTick().then(() => wrapper);
+  return Promise.resolve(wrapper);
 };
 
 /*
@@ -168,12 +166,10 @@ trigger.submit = (...args) => {
   const promise = fieldSelectorsAndValues != null
     ? trigger.fillForm(form, fieldSelectorsAndValues)
     : Promise.resolve();
-  return promise
-    .then(() => {
-      form.trigger('submit');
-      return Vue.nextTick();
-    })
-    .then(() => wrapper);
+  return promise.then(() => {
+    form.trigger('submit');
+    return wrapper;
+  });
 };
 // Deprecated: use trigger.submit() instead.
 export const submitForm = trigger.submit;
@@ -190,7 +186,7 @@ for (const eventName of ['dragenter', 'dragover', 'dragleave', 'drop']) {
       target: targetElement,
       originalEvent: $.Event(eventName, { dataTransfer: dataTransfer(files) })
     }));
-    return Vue.nextTick().then(() => wrapper);
+    return Promise.resolve(wrapper);
   };
 }
 

--- a/test/util/event.js
+++ b/test/util/event.js
@@ -47,8 +47,7 @@ trigger.click = (...args) => {
   const [wrapper, selector] = args;
   const target = selector == null ? wrapper : wrapper.first(selector);
   target.trigger('click');
-  const nextTick = Vue.nextTick();
-  return selector == null ? nextTick : nextTick.then(() => wrapper);
+  return Vue.nextTick().then(() => wrapper);
 };
 
 // Define methods for events that change the value of an <input> or <select>
@@ -191,8 +190,7 @@ for (const eventName of ['dragenter', 'dragover', 'dragleave', 'drop']) {
       target: targetElement,
       originalEvent: $.Event(eventName, { dataTransfer: dataTransfer(files) })
     }));
-    const nextTick = Vue.nextTick();
-    return selector == null ? nextTick : nextTick.then(() => wrapper);
+    return Vue.nextTick().then(() => wrapper);
   };
 }
 

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2661,15 +2661,9 @@
     "SubmissionDownloadDropdown": {
       "action": {
         "download": {
-          "allRecords": {
-            "withCount": {
-              "string": "{count, plural, one {Download all {count} record} other {Download all {count} records}}",
-              "developer_comment": "This is the text for an action, for example, the text of a button."
-            },
-            "withoutCount": {
-              "string": "Download all records",
-              "developer_comment": "This is the text for an action, for example, the text of a button."
-            }
+          "unfiltered": {
+            "string": "{count, plural, one {Download {count} record} other {Download {count} records}}",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
           },
           "withMedia": {
             "string": "All data and media files (.zip)",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2658,18 +2658,36 @@
         }
       }
     },
-    "SubmissionList": {
+    "SubmissionDownloadDropdown": {
       "action": {
         "download": {
-          "withCount": {
-            "string": "{count, plural, one {Download all {count} record} other {Download all {count} records}}",
+          "allRecords": {
+            "withCount": {
+              "string": "{count, plural, one {Download all {count} record} other {Download all {count} records}}",
+              "developer_comment": "This is the text for an action, for example, the text of a button."
+            },
+            "withoutCount": {
+              "string": "Download all records",
+              "developer_comment": "This is the text for an action, for example, the text of a button."
+            }
+          },
+          "withMedia": {
+            "string": "All data and media files (.zip)",
             "developer_comment": "This is the text for an action, for example, the text of a button."
           },
-          "withoutCount": {
-            "string": "Download all records",
+          "withoutMedia": {
+            "string": "All data without media files (.zip)",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          },
+          "primaryDataTable": {
+            "string": "Primary data table (.csv)",
             "developer_comment": "This is the text for an action, for example, the text of a button."
           }
-        },
+        }
+      }
+    },
+    "SubmissionList": {
+      "action": {
         "analyze": {
           "string": "Analyze via OData",
           "developer_comment": "This is the text for an action, for example, the text of a button."


### PR DESCRIPTION
This PR contains the frontend work for getodk/central#150. It also closes #133.

Most of the work is done in a new component, `SubmissionDownloadDropdown`. We use event bubbling in that component. We rarely use event bubbling, and I needed to make a change to `trigger` in order to test the event bubbling. I also made a couple of other small changes to `trigger`.