### PR TITLE
Reuse i18n message in EnketoPreview

### DIFF
--- a/src/components/enketo/preview.vue
+++ b/src/components/enketo/preview.vue
@@ -12,11 +12,11 @@ except according to the terms contained in the LICENSE file.
 <template>
   <a v-if="disabledTitle == null" class="enketo-preview btn btn-default"
     :href="href" target="_blank">
-    <span class="icon-eye"></span>{{ $t('action.preview') }}
+    <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </a>
   <button v-else type="button" class="enketo-preview btn btn-default" disabled
     :title="disabledTitle">
-    <span class="icon-eye"></span>{{ $t('action.preview') }}
+    <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </button>
 </template>
 
@@ -54,9 +54,6 @@ export default {
 <i18n lang="json5">
 {
   "en": {
-    "action": {
-      "preview": "Preview"
-    },
     "disabled": {
       "processing": "Preview has not finished processing for this Form. Please refresh later and try again.",
       "notOpen": "In this version of ODK Central, preview is only available for Forms in the Open state."

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1134,12 +1134,6 @@
       }
     },
     "EnketoPreview": {
-      "action": {
-        "preview": {
-          "string": "Preview",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        }
-      },
       "disabled": {
         "processing": {
           "string": "Preview has not finished processing for this Form. Please refresh later and try again."


### PR DESCRIPTION
As of #483, the i18n message for a "Preview" button now lives in `en.json5`. This PR reuses that message in `EnketoPreview` so that it's not translated twice.