### PR TITLE
Darken markdown 'preview' button

### DIFF
--- a/src/components/markdown/textarea.vue
+++ b/src/components/markdown/textarea.vue
@@ -106,7 +106,7 @@ export default {
   }
 
   .md-preview-btn {
-    background-color: #999;
+    background-color: #666;
     color: white;
     &:hover, &:focus, &:active:focus { background-color: #888; }
   }


### PR DESCRIPTION
@issa-tseng pointed out that darkening the button makes it look more active.

Before:
<img width="739" alt="Screen Shot 2021-09-16 at 8 53 45 AM" src="https://user-images.githubusercontent.com/76205/133645213-b6e41274-93c6-43dc-83ab-5bce3bd34024.png">


After:
<img width="726" alt="Screen Shot 2021-09-16 at 8 53 06 AM" src="https://user-images.githubusercontent.com/76205/133645175-e40e246f-bca7-4624-9fcf-8015d30e1855.png">


