### PR TITLE
Rewording delete form and abandon draft modals

### DIFF
--- a/src/components/form-draft/abandon.vue
+++ b/src/components/form-draft/abandon.vue
@@ -105,7 +105,7 @@ export default {
         "Your published Form definition, its Media Files, and Submissions will not be affected."
       ],
       "deleteForm": [
-        "You are about to permanently delete this draft Form definition, along with any draft Media Files you have uploaded, and all test Submissions. Because you have not yet published it, this Form will be entirely deleted."
+        "You are about to delete this draft Form definition, along with any draft Media Files you have uploaded, and all test Submissions. Because you have not yet published it, this entire Form will be deleted and moved to the Trash."
       ]
     },
     "action": {

--- a/src/components/form/delete.vue
+++ b/src/components/form/delete.vue
@@ -82,7 +82,7 @@ export default {
     "title": "Delete Form",
     "introduction": [
       "Are you sure you want to delete the Form {name} and all of its Submissions?",
-      "This action cannot be undone."
+      "This action will move the Form to the Trash. After 30 days in the Trash, it will be permanently purged, but it can be undeleted before then."
     ]
   }
 }

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -66,7 +66,7 @@ describe('FormDraftAbandon', () => {
 
       it('shows the correct text for the first paragraph', () => {
         const text = mountComponent().get('.modal-introduction p').text();
-        text.should.endWith('this Form will be entirely deleted.');
+        text.should.endWith('this entire Form will be deleted and moved to the Trash.');
       });
 
       it('does not render an additional paragraph', () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1824,7 +1824,7 @@
           "string": "Are you sure you want to delete the Form {name} and all of its Submissions?"
         },
         "1": {
-          "string": "This action cannot be undone."
+          "string": "This action will move the Form to the Trash. After 30 days in the Trash, it will be permanently purged, but it can be undeleted before then."
         }
       }
     },

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1850,7 +1850,7 @@
         },
         "deleteForm": {
           "0": {
-            "string": "You are about to permanently delete this draft Form definition, along with any draft Media Files you have uploaded, and all test Submissions. Because you have not yet published it, this Form will be entirely deleted."
+            "string": "You are about to delete this draft Form definition, along with any draft Media Files you have uploaded, and all test Submissions. Because you have not yet published it, this entire Form will be deleted and moved to the Trash."
           }
         }
       },


### PR DESCRIPTION
We had noticed a line of text on the delete modal that said "This action cannot be undone." But now it can! The delete modal now mentions the Trash and undeleting forms.

<img width="618" alt="Screen Shot 2022-02-15 at 9 34 00 AM" src="https://user-images.githubusercontent.com/76205/154118215-6f9211b0-b595-4b42-a478-6c950dfecca3.png">

New abandon draft modals:
<img width="618" alt="Screen Shot 2022-02-15 at 9 42 33 AM" src="https://user-images.githubusercontent.com/76205/154118734-776a099f-9e30-40f5-9f14-1c93e42d3088.png">

<img width="619" alt="Screen Shot 2022-02-15 at 9 42 42 AM" src="https://user-images.githubusercontent.com/76205/154118922-042d40c5-02c9-416a-9267-575b04912fd3.png">

