### PR TITLE
Add issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links: 
+  - name: "Report an issue"
+    about: "For when Central is behaving in an unexpected way"
+    url: "https://forum.getodk.org/c/support/6"
+  - name: "Request a feature"
+    about: "For when Central is missing functionality"
+    url: "https://forum.getodk.org/c/features/9"
+  - name: "Everything else"
+    about: "For everything else"
+    url: "https://forum.getodk.org/c/support/6"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We want ODK Central Frontend to be easy to use, yet flexible for a wide variety 
 
 ## Questions and Discussion
 
-If you are looking for help, please take a look at the [Documentation Website](https://docs.getodk.org/central-intro/). If that doesn't solve your problem, please head over to the [ODK Forum](https://forum.getodk.org/) and do a search to see if anybody else has had the same problem. If you've identified a new problem, please post on the forum. We prefer forum posts to Github issues because more of the community is on the forum.
+If you are looking for help, please take a look at the [Documentation Website](https://docs.getodk.org/central-intro/). If that doesn't solve your problem, please head over to the [ODK Forum](https://forum.getodk.org/) and do a search to see if anybody else has had the same problem. If you've identified a new problem, please post on the forum. We prefer forum posts to GitHub issues because more of the community is on the forum.
 
 If you have suggestions about how to improve ODK Central, please share them with us on the [Features board](https://forum.getodk.org/c/features) of the ODK Forum.
 


### PR DESCRIPTION
Using the same config as the `central` repository. See getodk/central#216.