### PR TITLE
Have ESLint return with error when there is a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vue-cli-service build --mode development --watch",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint --no-fix src/ bin/ test/",
+    "lint": "vue-cli-service lint --no-fix --max-warnings 0 src/ bin/ test/",
     "test": "karma start"
   },
   "gitHooks": {


### PR DESCRIPTION
Making this change so that it is clear from CircleCI when there is an ESLint warning.