### PR TITLE
Made comment in update review state textarea not required

### DIFF
--- a/src/components/markdown/textarea.vue
+++ b/src/components/markdown/textarea.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     <div class="form-group">
       <textarea :value="value" class="form-control"
         :placeholder="defaultText" :aria-label="defaultText"
-        required rows="2" @input="$emit('input', $event.target.value)">
+        :required="required" rows="2" @input="$emit('input', $event.target.value)">
       </textarea>
     </div>
     <div v-if="value !== '' && previewMode" class="preview-container">
@@ -50,6 +50,10 @@ export default {
     defaultText: {
       type: String,
       default: ''
+    },
+    required: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/src/components/submission/comment.vue
+++ b/src/components/submission/comment.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
       <span class="icon-pencil"></span>{{ $t('editWithoutComment') }}
     </div>
     <markdown-textarea v-model="body" :default-text="$t('field.comment')"
-      :show-footer="editWithoutComment || awaitingResponse">
+      :show-footer="editWithoutComment || awaitingResponse" required>
       <button type="submit" class="btn btn-primary"
         :disabled="awaitingResponse">
         {{ $t('action.comment') }} <spinner :state="awaitingResponse"/>

--- a/test/components/markdown/textarea.spec.js
+++ b/test/components/markdown/textarea.spec.js
@@ -7,6 +7,7 @@ const mountComponent = (propsData) => {
   const props = {
     defaultText: 'default text',
     showFooter: false,
+    required: false,
     ...propsData
   };
 
@@ -18,7 +19,8 @@ const mountComponent = (propsData) => {
     },
     template: `<div><markdown-textarea v-model="body"
       default-text="${props.defaultText}"
-      :show-footer="${props.showFooter}">
+      :show-footer="${props.showFooter}"
+      :required="${props.required}">
     </markdown-textarea></div>`,
     components: { 'markdown-textarea': MarkdownTextarea }
   });
@@ -99,5 +101,19 @@ describe('MarkdownTextarea', () => {
       slots: { default: '<button id="some-button">Button text</button>' }
     });
     component.find('#some-button').exists().should.be.true();
+  });
+
+  it('adds "required" to textarea if required prop is true', () => {
+    const component = mountComponent({
+      required: true
+    });
+    const required = component.get('textarea').attributes('required');
+    should.exist(required);
+  });
+
+  it('does not make textarea required by default', () => {
+    const component = mountComponent({});
+    const required = component.get('textarea').attributes('required');
+    should.not.exist(required);
   });
 });

--- a/test/components/submission/comment.spec.js
+++ b/test/components/submission/comment.spec.js
@@ -154,6 +154,13 @@ describe('SubmissionComment', () => {
     });
   });
 
+  it('should make the textarea required', async () => {
+    testData.extendedSubmissions.createPast(1);
+    const component = mountComponent();
+    const required = await component.get('textarea');
+    should.exist(required);
+  });
+
   describe('after a successful response', () => {
     const submit = () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a b' });

--- a/test/components/submission/comment.spec.js
+++ b/test/components/submission/comment.spec.js
@@ -157,8 +157,7 @@ describe('SubmissionComment', () => {
   it('should make the textarea required', async () => {
     testData.extendedSubmissions.createPast(1);
     const component = mountComponent();
-    const required = await component.get('textarea');
-    should.exist(required);
+    component.getComponent(MarkdownTextarea).props().required.should.equal(true);
   });
 
   describe('after a successful response', () => {

--- a/test/components/submission/update-review-state.spec.js
+++ b/test/components/submission/update-review-state.spec.js
@@ -73,6 +73,15 @@ describe('SubmissionUpdateReviewState', () => {
     modal.get('input[value="hasIssues"]').should.be.focused();
   });
 
+  it('does not require a comment in the text area', async () => {
+    testData.extendedSubmissions.createPast(1, { reviewState: 'hasIssues' });
+    const modal = mountComponent();
+    await modal.setProps({ state: true });
+    modal.getComponent(MarkdownTextarea).props().required.should.equal(false);
+    const required = await modal.get('textarea').attributes('required');
+    should.not.exist(required);
+  });
+
   it('resets the form after the modal is hidden', async () => {
     testData.extendedSubmissions.createPast(1, { reviewState: 'hasIssues' });
     const modal = mountComponent();

--- a/test/components/submission/update-review-state.spec.js
+++ b/test/components/submission/update-review-state.spec.js
@@ -78,8 +78,6 @@ describe('SubmissionUpdateReviewState', () => {
     const modal = mountComponent();
     await modal.setProps({ state: true });
     modal.getComponent(MarkdownTextarea).props().required.should.equal(false);
-    const required = await modal.get('textarea').attributes('required');
-    should.not.exist(required);
   });
 
   it('resets the form after the modal is hidden', async () => {


### PR DESCRIPTION
Fixes an issue that @matthew-white noticed where the comment in the Submission Update Review State modal was required when it said it wasn't. This was done by adding a `required` prop (which defaults to `false`) in the `MarkdownTextarea` component that gets applied to the inner `<textarea>`.

`SubmissionComment` on the Submission show page now explicitly sets this to `true`. `SubmissionUpdateReviewState`'s code does not change, but the comment is now optional.
