### PR TITLE
Adding separate table of submission states and changing project title

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -56,10 +56,6 @@ export default {
   .metric-value {
     text-align: right;
   }
-
-  tbody {
-    border-bottom: 1px solid #ddd;
-  }
 }
 </style>
 
@@ -82,7 +78,7 @@ export default {
       "num_public_access_links": "Number of Public Access Links",
       "num_forms": "Number of Forms",
       "num_forms_with_repeats": "Number of Forms with repeats",
-      "num_forms_with_geospatial": "Number of Forms with geosdata",
+      "num_forms_with_geospatial": "Number of Forms with geodata",
       "num_forms_with_encryption": "Number of Forms with encryption",
       "num_forms_with_audits": "Number of Forms with audits",
       "num_submissions_received": "Number of Submissions - Received",

--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -56,6 +56,10 @@ export default {
   .metric-value {
     text-align: right;
   }
+
+  tbody {
+    border-bottom: 1px solid #ddd;
+  }
 }
 </style>
 
@@ -78,14 +82,14 @@ export default {
       "num_public_access_links": "Number of Public Access Links",
       "num_forms": "Number of Forms",
       "num_forms_with_repeats": "Number of Forms with repeats",
-      "num_forms_with_geospatial": "Number of Forms with geospatial",
+      "num_forms_with_geospatial": "Number of Forms with geosdata",
       "num_forms_with_encryption": "Number of Forms with encryption",
       "num_forms_with_audits": "Number of Forms with audits",
-      "num_submissions_received": "Number of Submissions received",
-      "num_submissions_approved": "Number of Submissions approved",
-      "num_submissions_has_issues": "Number of Submissions with issues",
-      "num_submissions_rejected": "Number of Submissions rejected",
-      "num_submissions_edited": "Number of Submissions in edited state",
+      "num_submissions_received": "Number of Submissions - Received",
+      "num_submissions_approved": "Number of Submissions - Approved",
+      "num_submissions_has_issues": "Number of Submissions - Has Issues",
+      "num_submissions_rejected": "Number of Submissions - Rejected",
+      "num_submissions_edited": "Number of Submissions - Edited",
       "num_submissions_with_edits": "Number of Submissions with edits",
       "num_submissions_with_comments": "Number of Submissions with comments",
       "num_submissions_from_app_users": "Number of Submissions from App Users",

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -23,7 +23,7 @@ except according to the terms contained in the LICENSE file.
         <analytics-metrics-table :title="$t('common.system')" :metrics="systemSummary"/>
         <div id="analytics-preview-project-summary">
           <span class="header">{{ $t('projects.title') }}</span>
-          <span class="explanation">{{ $t('projects.subtitle', { numProjects }) }}</span>
+          <span class="explanation">{{ $tcn('projects.subtitle', numProjects) }}</span>
         </div>
         <div id="analytics-preview-project-tables">
           <div id="users-forms-column">
@@ -100,7 +100,7 @@ export default {
       return pick(submissionStateMetrics, this.firstProject.submissions);
     },
     numProjects() {
-      return this.$n(this.analyticsPreview.projects.length);
+      return this.analyticsPreview.projects.length;
     }
   },
   watch: {
@@ -165,7 +165,7 @@ export default {
     "projects": {
       // This is the title shown above a series of metrics about Project usage.
       "title": "Project Summaries",
-      "subtitle": "(Showing the most active Project of {numProjects} Projects)"
+      "subtitle": "(Showing the most active Project of {count} Project) | (Showing the most active Project of {count} Projects)"
     },
     // This is the title of a single table in the analytics metrics report
     // of metrics about submission state (approved, rejected, etc)

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -33,6 +33,8 @@ except according to the terms contained in the LICENSE file.
           <div id="submissions-column">
             <analytics-metrics-table :title="$t('resource.submissions')"
               :metrics="submissionSummary"/>
+            <analytics-metrics-table :title="$t('submissionStates')"
+              :metrics="submissionStateSummary"/>
           </div>
         </div>
       </template>
@@ -46,12 +48,23 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { omit, pick } from 'ramda';
 import Loading from '../loading.vue';
 import Modal from '../modal.vue';
 import AnalyticsMetricsTable from './metrics-table.vue';
 
 import { noop } from '../../util/util';
 import { requestData } from '../../store/modules/request';
+
+// Metrics to filter out (with pick/omit) and put in
+// a separate table
+const submissionStateMetrics = [
+  'num_submissions_received',
+  'num_submissions_approved',
+  'num_submissions_has_issues',
+  'num_submissions_rejected',
+  'num_submissions_edited'
+];
 
 export default {
   name: 'AnalyticsPreview',
@@ -77,7 +90,14 @@ export default {
       return this.firstProject.forms;
     },
     submissionSummary() {
-      return this.firstProject.submissions;
+      // The submission metrics come from the API together but will be split.
+      // This summary is for submission metrics NOT about state.
+      return omit(submissionStateMetrics, this.firstProject.submissions);
+    },
+    submissionStateSummary() {
+      // The submission metrics come from the API together but will be split.
+      // This summary is for submission state metrics (approved, rejected, etc.)
+      return pick(submissionStateMetrics, this.firstProject.submissions);
     },
     numProjects() {
       return this.$n(this.analyticsPreview.projects.length);
@@ -112,7 +132,6 @@ export default {
   padding-bottom: 5px;
 
   .header {
-    font-size: 18px;
     font-weight: 500;
     padding-right: 10px;
   }
@@ -146,8 +165,11 @@ export default {
     "projects": {
       // This is the title shown above a series of metrics about Project usage.
       "title": "Project Summaries",
-      "subtitle": "Showing 1 Project of {numProjects}"
-    }
+      "subtitle": "(Showing the most active Project of {numProjects} Projects)"
+    },
+    // This is the title of a single table in the analytics metrics report
+    // of metrics about submission state (approved, rejected, etc)
+    "submissionStates": "Submission States"
   }
 }
 </i18n>

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -10,12 +10,18 @@ const analyticsPreview = {
     {
       users: { num_managers: { recent: 0, total: 0 } },
       forms: { num_forms: { recent: 0, total: 0 } },
-      submissions: { num_submissions_received: { recent: 0, total: 0 } }
+      submissions: {
+        num_submissions_received: { recent: 0, total: 0 },
+        num_submissions_from_web_users: { recent: 0, total: 0 }
+      }
     },
     {
       users: { num_managers: { recent: 1, total: 1 } },
       forms: { num_forms: { recent: 1, total: 1 } },
-      submissions: { num_submissions_received: { recent: 1, total: 1 } }
+      submissions: {
+        num_submissions_received: { recent: 1, total: 1 },
+        num_submissions_from_web_users: { recent: 0, total: 0 }
+      }
     }
   ]
 };
@@ -40,7 +46,7 @@ describe('AnalyticsPreview', () => {
 
   it('renders the correct number of tables', async () => {
     const modal = await mockHttpForComponent();
-    modal.findAllComponents(AnalyticsMetricsTable).length.should.equal(4);
+    modal.findAllComponents(AnalyticsMetricsTable).length.should.equal(5);
   });
 
   it('shows system metrics', async () => {
@@ -52,7 +58,7 @@ describe('AnalyticsPreview', () => {
   it('shows the number of projects', async () => {
     const modal = await mockHttpForComponent();
     const text = modal.get('#analytics-preview-project-summary .explanation').text();
-    text.should.equal('Showing 1 Project of 2');
+    text.should.equal('(Showing the most active Project of 2 Projects)');
   });
 
   it('shows metrics for project with most submissions', async () => {
@@ -61,6 +67,14 @@ describe('AnalyticsPreview', () => {
     const projectMetrics = analyticsPreview.projects[1];
     tables.at(1).props().metrics.should.equal(projectMetrics.users);
     tables.at(2).props().metrics.should.equal(projectMetrics.forms);
-    tables.at(3).props().metrics.should.equal(projectMetrics.submissions);
+  });
+
+  it('shows submission metrics split into two tables', async () => {
+    const modal = await mockHttpForComponent();
+    const tables = modal.findAllComponents(AnalyticsMetricsTable);
+    const subMetrics = { num_submissions_from_web_users: { recent: 0, total: 0 } };
+    const stateMetrics = { num_submissions_received: { recent: 1, total: 1 } };
+    tables.at(3).props().metrics.should.eql(subMetrics);
+    tables.at(4).props().metrics.should.eql(stateMetrics);
   });
 });

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -20,7 +20,7 @@ const analyticsPreview = {
       forms: { num_forms: { recent: 1, total: 1 } },
       submissions: {
         num_submissions_received: { recent: 1, total: 1 },
-        num_submissions_from_web_users: { recent: 0, total: 0 }
+        num_submissions_from_web_users: { recent: 1, total: 1 }
       }
     }
   ]
@@ -55,7 +55,29 @@ describe('AnalyticsPreview', () => {
     table.props().metrics.should.equal(analyticsPreview.system);
   });
 
-  it('shows the number of projects', async () => {
+  it('shows the project number and plurailization for a single project', async () => {
+    const singleProject = {
+      system: { num_admins: { recent: 1, total: 1 } },
+      projects: [
+        {
+          users: { num_managers: { recent: 0, total: 0 } },
+          forms: { num_forms: { recent: 0, total: 0 } },
+          submissions: {
+            num_submissions_received: { recent: 0, total: 0 },
+            num_submissions_from_web_users: { recent: 0, total: 0 }
+          }
+        }
+      ]
+    };
+    const container = await mockHttp()
+      .mount(AnalyticsPreview)
+      .request(modal => modal.setProps({ state: true }))
+      .respondWithData(() => singleProject);
+    const text = container.get('#analytics-preview-project-summary .explanation').text();
+    text.should.equal('(Showing the most active Project of 1 Project)');
+  });
+
+  it('shows the project number and plurailization for multiple projects', async () => {
     const modal = await mockHttpForComponent();
     const text = modal.get('#analytics-preview-project-summary .explanation').text();
     text.should.equal('(Showing the most active Project of 2 Projects)');
@@ -72,7 +94,7 @@ describe('AnalyticsPreview', () => {
   it('shows submission metrics split into two tables', async () => {
     const modal = await mockHttpForComponent();
     const tables = modal.findAllComponents(AnalyticsMetricsTable);
-    const subMetrics = { num_submissions_from_web_users: { recent: 0, total: 0 } };
+    const subMetrics = { num_submissions_from_web_users: { recent: 1, total: 1 } };
     const stateMetrics = { num_submissions_received: { recent: 1, total: 1 } };
     tables.at(3).props().metrics.should.eql(subMetrics);
     tables.at(4).props().metrics.should.eql(stateMetrics);

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -959,7 +959,7 @@
           "string": "Number of Forms with repeats"
         },
         "num_forms_with_geospatial": {
-          "string": "Number of Forms with geosdata"
+          "string": "Number of Forms with geodata"
         },
         "num_forms_with_encryption": {
           "string": "Number of Forms with encryption"
@@ -1021,7 +1021,7 @@
           "developer_comment": "This is the title shown above a series of metrics about Project usage."
         },
         "subtitle": {
-          "string": "(Showing the most active Project of {numProjects} Projects)"
+          "string": "{count, plural, one {(Showing the most active Project of {count} Project)} other {(Showing the most active Project of {count} Projects)}}"
         }
       },
       "submissionStates": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -959,7 +959,7 @@
           "string": "Number of Forms with repeats"
         },
         "num_forms_with_geospatial": {
-          "string": "Number of Forms with geospatial"
+          "string": "Number of Forms with geosdata"
         },
         "num_forms_with_encryption": {
           "string": "Number of Forms with encryption"
@@ -968,19 +968,19 @@
           "string": "Number of Forms with audits"
         },
         "num_submissions_received": {
-          "string": "Number of Submissions received"
+          "string": "Number of Submissions - Received"
         },
         "num_submissions_approved": {
-          "string": "Number of Submissions approved"
+          "string": "Number of Submissions - Approved"
         },
         "num_submissions_has_issues": {
-          "string": "Number of Submissions with issues"
+          "string": "Number of Submissions - Has Issues"
         },
         "num_submissions_rejected": {
-          "string": "Number of Submissions rejected"
+          "string": "Number of Submissions - Rejected"
         },
         "num_submissions_edited": {
-          "string": "Number of Submissions in edited state"
+          "string": "Number of Submissions - Edited"
         },
         "num_submissions_with_edits": {
           "string": "Number of Submissions with edits"
@@ -1021,8 +1021,12 @@
           "developer_comment": "This is the title shown above a series of metrics about Project usage."
         },
         "subtitle": {
-          "string": "Showing 1 Project of {numProjects}"
+          "string": "(Showing the most active Project of {numProjects} Projects)"
         }
+      },
+      "submissionStates": {
+        "string": "Submission States",
+        "developer_comment": "This is the title of a single table in the analytics metrics report of metrics about submission state (approved, rejected, etc)"
       }
     },
     "App": {


### PR DESCRIPTION
Update to the analytics metrics preview on frontend to make the title/copy a little smaller and better explained, and to move the stats about submission states to their own table.

<img width="938" alt="Screen Shot 2021-09-24 at 10 00 24 AM" src="https://user-images.githubusercontent.com/76205/134718116-04da1200-91bc-47ba-82a4-73fc61f783b7.png">
