### PR TITLE
Add ability to remove Backups and/or "Usage Reporting" tabs

### DIFF
--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -40,12 +40,14 @@ except according to the terms contained in the LICENSE file.
         </div>
       </div>
     </nav>
-    <analytics-introduction v-bind="analyticsIntroduction"
+    <analytics-introduction v-if="showsAnalytics" v-bind="analyticsIntroduction"
       @hide="hideModal('analyticsIntroduction')"/>
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 import NavbarActions from './navbar/actions.vue';
 import NavbarHelpDropdown from './navbar/help-dropdown.vue';
 import NavbarLinks from './navbar/links.vue';
@@ -77,6 +79,7 @@ export default {
     // The component does not assume that this data will exist when the
     // component is created.
     ...requestData(['currentUser', 'analyticsConfig']),
+    ...mapState({ showsAnalytics: (state) => state.config.showsAnalytics }),
     // Usually once the user is logged in (either after their session has been
     // restored or after they have submitted the login form), we render a fuller
     // navbar. However, if after submitting the login form, the user is
@@ -86,8 +89,9 @@ export default {
       return this.currentUser != null && this.$route.path !== '/login';
     },
     showsAnalyticsNotice() {
-      return this.loggedIn && this.canRoute('/system/analytics') &&
-        this.analyticsConfig != null && this.analyticsConfig.isEmpty() &&
+      return this.showsAnalytics && this.loggedIn &&
+        this.canRoute('/system/analytics') && this.analyticsConfig != null &&
+        this.analyticsConfig.isEmpty() &&
         Date.now() - Date.parse(this.currentUser.createdAt) >= /* 14 days */ 1209600000;
     }
   }

--- a/src/components/navbar/links.vue
+++ b/src/components/navbar/links.vue
@@ -22,9 +22,9 @@ except according to the terms contained in the LICENSE file.
         {{ $t('resource.users') }} <span class="sr-only">{{ $t('current') }}</span>
       </router-link>
     </li>
-    <li v-if="canRoute('/system/backups')"
+    <li v-if="canRoute(systemPath)"
       :class="{ active: routePathStartsWith('/system') }">
-      <router-link to="/system/backups">
+      <router-link :to="systemPath">
         {{ $t('common.system') }} <span class="sr-only">{{ $t('current') }}</span>
       </router-link>
     </li>
@@ -32,14 +32,22 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 import routes from '../../mixins/routes';
 
 export default {
   name: 'NavbarLinks',
   mixins: [routes()],
   computed: {
+    ...mapState({
+      showsBackups: (state) => state.config.showsBackups
+    }),
     projectsLinkIsActive() {
       return this.$route.path === '/' || this.routePathStartsWith('/projects');
+    },
+    systemPath() {
+      return this.showsBackups ? '/system/backups' : '/system/audits';
     }
   },
   methods: {

--- a/src/components/system/home.vue
+++ b/src/components/system/home.vue
@@ -14,7 +14,8 @@ except according to the terms contained in the LICENSE file.
     <page-head>
       <template #title>{{ $t('systemHome.title') }}</template>
       <template #tabs>
-        <li :class="tabClass('backups')" role="presentation">
+        <li v-show="showsBackups" :class="tabClass('backups')"
+          role="presentation">
           <router-link :to="tabPath('backups')">
             {{ $t('systemHome.tab.backups') }}
           </router-link>
@@ -24,7 +25,8 @@ except according to the terms contained in the LICENSE file.
             {{ $t('systemHome.tab.audits') }}
           </router-link>
         </li>
-        <li :class="tabClass('analytics')" role="presentation">
+        <li v-show="showsAnalytics" :class="tabClass('analytics')"
+          role="presentation">
           <router-link :to="tabPath('analytics')">
             {{ $t('systemHome.tab.analytics') }}
           </router-link>
@@ -38,6 +40,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
 
@@ -48,6 +52,10 @@ export default {
   components: { PageBody, PageHead },
   mixins: [tab()],
   computed: {
+    ...mapState({
+      showsBackups: (state) => state.config.showsBackups,
+      showsAnalytics: (state) => state.config.showsAnalytics
+    }),
     tabPathPrefix() {
       return '/system';
     }

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,6 +13,7 @@ import AccountLogin from './components/account/login.vue';
 import AsyncRoute from './components/async-route.vue';
 
 import i18n from './i18n';
+import store from './store';
 import { instanceNameOrId } from './util/odata';
 import { routeProps } from './util/router';
 
@@ -646,6 +647,12 @@ const routes = [
             ])
           },
           title: { parts: () => [i18n.t('systemHome.tab.backups'), i18n.t('systemHome.title')] }
+        },
+        beforeEnter: (to, from, next) => {
+          if (store.state.config.showsBackups)
+            next();
+          else
+            next('/');
         }
       }),
       asyncRoute({
@@ -674,6 +681,12 @@ const routes = [
               i18n.t('systemHome.title')
             ]
           }
+        },
+        beforeEnter: (to, from, next) => {
+          if (store.state.config.showsAnalytics)
+            next();
+          else
+            next('/');
         }
       })
     ]
@@ -828,5 +841,3 @@ preserveDataForKey({
   ],
   params: ['projectId']
 });
-
-

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,9 +12,10 @@ except according to the terms contained in the LICENSE file.
 import Vuex from 'vuex';
 
 import alert from './modules/alert';
+import config from './modules/config';
 import request from './modules/request';
 import router from './modules/router';
 
 export default new Vuex.Store({
-  modules: { alert, request, router }
+  modules: { alert, config, request, router }
 });

--- a/src/store/modules/config.js
+++ b/src/store/modules/config.js
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+
+// This file contains configuration for Frontend. The configuration is stored in
+// the Vuex store for ease of access and to facilitate testing. However, these
+// properties are static: nothing in Frontend will change them.
+
+const config = {
+  // `true` to allow navigation to /system/backups and `false` not to.
+  showsBackups: true,
+  // `true` to allow navigation to /system/analytics and `false` not to.
+  showsAnalytics: true
+};
+
+export default {
+  state: { ...config },
+  mutations: {
+    resetConfig(state) {
+      for (const [key, value] of Object.entries(config))
+        state[key] = value;
+    },
+    setConfig(state, { key, value }) {
+      state[key] = value;
+    }
+  }
+};

--- a/src/util/session.js
+++ b/src/util/session.js
@@ -264,7 +264,8 @@ export const logIn = (router, store, newSession) => {
         });
     })
     .then(() => {
-      if (store.state.request.data.currentUser.can('config.read')) {
+      if (store.state.config.showsAnalytics &&
+        store.state.request.data.currentUser.can('config.read')) {
         store.dispatch('get', [{
           key: 'analyticsConfig',
           url: '/v1/config/analytics',

--- a/test/components/analytics/introduction.spec.js
+++ b/test/components/analytics/introduction.spec.js
@@ -1,5 +1,6 @@
 import AnalyticsIntroduction from '../../../src/components/analytics/introduction.vue';
 
+import store from '../../../src/store';
 import { ago } from '../../../src/util/date-time';
 
 import testData from '../../data';
@@ -57,6 +58,19 @@ describe('AnalyticsIntroduction', () => {
       return load('/account/edit', {}, false)
         .restoreSession()
         .respondWithProblem(404.1)
+        .respondFor('/account/edit')
+        .afterResponses(app => {
+          app.find('#navbar-analytics-notice').should.be.hidden();
+        });
+    });
+
+    it('does not show the notice if the showsAnalytics config is false', () => {
+      store.commit('setConfig', { key: 'showsAnalytics', value: false });
+      testData.extendedUsers.createPast(1, {
+        createdAt: ago({ days: 15 }).toISO()
+      });
+      return load('/account/edit', {}, false)
+        .restoreSession()
         .respondFor('/account/edit')
         .afterResponses(app => {
           app.find('#navbar-analytics-notice').should.be.hidden();

--- a/test/components/navbar/links.spec.js
+++ b/test/components/navbar/links.spec.js
@@ -3,6 +3,8 @@ import { RouterLinkStub } from '@vue/test-utils';
 import Navbar from '../../../src/components/navbar.vue';
 import NavbarLinks from '../../../src/components/navbar/links.vue';
 
+import store from '../../../src/store';
+
 import { mockLogin } from '../../util/session';
 import { mount } from '../../util/lifecycle';
 
@@ -38,6 +40,16 @@ describe('NavbarLinks', () => {
     });
     const links = component.findAllComponents(RouterLinkStub);
     links.wrappers.map(link => link.props().to).should.eql(['/']);
+  });
+
+  it('links to /system/audits if the showsBackups config is false', () => {
+    store.commit('setConfig', { key: 'showsBackups', value: false });
+    mockLogin();
+    const component = mountComponent({
+      mocks: { $route: '/' }
+    });
+    const { to } = component.findAllComponents(RouterLinkStub).at(2).props();
+    to.should.equal('/system/audits');
   });
 
   describe('active link', () => {

--- a/test/components/system/home.spec.js
+++ b/test/components/system/home.spec.js
@@ -1,42 +1,76 @@
-import { load } from '../../util/http';
+import { RouterLinkStub } from '@vue/test-utils';
+
+import PageHead from '../../../src/components/page/head.vue';
+import SystemHome from '../../../src/components/system/home.vue';
+
+import store from '../../../src/store';
+
 import { mockLogin } from '../../util/session';
+import { mount } from '../../util/lifecycle';
 
 describe('SystemHome', () => {
   beforeEach(mockLogin);
 
-  it('sets the correct href attributes for the tabs', async () => {
-    const app = await load('/system/backups');
-    const a = app.findAll('#page-head-tabs a');
-    a.wrappers.map(wrapper => wrapper.attributes().href).should.eql([
-      '/system/backups',
-      '/system/audits',
-      '/system/analytics'
-    ]);
+  it('renders the tabs', () => {
+    const component = mount(SystemHome, {
+      stubs: { RouterLink: RouterLinkStub, RouterView: true },
+      mocks: { $route: '/system/backups' }
+    });
+    const links = component.getComponent(PageHead).findAllComponents(RouterLinkStub);
+    const to = links.wrappers.map(link => link.props().to);
+    to.should.eql(['/system/backups', '/system/audits', '/system/analytics']);
+  });
+
+  it('hides the Backups tab if the showsBackups config is false', () => {
+    store.commit('setConfig', { key: 'showsBackups', value: false });
+    const component = mount(SystemHome, {
+      stubs: { RouterLink: RouterLinkStub, RouterView: true },
+      mocks: { $route: '/system/audits' }
+    });
+    component.get('#page-head-tabs li').should.be.hidden();
+  });
+
+  it('hides "Usage Reporting" tab if showsAnalytics config is false', () => {
+    store.commit('setConfig', { key: 'showsAnalytics', value: false });
+    const component = mount(SystemHome, {
+      stubs: { RouterLink: RouterLinkStub, RouterView: true },
+      mocks: { $route: '/system/backups' }
+    });
+    component.findAll('#page-head-tabs li').at(2).should.be.hidden();
   });
 
   describe('active tab', () => {
-    it('activates correct tab after user navigates to .../backups', () =>
-      load('/system/backups').then(app => {
-        const active = app.findAll('#page-head-tabs .active');
-        active.length.should.equal(1);
-        const { href } = active.at(0).get('a').attributes();
-        href.should.endWith('/system/backups');
-      }));
+    it('activates correct tab after user navigates to .../backups', () => {
+      const component = mount(SystemHome, {
+        stubs: { RouterLink: RouterLinkStub, RouterView: true },
+        mocks: { $route: '/system/backups' }
+      });
+      const links = component.getComponent(PageHead).findAllComponents(RouterLinkStub)
+        .filter(link => (link.element.closest('.active') != null));
+      links.length.should.equal(1);
+      links.at(0).props().to.should.equal('/system/backups');
+    });
 
-    it('activates correct tab after user navigates to .../audits', () =>
-      load('/system/audits').then(app => {
-        const active = app.findAll('#page-head-tabs .active');
-        active.length.should.equal(1);
-        const { href } = active.at(0).get('a').attributes();
-        href.should.endWith('/system/audits');
-      }));
+    it('activates correct tab after user navigates to .../audits', () => {
+      const component = mount(SystemHome, {
+        stubs: { RouterLink: RouterLinkStub, RouterView: true },
+        mocks: { $route: '/system/audits' }
+      });
+      const links = component.getComponent(PageHead).findAllComponents(RouterLinkStub)
+        .filter(link => (link.element.closest('.active') != null));
+      links.length.should.equal(1);
+      links.at(0).props().to.should.equal('/system/audits');
+    });
 
-    it('activates correct tab after user navigates to .../analytics', async () => {
-      const app = await load('/system/analytics');
-      const active = app.findAll('#page-head-tabs .active');
-      active.length.should.equal(1);
-      const { href } = active.at(0).get('a').attributes();
-      href.should.endWith('/system/analytics');
+    it('activates correct tab after user navigates to .../analytics', () => {
+      const component = mount(SystemHome, {
+        stubs: { RouterLink: RouterLinkStub, RouterView: true },
+        mocks: { $route: '/system/analytics' }
+      });
+      const links = component.getComponent(PageHead).findAllComponents(RouterLinkStub)
+        .filter(link => (link.element.closest('.active') != null));
+      links.length.should.equal(1);
+      links.at(0).props().to.should.equal('/system/analytics');
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,7 @@ afterEach(() => {
 
 afterEach(() => {
   store.commit('resetAlert');
+  store.commit('resetConfig');
   store.commit('resetRequests');
   store.commit('clearData');
   store.commit('resetRouterState');

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 
 import i18n from '../src/i18n';
+import store from '../src/store';
 import { loadLocale } from '../src/util/i18n';
 import { noop } from '../src/util/util';
 
@@ -1005,5 +1006,27 @@ describe('router', () => {
         .afterResponses(() => {
           document.title.should.equal('Log in | ODK Central');
         }));
+  });
+
+  describe('config', () => {
+    beforeEach(mockLogin);
+
+    it('redirects user from /system/backups if showsBackups is false', () => {
+      store.commit('setConfig', { key: 'showsBackups', value: false });
+      return load('/system/backups', {}, false)
+        .respondFor('/')
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/');
+        });
+    });
+
+    it('redirects user from /system/analytics if showsAnalytics is false', () => {
+      store.commit('setConfig', { key: 'showsAnalytics', value: false });
+      return load('/system/analytics', {}, false)
+        .respondFor('/')
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/');
+        });
+    });
   });
 });

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -146,20 +146,38 @@ describe('util/session', () => {
       });
     });
 
-    it('sends a request for analytics config if user can config.read', () => {
-      testData.extendedUsers.createPast(1, { role: 'admin' });
-      setData({ session: testData.sessions.createNew({ token: 'foo' }) });
-      return mockHttp()
-        .request(() => logIn(router, store, true))
-        .respondWithData(() => testData.extendedUsers.first())
-        .respondWithProblem(404.1)
-        .testRequests([
-          null,
-          {
-            url: '/v1/config/analytics',
-            headers: { Authorization: 'Bearer foo' }
-          }
-        ]);
+    describe('request for the analytics config', () => {
+      it('sends the request if the user can config.read', () => {
+        testData.extendedUsers.createPast(1, { role: 'admin' });
+        setData({ session: testData.sessions.createNew({ token: 'foo' }) });
+        return mockHttp()
+          .request(() => logIn(router, store, true))
+          .respondWithData(() => testData.extendedUsers.first())
+          .respondWithProblem(404.1)
+          .testRequests([
+            null,
+            {
+              url: '/v1/config/analytics',
+              headers: { Authorization: 'Bearer foo' }
+            }
+          ]);
+      });
+
+      it('does not send request if showsAnalytics config is false', () => {
+        store.commit('setConfig', { key: 'showsAnalytics', value: false });
+        testData.extendedUsers.createPast(1, { role: 'admin' });
+        setData({ session: testData.sessions.createNew({ token: 'foo' }) });
+        return mockHttp()
+          .request(() => logIn(router, store, true))
+          .respondWithData(() => testData.extendedUsers.first())
+          .testRequests([
+            {
+              url: '/v1/users/current',
+              headers: { Authorization: 'Bearer foo' },
+              extended: true
+            }
+          ]);
+      });
     });
   });
 


### PR DESCRIPTION
- We are not hiding the System link in the navbar, which is a possibility we discussed. Instead, the System link will link to /system/audits rather than /system/backups. This allows users to continue to visit the audit log.
- And when the user visits /system/audits, there are no longer tabs for Backups and "Usage Reporting".
- And the analytics notice will never be shown.