### PR TITLE
Metrics preview CSS adjustments to even out columns

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
       <tr>
         <th>{{ title }}</th>
         <th class="metric-value recent-col">{{ $t('recent') }}</th>
-        <th class="metric-value">{{ $t('common.total') }}</th>
+        <th class="metric-value total-col">{{ $t('common.total') }}</th>
       </tr>
     </thead>
     <tbody>
@@ -55,6 +55,10 @@ export default {
 .analytics-metrics-table {
   .metric-value {
     text-align: right;
+  }
+
+  .total-col {
+    width: 50px;
   }
 }
 </style>

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -141,14 +141,14 @@ export default {
   display: flex;
   flex-wrap: wrap;
 
-  #users-forms-column {
-    padding-right: 10px;
+  #users-forms-column, #submissions-column {
+    margin-right: 5px;
+    margin-left: 5px;
     flex-grow: 1;
   }
 
-  #submissions-column {
-    flex-grow: 1;
-  }
+  margin-left: -5px;
+  margin-right: -5px;
 }
 </style>
 


### PR DESCRIPTION
Evens out some padding that had been put in between the two columns in the English metrics modal. When translated to a different language, the strings are generally longer and the tables widen and stack vertically. The padding meant to separate columns was making the single column layout look uneven. That's been fixed by adding more even margins to both columns (and negative margins on the outer element) so the tables look good in both 1-column and 2-column modes.

Before and After:
<img height="600" alt="before" src="https://user-images.githubusercontent.com/76205/135498526-b4064506-3589-48be-a91f-d29084d5627a.png"> <img height="600" alt="after" src="https://user-images.githubusercontent.com/76205/135498548-21eff411-4e45-40e1-90bb-81be0f1973c3.png">

English still okay:
<img width="400" alt="Screen Shot 2021-09-30 at 9 54 07 AM" src="https://user-images.githubusercontent.com/76205/135498612-6662d3fd-2cc7-4cbd-8132-7e3ba899cccd.png">


<img width="400" alt="Screen Shot 2021-09-30 at 9 54 21 AM" src="https://user-images.githubusercontent.com/76205/135498630-bbae9f25-7edd-40e1-add1-e05db4a7e595.png">
 