### PR TITLE
Update nginx.conf so that it more closely matches production

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,9 @@
 
 # This configuration file is for development only. For production, see
 # https://github.com/getodk/central.
+#
+# One difference between this file and the configuration for production is that
+# this configuration does not support request body decompression.
 
 events {
 }
@@ -25,10 +28,19 @@ http {
   server {
     listen 8989;
     server_name localhost;
-    # Specify the dist/ directory of the repository to `nginx -p` so that . is
-    # relative to dist/.
-    root .;
-    expires -1;
+
+    server_tokens off;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options nosniff;
+
+    client_max_body_size 100m;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1280;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml text/csv;
 
     location /- {
       proxy_pass http://localhost:8005/-;
@@ -36,12 +48,27 @@ http {
       proxy_set_header Host $host;
     }
 
-    location /v1/ {
+    location ~ ^/v\d {
       proxy_pass http://localhost:8383;
       proxy_redirect off;
 
       add_header Set-Cookie $session_cookie;
       proxy_set_header X-Forwarded-Proto https;
+
+      # buffer requests, but not responses, so streaming out works.
+      proxy_request_buffering on;
+      proxy_buffering off;
+      proxy_read_timeout 2m;
+    }
+
+    location / {
+      # Specify the dist/ directory of the repository to `nginx -p` so that . is
+      # relative to dist/.
+      root .;
+
+      location /index.html {
+        add_header Cache-Control no-cache;
+      }
     }
   }
 }

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -234,7 +234,13 @@ export default {
     When we gzip a CSV file, we read the entire file into memory. That should be
     OK, because any CSV file is likely intended for a data collection client on
     a relatively low-resource device: we expect that a CSV file will not exceed
-    a few dozen MBs. */
+    a few dozen MBs.
+
+    Note that the development nginx.conf does not support request body
+    decompression. That means that in development, if this component gzips a CSV
+    file, Backend will store the gzipped contents rather than the file's
+    original contents.
+    */
     maybeGzip(file) {
       // We determine whether the file is CSV using its file extension rather
       // than its MIME type. I think the MIME type for a CSV file should be


### PR DESCRIPTION
There have been some differences between the development `nginx.conf` and the one used in [production](https://github.com/getodk/central/blob/d5d430ae204001d23528e092d56b0586e4512394/files/nginx/odk.conf.template). Some of those differences have come up from time and time and have resulted in surprising behavior. Those differences also make some investigation more difficult.

The goal of this PR is to make the development `nginx.conf` as close as possible to the one in production without making it harder to set up Frontend. Development and production are still two pretty different environments/scenarios, and the configuration files will continue to differ. However, where it was easy to do so, I changed the development `nginx.conf` to match production.

One notable difference that will remain is the fact that the development `nginx.conf` does not support request body decompression. I don't think we necessarily want to change that, but I've tried to better document that fact. Right now the only component that compresses the request body is `AttachmentList`, and I've added a comment in that component and in `nginx.conf`.