### PR TITLE
Use darker background color for .btn-default in #form-overview-draft

### DIFF
--- a/src/components/form/overview.vue
+++ b/src/components/form/overview.vue
@@ -131,6 +131,15 @@ export default {
   .page-section-heading > span:first-child {
     color: $color-accent-secondary;
   }
+
+  .btn-default {
+    background-color: #ccc;
+
+    &:hover, &:focus, &:active:focus {
+      background-color: #bbb;
+      &[disabled] { background-color: #ccc; }
+    }
+  }
 }
 </style>
 


### PR DESCRIPTION
Right now the background color of `.btn-default` is the same as the background color of `#form-overview-draft`. #ccc is a little darker than the current color, #ddd.