### PR TITLE
Add ability to filter submissions table by review state

### DIFF
--- a/src/components/submission/filters.vue
+++ b/src/components/submission/filters.vue
@@ -19,16 +19,23 @@ except according to the terms contained in the LICENSE file.
     <date-range-picker :value="submissionDate"
       :placeholder="$t('field.submissionDate')"
       @input="$emit('update:submissionDate', $event)"/>
+    <submission-filters-review-state :value="reviewState"
+      @input="$emit('update:reviewState', $event)"/>
   </span>
 </template>
 
 <script>
 import DateRangePicker from '../date-range-picker.vue';
+import SubmissionFiltersReviewState from './filters/review-state.vue';
 import SubmissionFiltersSubmitter from './filters/submitter.vue';
 
 export default {
   name: 'SubmissionFilters',
-  components: { DateRangePicker, SubmissionFiltersSubmitter },
+  components: {
+    DateRangePicker,
+    SubmissionFiltersReviewState,
+    SubmissionFiltersSubmitter
+  },
   props: {
     submitterId: {
       type: String,
@@ -36,6 +43,10 @@ export default {
     },
     submissionDate: {
       type: Array,
+      required: true
+    },
+    reviewState: {
+      type: String,
       required: true
     }
   }

--- a/src/components/submission/filters/review-state.vue
+++ b/src/components/submission/filters/review-state.vue
@@ -1,0 +1,47 @@
+<!--
+Copyright 2021 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <label id="submission-filters-review-state" class="form-group">
+    <select class="form-control" :value="value"
+      @change="$emit('input', $event.target.value)">
+      <option value="">{{ $t('anyState') }}</option>
+      <option value="null">{{ $t('reviewState.null') }}</option>
+      <option value="'approved'">{{ $t('reviewState.approved') }}</option>
+      <option value="'hasIssues'">{{ $t('reviewState.hasIssues') }}</option>
+      <option value="'edited'">{{ $t('reviewState.edited') }}</option>
+      <option value="'rejected'">{{ $t('reviewState.rejected') }}</option>
+    </select>
+    <span class="form-label">{{ $t('field.reviewState') }}</span>
+  </label>
+</template>
+
+<script>
+export default {
+  name: 'SubmissionFiltersReviewState',
+  props: {
+    value: {
+      type: String,
+      required: true
+    }
+  }
+};
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    // This text is shown in a dropdown that allows the user to filter to show
+    // only Submissions in a particular Review State.
+    "anyState": "(Any State)"
+  }
+}
+</i18n>

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -13,21 +13,23 @@ except according to the terms contained in the LICENSE file.
   <div id="submission-list">
     <loading :state="$store.getters.initiallyLoading(['fields'])"/>
     <div v-show="fields != null">
-      <form class="form-inline" @submit.prevent>
-        <submission-filters v-if="!draft" v-bind.sync="filters"/>
-        <submission-field-dropdown
-          v-if="fields != null && selectableFields.length > 11"
-          v-model="selectedFields"/>
-        <button id="submission-list-refresh-button" type="button"
-          class="btn btn-default" :disabled="refreshing"
-          @click="fetchChunk(0, false)">
-          <span class="icon-refresh"></span>{{ $t('action.refresh') }}
-          <spinner :state="refreshing"/>
-        </button>
+      <div id="submission-list-actions">
+        <form class="form-inline" @submit.prevent>
+          <submission-filters v-if="!draft" v-bind.sync="filters"/>
+          <submission-field-dropdown
+            v-if="fields != null && selectableFields.length > 11"
+            v-model="selectedFields"/>
+          <button id="submission-list-refresh-button" type="button"
+            class="btn btn-default" :disabled="refreshing"
+            @click="fetchChunk(0, false)">
+            <span class="icon-refresh"></span>{{ $t('action.refresh') }}
+            <spinner :state="refreshing"/>
+          </button>
+        </form>
         <submission-download-dropdown v-if="formVersion != null"
           :form-version="formVersion" :odata-filter="odataFilter"
           @decrypt="showDecrypt"/>
-      </form>
+      </div>
       <template v-if="submissions != null">
         <submission-table v-if="submissions.length !== 0"
           :project-id="projectId" :xml-form-id="xmlFormId" :draft="draft"
@@ -97,7 +99,8 @@ export default {
     return {
       filters: {
         submitterId: '',
-        submissionDate: []
+        submissionDate: [],
+        reviewState: ''
       },
       selectedFields: null,
       refreshing: false,
@@ -136,6 +139,8 @@ export default {
         conditions.push(`__system/submissionDate ge ${start}`);
         conditions.push(`__system/submissionDate le ${end}`);
       }
+      if (this.filters.reviewState !== '')
+        conditions.push(`__system/reviewState eq ${this.filters.reviewState}`);
       return conditions.length !== 0 ? conditions.join(' and ') : null;
     },
     loadingOData() {
@@ -177,6 +182,7 @@ export default {
   watch: {
     'filters.submitterId': 'filter',
     'filters.submissionDate': 'filter',
+    'filters.reviewState': 'filter',
     selectedFields(_, oldFields) {
       if (oldFields != null) this.fetchChunk(0, true);
     },
@@ -305,14 +311,25 @@ export default {
   min-height: 375px;
 }
 
-#submission-filters + #submission-field-dropdown { margin-left: 15px }
-#submission-filters + #submission-list-refresh-button { margin-left: 10px; }
-#submission-field-dropdown + #submission-list-refresh-button {
+#submission-list-actions {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap-reverse;
+}
+#submission-field-dropdown {
   margin-left: 15px;
+  margin-right: 5px;
+}
+#submission-list-refresh-button {
+  margin-left: 10px;
+  margin-right: 5px;
 }
 #submission-download-dropdown {
-  float: right;
-  top: 3px;
+  margin-bottom: 10px;
+  margin-left: auto;
+
+  // Needed to work with align-items above.
+  .btn { float: none; }
 }
 
 #submission-list-message {

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -189,6 +189,7 @@
     "passphrase": "Passphrase",
     "password": "Password",
     "passwordConfirm": "New password (confirm)",
+    "reviewState": "Review State",
     "type": "Type"
   },
   "header": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -398,6 +398,10 @@
       "string": "New password (confirm)",
       "developer_comment": "This is the text of a form field."
     },
+    "reviewState": {
+      "string": "Review State",
+      "developer_comment": "This is the text of a form field."
+    },
     "type": {
       "string": "Type",
       "developer_comment": "This is the text of a form field."
@@ -3133,6 +3137,12 @@
           "string": "Submitted at",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
+      }
+    },
+    "SubmissionFiltersReviewState": {
+      "anyState": {
+        "string": "(Any State)",
+        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {


### PR DESCRIPTION
This PR adds the review state filter to `SubmissionList`. The presence of the additional filter means that the filters and buttons might not fit on a single row. I have set it up so that if possible, everything will remain on a single row. However, if there is not enough space, the download dropdown will go onto its own row above the filters. We may revisit this row as part of block 13.