### PR TITLE
Do not show alert for 401.2 response to logout request

### DIFF
--- a/src/util/session.js
+++ b/src/util/session.js
@@ -47,7 +47,7 @@ expiration date is also stored in local storage. This approach is designed to:
 
   - Support cookie auth
   - Ensure the user knows when they are logged out; prevent the user from seeing
-    403 messages after their session has been deleted
+    401 messages after their session has been deleted
   - Prevent one user from using another user's cookie
   - Ensure that the cookie is removed when the user logs out
 
@@ -79,10 +79,11 @@ const requestLogout = (store) => {
   })
     .catch(error => {
       // logOutBeforeSessionExpires() and logOutAfterStorageChange() may try to
-      // log out a session that has already been logged out. Backend returns a
-      // 403.1 in that case, which we ignore.
-      if (error.response != null && isProblem(error.response.data) &&
-        error.response.data.code === 403.1) {
+      // log out a session that has already been logged out. That will result in
+      // a 401.2 or a 403.1, which we ignore.
+      const { response } = error;
+      if (response != null && isProblem(response.data) &&
+        (response.data.code === 401.2 || response.data.code === 403.1)) {
         return;
       }
 

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -201,6 +201,14 @@ describe('util/session', () => {
             alert.message.should.endWith('logOut() problem.');
           }));
 
+      it('returns a fulfilled promise for a 401.2 Problem', () =>
+        mockHttp()
+          .request(() => logIn(router, store, true))
+          .respondWithData(() => testData.extendedUsers.first())
+          .complete()
+          .request(() => logOut(router, store, false).should.be.fulfilled())
+          .respondWithProblem(401.2));
+
       it('returns a fulfilled promise for a 403.1 Problem', () =>
         mockHttp()
           .request(() => logIn(router, store, true))
@@ -224,7 +232,7 @@ describe('util/session', () => {
             })
             .respondWithData(() => testData.sessions.createNew())
             .respondWithData(() => testData.extendedUsers.first())
-            .respondWithProblem(403.1)
+            .respondWithProblem(401.2)
             .afterResponses(app => {
               const { state } = app.vm.$store.state.request.requests.currentUser.last;
               state.should.equal('canceled');
@@ -240,7 +248,7 @@ describe('util/session', () => {
             })
             .respondWithData(() => testData.sessions.createNew())
             .respondWithData(() => testData.extendedUsers.first())
-            .respondWithProblem(403.1)
+            .respondWithProblem(401.2)
             .afterResponses(app => {
               app.vm.$route.path.should.equal('/reset-password');
               replace.called.should.be.false();
@@ -267,7 +275,7 @@ describe('util/session', () => {
             })
             .respondWithData(() => testData.sessions.createNew())
             .respondWithData(() => testData.extendedUsers.first())
-            .respondWithProblem(403.1)
+            .respondWithProblem(401.2)
             .afterResponses(app => {
               const { state } = app.vm.$store.state.request.requests.currentUser.last;
               state.should.equal('canceled');
@@ -287,7 +295,7 @@ describe('util/session', () => {
             })
             .respondWithData(() => testData.sessions.createNew())
             .respondWithData(() => testData.extendedUsers.first())
-            .respondWithProblem(403.1)
+            .respondWithProblem(401.2)
             .afterResponses(app => {
               app.vm.$route.fullPath.should.equal('/login?next=%2Fusers');
             }));
@@ -550,7 +558,7 @@ describe('util/session', () => {
             url: window.location.href
           }));
         })
-        .respondWithProblem(403.1)
+        .respondWithProblem(401.2)
         .afterResponse(() => {
           should.not.exist(store.state.request.data.session);
         })
@@ -588,7 +596,7 @@ describe('util/session', () => {
             url: window.location.href
           }));
         })
-        .respondWithProblem(403.1)
+        .respondWithProblem(401.2)
         .afterResponse(app => {
           app.vm.$route.query.next.should.equal('/users');
         });


### PR DESCRIPTION
Two different tabs may send a logout request at the same time. Depending on the timing of the requests, it's possible for one of the requests to succeed and for that to cause the other request to fail (because the session has already been logged out). That case used to be quite common when we scheduled logout for a particular moment (before #448). It's maybe less common now, but it will happen if the user clears local storage (immediately logging out all tabs) and can probably also happen if there are many tabs open. To account for this case, Frontend would previously ignore a 403.1 response to a logout request: other error responses would be shown to the user, but a 403.1 would not.

However, that intended behavior is not what's being seen right now. Instead, logging out one tab can result in an alert being shown in another tab. I think the issue is that the correct code for Frontend to account for is 401.2, not 403.1. I thought that if you try to log out a session that has already been logged out, that will result in a 403.1. I do think that's how the session endpoint works, but actually, I'm pretty sure that a request that will fail here won't even reach the session endpoint: it'll fail in the `sessionHandler()` preprocessor. That's because not only is the request attempting to delete a session that has already been deleted, but that deleted session's token is also what's used to auth, which will result in a 401.2.

There is likely more that could be done here in order to send a duplicate logout request in fewer cases. However, for now I'm just patching the existing functionality.

This issue is a little intermittent, which is maybe why I missed it before. I think it's possible for two different DELETE requests of the same session to both be successful, if the transaction for the second request begins before the transaction for the first request ends.