### PR TITLE
Slightly increase width of date range picker to accommodate locales

### DIFF
--- a/src/components/date-range-picker.vue
+++ b/src/components/date-range-picker.vue
@@ -163,7 +163,7 @@ export default {
 
 .form-inline .flatpickr-input {
   // Leave space for the .close button.
-  width: 201px;
-  &.required { width: 189px };
+  width: 205px;
+  &.required { width: 193px };
 }
 </style>


### PR DESCRIPTION
The word or symbol shown between the two dates in the date range depends on the locale. In Czech, French, and German, the word is longer than it is in English, and the date range is slightly truncated. For example, in German:

<img width="202" src="https://user-images.githubusercontent.com/5970131/117498825-5005de00-af48-11eb-950e-89ebff33e717.png">

I've increased the width of the date range picker by 3px in order to accommodate these locales.

Note that it is preferable for the date range picker to be as narrow as possible while still showing the date range. That's because it may be part of a row with multiple filters and other actions (in `SubmissionList`). If there were a larger difference between the locale that requires the least width and the locale that requires the most, I'd consider selecting on the `lang` attribute. However, I think it makes sense here to slightly increase the width of the date range picker.