### PR TITLE
Reuse action.logIn message in audit log

### DIFF
--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -147,7 +147,7 @@
         "update": "@:audit.action.default.update",
         "assignment_create": "Assign Role",
         "assignment_delete": "Revoke Role",
-        "session_create": "Log in",
+        "session_create": "@:action.logIn",
         "delete": "Retire"
       }
     }

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -260,10 +260,6 @@
           "string": "Revoke Role",
           "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on or for a Web User."
         },
-        "session_create": {
-          "string": "Log in",
-          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on or for a Web User."
-        },
         "delete": {
           "string": "Retire",
           "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on or for a Web User."


### PR DESCRIPTION
Related to #479. I realized that "Log in" is already translated, which means that we can reuse the existing translation in the audit log.