### PR TITLE
Improve appearance of <select> elements in Safari

### DIFF
--- a/src/assets/css/bootstrap.css
+++ b/src/assets/css/bootstrap.css
@@ -1747,8 +1747,6 @@ input[type="search"] {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
 }
 input[type="file"] {
@@ -4176,8 +4174,6 @@ button.close {
   cursor: pointer;
   background: transparent;
   border: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
 }
 .modal-open {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -417,6 +417,14 @@ input[type="radio"], input[type="checkbox"] {
 
 .checkbox label { cursor: pointer; }
 
+select {
+  // We want to specify `appearance: auto;` for Chrome and Firefox and
+  // `-webkit-appearance: none;` for Safari. Safari does not support `auto`, so
+  // it will ignore the second `appearance`.
+  appearance: none;
+  appearance: auto;
+}
+
 .form-inline {
   margin-bottom: 15px;
   padding-bottom: $form-group-padding-bottom;


### PR DESCRIPTION
Right now `select` elements look different in Safari than other browsers. Even within Safari, `select` elements look different from `input` elements. Right now in Safari, a `select` element looks like this:

<img width="223" alt="select_safari_default" src="https://user-images.githubusercontent.com/5970131/138380022-791bb1f5-1c5b-4853-931e-62b2248a91ce.png">

In Chrome, it looks like:

<img width="238" alt="select_chrome" src="https://user-images.githubusercontent.com/5970131/138380059-21a5406c-3730-499f-8bb9-4cc55f3b9ee3.png">

Firefox:

<img width="256" alt="select_firefox" src="https://user-images.githubusercontent.com/5970131/138380067-cd19befb-09f5-4ef6-b7fa-f8624a2f6d0f.png">

After this change, Chrome and Firefox will look like the same as now, but Safari will look like this:

<img width="218" alt="select_safari_none" src="https://user-images.githubusercontent.com/5970131/138380101-c122cae0-7507-4b89-9c77-33d5b4fe23fe.png">