### PR TITLE
Add forward to default Enketo config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -30,5 +30,10 @@ http {
       proxy_pass http://localhost:8383;
       proxy_redirect off;
     }
+
+    location /-/ {
+      proxy_pass http://localhost:8005/-/;
+      proxy_redirect off;
+    }
   }
 }


### PR DESCRIPTION
As we add more functionality that depends on Enketo, it would be good to make it easier to use in development. This addition should have no effect for folks who don't have Enketo running.

It likely won't be reasonable to get working with submission (non-draft, non public) links because those require cookie auth. Maybe that makes it not worth doing, I'm not sure.