### PR TITLE
Add warning about Enketo-based links to "Set up Backups" modal

### DIFF
--- a/src/components/backup/new.vue
+++ b/src/components/backup/new.vue
@@ -15,6 +15,13 @@ except according to the terms contained in the LICENSE file.
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <template v-if="step === 0">
+        <div class="modal-warnings">
+          <i18n tag="p" path="steps[0].warning.full">
+            <template #forum>
+              <a href="https://forum.getodk.org/" target="_blank">{{ $t('steps[0].warning.forum') }}</a>
+            </template>
+          </i18n>
+        </div>
         <p class="modal-introduction">
           {{ $t('steps[0].introduction[0]') }}
           <strong>{{ $t('steps[0].introduction[1]') }}</strong>
@@ -179,6 +186,10 @@ export default {
     "title": "Set up Backups",
     "steps": [
       {
+        "warning": {
+          "full": "This backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help.",
+          "forum": "the forum"
+        },
         "introduction": [
           "If you want, you may set up an encryption passphrase which must be used to unlock the backup.",
           "There is no way to recover the passphrase if you lose it!",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -790,6 +790,16 @@
       },
       "steps": {
         "0": {
+          "warning": {
+            "full": {
+              "string": "This backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help.",
+              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
+            },
+            "forum": {
+              "string": "the forum",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
+            }
+          },
           "introduction": {
             "0": {
               "string": "If you want, you may set up an encryption passphrase which must be used to unlock the backup."


### PR DESCRIPTION
Using our existing `modal-warnings` class. Screenshot:

<img width="610" alt="Screen Shot 2021-04-22 at 5 45 34 PM" src="https://user-images.githubusercontent.com/5970131/115790020-0b007a00-a394-11eb-8676-d75e6af1fc9f.png">