### PR TITLE
Publish draft modal shows version input on duplicate version problem

### DIFF
--- a/src/components/form-draft/publish.vue
+++ b/src/components/form-draft/publish.vue
@@ -36,7 +36,7 @@ except according to the terms contained in the LICENSE file.
         <p>{{ $t('introduction[1]') }}</p>
         <p v-if="draftVersionStringIsDuplicate">{{ $t('introduction[2]') }}</p>
       </div>
-      <form v-if="draftVersionStringIsDuplicate" @submit.prevent="publish">
+      <form v-if="draftVersionStringIsDuplicate || versionConflict" @submit.prevent="publish">
         <form-group ref="versionString" v-model.trim="versionString"
           :placeholder="$t('field.version')" required autocomplete="off"/>
         <!-- We specify two nearly identical .modal-actions, because here we
@@ -92,7 +92,8 @@ export default {
   data() {
     return {
       awaitingResponse: false,
-      versionString: ''
+      versionString: '',
+      versionConflict: false
     };
   },
   computed: {
@@ -134,7 +135,11 @@ export default {
           this.versionString !== this.formDraft.version
             ? { version: this.versionString }
             : null
-        )
+        ),
+        fulfillProblem: (problem) => {
+          if (problem.code === 409.6)
+            this.versionConflict = true;
+        }
       })
         .then(() => {
           this.$emit('success');
@@ -173,7 +178,7 @@ export default {
       "version": "Version"
     },
     "problem": {
-      "409_6": "The version name you’ve specified conflicts with a past version of this Form. Please change it to something new and try again."
+      "409_6": "The version name of this Draft conflicts with a past version of this Form or a deleted Form. Please use the field below to change it to something new or upload a new Form definition."
     }
   }
 }

--- a/src/mixins/request.js
+++ b/src/mixins/request.js
@@ -44,7 +44,22 @@ following options:
     fulfillProblem is passed the Backend Problem. (Any error response that is
     not a Problem is automatically considered unsuccessful.) fulfillProblem
     should return `true` if the response is considered successful and `false` if
-    not.
+    not. The response can then be handled in a then() callback. For example:
+
+      this.request({
+        method: 'POST',
+        url: '...',
+        fulfillProblem: (problem) => problem.code === <some code>
+      })
+        .then(({ data }) => {
+          if (!isProblem(data)) {
+            // success
+          } else {
+            // respond to specific problem
+          }
+        })
+        .catch(noop);
+
   - problemToAlert. If the request results in an error response, request() shows
     an alert. By default, the alert message is the same as that of the Backend
     Problem. However, there are two ways to show a different message:

--- a/test/components/form-draft/publish.spec.js
+++ b/test/components/form-draft/publish.spec.js
@@ -297,6 +297,23 @@ describe('FormDraftPublish', () => {
       });
   });
 
+  it('does not show the version input field if backend returns a different problem', () => {
+    testData.extendedForms.createPast(1);
+    testData.extendedFormVersions.createPast(1, { version: 'v2', draft: true });
+    return mockHttp()
+      .mount(FormDraftPublish, mountOptions())
+      .request(async (modal) => {
+        await modal.setProps({ state: true });
+        return modal.get('#form-draft-publish .btn-primary').trigger('click');
+      })
+      .respondWithProblem(500.1)
+      .afterResponse(modal => {
+        modal.should.alert('danger');
+        modal.find('input').exists().should.be.false();
+        modal.findAll('.modal-introduction p').length.should.equal(2);
+      });
+  });
+
   describe('after a successful response', () => {
     const publish = () => {
       testData.extendedForms.createPast(1, { draft: true });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2017,7 +2017,7 @@
       },
       "problem": {
         "409_6": {
-          "string": "The version name you’ve specified conflicts with a past version of this Form. Please change it to something new and try again."
+          "string": "The version name of this Draft conflicts with a past version of this Form or a deleted Form. Please use the field below to change it to something new or upload a new Form definition."
         }
       }
     },


### PR DESCRIPTION
In the scenario where a Form Draft version conflicts with another Form in the system, but that duplication conflict is not known ahead of time (e.g. a Form with the same ID and version that is currently in the trash), when the user tries to publish the Draft Form, backend returns a Problem. That problem shows up as an alert in the Form Draft publish modal.

This PR changes the modal behavior to let the user specify a new Form version after they encounter that specific problem. The version input field was already part of the modal for situations where the version duplication issue was known, so this was a simple change to unhide it when appropriate. 

<img width="620" alt="Screen Shot 2022-02-14 at 3 17 45 PM" src="https://user-images.githubusercontent.com/76205/153963363-b8e3bf4a-30ed-430d-a620-495fa8c5ac74.png">
 