### PR TITLE
Update translations before upgrading to Vue I18n v9

### DIFF
--- a/src/components/analytics/form.vue
+++ b/src/components/analytics/form.vue
@@ -332,8 +332,25 @@ export default {
       "null": [
         "後で通知する。",
         "管理者には引き続きスクリーン上部にメッセージが表示されます。"
+      ],
+      "true": [
+        {
+          "full": "{weWillShare}また、{termsOfService}と{privacyPolicy}に同意します。",
+          "weWillShare": "私たちは毎月、匿名化された利用情報をCentralチームと共有します。",
+          "termsOfService": "利用規約",
+          "privacyPolicy": "プライバシーポリシー"
+        },
+        "どのような情報が送信されるのか？"
+      ],
+      "false": [
+        "私たちはデータを共有することに興味はありません。",
+        "あなたはこれに関する再通知を受け取ることはありません。"
       ]
     },
+    "contact": [
+      "私は報告にコンタクトの情報を含みます。",
+      "私たちからあなたのODK Centralの利用状況について問い合わせることがあります。"
+    ],
     "field": {
       "workEmail": "職場のメールアドレス",
       "organization": "組織名"

--- a/src/components/analytics/introduction.vue
+++ b/src/components/analytics/introduction.vue
@@ -140,6 +140,13 @@ export default {
   },
   "ja": {
     "title": "Centralの改善に貢献",
+    "introduction": [
+      {
+        "full": "システム管理の{usageReporting}タブで、あなたは匿名の利用データを共有するか、あなたのコンタクトをCentralの開発チームと共有するかを選択できます。",
+        "usageReporting": "利用状況報告"
+      },
+      "そこで、あなたはこのメッセージを再び表示しないように設定できます。"
+    ],
     "action": {
       "improveCentral": "Centralを改善する。"
     }

--- a/src/components/analytics/list.vue
+++ b/src/components/analytics/list.vue
@@ -121,7 +121,8 @@ export default {
   "es": {
     "heading": [
       "A continuación, puede elegir si este servidor Central compartirá información de uso anónima con el equipo Central. Esta configuración afecta a todo el servidor."
-    ]
+    ],
+    "auditsTitle": "Últimos informes de uso"
   },
   "fr": {
     "heading": [
@@ -134,6 +135,12 @@ export default {
       "Di seguito, puoi scegliere se questo server Central condividerà le informazioni di utilizzo anonime con il team Central. Questa impostazione interessa l'intero server."
     ],
     "auditsTitle": "Ultimo rapporto di utilizzo"
+  },
+  "ja": {
+    "heading": [
+      "以下で、あなたはこのCentralサーバーがCentralチームと匿名化された利用情報を共有するかどうかを選択できます。この設定はサーバー全体の及びます。"
+    ],
+    "auditsTitle": "最新の利用情報"
   }
 }
 </i18n>

--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -152,8 +152,14 @@ export default {
       "num_public_access_links": "Número de enlaces de acceso público",
       "num_forms": "Número de formularios",
       "num_forms_with_repeats": "Número de formularios con repeticiones",
+      "num_forms_with_geospatial": "Número de formularios con geodatos",
       "num_forms_with_encryption": "Número de formularios con cifrado",
       "num_forms_with_audits": "Número de formularios con auditorías",
+      "num_submissions_received": "Número de envíos - Recibidos",
+      "num_submissions_approved": "Número de envíos - Aprobados",
+      "num_submissions_has_issues": "Número de envíos - Con problemas",
+      "num_submissions_rejected": "Número de envíos - Rechazados",
+      "num_submissions_edited": "Número de envíos - Con ediciones",
       "num_submissions_with_edits": "Número de envíos con ediciones",
       "num_submissions_with_comments": "Número de envíos con comentarios",
       "num_submissions_from_app_users": "Número de envíos de Usuarios móviles",
@@ -238,6 +244,38 @@ export default {
       "num_submissions_from_app_users": "Numero di invii ricevuti da utenti applicazione",
       "num_submissions_from_public_links": "Numero di invii ricevuti da link pubblici",
       "num_submissions_from_web_users": "Numero di invii ricevuti da utenti web"
+    }
+  },
+  "ja": {
+    "recent": "過去45日間",
+    "fields": {
+      "num_admins": "管理者数",
+      "num_projects_encryption": "暗号化が有効化されたプロジェクト数",
+      "num_questions_biggest_form": "最も大きなフォームの質問数",
+      "num_audit_log_entries": "監査ログ数",
+      "backups_configured": "設定されたバックアップ",
+      "database_size": "システムのデータベースサイズ",
+      "num_managers": "プロジェクト・マネージャー数",
+      "num_viewers": "プロジェクト・閲覧者数",
+      "num_data_collectors": "データ収集者数",
+      "num_app_users": "アプリユーザー数",
+      "num_device_ids": "デバイスID数",
+      "num_public_access_links": "一般公開リンク数",
+      "num_forms": "フォーム数",
+      "num_forms_with_repeats": "リピートを有するフォーム数",
+      "num_forms_with_geospatial": "ジオデータを有するフォーム数",
+      "num_forms_with_encryption": "暗号化されたフォーム数",
+      "num_forms_with_audits": "監査を受けたフォーム数",
+      "num_submissions_received": "提出済みフォーム数 ー 受信済み",
+      "num_submissions_approved": "提出済みフォーム数 ー 承認済み",
+      "num_submissions_has_issues": "提出済みフォーム数 ー 問題有り",
+      "num_submissions_rejected": "提出済みフォーム数 ー リジェクト済み",
+      "num_submissions_edited": "提出済みフォーム数 ー 編集済み",
+      "num_submissions_with_edits": "編集された提出済みフォーム数",
+      "num_submissions_with_comments": "コメントのある提出済みフォーム数",
+      "num_submissions_from_app_users": "アプリユーザーから提出されたフォーム数",
+      "num_submissions_from_public_links": "一般公開リンクから提出されたフォーム数",
+      "num_submissions_from_web_users": "Webユーザーから提出されたフォーム数"
     }
   }
 }

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -198,8 +198,10 @@ export default {
       "Siempre puedes venir aquí para ver qué se está recolectando."
     ],
     "projects": {
-      "title": "Resúmenes de proyectos"
-    }
+      "title": "Resúmenes de proyectos",
+      "subtitle": "(Mostrando el Proyecto más activo de {count} Proyecto) | (Mostrando el Proyecto más activo de {count} Proyectos)"
+    },
+    "submissionStates": "Estados de envío"
   },
   "fr": {
     "title": "Rapport d'utilisation anonymisé",
@@ -226,6 +228,19 @@ export default {
       "subtitle": "(Visualizzazione del progetto più attivo di {count} Progetto) | (Visualizzazione del progetto più attivo di {count} Progetti)"
     },
     "submissionStates": "Stato invio"
+  },
+  "ja": {
+    "title": "匿名化された利用状況報告",
+    "introduction": [
+      "利用データの送信を検討して頂き、ありがとうございます。データによりあなたのニーズは満たされやすくなります。",
+      "ここで表示されている情報を私たちは収集しています。新たな機能や要望に応えるため、収集する情報を時折変更しますが、ここで表示されるような集計データのみを収集します。",
+      "あなたはいつでもここで何が収集されているのかを確認できます。"
+    ],
+    "projects": {
+      "title": "プロジェクトの概要",
+      "subtitle": "（最もアクティブな{count}つのプロジェクトについて）"
+    },
+    "submissionStates": "提出済フォームの状態"
   }
 }
 </i18n>

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -166,6 +166,11 @@ body.modal-open #app-alert {
     "alert": {
       "versionChange": "Il server è stato aggiornato. Aggiorna la pagina per evitare comportamenti imprevedibili."
     }
+  },
+  "ja": {
+    "alert": {
+      "versionChange": "サーバーがアップデートされました。予期しない動作を避けるため、ページを更新してください。"
+    }
   }
 }
 </i18n>

--- a/src/components/async-route.vue
+++ b/src/components/async-route.vue
@@ -149,6 +149,11 @@ export default {
     "alert": {
       "loadError": "Impossibile caricare la pagina richiesta. Perfavore ricarica la pagina e riprova."
     }
+  },
+  "ja": {
+    "alert": {
+      "loadError": "リクエストされたページを読み込むことができませんでした。ページを更新して、もう一度試みて下さい。"
+    }
   }
 }
 </i18n>

--- a/src/components/form-draft/checklist.vue
+++ b/src/components/form-draft/checklist.vue
@@ -218,7 +218,7 @@ export default {
         ]
       },
       {
-        "title": "Vyzkoušejte formulář na svém mobilním zařízení",
+        "title": "Otestujte formulář vytvořením podání",
         "body": [
           {
             "full": "Můžete {test} formulář abyste se ujistili, že funguje tak, jak očekáváte. Testovací odeslání nejsou součástí vašich konečných údajů.",
@@ -272,7 +272,6 @@ export default {
         ]
       },
       {
-        "title": "Testen Sie das Formular auf Ihrem Mobilgerät",
         "body": [
           {
             "full": "Sie können ein Formular {test}, um sicher zu sein, dass es wie erwartet funktioniert. Test-Übermittlungen sind in den endgültigen Daten nicht enthalten.",
@@ -326,7 +325,6 @@ export default {
         ]
       },
       {
-        "title": "Pruebe el formulario en su dispositivo móvil",
         "body": [
           {
             "full": "Puede {test} un formulario para asegurarse de que funciona como usted espera. Los envíos de prueba no son incluidos en sus datos finales.",
@@ -380,7 +378,6 @@ export default {
         ]
       },
       {
-        "title": "Testez le formulaire sur votre appareil mobile",
         "body": [
           {
             "full": "Vous pouvez {test} un formulaire pour vérifier qu'il fonctionne comme prévu. Les soumissions de test ne seront pas incluses dans vos vraies données.",
@@ -434,7 +431,6 @@ export default {
         ]
       },
       {
-        "title": "Tes formulir pada perangkat seluler Anda",
         "body": [
           {
             "full": "Anda bisa {test} formulir untuk memastikan kesesuaiannya dengan yang Anda ekspektasikan. Kiriman data dari hasil tes tidak akan dimasukkan ke dalam data akhir Anda.",
@@ -488,7 +484,6 @@ export default {
         ]
       },
       {
-        "title": "Testa il formulario sul tuo dispositivo mobile",
         "body": [
           {
             "full": "Puoi {test} un formulario per assicurarti che funzioni come previsto. Gli invii di prova non sono inclusi nei dati finali.",
@@ -542,7 +537,7 @@ export default {
         ]
       },
       {
-        "title": "フォームをモバイル端末でテスト",
+        "title": "提出フォームを作成して、フォームをテストする。",
         "body": [
           {
             "full": "フォームが期待通りに動作するかを{test}できます。テストの目的で提出されたフォームは、最終的なデータには含まれません。",

--- a/src/components/form-draft/publish.vue
+++ b/src/components/form-draft/publish.vue
@@ -190,7 +190,7 @@ export default {
         "mediaFiles": "Mediální soubory"
       },
       "testing": {
-        "full": "Ještě nemáte {tested} na mobilním zařízení a nahráli jste zkušební příspěvek. Nemusíte to dělat, ale je to velmi doporučeno.",
+        "full": "Ještě jste nenahráli {tested} nahráním testovacího podání. Nemusíte to dělat, ale důrazně to doporučujeme.",
         "tested": "otestovaný tento formulář"
       }
     },
@@ -212,10 +212,6 @@ export default {
       "attachments": {
         "full": "Sie haben die {mediaFiles} für Ihr Formular benötigten Dateien nicht bereitgestellt. Sie können dies ignorieren, aber Sie müssen Entwurfsversionen zum späteren Hochladen bereitstellen.",
         "mediaFiles": "Mediendateien"
-      },
-      "testing": {
-        "full": "Sie haben {tested} noch nicht auf einem Mobilgerät getestet und eine Test-Datenübermittlung hochgeladen. Sie müssen das nicht tun, aber es wird dringend empfohlen.",
-        "tested": "dieses Formular"
       }
     },
     "introduction": [
@@ -236,10 +232,6 @@ export default {
       "attachments": {
         "full": "No ha proporcionado todos los {mediaFiles} que requiere su formulario. Puede ignorar esto si lo desea, pero deberá crear una nueva versión de borrador para cargar esos archivos más tarde.",
         "mediaFiles": "archivos multimedia"
-      },
-      "testing": {
-        "full": "Aún no ha {tested} con un dispositivo móvil y subido un envío de prueba. No tiene que hacer esto, pero es muy recomendable.",
-        "tested": "probado este formulario"
       }
     },
     "introduction": [
@@ -260,10 +252,6 @@ export default {
       "attachments": {
         "full": "Vous n'avez pas fourni tous les {mediaFiles} requis par votre formulaire. Vous pouvez ignorer cette notification, mais vous devrez créer une nouvelle ébauche pour ajouter ces fichiers plus tard.",
         "mediaFiles": "fichiers média"
-      },
-      "testing": {
-        "full": "Vous n'avez pas encore {tested} sur un appareil mobile et téléchargé une soumission de test. Vous n'êtes pas obligé de le faire, mais c'est fortement recommandé.",
-        "tested": "testé ce formulaire"
       }
     },
     "introduction": [
@@ -284,10 +272,6 @@ export default {
       "attachments": {
         "full": "Anda belum melengkapi {mediaFiles} yang dibutuhkan formulir Anda. Anda dapat mengabaikan ini sekarang, tetapi Anda harus membuat Draf versi baru untuk mengunggah file-file tersebut nanti.",
         "mediaFiles": "File Media"
-      },
-      "testing": {
-        "full": "Anda belum {tested} dan mengunggah tes kiriman data pada perangkat seluler. Hal ini tidak harus, tetapi sangat direkomendasikan.",
-        "tested": "mengetes formulir ini"
       }
     },
     "introduction": [
@@ -308,10 +292,6 @@ export default {
       "attachments": {
         "full": "Non hai fornito tutti i {mediaFiles} che il tuo formulario richiede. Puoi ignorarlo se lo desideri, ma dovrai creare una nuova versione bozza per caricare quei file in un secondo momento.",
         "mediaFiles": "File multimediali"
-      },
-      "testing": {
-        "full": "Non hai ancora {tested} su un dispositivo mobile e caricato un invio di prova. Non devi farlo, ma è altamente raccomandato.",
-        "tested": "testato questo Formulario"
       }
     },
     "introduction": [
@@ -334,7 +314,7 @@ export default {
         "mediaFiles": "メディアファイル"
       },
       "testing": {
-        "full": "まだモバイル端末で{tested}し、フォームのテスト提出がされていません。これは必須ではありませんが、強く推奨します。",
+        "full": "まだテストフォームのアップロードにより、{tested}していません。これは必須ではありませんが、強く推奨します。",
         "tested": "このフォームをテスト"
       }
     },

--- a/src/components/markdown/textarea.vue
+++ b/src/components/markdown/textarea.vue
@@ -174,6 +174,10 @@ export default {
   "it": {
     "markdownSupported": "Markdown supportato",
     "preview": "Anteprima"
+  },
+  "ja": {
+    "markdownSupported": "マークダウンがサポートされています。",
+    "preview": "プレビュー"
   }
 }
 </i18n>

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -298,7 +298,8 @@ $border-height: 3px;
   "ja": {
     "action": {
       "toggle": "ナビゲーションを有効化"
-    }
+    },
+    "analyticsNotice": "Centralの改善を支援！"
   }
 }
 </i18n>

--- a/src/components/project/form-access/states.vue
+++ b/src/components/project/form-access/states.vue
@@ -108,16 +108,16 @@ export default {
     "introduction": [
       "Stavy formuláře kontrolují stav životního cyklu každého formuláře. Obvykle, ale ne vždy, bude formulář otevřen a bude pokračovat přes Uzavření až do Uzavřeno, pokud již nebude potřeba.",
       {
-        "full": "{open} formuláře jsou k dispozici ke stažení na mobilních zařízeních a budou přijímat nové příspěvky.",
+        "full": "{open} Formuláře jsou k dispozici ke stažení a přijímají nová podání.",
         "open": "Otevřené"
       },
       {
-        "full": "{closing} formuláře přijímají nové příspěvky, ale {not} k dispozici ke stažení na mobilních zařízeních.",
+        "full": "{closing} Formuláře přijímají nová podání, ale {not}jsou k dispozici ke stažení.",
         "closing": "Uzavřené",
         "not": "nejsou"
       },
       {
-        "full": "{closed} formuláře {not1}jsou k dispozici ke stažení na mobilních zařízeních a {not2}přijímají nová podání.",
+        "full": "{closed} Formuláře {not1}jsou k dispozici ke stažení a {not2}přijímají nová podání.",
         "closed": "Uzavřené",
         "not1": "ne",
         "not2": "ne"
@@ -128,105 +128,45 @@ export default {
     "title": "Formular-Status",
     "introduction": [
       "Formular-Status steuern den Lebenszyklusstatus eines jeden Formulars. Normalerweise, aber nicht immer, beginnt ein Formular im Status Offen und geht weiter über Schließen nach Geschlossen, wenn es nicht mehr benötigt wird.",
-      {
-        "full": "{open} Formulare können auf mobile Geräte heruntergeladen werden und akzeptieren neue Übermittlungen.",
-        "open": "Offen"
-      },
-      {
-        "full": "{closing} Formulare akzeptieren neue Übermittlungen, aber können {not} auf mobile Geräte heruntergeladen werden.",
-        "closing": "Schließen",
-        "not": "nicht"
-      },
-      {
-        "full": "{closed} Formulare können {not1} auf mobile Geräte heruntergeladen werden und akzeptieren {not2} neuen Übermittlungen.",
-        "closed": "Geschlossene",
-        "not1": "nicht",
-        "not2": "nicht"
-      }
+      {},
+      {},
+      {}
     ]
   },
   "es": {
     "title": "Estado del formulario",
     "introduction": [
       "El estado del formulario controla el ciclo de vida de cada formulario. Por lo general, pero en algunas ocasiones no será de este modo, el formulario comenzará abierto y luego procederá a cerrarse cuando ya no sea necesario.",
-      {
-        "full": "Los formularios {open} están disponibles para descarga en dispositivos móviles y aceptán nuevos envíos.",
-        "open": "abiertos"
-      },
-      {
-        "full": "Los formularios {closing} aceptán nuevos envíos pero {not} están disponibles para descarga en dispositivos móviles.",
-        "closing": "cerrando",
-        "not": "no"
-      },
-      {
-        "full": "Los formularios {closed} {not1} están disponibles para descarga en dispositivos móviles, y {not2} aceptán nuevos envíos.",
-        "closed": "cerrados",
-        "not1": "no",
-        "not2": "no"
-      }
+      {},
+      {},
+      {}
     ]
   },
   "fr": {
     "title": "États des formulaires",
     "introduction": [
       "Les États de formulaire contrôlent le cycle de vie de chaque formulaire. Généralement, mais pas toujours, un formulaire démarrera \"Ouvert\", sera utilisé jusqu'à sa \"Fermeture\", et sera \"Fermé\" quand il ne sera plus utile.",
-      {
-        "full": "Les formulaires {open} sont téléchargeables sur les appareils mobiles, et peuvent accepter des soumissions.",
-        "open": "Ouvert"
-      },
-      {
-        "full": "Les formulaires {closing} acceptent les nouvelles soumissions, mais ne sont {not} disponibles en téléchargement sur les appareils mobiles.",
-        "closing": "Fermeture",
-        "not": "pas"
-      },
-      {
-        "full": "Les formulaires {closed} ne sont {not1} disponibles en téléchargement sur les appareils mobiles, et n'accepteront {not2} de nouvelles soumissions.",
-        "closed": "Fermé",
-        "not1": "pas",
-        "not2": "pas"
-      }
+      {},
+      {},
+      {}
     ]
   },
   "id": {
     "title": "Status Formulir",
     "introduction": [
       "Status Formulir mengontrol keadaan lingkar keaktifan setiap formulir. Biasanya, tidak selalu, sebuah formulir akan dimulai dengan status Terbuka, kemudian Penutupan, hingga Ditutup, ketika sudah tidak diperlukan lagi.",
-      {
-        "full": "Formulir {open} tersedia untuk diunduh lewat perangkat seluler dan akan menerima kiriman data baru.",
-        "open": "Terbuka"
-      },
-      {
-        "full": "{closing} Formulir akan menerima kiriman data baru, tetapi {not} tersedia untuk diunduh di perangkat seluler.",
-        "closing": "Penutupan",
-        "not": "tidak"
-      },
-      {
-        "full": "Formulir {closed} {not1} tersedia untuk diunduh di perangkat seluler dan {not2} menerima kiriman data baru.",
-        "closed": "Ditutup",
-        "not1": "tidak",
-        "not2": "tidak"
-      }
+      {},
+      {},
+      {}
     ]
   },
   "it": {
     "title": "Stato del Formulario",
     "introduction": [
       "Gli stati del formulario controllano lo stato del ciclo di vita di ogni formulario. Di solito, ma non sempre, un formulario inizia nello stato \"aperto\" e procede negli stati da \"in chiusura\" a \"chiuso\" quando non è più necessario.",
-      {
-        "full": "{open} formulari sono disponibili per il download su dispositivi mobili e accetteranno nuovi Invii.",
-        "open": "Aperto"
-      },
-      {
-        "full": "{closing} I formulari accetteranno nuovi Invii, ma {not} sono disponibili per il download su dispositivi mobili.",
-        "closing": "In fase di chiusura",
-        "not": "non"
-      },
-      {
-        "full": "I formulari {closed} {not1} sono disponibili per il download su dispositivi mobili e {not2}accetteranno nuovi Invii.",
-        "closed": "Chiuso",
-        "not1": "non",
-        "not2": "non"
-      }
+      {},
+      {},
+      {}
     ]
   },
   "ja": {
@@ -234,16 +174,16 @@ export default {
     "introduction": [
       "フォームの状態では、各フォームのライフサイクルにおける状態を制御します。例外もありますが、通常、フォームは「公開」から始まり、「クロージング状態」を経て、不要になったら「終了」となります。",
       {
-        "full": "{open}のフォームはモバイル端末にダウンロードでき、新規のフォームの提出も受け付けます。",
+        "full": "{open}のフォームはダウンロードでき、新規のフォームの提出も受け付けます。",
         "open": "公開中"
       },
       {
-        "full": "{closing}のフォームは新規のフォームの提出を受け付けますが、モバイル端末にダウンロードはでき{not}。",
+        "full": "{closing}のフォームは新規のフォームの提出を受け付けますが、ダウンロードはでき{not}。",
         "closing": "クロージング状態",
         "not": "ません"
       },
       {
-        "full": "{closed}したフォームはモバイル端末にダウンロードでき{not1}。また新規のフォームの提出も受け付け{not2}。",
+        "full": "{closed}したフォームはダウンロードでき{not1}。また新規のフォームの提出も受け付け{not2}。",
         "closed": "終了",
         "not1": "ません",
         "not2": "ません"

--- a/src/components/project/overview/right-now.vue
+++ b/src/components/project/overview/right-now.vue
@@ -107,10 +107,10 @@ export default {
     },
     "forms": {
       "full": [
-        "{forms} který lze stáhnout a zadat jako průzkumy mobilních klientů.",
-        "{forms} které lze stáhnout a zadat jako průzkumy mobilních klientů.",
-        "{forms} které lze stáhnout a zadat jako průzkumy mobilních klientů.",
-        "{forms} které lze stáhnout a zadat jako průzkumy mobilních klientů."
+        "{forms} který lze stáhnout a zadat jako dotazník.",
+        "{forms} které lze stáhnout a zadat jako dotazník.",
+        "{forms} které lze stáhnout a zadat jako dotazník.",
+        "{forms} které lze stáhnout a zadat jako dotazník."
       ],
       "forms": "Formulář | Formulářů | Formulářů | Formuláře"
     }
@@ -122,13 +122,6 @@ export default {
         "{appUsers}, die eine Datensammel-App verwenden können, um Formulare herunterzuladen und Daten zu diesem Projekt übermitteln können."
       ],
       "appUsers": "App-Benutzer | App-Benutzer"
-    },
-    "forms": {
-      "full": [
-        "{forms}, das heruntergeladen und als Umfrage auf mobilen Geräten ausgegeben werden kann.",
-        "{forms}, die heruntergeladen und als Umfragen auf mobilen Geräten ausgegeben werden können."
-      ],
-      "forms": "Formular | Formulare"
     }
   },
   "es": {
@@ -138,13 +131,6 @@ export default {
         "{appUsers} que pueda utilizar un cliente de recopilación de datos para descargar y enviar datos de Formulario a este proyecto."
       ],
       "appUsers": "Usuario móvil | Usuarios móviles"
-    },
-    "forms": {
-      "full": [
-        "{forms} que puede ser descargado y mostrado como encuesta en dispositivos móviles.",
-        "{forms} que pueden ser descargados y mostrados como encuestas en dispositivos móviles."
-      ],
-      "forms": "Formulario | Formularios"
     }
   },
   "fr": {
@@ -154,13 +140,6 @@ export default {
         "{appUsers} qui peuvent utiliser un client de collecte de données pour télécharger les formulaires du projet et soumettre des données."
       ],
       "appUsers": "Utilisateur mobile | Utilisateurs mobiles"
-    },
-    "forms": {
-      "full": [
-        "{forms} qui peut être téléchargé et donné sous forme d'une enquête sur les clients mobiles.",
-        "{forms} qui peuvent être téléchargés et donnés sous forme d'enquêtes sur les clients mobiles."
-      ],
-      "forms": "Formulaire | Formulaires"
     }
   },
   "id": {
@@ -169,12 +148,6 @@ export default {
         "{appUsers} yang dapat menggunakan klien pengumpul data untuk mengunduh dan mengirim data formulir ke Proyek ini."
       ],
       "appUsers": "Pengguna Aplikasi"
-    },
-    "forms": {
-      "full": [
-        "{forms} yang dapat diunduh dan diberikan sebagai survei di klien seluler."
-      ],
-      "forms": "Formulir"
     }
   },
   "it": {
@@ -184,13 +157,6 @@ export default {
         "{appUsers} che possono utilizzare un client di raccolta dati per scaricare e inviare i dati del formulario a questo progetto."
       ],
       "appUsers": "Utente dell'applicazione | Utenti dell'applicazione"
-    },
-    "forms": {
-      "full": [
-        "{forms} che può essere scaricato e dato come questionario su client mobili.",
-        "{forms} che possono essere scaricati e forniti come questionari su client mobili."
-      ],
-      "forms": "Formulari | Formulari"
     }
   },
   "ja": {
@@ -202,7 +168,7 @@ export default {
     },
     "forms": {
       "full": [
-        "{forms}は、モバイル端末にダウンロードし、調査が可能です。"
+        "{forms}は、ダウンロードし、調査が可能です。"
       ],
       "forms": "フォーム"
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -71,6 +71,7 @@
         "session_end": "Revocar",
         "delete": "Borrar"
       },
+      "analytics": "Informe de uso",
       "backup": "Copia de seguridad",
       "config": {
         "set": "Establecer"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -71,6 +71,7 @@
         "session_end": "無効化",
         "delete": "削除"
       },
+      "analytics": "利用状況報告",
       "backup": "バックアップ",
       "config": {
         "set": "設定"
@@ -219,7 +220,11 @@
     "learnMore": "さらに詳しく知る。"
   },
   "analytics": {
-    "alwaysImprove": "私たちはいつもODK Centralを改良しようとしています。"
+    "alwaysImprove": "私たちは常にODK Centralを改良しようとしています。",
+    "needFeedback": {
+      "full": "そのために、私たちは{your}フィードバックが必要です。それによりあなたがどの様にCentralを使い、またどの様にすればあなたにとって良くなるのかが分かります。",
+      "your": "あなたの"
+    }
   },
   "submission": {
     "missingMedia": "メディアファイルが見つかりません",
@@ -247,7 +252,8 @@
     "tab": {
       "settings": "設定",
       "overview": "概要"
-    }
+    },
+    "total": "全期間"
   },
   "mixin": {
     "request": {

--- a/transifex/strings_cs.json
+++ b/transifex/strings_cs.json
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "Vyzkoušejte formulář na svém mobilním zařízení",
+            "string": "Otestujte formulář vytvořením podání",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "Ještě nemáte {tested} na mobilním zařízení a nahráli jste zkušební příspěvek. Nemusíte to dělat, ale je to velmi  doporučeno.",
+            "string": "Ještě jste nenahráli {tested} nahráním testovacího podání. Nemusíte to dělat, ale důrazně to doporučujeme.",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "otestovaný tento formulář",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "{open} formuláře jsou k dispozici ke stažení na mobilních zařízeních a budou přijímat nové příspěvky.",
+            "string": "{open}  Formuláře jsou k dispozici ke stažení a přijímají nová podání.",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "Otevřené",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "{closing} formuláře přijímají nové příspěvky, ale {not} k dispozici ke stažení na mobilních zařízeních.",
+            "string": " {closing} Formuláře přijímají nová podání, ale {not}jsou k dispozici ke stažení.",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "Uzavřené",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "nejsou",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "{closed} formuláře {not1}jsou k dispozici ke stažení na mobilních zařízeních a {not2}přijímají nová podání.",
+            "string": " {closed} Formuláře {not1}jsou k dispozici ke stažení a {not2}přijímají nová podání.",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "Uzavřené",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "ne",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "ne",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, one {{forms} který lze stáhnout a zadat jako průzkumy mobilních klientů.} few {{forms} které lze stáhnout a zadat jako průzkumy mobilních klientů.} many {{forms} které lze stáhnout a zadat jako průzkumy mobilních klientů.} other {{forms} které lze stáhnout a zadat jako průzkumy mobilních klientů.}}",
+          "string": "{count, plural, one {{forms} který lze stáhnout a zadat jako dotazník. } few {{forms}  které lze stáhnout a zadat jako dotazník.} many {{forms} které lze stáhnout a zadat jako dotazník.} other {{forms}  které lze stáhnout a zadat jako dotazník.}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, one {Formulář} few {Formulářů} many {Formulářů} other {Formuláře}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "Odesláno v",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "(jakýkoliv stav)",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {

--- a/transifex/strings_de.json
+++ b/transifex/strings_de.json
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "Testen Sie das Formular auf Ihrem Mobilgerät",
+            "string": "",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "Sie haben {tested} noch nicht auf einem Mobilgerät getestet und eine Test-Datenübermittlung hochgeladen. Sie müssen das nicht tun, aber es wird dringend empfohlen.",
+            "string": "",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "dieses Formular ",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "{open} Formulare können auf mobile Geräte heruntergeladen werden und akzeptieren neue Übermittlungen.",
+            "string": "",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "Offen",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "{closing} Formulare akzeptieren neue Übermittlungen, aber können {not} auf mobile Geräte heruntergeladen werden. ",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "Schließen",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "nicht",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "{closed} Formulare können {not1} auf mobile Geräte heruntergeladen werden und akzeptieren {not2} neuen Übermittlungen.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "Geschlossene",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "nicht",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "nicht",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, one {{forms}, das heruntergeladen und als Umfrage auf mobilen Geräten ausgegeben werden kann. } other {{forms}, die heruntergeladen und als Umfragen auf mobilen Geräten ausgegeben werden können. }}",
+          "string": "{count, plural, one {} other {}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, one {Formular} other {Formulare}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "Übermittelt um",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "(Beliebiger Status)",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {

--- a/transifex/strings_es.json
+++ b/transifex/strings_es.json
@@ -194,7 +194,7 @@
         }
       },
       "analytics": {
-        "string": "",
+        "string": "Informe de uso",
         "developer_comment": "This is shown in the log of actions performed on the server."
       },
       "backup": {
@@ -915,7 +915,7 @@
         }
       },
       "auditsTitle": {
-        "string": "",
+        "string": "Últimos informes de uso",
         "developer_comment": "This is a title shown above a section of the page."
       }
     },
@@ -967,7 +967,7 @@
           "string": "Número de formularios con repeticiones"
         },
         "num_forms_with_geospatial": {
-          "string": ""
+          "string": "Número de formularios con geodatos"
         },
         "num_forms_with_encryption": {
           "string": "Número de formularios con cifrado"
@@ -976,19 +976,19 @@
           "string": "Número de formularios con auditorías"
         },
         "num_submissions_received": {
-          "string": ""
+          "string": "Número de envíos - Recibidos"
         },
         "num_submissions_approved": {
-          "string": ""
+          "string": "Número de envíos - Aprobados"
         },
         "num_submissions_has_issues": {
-          "string": ""
+          "string": "Número de envíos - Con problemas"
         },
         "num_submissions_rejected": {
-          "string": ""
+          "string": "Número de envíos - Rechazados"
         },
         "num_submissions_edited": {
-          "string": ""
+          "string": "Número de envíos - Con ediciones"
         },
         "num_submissions_with_edits": {
           "string": "Número de envíos con ediciones"
@@ -1029,11 +1029,11 @@
           "developer_comment": "This is the title shown above a series of metrics about Project usage."
         },
         "subtitle": {
-          "string": "{count, plural, one {} other {}}"
+          "string": "{count, plural, one {(Mostrando el Proyecto más activo de {count} Proyecto)} other {(Mostrando el Proyecto más activo de {count} Proyectos)}}"
         }
       },
       "submissionStates": {
-        "string": "",
+        "string": "Estados de envío",
         "developer_comment": "This is the title of a single table in the analytics metrics report of metrics about submission state (approved, rejected, etc)"
       }
     },
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "Pruebe el formulario en su dispositivo móvil",
+            "string": "",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "Aún no ha {tested} con un dispositivo móvil y subido un envío de prueba. No tiene que hacer esto, pero es muy recomendable.",
+            "string": "",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "probado este formulario",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "Los formularios {open} están disponibles para descarga en dispositivos móviles y aceptán nuevos envíos.",
+            "string": "",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "abiertos",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "Los formularios {closing} aceptán nuevos envíos pero {not} están disponibles para descarga en dispositivos móviles.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "cerrando",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "no",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "Los formularios {closed} {not1} están disponibles para descarga en dispositivos móviles, y {not2} aceptán nuevos envíos.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "cerrados",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "no",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "no",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, one {{forms} que puede ser descargado y mostrado como encuesta en dispositivos móviles.} other {{forms} que pueden ser descargados y mostrados como encuestas en dispositivos móviles.}}",
+          "string": "{count, plural, one {} other {}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, one {Formulario} other {Formularios}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "Enviado a",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "(Cualquier estado)",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {

--- a/transifex/strings_fr.json
+++ b/transifex/strings_fr.json
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "Testez le formulaire sur votre appareil mobile",
+            "string": "",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "Vous n'avez pas encore {tested} sur un appareil mobile et téléchargé une soumission de test. Vous n'êtes pas obligé de le faire, mais c'est fortement recommandé.",
+            "string": "",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "testé ce formulaire",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "Les formulaires {open} sont téléchargeables sur les appareils mobiles, et peuvent accepter des soumissions.",
+            "string": "",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "Ouvert",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "Les formulaires {closing} acceptent les nouvelles soumissions, mais ne sont {not} disponibles en téléchargement sur les appareils mobiles.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "Fermeture",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "pas",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "Les formulaires {closed} ne sont {not1} disponibles en téléchargement sur les appareils mobiles, et n'accepteront {not2} de nouvelles soumissions.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "Fermé",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "pas",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "pas",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, one {{forms} qui peut être téléchargé et donné sous forme d'une enquête sur les clients mobiles.} other {{forms} qui peuvent être téléchargés et donnés sous forme d'enquêtes sur les clients mobiles.}}",
+          "string": "{count, plural, one {} other {}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, one {Formulaire} other {Formulaires}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "Soumis à",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "(Tous états)",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {

--- a/transifex/strings_id.json
+++ b/transifex/strings_id.json
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "Tes formulir pada perangkat seluler Anda",
+            "string": "",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "Anda belum {tested} dan mengunggah tes kiriman data pada perangkat seluler. Hal ini tidak harus, tetapi sangat direkomendasikan.",
+            "string": "",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "mengetes formulir ini",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "Formulir {open} tersedia untuk diunduh lewat perangkat seluler dan akan menerima kiriman data baru.",
+            "string": "",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "Terbuka",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "{closing} Formulir  akan menerima kiriman data baru, tetapi {not} tersedia untuk diunduh di perangkat seluler.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "Penutupan",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "tidak",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "Formulir {closed} {not1} tersedia untuk diunduh di perangkat seluler dan {not2} menerima kiriman data baru.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "Ditutup",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "tidak",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "tidak",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, other {{forms} yang dapat diunduh dan diberikan sebagai survei di klien seluler.}}",
+          "string": "{count, plural, other {}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, other {Formulir}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "Terkirim pada",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "(Status apapun)",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {

--- a/transifex/strings_it.json
+++ b/transifex/strings_it.json
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "Testa il formulario sul tuo dispositivo mobile",
+            "string": "",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "Non hai ancora {tested} su un dispositivo mobile e caricato un invio di prova. Non devi farlo, ma è altamente raccomandato. ",
+            "string": "",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "testato questo Formulario",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "{open} formulari sono disponibili per il download su dispositivi mobili e accetteranno nuovi Invii. ",
+            "string": "",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "Aperto",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "{closing} I formulari accetteranno nuovi Invii, ma {not} sono disponibili per il download su dispositivi mobili.",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "In fase di chiusura",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "non",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "I formulari {closed} {not1} sono disponibili per il download su dispositivi mobili e {not2}accetteranno nuovi Invii. ",
+            "string": "",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "Chiuso",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "non",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "non",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, one {{forms} che può essere scaricato e dato come questionario su client mobili.} other {{forms} che possono essere scaricati e forniti come questionari su client mobili.}}",
+          "string": "{count, plural, one {} other {}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, one {Formulari} other {Formulari}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "Inviato alle",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "(ogni Stato)",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {

--- a/transifex/strings_ja.json
+++ b/transifex/strings_ja.json
@@ -194,7 +194,7 @@
         }
       },
       "analytics": {
-        "string": "",
+        "string": "利用状況報告",
         "developer_comment": "This is shown in the log of actions performed on the server."
       },
       "backup": {
@@ -611,11 +611,11 @@
   },
   "analytics": {
     "alwaysImprove": {
-      "string": "私たちはいつもODK Centralを改良しようとしています。"
+      "string": "私たちは常にODK Centralを改良しようとしています。"
     },
     "needFeedback": {
       "full": {
-        "string": "",
+        "string": "そのために、私たちは{your}フィードバックが必要です。それによりあなたがどの様にCentralを使い、またどの様にすればあなたにとって良くなるのかが分かります。",
         "developer_comment": "\"This\" refers to improving Central.\n\n{your} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nyour"
       },
       "your": {
@@ -707,7 +707,7 @@
       }
     },
     "total": {
-      "string": ""
+      "string": "全期間"
     }
   },
   "mixin": {
@@ -828,11 +828,11 @@
         "true": {
           "0": {
             "full": {
-              "string": "",
+              "string": "{weWillShare}また、{termsOfService}と{privacyPolicy}に同意します。",
               "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {weWillShare} has the text: We are willing to share anonymous usage data monthly with the Central team,\n- {termsOfService} has the text: Terms of Service\n- {privacyPolicy} has the text: Privacy Policy"
             },
             "weWillShare": {
-              "string": "",
+              "string": "私たちは毎月、匿名化された利用情報をCentralチームと共有します。",
               "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {weWillShare} is in the following text:\n\n{weWillShare} and we accept the {termsOfService} and {privacyPolicy}."
             },
             "termsOfService": {
@@ -845,21 +845,21 @@
             }
           },
           "1": {
-            "string": ""
+            "string": "どのような情報が送信されるのか？"
           }
         },
         "false": {
           "0": {
-            "string": ""
+            "string": "私たちはデータを共有することに興味はありません。"
           },
           "1": {
-            "string": ""
+            "string": "あなたはこれに関する再通知を受け取ることはありません。"
           }
         }
       },
       "contact": {
         "0": {
-          "string": ""
+          "string": "私は報告にコンタクトの情報を含みます。"
         },
         "1": {
           "string": "私たちからあなたのODK Centralの利用状況について問い合わせることがあります。"
@@ -889,16 +889,16 @@
       "introduction": {
         "0": {
           "full": {
-            "string": "",
+            "string": "システム管理の{usageReporting}タブで、あなたは匿名の利用データを共有するか、あなたのコンタクトをCentralの開発チームと共有するかを選択できます。",
             "developer_comment": "{usageReporting} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nUsage Reporting"
           },
           "usageReporting": {
-            "string": "",
+            "string": "利用状況報告",
             "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {usageReporting} is in the following text:\n\nIn the {usageReporting} tab in System Settings, you can choose to share anonymized usage data or contact information with the Central team."
           }
         },
         "1": {
-          "string": ""
+          "string": "そこで、あなたはこのメッセージを再び表示しないように設定できます。"
         }
       },
       "action": {
@@ -911,143 +911,143 @@
     "AnalyticsList": {
       "heading": {
         "0": {
-          "string": ""
+          "string": "以下で、あなたはこのCentralサーバーがCentralチームと匿名化された利用情報を共有するかどうかを選択できます。この設定はサーバー全体の及びます。"
         }
       },
       "auditsTitle": {
-        "string": "",
+        "string": "最新の利用情報",
         "developer_comment": "This is a title shown above a section of the page."
       }
     },
     "AnalyticsMetricsTable": {
       "recent": {
-        "string": ""
+        "string": "過去45日間"
       },
       "fields": {
         "num_admins": {
-          "string": ""
+          "string": "管理者数"
         },
         "num_projects_encryption": {
-          "string": ""
+          "string": "暗号化が有効化されたプロジェクト数"
         },
         "num_questions_biggest_form": {
-          "string": ""
+          "string": "最も大きなフォームの質問数"
         },
         "num_audit_log_entries": {
-          "string": ""
+          "string": "監査ログ数"
         },
         "backups_configured": {
-          "string": ""
+          "string": "設定されたバックアップ"
         },
         "database_size": {
-          "string": ""
+          "string": "システムのデータベースサイズ"
         },
         "num_managers": {
-          "string": ""
+          "string": "プロジェクト・マネージャー数"
         },
         "num_viewers": {
-          "string": ""
+          "string": "プロジェクト・閲覧者数"
         },
         "num_data_collectors": {
-          "string": ""
+          "string": "データ収集者数"
         },
         "num_app_users": {
-          "string": ""
+          "string": "アプリユーザー数"
         },
         "num_device_ids": {
-          "string": ""
+          "string": "デバイスID数"
         },
         "num_public_access_links": {
-          "string": ""
+          "string": "一般公開リンク数"
         },
         "num_forms": {
-          "string": ""
+          "string": "フォーム数"
         },
         "num_forms_with_repeats": {
-          "string": ""
+          "string": "リピートを有するフォーム数"
         },
         "num_forms_with_geospatial": {
-          "string": ""
+          "string": "ジオデータを有するフォーム数"
         },
         "num_forms_with_encryption": {
-          "string": ""
+          "string": "暗号化されたフォーム数"
         },
         "num_forms_with_audits": {
-          "string": ""
+          "string": "監査を受けたフォーム数"
         },
         "num_submissions_received": {
-          "string": ""
+          "string": "提出済みフォーム数　ー　受信済み"
         },
         "num_submissions_approved": {
-          "string": ""
+          "string": "提出済みフォーム数　ー　承認済み"
         },
         "num_submissions_has_issues": {
-          "string": ""
+          "string": "提出済みフォーム数　ー　問題有り"
         },
         "num_submissions_rejected": {
-          "string": ""
+          "string": "提出済みフォーム数　ー　リジェクト済み"
         },
         "num_submissions_edited": {
-          "string": ""
+          "string": "提出済みフォーム数　ー　編集済み"
         },
         "num_submissions_with_edits": {
-          "string": ""
+          "string": "編集された提出済みフォーム数"
         },
         "num_submissions_with_comments": {
-          "string": ""
+          "string": "コメントのある提出済みフォーム数"
         },
         "num_submissions_from_app_users": {
-          "string": ""
+          "string": "アプリユーザーから提出されたフォーム数"
         },
         "num_submissions_from_public_links": {
-          "string": ""
+          "string": "一般公開リンクから提出されたフォーム数"
         },
         "num_submissions_from_web_users": {
-          "string": ""
+          "string": "Webユーザーから提出されたフォーム数"
         }
       }
     },
     "AnalyticsPreview": {
       "title": {
-        "string": "",
+        "string": "匿名化された利用状況報告",
         "developer_comment": "This is the title at the top of a pop-up."
       },
       "introduction": {
         "0": {
-          "string": ""
+          "string": "利用データの送信を検討して頂き、ありがとうございます。データによりあなたのニーズは満たされやすくなります。"
         },
         "1": {
-          "string": ""
+          "string": "ここで表示されている情報を私たちは収集しています。新たな機能や要望に応えるため、収集する情報を時折変更しますが、ここで表示されるような集計データのみを収集します。"
         },
         "2": {
-          "string": ""
+          "string": "あなたはいつでもここで何が収集されているのかを確認できます。"
         }
       },
       "projects": {
         "title": {
-          "string": "",
+          "string": "プロジェクトの概要",
           "developer_comment": "This is the title shown above a series of metrics about Project usage."
         },
         "subtitle": {
-          "string": "{count, plural, other {}}"
+          "string": "{count, plural, other {（最もアクティブな{count}つのプロジェクトについて）}}"
         }
       },
       "submissionStates": {
-        "string": "",
+        "string": "提出済フォームの状態",
         "developer_comment": "This is the title of a single table in the analytics metrics report of metrics about submission state (approved, rejected, etc)"
       }
     },
     "App": {
       "alert": {
         "versionChange": {
-          "string": ""
+          "string": "サーバーがアップデートされました。予期しない動作を避けるため、ページを更新してください。"
         }
       }
     },
     "AsyncRoute": {
       "alert": {
         "loadError": {
-          "string": ""
+          "string": "リクエストされたページを読み込むことができませんでした。ページを更新して、もう一度試みて下さい。"
         }
       }
     },
@@ -1908,7 +1908,7 @@
         },
         "3": {
           "title": {
-            "string": "フォームをモバイル端末でテスト",
+            "string": "提出フォームを作成して、フォームをテストする。",
             "developer_comment": "This is the title of a checklist item."
           },
           "body": {
@@ -1967,12 +1967,12 @@
         },
         "testing": {
           "full": {
-            "string": "まだモバイル端末で{tested}し、フォームのテスト提出がされていません。これは必須ではありませんが、強く推奨します。",
+            "string": "まだテストフォームのアップロードにより、{tested}していません。これは必須ではありませんが、強く推奨します。",
             "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
           },
           "tested": {
             "string": "このフォームをテスト",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} on a mobile device and uploaded a test Submission. You do not have to do this, but it is highly recommended."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
           }
         }
       },
@@ -2377,11 +2377,11 @@
     },
     "MarkdownTextarea": {
       "markdownSupported": {
-        "string": "",
+        "string": "マークダウンがサポートされています。",
         "developer_comment": "This is a link to an external website with Markdown style guidelines"
       },
       "preview": {
-        "string": "",
+        "string": "プレビュー",
         "developer_comment": "This is text shown as a label above the preview of Markdown formatting (special formatting of user-submitted text)"
       }
     },
@@ -2393,7 +2393,7 @@
         }
       },
       "analyticsNotice": {
-        "string": ""
+        "string": "Centralの改善を支援！"
       }
     },
     "NavbarActions": {
@@ -2626,44 +2626,44 @@
         },
         "1": {
           "full": {
-            "string": "{open}のフォームはモバイル端末にダウンロードでき、新規のフォームの提出も受け付けます。",
+            "string": "{open}のフォームはダウンロードでき、新規のフォームの提出も受け付けます。",
             "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
           },
           "open": {
             "string": "公開中",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download on mobile devices, and will accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
           }
         },
         "2": {
           "full": {
-            "string": "{closing}のフォームは新規のフォームの提出を受け付けますが、モバイル端末にダウンロードはでき{not}。",
+            "string": "{closing}のフォームは新規のフォームの提出を受け付けますが、ダウンロードはでき{not}。",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
           },
           "closing": {
             "string": "クロージング状態",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           },
           "not": {
             "string": "ません",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download on mobile devices."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
           }
         },
         "3": {
           "full": {
-            "string": "{closed}したフォームはモバイル端末にダウンロードでき{not1}。また新規のフォームの提出も受け付け{not2}。",
+            "string": "{closed}したフォームはダウンロードでき{not1}。また新規のフォームの提出も受け付け{not2}。",
             "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
           },
           "closed": {
             "string": "終了",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not1": {
             "string": "ません",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           },
           "not2": {
             "string": "ません",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download on mobile devices, and will {not2} accept new Submissions."
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
           }
         }
       }
@@ -2832,12 +2832,12 @@
       },
       "forms": {
         "full": {
-          "string": "{count, plural, other {{forms}は、モバイル端末にダウンロードし、調査が可能です。}}",
+          "string": "{count, plural, other {{forms}は、ダウンロードし、調査が可能です。}}",
           "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
         },
         "forms": {
           "string": "{count, plural, other {フォーム}}",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys on mobile clients."
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
         }
       }
     },
@@ -3444,12 +3444,6 @@
           "string": "フォームの送信日",
           "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
         }
-      }
-    },
-    "SubmissionFiltersReviewState": {
-      "anyState": {
-        "string": "（全ステータス）",
-        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
       }
     },
     "SubmissionFiltersSubmitter": {


### PR DESCRIPTION
We have to upgrade to Vue I18n v9 as part of moving to Vue 3. As part of that, I need to make a few changes to `bin/util/transifex.js`. I want to make sure that `restructure.js` and `destructure.js` still work as before after those changes. However, the structure of the Transifex translation files no longer match Frontend, because a message has been removed since the last time we updated translations. `destructure.js` won't work under those circumstances, so I'm doing a quick update of translations before upgrading to Vue I18n v9.