### PR TITLE
Fix left margin of submission actions in FormDraftTesting

### DIFF
--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -349,6 +349,8 @@ export default {
   align-items: baseline;
   display: flex;
   flex-wrap: wrap-reverse;
+
+  form > :first-child { margin-left: 0; }
 }
 #submission-field-dropdown {
   margin-left: 15px;


### PR DESCRIPTION
In `FormDraftTesting`, the leftmost control (either the refresh button or the field dropdown) is not aligned with the edge of the page:

<img width="1024" alt="Screen Shot 2022-02-17 at 7 46 25 PM" src="https://user-images.githubusercontent.com/5970131/154597182-7de42bb6-9566-4e5a-b937-6578c3eeffc3.png">

The margin is there because in `FormSubmissions`, those elements always have something to the left, because that page has the filters. This PR tweaks the styles so that if the element is the first child, it won't have left margin.