### PR TITLE
Check for session expiration on an interval

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -32,11 +32,11 @@ import { useSessions } from '../util/session';
 export default {
   name: 'App',
   components: { Alert, Navbar },
-  // Vue seems to trigger the initial navigation before creating App. If the
-  // initial navigation is synchronous, Vue seems to confirm the navigation
-  // before creating App. However, if the initial navigation is asynchronous,
-  // Vue seems to create App before confirming the navigation.
   computed: mapState({
+    // Vue seems to trigger the initial navigation before creating App. If the
+    // initial navigation is synchronous, Vue seems to confirm the navigation
+    // before creating App. However, if the initial navigation is asynchronous,
+    // Vue seems to create App before confirming the navigation.
     anyNavigationConfirmed: (state) => state.router.anyNavigationConfirmed
   }),
   created() {

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -27,35 +27,20 @@ import { mapState } from 'vuex';
 import Alert from './alert.vue';
 import Navbar from './navbar.vue';
 
-import { logOut } from '../util/session';
-import { noop } from '../util/util';
-import { requestData } from '../store/modules/request';
+import { useSessions } from '../util/session';
 
 export default {
   name: 'App',
   components: { Alert, Navbar },
-  computed: {
-    ...requestData(['session']),
-    // Vue seems to trigger the initial navigation before creating App. If the
-    // initial navigation is synchronous, Vue seems to confirm the navigation
-    // before creating App. However, if the initial navigation is asynchronous,
-    // Vue seems to create App before confirming the navigation.
-    ...mapState({
-      anyNavigationConfirmed: (state) => state.router.anyNavigationConfirmed
-    })
-  },
+  // Vue seems to trigger the initial navigation before creating App. If the
+  // initial navigation is synchronous, Vue seems to confirm the navigation
+  // before creating App. However, if the initial navigation is asynchronous,
+  // Vue seems to create App before confirming the navigation.
+  computed: mapState({
+    anyNavigationConfirmed: (state) => state.router.anyNavigationConfirmed
+  }),
   created() {
-    window.addEventListener('storage', this.logOutAfterSessionChange);
-  },
-  beforeDestroy() {
-    window.removeEventListener('storage', this.logOutAfterSessionChange);
-  },
-  methods: {
-    logOutAfterSessionChange({ key }) {
-      // key == null if the user clears local storage in Chrome.
-      if ((key == null || key === 'sessionExpires') && this.session != null)
-        logOut(this.$router, this.$store, true).catch(noop);
-    }
+    this.$once('hook:beforeDestroy', useSessions(this.$router, this.$store));
   }
 };
 </script>

--- a/src/store/modules/request.js
+++ b/src/store/modules/request.js
@@ -308,9 +308,10 @@ export default {
         const { cancelId } = requestsForKey;
 
         const baseConfig = { method: 'GET', url };
-        baseConfig.headers = extended
-          ? { ...headers, 'X-Extended-Metadata': 'true' }
-          : headers;
+        if (extended)
+          baseConfig.headers = { ...headers, 'X-Extended-Metadata': 'true' };
+        else if (headers != null)
+          baseConfig.headers = headers;
         const { session } = data;
         const token = session != null ? session.token : null;
         const axiosConfig = configForPossibleBackendRequest(baseConfig, token);

--- a/src/util/session.js
+++ b/src/util/session.js
@@ -181,7 +181,7 @@ const logOutAfterStorageChange = (router, store) => (event) => {
 };
 
 export const useSessions = (router, store) => {
-  const id = setInterval(logOutBeforeSessionExpires(router, store), 1000);
+  const id = setInterval(logOutBeforeSessionExpires(router, store), 15000);
   const handler = logOutAfterStorageChange(router, store);
   window.addEventListener('storage', handler);
   return () => {

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,6 @@ import 'should';
 import i18n from '../src/i18n';
 import router from '../src/router';
 import store from '../src/store';
-import { cancelScheduledLogout } from '../src/util/session';
 import { forceReplace } from '../src/util/router';
 import { noop } from '../src/util/util';
 
@@ -156,8 +155,6 @@ afterEach(() => {
 afterEach(() => {
   localStorage.clear();
 });
-
-afterEach(cancelScheduledLogout);
 
 
 

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -323,7 +323,7 @@ describe('util/session', () => {
       const cleanup = useSessions(router, store);
       setData({
         session: testData.sessions.createNew({
-          expiresAt: '1970-01-01T00:05:01Z'
+          expiresAt: '1970-01-01T00:05:00Z'
         })
       });
       return mockHttp()
@@ -331,7 +331,7 @@ describe('util/session', () => {
         .respondWithData(() => testData.extendedUsers.first())
         .complete()
         .testNoRequest(() => {
-          clock.tick(240000);
+          clock.tick(239000);
         })
         .request(() => {
           clock.tick(1000);
@@ -454,14 +454,14 @@ describe('util/session', () => {
       const cleanup = useSessions(router, store);
       setData({
         session: testData.sessions.createNew({
-          expiresAt: '1970-01-01T00:05:01Z'
+          expiresAt: '1970-01-01T00:05:00Z'
         })
       });
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
         .afterResponse(() => {
-          clock.tick(120000);
+          clock.tick(119000);
           const { alert } = store.state;
           alert.state.should.be.false();
           clock.tick(1000);

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import router from '../../src/router';
 import store from '../../src/store';
-import { logIn, logOut } from '../../src/util/session';
+import { logIn, logOut, useSessions } from '../../src/util/session';
 import { noop } from '../../src/util/util';
 
 import testData from '../data';
@@ -71,7 +71,6 @@ describe('util/session', () => {
     it('sends the correct request', () => {
       testData.extendedUsers.createPast(1);
       setData({ session: testData.sessions.createNew({ token: 'foo' }) });
-      store.commit('setSendInitialRequests', false);
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -88,7 +87,6 @@ describe('util/session', () => {
     it('returns a promise', () => {
       testData.extendedUsers.createPast(1);
       setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -100,7 +98,6 @@ describe('util/session', () => {
     it('clears response data', () => {
       testData.extendedUsers.createPast(1);
       setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -121,7 +118,6 @@ describe('util/session', () => {
     it('removes sessionExpires from local storage', () => {
       testData.extendedUsers.createPast(1);
       setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -177,7 +173,6 @@ describe('util/session', () => {
       beforeEach(() => {
         testData.extendedUsers.createPast(1);
         setData({ session: testData.sessions.createNew() });
-        store.commit('setSendInitialRequests', false);
       });
 
       it('returns a rejected promise', () =>
@@ -303,7 +298,6 @@ describe('util/session', () => {
   describe('request for the current user results in an error', () => {
     beforeEach(() => {
       setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
     });
 
     it('logs out', () =>
@@ -326,12 +320,12 @@ describe('util/session', () => {
     it('logs out a minute before the session expires', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
       setData({
         session: testData.sessions.createNew({
           expiresAt: '1970-01-01T00:05:01Z'
         })
       });
-      store.commit('setSendInitialRequests', false);
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -345,39 +339,21 @@ describe('util/session', () => {
         .respondWithSuccess()
         .afterResponse(() => {
           should.not.exist(store.state.request.data.session);
-        });
-    });
-
-    it('logs out immediately for a login within a minute of expiration', () => {
-      const clock = sinon.useFakeTimers();
-      testData.extendedUsers.createPast(1);
-      setData({
-        session: testData.sessions.createNew({
-          expiresAt: '1970-01-01T00:00:59Z'
         })
-      });
-      store.commit('setSendInitialRequests', false);
-      return mockHttp()
-        .request(() => {
-          logIn(router, store, true);
-          clock.tick(0);
-        })
-        .respondWithData(() => testData.extendedUsers.first())
-        .respondWithSuccess()
-        .afterResponses(() => {
-          should.not.exist(store.state.request.data.session);
-        });
+        .finally(cleanup);
     });
 
     it('sets the ?next query parameter', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
       return load('/users', {}, false)
-        .restoreSession(true)
+        .respondWithData(() =>
+          testData.sessions.createNew({ expiresAt: '1970-01-01T00:05:00Z' }))
+        .respondWithData(() => testData.extendedUsers.first())
         .respondFor('/users')
         .complete()
         .request(() => {
-          clock.runAll();
+          clock.tick(240000);
         })
         .respondWithSuccess()
         .afterResponse(app => {
@@ -388,14 +364,18 @@ describe('util/session', () => {
     it('shows an alert after the logout', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
-      setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
+      const cleanup = useSessions(router, store);
+      setData({
+        session: testData.sessions.createNew({
+          expiresAt: '1970-01-01T00:05:00Z'
+        })
+      });
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
         .complete()
         .request(() => {
-          clock.runAll();
+          clock.tick(240000);
         })
         .respondWithSuccess()
         .afterResponse(() => {
@@ -403,14 +383,19 @@ describe('util/session', () => {
           alert.state.should.be.true();
           alert.type.should.equal('info');
           alert.message.should.startWith('Your session has expired.');
-        });
+        })
+        .finally(cleanup);
     });
 
     it('does not attempt to log out if there was already a logout', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
-      setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
+      const cleanup = useSessions(router, store);
+      setData({
+        session: testData.sessions.createNew({
+          expiresAt: '1970-01-01T00:05:00Z'
+        })
+      });
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -419,7 +404,45 @@ describe('util/session', () => {
         .respondWithSuccess()
         .complete()
         .testNoRequest(() => {
-          clock.runAll();
+          clock.tick(240000);
+        })
+        .finally(cleanup);
+    });
+  });
+
+  describe('logout after session expiration', () => {
+    it('does not send a request', () => {
+      const clock = sinon.useFakeTimers();
+      testData.extendedUsers.createPast(1);
+      setData({
+        session: testData.sessions.createNew({
+          expiresAt: '1970-01-01T00:05:00Z'
+        })
+      });
+      return mockHttp()
+        .request(() => logIn(router, store, true))
+        .respondWithData(() => testData.extendedUsers.first())
+        .complete()
+        .testNoRequest(() => {
+          clock.tick(300000);
+          return logOut(router, store, false);
+        });
+    });
+
+    it('returns a fulfilled promise', () => {
+      const clock = sinon.useFakeTimers();
+      testData.extendedUsers.createPast(1);
+      setData({
+        session: testData.sessions.createNew({
+          expiresAt: '1970-01-01T00:05:00Z'
+        })
+      });
+      return mockHttp()
+        .request(() => logIn(router, store, true))
+        .respondWithData(() => testData.extendedUsers.first())
+        .afterResponse(() => {
+          clock.tick(300000);
+          return logOut(router, store, false).should.be.fulfilled();
         });
     });
   });
@@ -428,6 +451,7 @@ describe('util/session', () => {
     it('shows an alert 2 minutes before logout', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
       setData({
         session: testData.sessions.createNew({
           expiresAt: '1970-01-01T00:05:01Z'
@@ -444,31 +468,58 @@ describe('util/session', () => {
           alert.state.should.be.true();
           alert.type.should.equal('info');
           alert.message.should.startWith('Your session will expire in 2 minutes,');
-        });
+        })
+        .finally(cleanup);
     });
 
-    it('does not show the alert for a login within 2 minutes of logout', () => {
+    it('does not show the alert more than once for the same session', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
       setData({
         session: testData.sessions.createNew({
-          expiresAt: '1970-01-01T00:02:59Z'
+          expiresAt: '1970-01-01T00:05:00Z'
         })
       });
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
         .afterResponse(() => {
-          clock.tick(118000);
-          store.state.alert.state.should.be.false();
-        });
+          clock.tick(120000);
+          const { alert } = store.state;
+          alert.state.should.be.true();
+          store.commit('hideAlert');
+          clock.tick(30000);
+          alert.state.should.be.false();
+        })
+        .request(() => logOut(router, store, false))
+        .respondWithSuccess()
+        .complete()
+        .request(() => {
+          setData({
+            session: testData.sessions.createNew({
+              expiresAt: '1970-01-01T00:07:30Z'
+            })
+          });
+          return logIn(router, store, true);
+        })
+        .respondWithData(() => testData.extendedUsers.first())
+        .afterResponse(() => {
+          clock.tick(120000);
+          store.state.alert.state.should.be.true();
+        })
+        .finally(cleanup);
     });
 
     it('does not show the alert if there was already a logout', () => {
       const clock = sinon.useFakeTimers();
       testData.extendedUsers.createPast(1);
-      setData({ session: testData.sessions.createNew() });
-      store.commit('setSendInitialRequests', false);
+      const cleanup = useSessions(router, store);
+      setData({
+        session: testData.sessions.createNew({
+          expiresAt: '1970-01-01T00:05:00Z'
+        })
+      });
       return mockHttp()
         .request(() => logIn(router, store, true))
         .respondWithData(() => testData.extendedUsers.first())
@@ -477,17 +528,21 @@ describe('util/session', () => {
         .respondWithSuccess()
         .afterResponse(() => {
           store.commit('hideAlert');
-          clock.runAll();
+          clock.tick(120000);
           store.state.alert.state.should.be.false();
-        });
+        })
+        .finally(cleanup);
     });
   });
 
   describe('local storage changes', () => {
-    beforeEach(mockLogin);
-
-    it('logs out after sessionExpires changes', () =>
-      load('/users')
+    it('logs out after sessionExpires changes', () => {
+      testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
+      setData({ session: testData.sessions.createNew() });
+      return mockHttp()
+        .request(() => logIn(router, store, true))
+        .respondWithData(() => testData.extendedUsers.first())
         .complete()
         .request(() => {
           window.dispatchEvent(new StorageEvent('storage', {
@@ -498,10 +553,17 @@ describe('util/session', () => {
         .respondWithProblem(403.1)
         .afterResponse(() => {
           should.not.exist(store.state.request.data.session);
-        }));
+        })
+        .finally(cleanup);
+    });
 
-    it('logs out after local storage is cleared', () =>
-      load('/users')
+    it('logs out after local storage is cleared', () => {
+      testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
+      setData({ session: testData.sessions.createNew() });
+      return mockHttp()
+        .request(() => logIn(router, store, true))
+        .respondWithData(() => testData.extendedUsers.first())
         .complete()
         .request(() => {
           window.dispatchEvent(new StorageEvent('storage', {
@@ -512,10 +574,13 @@ describe('util/session', () => {
         .respondWithSuccess()
         .afterResponse(() => {
           should.not.exist(store.state.request.data.session);
-        }));
+        })
+        .finally(cleanup);
+    });
 
-    it('sets the ?next query parameter', () =>
-      load('/users')
+    it('sets the ?next query parameter', () => {
+      mockLogin();
+      return load('/users')
         .complete()
         .request(() => {
           window.dispatchEvent(new StorageEvent('storage', {
@@ -526,12 +591,18 @@ describe('util/session', () => {
         .respondWithProblem(403.1)
         .afterResponse(app => {
           app.vm.$route.query.next.should.equal('/users');
-        }));
+        });
+    });
 
-    it('does not attempt to log out if there was already a logout', () =>
-      load('/users')
+    it('does not attempt to log out if there was already a logout', () => {
+      testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
+      setData({ session: testData.sessions.createNew() });
+      return mockHttp()
+        .request(() => logIn(router, store, true))
+        .respondWithData(() => testData.extendedUsers.first())
         .complete()
-        .request(trigger.click('#navbar-actions-log-out'))
+        .request(() => logOut(router, store, false))
         .respondWithSuccess()
         .complete()
         .testNoRequest(() => {
@@ -539,16 +610,25 @@ describe('util/session', () => {
             key: 'sessionExpires',
             url: window.location.href
           }));
-        }));
+        })
+        .finally(cleanup);
+    });
 
-    it('does not log out after a different item in local storage changes', () =>
-      load('/users')
+    it('does not log out after a different item in local storage changes', () => {
+      testData.extendedUsers.createPast(1);
+      const cleanup = useSessions(router, store);
+      setData({ session: testData.sessions.createNew() });
+      return mockHttp()
+        .request(() => logIn(router, store, true))
+        .respondWithData(() => testData.extendedUsers.first())
         .complete()
         .testNoRequest(() => {
           window.dispatchEvent(new StorageEvent('storage', {
             key: 'foo',
             url: window.location.href
           }));
-        }));
+        })
+        .finally(cleanup);
+    });
   });
 });

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -210,7 +210,7 @@ describe('util/session', () => {
           .respondWithProblem(403.1));
     });
 
-    describe('logout during login', () => {
+    describe('logout during the request for the current user', () => {
       describe('initial navigation', () => {
         beforeEach(() => {
           testData.extendedUsers.createPast(1);


### PR DESCRIPTION
This PR fixes an issue related to automatic logout before session expiration. Previously, we used `setTimeout()` to schedule logout for some point in the future. However, it seems that `setTimeout()` does not count time while the computer is asleep (!). Instead, I've switched to using `setInterval()` to check for session expiration once a second. I've also changed it so that a logout request is not sent if the session has already expired. Right now, if your computer was asleep, and you are later (belatedly) automatically logged out, an error message is shown, because the logout request fails.

Things have been shuffled around, but the core logic is mostly the same. I'll also add some comments to the PR now about specific lines.