### PR TITLE
Add Swahili

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ To add a new locale to ODK Central Frontend:
 1. Add the locale to Transifex.
 2. Add the locale to `locales` in [`/src/i18n.js`](/src/i18n.js) and [`/bin/util/transifex.js`](/bin/util/transifex.js).
 3. If the locale pluralizes differently from the default, specify its pluralization rules in `/src/i18n.js`.
-4. Check that there is a flatpickr config for the locale. If there isn't one, create a GitHub issue in this repository or contact us on Slack.
+4. Check whether there is a [flatpickr localization](https://github.com/flatpickr/flatpickr/tree/master/src/l10n) for the locale. If there is, add it to [`DateRangePicker`](/src/components/date-range-picker.vue). If there isn't, create a GitHub issue in this repository or contact us on Slack.
 5. Consider spot-checking the translations. In particular, check that messages used in component interpolation have been translated correctly.
 
 Note that right now, the router will use the user's preferred language to load the locale, but it will only use the first subtag of the language. If/when we add a locale with multiple subtags, we will need to update the router.

--- a/bin/util/transifex.js
+++ b/bin/util/transifex.js
@@ -18,7 +18,8 @@ const locales = {
   fr: { pluralCategories: ['one', 'other'] },
   id: {},
   it: {},
-  ja: { warnVariableSeparator: false }
+  ja: { warnVariableSeparator: false },
+  sw: {}
 };
 
 const sourceLocale = 'en';

--- a/bin/util/transifex.js
+++ b/bin/util/transifex.js
@@ -87,7 +87,7 @@ class PluralForms {
   // Transifex uses ICU plurals.
   static fromTransifex(string, locale) {
     const forms = [];
-    const icuMatch = string.match(/^({count, plural,).+}$/);
+    const icuMatch = string.match(/^({count, plural,).+}$/s);
     if (icuMatch == null) {
       forms.push(string);
     } else {

--- a/src/components/account/claim.vue
+++ b/src/components/account/claim.vue
@@ -179,6 +179,17 @@ export default {
     "alert": {
       "success": "パスワードが正常にリセットされました。"
     }
+  },
+  "sw": {
+    "action": {
+      "set": "Weka nenosiri"
+    },
+    "problem": {
+      "401_2": "{message} Huenda muda wa kiungo katika barua pepe yako umeisha, na huenda barua pepe mpya ikatumwa."
+    },
+    "alert": {
+      "success": "Nenosiri limewekwa upya."
+    }
   }
 }
 </i18n>

--- a/src/components/account/login.vue
+++ b/src/components/account/login.vue
@@ -211,6 +211,15 @@ export default {
     "problem": {
       "401_2": "メールアドレスとパスワードの一方、または両方が違います。"
     }
+  },
+  "sw": {
+    "alert": {
+      "alreadyLoggedIn": "Mtumiaji tayari ameingia. Tafadhali onyesha upya ukurasa ili kuendelea.",
+      "changePassword": "Nenosiri lako ni fupi kuliko vibambo 10. Ili kulinda akaunti yako, tafadhali badilisha nenosiri lako ili kuifanya iwe ndefu."
+    },
+    "problem": {
+      "401_2": "Anwani ya barua pepe na/au nenosiri si sahihi."
+    }
   }
 }
 </i18n>

--- a/src/components/account/reset-password.vue
+++ b/src/components/account/reset-password.vue
@@ -120,6 +120,11 @@ export default {
     "alert": {
       "success": "{email}に詳細の対応についての情報が記されたメールが送信されました。"
     }
+  },
+  "sw": {
+    "alert": {
+      "success": "Barua pepe imetumwa kwa {email} ikiwa na maagizo zaidi."
+    }
   }
 }
 </i18n>

--- a/src/components/analytics/form.vue
+++ b/src/components/analytics/form.vue
@@ -390,6 +390,38 @@ export default {
     "alert": {
       "success": "設定が保存されました！"
     }
+  },
+  "sw": {
+    "enabled": {
+      "null": [
+        "Tukumbushe baadaye",
+        "Wasimamizi wataendelea kuona ujumbe juu ya skrini"
+      ],
+      "true": [
+        {
+          "full": "{weWillShare} na tunakubali {termsOfService} na {privacyPolicy}.",
+          "weWillShare": "Tuko tayari kushiriki data ya matumizi isiyojulikana kila mwezi na timu ya Kati",
+          "termsOfService": "Masharti ya Huduma",
+          "privacyPolicy": "Sera ya Faragha"
+        },
+        "Ni vipimo gani vinatumwa?"
+      ],
+      "false": [
+        "Hatutashiriki habari yoyote.",
+        "hutaona kikumbusho kuhusu hili tena"
+      ]
+    },
+    "contact": [
+      "Niko tayari kujumuisha maelezo yangu ya mawasiliano na ripoti",
+      "Tunaweza kuwasiliana nawe ili kupata maelezo zaidi kuhusu matumizi yako ya Central"
+    ],
+    "field": {
+      "workEmail": "Anwani ya barua pepe ya kazini",
+      "organization": "Jina la shirika"
+    },
+    "alert": {
+      "success": "Mipangilio imehifadhiwa!"
+    }
   }
 }
 </i18n>

--- a/src/components/analytics/introduction.vue
+++ b/src/components/analytics/introduction.vue
@@ -163,6 +163,19 @@ export default {
     "action": {
       "improveCentral": "Centralを改善する。"
     }
+  },
+  "sw": {
+    "title": "Saidia Kuboresha Central!",
+    "introduction": [
+      {
+        "full": "Katika kichupo cha {usageReporting} katika Mipangilio ya Mfumo, unaweza kuchagua kushiriki data ya matumizi isiyojulikana au maelezo ya mawasiliano na timu ya Kati.",
+        "usageReporting": "Ripoti ya Matumizi"
+      },
+      "Huko, unaweza pia kuchagua kutouona ujumbe huu tena"
+    ],
+    "action": {
+      "improveCentral": "Boresha Central"
+    }
   }
 }
 </i18n>

--- a/src/components/analytics/list.vue
+++ b/src/components/analytics/list.vue
@@ -147,6 +147,12 @@ export default {
       "以下で、あなたはこのCentralサーバーがCentralチームと匿名化された利用情報を共有するかどうかを選択できます。この設定はサーバー全体の及びます。"
     ],
     "auditsTitle": "最新の利用情報"
+  },
+  "sw": {
+    "heading": [
+      "Hapo chini, unaweza kuchagua kama seva hii ya Central itashiriki maelezo ya matumizi yasiyokutambulisha na timu ya Central. Mpangilio huu unaathiri seva nzima"
+    ],
+    "auditsTitle": "Ripoti za Matumizi ya Hivi Punde"
   }
 }
 </i18n>

--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -309,6 +309,38 @@ export default {
       "num_submissions_from_public_links": "一般公開リンクから提出されたフォーム数",
       "num_submissions_from_web_users": "Webユーザーから提出されたフォーム数"
     }
+  },
+  "sw": {
+    "recent": "katika siku 45 zilizopita",
+    "fields": {
+      "num_admins": "Idadi ya Wasimamizi",
+      "num_projects_encryption": "Idadi ya Miradi ambayo usimbaji fiche umewezeshwa",
+      "num_questions_biggest_form": "Idadi ya maswali katika kidato kikubwa zaidi",
+      "num_audit_log_entries": "Idadi ya maingizo ya Kumbukumbu ya Ukaguzi",
+      "backups_configured": "Hifadhi rudufu zilizosanidiwa",
+      "database_size": "Saizi ya hifadhidata ya mfumo",
+      "num_managers": "Idadi ya wasimamizi wa miradi",
+      "num_viewers": "Idadi ya watazamaji wa mradi",
+      "num_data_collectors": "Idadi ya wakusanyaji data",
+      "num_app_users": "Idadi ya watumiaji wa programu",
+      "num_device_ids": "Idadi ya vitambulisho vya kifaa",
+      "num_public_access_links": "Idadi ya viungo vya ufikiaji wa umma",
+      "num_forms": "Idadi ya Fomu",
+      "num_forms_with_repeats": "Idadi ya Fomu zilizo na marudio",
+      "num_forms_with_geospatial": "Idadi ya Fomu zilizo na jiografia",
+      "num_forms_with_encryption": "Idadi ya Fomu zilizo na usimbaji fiche",
+      "num_forms_with_audits": "Idadi ya Fomu zilizo na ukaguzi",
+      "num_submissions_received": "Idadi ya Mawasilisho - Yaliyopokelewa",
+      "num_submissions_approved": "Idadi ya Mawasilisho - Yameidhinishwa",
+      "num_submissions_has_issues": "Idadi ya Mawasilisho - Ina Masuala",
+      "num_submissions_rejected": "Idadi ya Mawasilisho - Yamekataliwa",
+      "num_submissions_edited": "Idadi ya Mawasilisho - Yaliyohaririwa",
+      "num_submissions_with_edits": "Idadi ya Mawasilisho yenye mabadiliko",
+      "num_submissions_with_comments": "Idadi ya Mawasilisho yenye maoni",
+      "num_submissions_from_app_users": "Idadi ya Mawasilisho kutoka kwa Watumiaji wa Programu",
+      "num_submissions_from_public_links": "Idadi ya Mawasilisho kutoka kwa Viungo vya Umma",
+      "num_submissions_from_web_users": "Idadi ya Mawasilisho kutoka kwa Watumiaji wa Wavuti"
+    }
   }
 }
 </i18n>

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -254,6 +254,19 @@ export default {
       "subtitle": "（最もアクティブな{count}つのプロジェクトについて）"
     },
     "submissionStates": "提出済フォームの状態"
+  },
+  "sw": {
+    "title": "Ripoti ya Matumizi Isiyojulikana",
+    "introduction": [
+      "Asante kwa kufikiria kutuma habari ya matumizi. Data hii itatusaidia kutanguliza mahitaji yako!",
+      "Inayoonyeshwa hapa ni ripoti tunayokusanya kwa sasa. Ili kukabiliana na vipengele na mahitaji mapya, wakati mwingine tutabadilisha kile kinachoripotiwa, lakini tutawahi tu kukusanya wastani wa muhtasari kama unavyoona hapa.",
+      "Unaweza kuja hapa kila wakati ili kuona kile kinachokusanywa."
+    ],
+    "projects": {
+      "title": "Muhtasari wa Mradi",
+      "subtitle": "(Inaonyesha Mradi amilifu zaidi wa Mradi ya {count}) | (Inaonyesha Mradi amilifu zaidi wa Miradi ya {count})"
+    },
+    "submissionStates": "Nchi za Uwasilishaji"
   }
 }
 </i18n>

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -178,6 +178,11 @@ body.modal-open #app-alert {
     "alert": {
       "versionChange": "サーバーがアップデートされました。予期しない動作を避けるため、ページを更新してください。"
     }
+  },
+  "sw": {
+    "alert": {
+      "versionChange": "Seva imesasishwa. Tafadhali onyesha upya ukurasa ili kuepuka yasiyotabirika."
+    }
   }
 }
 </i18n>

--- a/src/components/async-route.vue
+++ b/src/components/async-route.vue
@@ -159,6 +159,11 @@ export default {
     "alert": {
       "loadError": "リクエストされたページを読み込むことができませんでした。ページを更新して、もう一度試みて下さい。"
     }
+  },
+  "sw": {
+    "alert": {
+      "loadError": "ukurasa ulioomba haukuweza kupakiwa. Tafadhali onyesha upya ukurasa na ujaribu tena"
+    }
   }
 }
 </i18n>

--- a/src/components/audit/list.vue
+++ b/src/components/audit/list.vue
@@ -128,6 +128,12 @@ export default {
       "ここでは、このサーバーで行われた重要な操作履歴を閲覧できます。ユーザーやプロジェクト、フォーム設定への変更は、ここで確認できます。"
     ],
     "emptyTable": "照合できる監査ログの記録がありません。"
+  },
+  "sw": {
+    "heading": [
+      "Hapa utapata logi ya vitendo muhimu vilivyofanywa kwenye seva hii. Mabadiliko yaliyofanywa kwa mipangilio ya mtumiaji, Mradi, au Fomu yanaweza kupatikana hapa."
+    ],
+    "emptyTable": "Hakuna maingizo ya kumbukumbu ya ukaguzi yanayolingana"
   }
 }
 </i18n>

--- a/src/components/audit/row.vue
+++ b/src/components/audit/row.vue
@@ -193,6 +193,10 @@ export default {
   "it": {
     "deletedMessage": "Questa risorsa è stata eliminata.",
     "purgedMessage": "Questa risorsa è stata eliminata definitivamente."
+  },
+  "sw": {
+    "deletedMessage": "Rasimali hii imefutwa",
+    "purgedMessage": "Rasilimali hii imesafishwa."
   }
 }
 </i18n>

--- a/src/components/audit/table.vue
+++ b/src/components/audit/table.vue
@@ -108,6 +108,13 @@ export default {
       "target": "操作の対象",
       "details": "詳細"
     }
+  },
+  "sw": {
+    "header": {
+      "initiator": "Mwanzilishi",
+      "target": "Lengo",
+      "details": "Maelezo"
+    }
   }
 }
 </i18n>

--- a/src/components/backup/list.vue
+++ b/src/components/backup/list.vue
@@ -178,6 +178,13 @@ export default {
       "create": "成功です！自動バックアップは設定されました。",
       "terminate": "自動バックアップを停止しました。 なるべく早急に新たなバックアップ設定を行うことを推奨します。"
     }
+  },
+  "sw": {
+    "auditsTitle": "Hifadhi Nakala za Hivi Punde",
+    "alert": {
+      "create": "Mafanikio! Hifadhi rudufu za kiotomatiki sasa zimesanidiwa.",
+      "terminate": "Nakala zako za kiotomatiki zimekatishwa. Inapendekezwa kuwa usanidi mpya haraka iwezekanavyo"
+    }
   }
 }
 </i18n>

--- a/src/components/backup/new.vue
+++ b/src/components/backup/new.vue
@@ -522,6 +522,48 @@ export default {
     "problem": {
       "verify": "再度試し、問題が解決しない場合はコミュニティフォーラムを確認して下さい。"
     }
+  },
+  "sw": {
+    "title": "Sanidi Hifadhi Nakala",
+    "steps": [
+      {
+        "warning": {
+          "full": "Hifadhi rudufu hii kwa sasa haijumuishi viungo vya Fomu ya Wavuti. Ukishiriki Viungo vya Ufikiaji wa Umma au kuunganisha kwa nje moja kwa moja kwa Fomu za Wavuti kwa ajili ya kufanya Mawasilisho mapya, tunapendekeza kwa dhati kwamba ufanye hifadhi kamili ya mfumo hadi hili lishughulikiwe. Iwapo itabidi urejeshe kutoka kwa nakala na uishie na viungo vilivyovunjika vya Onyesho la Kuchungulia, tafadhali ichapishe kwenye {forum} ili upate usaidizi.",
+          "forum": "jukwaa"
+        },
+        "introduction": [
+          "Ukipenda, unaweza kusanidi kaulisiri ya usimbaji ambayo lazima itumike kufungua nakala rudufu.",
+          "Hakuna njia ya kurejesha kaulisiri ikiwa utaipoteza!",
+          "Hakikisha umechagua kitu ambacho utakumbuka, au uandike mahali salama"
+        ]
+      },
+      {
+        "introduction": [
+          {
+            "full": "Kwa usalama, seva hutuma data yako kwenye Hifadhi ya Google. Unaweza kujiandikisha kwa akaunti isiyolipishwa {here}",
+            "here": "hapa"
+          },
+          "Unapobofya inayofuata, Google itathibitisha kwamba ungependa kuruhusu seva kufikia akaunti yako. Kitu pekee ambacho seva itaruhusiwa kugusa ni faili za chelezo inazounda",
+          "Ukishathibitisha hili, utaombwa kunakili na kubandika maandishi hapa nyuma."
+        ]
+      },
+      {
+        "introduction": [
+          {
+            "full": "Karibu tena! Je, umepata maandishi ya kunakili na kubandika? Ikiwa sivyo, bofya {here} ili kujaribu tena.",
+            "here": "hapa"
+          },
+          "Vinginevyo, bandika hapa chini na umemaliza!"
+        ]
+      }
+    ],
+    "field": {
+      "passphrase": "Nenosiri (hiari)",
+      "confirmationText": "Maandishi ya uthibitisho"
+    },
+    "problem": {
+      "verify": "Tafadhali jaribu tena, na uende kwenye jamii forum tatizo likiendelea."
+    }
   }
 }
 </i18n>

--- a/src/components/backup/status.vue
+++ b/src/components/backup/status.vue
@@ -560,6 +560,52 @@ export default {
     "alert": {
       "download": "現在、バックアップが実行中です。バックアップデータは暗号化され、あなたのコンピュータにダウンロードされます。処理にしばらく時間がかかります。ダウンロードが始まると、このページを閉じても構いません。"
     }
+  },
+  "sw": {
+    "getHelp": {
+      "full": "Ikiwa unatatizika, tafadhali jaribu {forum}.",
+      "forum": "jamii forum"
+    },
+    "notConfigured": [
+      "Hifadhi rudufu hazijasanidiwa.",
+      "Seva ya data haijawekwa ili kuhifadhi nakala kiotomatiki data yake popote pale.",
+      {
+        "full": "Isipokuwa umeweka aina nyingine ya kuhifadhi nakala ya data ambayo seva haijui, {recommended} ufanye hivi sasa. Ikiwa huna uhakika, ni bora kufanya hivyo ili tu kuwa salama.",
+        "recommended": "inapendekezwa sana"
+      },
+      "Hifadhi rudufu za data otomatiki hufanyika kupitia mfumo huu mara moja kwa siku. Data yako yote imesimbwa kwa njia fiche kwa nenosiri ulilotoa ili wewe tu uweze kulifungua."
+    ],
+    "neverRun": [
+      "Hifadhi rudufu iliyosanidiwa bado haijatekelezwa",
+      "Ikiwa umesanidi nakala rudufu ndani ya siku chache zilizopita, hii ni kawaida. Vinginevyo, kitu kimeenda vibaya.",
+      {
+        "full": "Katika hali hiyo, marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma.",
+        "terminate": "sitisha"
+      }
+    ],
+    "somethingWentWrong": [
+      "Kuna kitu hakiko sawa",
+      {
+        "full": "Hifadhi rudufu ya hivi punde iliyokamilika kwa ufanisi ilikuwa {moreThanThreeDaysAgo}.",
+        "moreThanThreeDaysAgo": "zaidi ya siku tatu zilizopita"
+      },
+      {
+        "full": "Marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma",
+        "terminate": "sitisha"
+      }
+    ],
+    "success": [
+      "Hifadhi rudufu inafanya kazi.",
+      "Hifadhi rudufu ya mwisho ilikamilika {dateTime}."
+    ],
+    "action": {
+      "setUp": "Sanidi sasa",
+      "download": "Pakua nakala rudufu sasa",
+      "terminate": "Sitisha"
+    },
+    "alert": {
+      "download": "Hifadhi rudufu inaendelea sasa, na itasimbwa kwa njia fiche na kupakuliwa kwenye kompyuta yako. Hii inaweza kuchukua muda. Mara tu upakuaji unapoanza, unaweza kuondoka kwenye ukurasa huu."
+    }
   }
 }
 </i18n>

--- a/src/components/backup/terminate.vue
+++ b/src/components/backup/terminate.vue
@@ -129,6 +129,13 @@ export default {
       "自動バックアップを本当に停止しますか？",
       "バックアップを再開するには、また初めから設定し直す必要があります。なお、この操作は取り消しできません。"
     ]
+  },
+  "sw": {
+    "title": "Sitisha Hifadhi Nakala za Kiotomatiki",
+    "introduction": [
+      "Je, una uhakika kuwa ungependa kusitisha hifadhi rudufu zako otomatiki?",
+      "Utalazimika kuzisanidi tena kutoka mwanzo ili kuzianzisha tena, na kitendo hiki hakiwezi kutenduliwa"
+    ]
   }
 }
 </i18n>

--- a/src/components/date-range-picker.vue
+++ b/src/components/date-range-picker.vue
@@ -30,11 +30,16 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 import flatpickr from 'vue-flatpickr-component';
-
 import { DateTime } from 'luxon';
 import 'flatpickr/dist/flatpickr.css';
 
-import { flatpickrLocales } from '../util/i18n';
+import 'flatpickr/dist/l10n/cs';
+import 'flatpickr/dist/l10n/de';
+import 'flatpickr/dist/l10n/es';
+import 'flatpickr/dist/l10n/fr';
+import 'flatpickr/dist/l10n/id';
+import 'flatpickr/dist/l10n/it';
+import 'flatpickr/dist/l10n/ja';
 
 export default {
   name: 'DateRangePicker',
@@ -63,28 +68,13 @@ export default {
     };
   },
   computed: {
-    flatpickrLocale() {
-      // flatpickr bundles the flatpickr locale for en.
-      if (this.$i18n.locale === 'en') return null;
-      if (this.$i18n.locale === this.$i18n.fallbackLocale) {
-        // DateRangePicker does not currently bundle the flatpickr locale for
-        // the i18n fallback locale, because the i18n fallback locale is en, and
-        // flatpickr itself bundles the flatpickr locale for en.
-        throw new Error('DateRangePicker must bundle the flatpickr locale for the i18n fallback locale');
-      }
-      return flatpickrLocales[this.$i18n.locale];
-    },
     config() {
       const config = {
         mode: 'range',
         // See https://github.com/flatpickr/flatpickr/issues/1549
         dateFormat: 'Y/m/d'
       };
-      // If this.$i18n.locale changes, this.config will change, but flatpickr
-      // itself won't change:
-      // https://github.com/flatpickr/flatpickr/issues/1882
-      // https://github.com/flatpickr/flatpickr/issues/2019
-      if (this.flatpickrLocale != null) config.locale = this.flatpickrLocale;
+      config.locale = this.$i18n.locale;
       return config;
     },
     star() {

--- a/src/components/date-range-picker.vue
+++ b/src/components/date-range-picker.vue
@@ -29,7 +29,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
-import flatpickr from 'vue-flatpickr-component';
+import flatpickr from 'flatpickr';
+import flatpickrComponent from 'vue-flatpickr-component';
 import { DateTime } from 'luxon';
 import 'flatpickr/dist/flatpickr.css';
 
@@ -43,7 +44,7 @@ import 'flatpickr/dist/l10n/ja';
 
 export default {
   name: 'DateRangePicker',
-  components: { flatpickr },
+  components: { flatpickr: flatpickrComponent },
   props: {
     // Either an array of two DateTime objects or an empty array
     value: {
@@ -74,7 +75,8 @@ export default {
         // See https://github.com/flatpickr/flatpickr/issues/1549
         dateFormat: 'Y/m/d'
       };
-      config.locale = this.$i18n.locale;
+      const l10n = flatpickr.l10ns[this.$i18n.locale];
+      if (l10n != null) config.locale = l10n;
       return config;
     },
     star() {

--- a/src/components/download.vue
+++ b/src/components/download.vue
@@ -79,6 +79,9 @@ export default {
   },
   "ja": {
     "body": "{filename}はすぐにダウンロードされます。ダウンロードが始めると、このページから移動しても構いません。"
+  },
+  "sw": {
+    "body": "{filename} itaanza kupakuliwa hivi karibuni. Mara tu upakuaji unapoanza, unaweza kuondoka kwenye ukurasa huu"
   }
 }
 </i18n>

--- a/src/components/enketo/fill.vue
+++ b/src/components/enketo/fill.vue
@@ -104,6 +104,12 @@ export default {
       "processing": "Webフォームはまだ利用できません。現在、処理中です。後ほどページを更新し、もう一度試して下さい。",
       "notOpen": "このフォームは現在、新規のフォーム提出を受け付けていません。"
     }
+  },
+  "sw": {
+    "disabled": {
+      "processing": "Fomu ya Wavuti bado haipatikani. Haijamaliza kuchakatwa. Tafadhali onyesha upya baadaye na ujaribu tena",
+      "notOpen": "Fomu hii haikubali Mawasilisho mapya kwa sasa"
+    }
   }
 }
 </i18n>

--- a/src/components/enketo/preview.vue
+++ b/src/components/enketo/preview.vue
@@ -106,6 +106,12 @@ export default {
       "processing": "このフォームのプレビュー処理が終了していません。後ほどページを更新し、もう一度試して下さい。",
       "notOpen": "このバージョンのODK Centralでは、プレビューは、公開状態のフォームでのみ利用可能です。"
     }
+  },
+  "sw": {
+    "disabled": {
+      "processing": "Onyesho la kuchungulia halijamaliza kuchakata Fomu hii. Tafadhali onyesha upya baadaye na ujaribu tena.",
+      "notOpen": "Katika toleo hili la ODK Central, onyesho la kukagua linapatikana kwa Fomu zilizo katika \"OPEN STATE\""
+    }
   }
 }
 </i18n>

--- a/src/components/field-key/list.vue
+++ b/src/components/field-key/list.vue
@@ -399,6 +399,30 @@ export default {
       "create": "アプリユーザー\"{displayName}\"は正常に作成されました。",
       "revoke": "アプリユーザー\"{displayName}\"のアクセス権は取り消されました。"
     }
+  },
+  "sw": {
+    "action": {
+      "create": "Unda Mtumiaji wa Programu"
+    },
+    "heading": [
+      {
+        "full": "Watumiaji wa Programu hutumiwa kukusanya data kutoka kwa programu kama vile {collect}. Kwa kawaida huwakilisha jukumu la pamoja kama vile \"Chanjo\" lakini pia zinaweza kuwakilisha watu binafsi. Watumiaji wa Programu katika Mradi huu wanaweza kupakua na kutumia Fomu ndani ya Mradi huu pekee. Unapounda Mtumiaji mpya wa Programu, haitakuwa na ufikiaji wa Fomu zozote mwanzoni. Ili kuweka Fomu ambazo kila Mtumiaji wa Programu anaweza kufikia, tumia kichupo cha {formAccess}.",
+        "formAccess": "Ufikiaji wa Fomu"
+      },
+      {
+        "full": "Watumiaji wa Programu wanafaa zaidi wakati wakusanyaji wa data wanahitaji ufikiaji wa Fomu nyingi, wako nje ya mtandao, au una Fomu ngumu. Ikiwa unahitaji watu waliojibu kuripoti binafsi au kuwa na fomu ya mtandaoni pekee, {clickHere} kwa chaguo zingine.",
+        "clickHere": "bonyeza hapa"
+      }
+    ],
+    "header": {
+      "lastUsed": "Iliyotumika Mwisho",
+      "configureClient": "Sanidi Mteja"
+    },
+    "emptyTable": "Bado hakuna Watumiaji wa Programu. Utahitaji kuunda baadhi ili kupakua Fomu na kuwasilisha data kutoka kwa kifaa chako",
+    "alert": {
+      "create": "Mtumiaji wa Programu \"{displayName}\" ameundwa.",
+      "revoke": "Ufikiaji umebatilishwa kwa Mtumiaji wa Programu \"{displayName}\"."
+    }
   }
 }
 </i18n>

--- a/src/components/field-key/new.vue
+++ b/src/components/field-key/new.vue
@@ -320,6 +320,23 @@ export default {
     "action": {
       "createAnother": "別のものを作成"
     }
+  },
+  "sw": {
+    "title": "Unda Mtumiaji wa Programu",
+    "introduction": [
+      "Mtumiaji huyu hatakuwa na ufikiaji wa Fomu zozote mwanzoni. Utaweza kukabidhi Fomu baada ya mtumiaji kuunda."
+    ],
+    "success": [
+      "Mtumiaji wa Programu \"{displayName}\" ameundwa.",
+      "Unaweza kusanidi kifaa cha mkononi kwa ajili ya \"{displayName}\" sasa hivi, au unaweza kuifanya baadaye kwenye jedwali la Watumiaji wa Programu kwa kubofya \"Angalia nambari ya kuthibitisha.\"",
+      {
+        "full": "Unaweza kutaka kutembelea {formAccessSettings} za Mradi huu ili kumpa mtumiaji huyu idhini ya kufikia Fomu.",
+        "formAccessSettings": "Mipangilio ya Ufikiaji wa Fomu"
+      }
+    ],
+    "action": {
+      "createAnother": "Unda nyingine"
+    }
   }
 }
 </i18n>

--- a/src/components/field-key/qr-panel.vue
+++ b/src/components/field-key/qr-panel.vue
@@ -446,6 +446,41 @@ export default {
       },
       "このQRコードをスキャンして、アカウント名\"{displayName}\"の端末を設定する。"
     ]
+  },
+  "sw": {
+    "title": {
+      "managed": "Msimbo wa Usanidi wa Mteja",
+      "legacy": "Msimbo wa Usanidi wa Mteja wa Urithi"
+    },
+    "body": [
+      {
+        "managed": {
+          "full": "Hii ni {managedCode}",
+          "managedCode": "Msimbo wa QR unaosimamiwa"
+        },
+        "legacy": {
+          "full": "Hii ni {legacyCode}.",
+          "legacyCode": "Msimbo wa QR wa urithi"
+        }
+      },
+      {
+        "managed": "Mkusanyiko utalingana kabisa na Fomu zinazopatikana kwa \"{displayName}\" ikijumuisha kutumia masasisho kiotomatiki. Watumiaji hawatahitaji Kujipatia Fomu tupu. Zaidi ya hayo, Fomu zilizokamilishwa zitatumwa kiotomatiki mara tu muunganisho utakapopatikana.",
+        "legacy": "Watumiaji watalazimika Kupata mwenyewe Fomu tupu kwenye kifaa na kuamua ni Fomu zipi za kusasisha. Pia watahitaji Kutuma mwenyewe Fomu Zilizokamilishwa"
+      },
+      {
+        "managed": {
+          "full": "Kwa tabia ya zamani, {switchToLegacy}",
+          "switchToLegacy": "badilisha hadi {legacyCode}",
+          "legacyCode": "Msimbo wa QR wa urithi"
+        },
+        "legacy": {
+          "full": "Kwa mchakato unaodhibitiwa zaidi na usiofaa, {switchToManaged}",
+          "switchToManaged": "badilisha hadi {managedCode}",
+          "managedCode": "Msimbo wa QR unaosimamiwa"
+        }
+      },
+      "Changanua msimbo huu wa QR ili kusanidi kifaa kilicho na akaunti \"{displayName}\"."
+    ]
   }
 }
 </i18n>

--- a/src/components/field-key/revoke.vue
+++ b/src/components/field-key/revoke.vue
@@ -148,6 +148,14 @@ export default {
       "このユーザーからこれまでに提出されたフォームは残りますが、このユーザーに依存している人は、フォームのダウンロードや提出フォームのアップロードを継続するために、新しいユーザーを作成する必要があります。",
       "この操作は取り消しできません。"
     ]
+  },
+  "sw": {
+    "title": "Batilisha Ufikiaji wa Mtumiaji",
+    "introduction": [
+      "Je, una uhakika unataka kubatilisha ufikiaji kutoka kwa Mtumiaji wa Programu {displayName}?",
+      "Mawasilisho yaliyopo kutoka kwa mtumiaji huyu yatasalia, lakini mtu yeyote anayemtegemea mtumiaji huyu atalazimika kuunda upya ili kuendelea kupakua Fomu au kupakia Mawasilisho",
+      "Kitendo hiki hakiwezi kutenduliwa"
+    ]
   }
 }
 </i18n>

--- a/src/components/field-key/row.vue
+++ b/src/components/field-key/row.vue
@@ -156,6 +156,13 @@ export default {
     "action": {
       "revokeAccess": "アクセス権の取消"
     }
+  },
+  "sw": {
+    "seeCode": "Angalia msimbo",
+    "accessRevoked": "Ufikiaji umebatilishwa",
+    "action": {
+      "revokeAccess": "Batilisha ufikiaji"
+    }
   }
 }
 </i18n>

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -571,6 +571,26 @@ export default {
       "readError": "ファイル\"{filename}\"を読み込み中に問題が発生しました。",
       "success": "{count}のファイルのアップロードに成功"
     }
+  },
+  "sw": {
+    "action": {
+      "upload": "Pakia faili"
+    },
+    "heading": [
+      "Kulingana na Fomu uliyopakia, faili zifuatazo zinatarajiwa. Unaweza kuona ni zipi zimepakiwa au bado hazipo.",
+      "Ili kupakia faili, buruta na udondoshe faili moja au zaidi kwenye ukurasa"
+    ],
+    "header": {
+      "uploaded": "Imepakiwa"
+    },
+    "problem": {
+      "noneUploaded": "{message} Hakuna faili zilizopakiwa.",
+      "someUploaded": "{message} {uploaded} pekee kati ya faili {total} ndizo zilizopakiwa. | {message} {uploaded} pekee kati ya faili {total} ndizo zilizopakiwa."
+    },
+    "alert": {
+      "readError": "Hitilafu fulani imetokea wakati wa kusoma \"{filename}\"",
+      "success": "faili {count} imepakiwa. | faili {count} zimepakiwa."
+    }
   }
 }
 </i18n>

--- a/src/components/form-attachment/name-mismatch.vue
+++ b/src/components/form-attachment/name-mismatch.vue
@@ -170,6 +170,16 @@ export default {
       "{filename}を{attachmentName}としてアップロードしますか？",
       "ファイル名が一致しないため、ダブルチェックしています。"
     ]
+  },
+  "sw": {
+    "title": {
+      "upload": "Pakia Faili",
+      "replace": "Badilisha Faili"
+    },
+    "introduction": [
+      "Je, una uhakika unataka kupakia {filename} kama {attachmentName}?",
+      "Tunakagua mara mbili kwa sababu majina ya faili hayalingani"
+    ]
   }
 }
 </i18n>

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -561,6 +561,42 @@ $popup-width: 300px;
         "last": "末尾のデータ"
       }
     }
+  },
+  "sw": {
+    "title": "Pakia Faili",
+    "duringDragover": {
+      "dropToUpload": "Dondosha sasa ili upakie faili hii kama {attachmentName}.",
+      "dragover": "Buruta juu ya ingizo la faili unalotaka kubadilisha na faili na uangushe ili kupakia",
+      "dropToPrepare": {
+        "full": "Dondosha sasa ili kuandaa {countOfFiles} kwa ajili ya kupakiwa kwenye Fomu hii.",
+        "countOfFiles": "faili {count} | faili {count}"
+      }
+    },
+    "afterSelection": {
+      "matched": {
+        "full": [
+          "{countOfFiles} tayari kupakiwa.",
+          "{countOfFiles} tayari kupakiwa."
+        ],
+        "countOfFiles": "faili {count} | faili {count}"
+      },
+      "someUnmatched": {
+        "full": [
+          "{countOfFiles} wana jina ambalo hatulitambui na tutapuuzwa. Ili kuzipakia, zipe jina jipya au ziburute kibinafsi hadi kwenye malengo yao",
+          "{countOfFiles} wana jina ambalo hatulitambui na tutapuuzwa. Ili kuzipakia, zipe jina jipya au ziburute kibinafsi hadi kwenye malengo yao."
+        ],
+        "countOfFiles": "faili {count} | faili {count}"
+      },
+      "noneMatched": "Hatutambui faili zozote unazojaribu kupakia. Tafadhali zipe jina jipya ili zilingane na majina yaliyoorodheshwa hapo juu, au ziburute moja moja hadi kwenye malengo yao | Hatutambui faili zozote unazojaribu kupakia. Tafadhali zipe jina jipya ili zilingane na majina yaliyoorodheshwa hapo juu, au ziburute moja moja hadi kwenye malengo yao"
+    },
+    "duringUpload": {
+      "total": "Tafadhali subiri, faili yako inapakiwa {count}: | Tafadhali subiri, faili zako zinapakiwa {count}:",
+      "current": "Inatuma {filename} ({percentUploaded})",
+      "remaining": {
+        "beforeLast": "faili {count} itasalia. | faili {count} zitasalia.",
+        "last": "Hili ndilo faili la mwisho."
+      }
+    }
   }
 }
 </i18n>

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -256,6 +256,19 @@ export default {
       "text": "アップロード未完了",
       "title": "１つ以上のファイルをドラッグ＆ドロップしてアップロードする。"
     }
+  },
+  "sw": {
+    "type": {
+      "image": "Picha",
+      "audio": "Sauti",
+      "video": "Video",
+      "file": "Faili ya Data"
+    },
+    "replace": "Badilisha",
+    "notUploaded": {
+      "text": "Bado haijapakiwa",
+      "title": "Ili kupakia faili, buruta na udondoshe faili moja au zaidi kwenye ukurasa huu"
+    }
   }
 }
 </i18n>

--- a/src/components/form-attachment/upload-files.vue
+++ b/src/components/form-attachment/upload-files.vue
@@ -174,6 +174,19 @@ export default {
         "clickHere": "こちらをクリックして選択する"
       }
     ]
+  },
+  "sw": {
+    "title": "Pakia Faili",
+    "introduction": [
+      {
+        "full": "Ili kupakia faili, unaweza {dragAndDrop} faili moja au zaidi kwenye jedwali kwenye ukurasa huu.",
+        "dragAndDrop": "buruta na udondoshe"
+      },
+      {
+        "full": "ikiwa ungependa kuchagua faili kutoka kwa haraka, hakikisha kwamba majina yao yanalingana na yale yaliyo kwenye jedwali kisha {clickHere}",
+        "clickHere": "bonyeza hapa kuchagua"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/form-draft/abandon.vue
+++ b/src/components/form-draft/abandon.vue
@@ -231,6 +231,24 @@ export default {
     "action": {
       "abandon": "削除"
     }
+  },
+  "sw": {
+    "title": {
+      "abandon": "acha rasimu",
+      "deleteForm": "Achana na Rasimu na ufute Fomu"
+    },
+    "introduction": {
+      "abandon": [
+        "Unakaribia kufuta kabisa Rasimu ya toleo la Fomu hii. Hii inamaanisha kuwa rasimu ya ufafanuzi wa Fomu, rasimu ya Faili zozote za Midia ulizopakia na Mawasilisho yote ya majaribio yataondolewa.",
+        "Ufafanuzi wako wa Fomu uliochapishwa, Faili zake za Midia na Mawasilisho hayataathiriwa"
+      ],
+      "deleteForm": [
+        "Unakaribia kufuta rasimu hii ya ufafanuzi wa Fomu, pamoja na rasimu ya Faili zozote za Midia ambazo umepakia, na Mawasilisho yote ya majaribio. Kwa sababu bado hujaichapisha, Fomu hii yote itafutwa na kuhamishiwa kwenye Tupio."
+      ]
+    },
+    "action": {
+      "abandon": "Achana"
+    }
   }
 }
 </i18n>

--- a/src/components/form-draft/checklist.vue
+++ b/src/components/form-draft/checklist.vue
@@ -562,6 +562,60 @@ export default {
         ]
       }
     ]
+  },
+  "sw": {
+    "clickForInfo": "Bonyeza hapa kujua zaidi",
+    "steps": [
+      {
+        "title": "Pakia ufafanuzi wa awali wa Fomu",
+        "body": [
+          "Kazi nzuri!",
+          "Muundo wako wa Fomu umepakiwa."
+        ]
+      },
+      {
+        "title": "Pakia ufafanuzi wa Fomu uliorekebishwa (si lazima)",
+        "body": [
+          {
+            "status": "Ikiwa umefanya mabadiliko kwenye Fomu yenyewe, ikijumuisha maandishi ya swali au sheria za mantiki, sasa ni wakati wa kupakia XML au XLSForm mpya kwa kutumia kitufe kilicho kulia.",
+            "link": {
+              "full": "Ikiwa umefanya mabadiliko kwenye Fomu yenyewe, ikijumuisha maandishi ya swali au sheria za mantiki, sasa ni wakati wa {upload} XML au XLSForm mpya.",
+              "upload": "pakia"
+            }
+          }
+        ]
+      },
+      {
+        "title": "Pakia Faili za Midia ya Fomu",
+        "body": [
+          {
+            "full": "Usanifu wa Fomu yako unarejelea faili ambazo zinahitajika ili kuwasilisha Fomu yako. Unaweza kupakia nakala mpya au zilizosasishwa za hizi kwa usambazaji chini ya kichupo cha {mediaFiles}",
+            "mediaFiles": "Faili za Midia"
+          }
+        ]
+      },
+      {
+        "title": "Jaribu Fomu kwa kuunda Wasilisho",
+        "body": [
+          {
+            "full": "Unaweza {test} Fomu ili kuhakikisha kuwa inafanya kazi jinsi unavyotarajia. Mawasilisho ya Jaribio hayajumuishwi katika data yako ya mwisho.",
+            "test": "Jaribia"
+          }
+        ]
+      },
+      {
+        "title": "Chapisha Rasimu",
+        "body": [
+          {
+            "status": "Unapokuwa na uhakika kuwa Rasimu yako iko tayari na ungependa kuisambaza kwa vifaa vyako kwenye uga, unaweza kuichapisha kwa kutumia kitufe kilicho kulia.",
+            "link": {
+              "full": "Unapokuwa na uhakika kuwa Rasimu yako iko tayari na ungependa kuisambaza kwa vifaa vyako kwenye uga, unaweza {publish}.",
+              "publish": "Chapisha"
+            }
+          }
+        ]
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/form-draft/publish.vue
+++ b/src/components/form-draft/publish.vue
@@ -346,6 +346,30 @@ export default {
     "field": {
       "version": "バージョン"
     }
+  },
+  "sw": {
+    "title": "Chapisha Rasimu",
+    "warnings": {
+      "attachments": {
+        "full": "Hujatoa {mediaFiles} zote ambazo Fomu yako inahitaji. Unaweza kupuuza hili ukipenda, lakini utahitaji kutengeneza toleo jipya la Rasimu ili kupakia faili hizo baadaye.",
+        "mediaFiles": "Faili za Midia"
+      },
+      "testing": {
+        "full": "Bado huja {tested} kwa kupakia Wasilisho la jaribio. Sio lazima kufanya hivi, lakini inashauriwa sana.",
+        "tested": "Fomu hii imejaribiwa"
+      }
+    },
+    "introduction": [
+      "Unakaribia kuifanya Rasimu hii kuwa toleo lililochapishwa la Fomu yako. Hii itakamilisha mabadiliko yoyote ambayo umefanya kwa ufafanuzi wa Fomu na Faili zake za Midia zilizoambatishwa",
+      "Mawasilisho ya Fomu Yaliyopo hayataathiriwa, lakini Mawasilisho yote ya Rasimu ya majaribio yataondolewa",
+      "Kila toleo la Fomu linahitaji jina la toleo la kipekee. Kwa sasa, Rasimu ya Fomu yako ina jina la toleo sawa na toleo lililochapishwa hapo awali. Unaweza kuweka mpya kwa kupakia ufafanuzi wa Fomu kwa jina unalotaka, au unaweza kuandika mpya hapa chini na seva itakubadilisha."
+    ],
+    "field": {
+      "version": "Toleo"
+    },
+    "problem": {
+      "409_6": "Jina la toleo la Rasimu hii linakinzana na toleo la awali la Fomu hii au Fomu iliyofutwa. Tafadhali tumia sehemu iliyo hapa chini ili kuibadilisha hadi kitu kipya au kupakia ufafanuzi mpya wa Fomu"
+    }
   }
 }
 </i18n>

--- a/src/components/form-draft/status.vue
+++ b/src/components/form-draft/status.vue
@@ -435,6 +435,33 @@ export default {
       "abandon": "このフォームの下書きは正常に削除されました。",
       "delete": "フォーム\"{name}\"は削除されました。"
     }
+  },
+  "sw": {
+    "draftChecklist": {
+      "title": "Orodha ya rasimu"
+    },
+    "currentDraft": {
+      "versionCaption": {
+        "full": "{draftVersion} ya Fomu hii.",
+        "draftVersion": "Toleo la rasimu"
+      },
+      "action": {
+        "upload": "Pakia ufafanuzi mpya"
+      }
+    },
+    "actions": {
+      "title": "Vitendo",
+      "action": {
+        "publish": "Chapisha Rasimu",
+        "abandon": "Achana na Rasimu"
+      }
+    },
+    "alert": {
+      "upload": "Mafanikio! Ufafanuzi mpya wa Fomu umehifadhiwa kama Rasimu yako",
+      "publish": "Rasimu yako sasa imechapishwa. Kifaa chochote kinachorejesha Fomu za Mradi huu sasa kitapokea ufafanuzi mpya wa Fomu na Faili za Midia",
+      "abandon": "Toleo la Rasimu la Fomu hii limefutwa kwa ufanisi.",
+      "delete": "Fomu \"{name}\" ilifutwa."
+    }
   }
 }
 </i18n>

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -229,6 +229,14 @@ export default {
       "下書きにテスト提出されたフォームは、以下の表に示されます。ここではデータのプレビューやダウンロードが可能です。この下書きフォームを公開した場合、テスト提出済フォームは永久に削除されます。"
     ],
     "collectProjectName": "[下書き] {name}"
+  },
+  "sw": {
+    "title": "Mtihani wa Rasimu",
+    "body": [
+      "Unaweza kutumia msimbo wa usanidi ulio kulia ili kusanidi kifaa cha mkononi ili kupakua Rasimu hii. Unaweza pia kubofya kitufe kipya hapo juu ili kuunda Wasilisho jipya kutoka kwa kivinjari chako cha wavuti.",
+      "Rasimu ya Mawasilisho huenda kwenye jedwali la majaribio hapa chini, ambapo unaweza kuhakiki na kupakua. Unapochapisha Rasimu ya Fomu hii, Mawasilisho yake ya majaribio yataondolewa kabisa."
+    ],
+    "collectProjectName": "[Rasimu] {name}"
   }
 }
 </i18n>

--- a/src/components/form-version/def-dropdown.vue
+++ b/src/components/form-version/def-dropdown.vue
@@ -152,6 +152,14 @@ export default {
       "downloadXForm": "XFormとしてダウンロード（.xml形式）",
       "downloadXlsForm": "XLSFormとしてダウンロード（{extension}形式）"
     }
+  },
+  "sw": {
+    "action": {
+      "def": "Ufafanuzi",
+      "viewXml": "Tazama XML kwenye kivinjari",
+      "downloadXForm": "Pakua kama XForm (.xml)",
+      "downloadXlsForm": "Pakua kama XLSForm ({extension})"
+    }
   }
 }
 </i18n>

--- a/src/components/form-version/string.vue
+++ b/src/components/form-version/string.vue
@@ -64,6 +64,9 @@ export default {
   },
   "it": {
     "blank": "(vuoto)"
+  },
+  "sw": {
+    "blank": "(tupu)"
   }
 }
 </i18n>

--- a/src/components/form-version/table.vue
+++ b/src/components/form-version/table.vue
@@ -107,6 +107,12 @@ export default {
       "published": "公開済み",
       "definition": "定義フォーム"
     }
+  },
+  "sw": {
+    "header": {
+      "published": "Imechapishwa",
+      "definition": "Ufafanuzi"
+    }
   }
 }
 </i18n>

--- a/src/components/form-version/view-xml.vue
+++ b/src/components/form-version/view-xml.vue
@@ -113,6 +113,9 @@ export default {
   },
   "ja": {
     "title": "XMLの閲覧"
+  },
+  "sw": {
+    "title": "Tazama XML"
   }
 }
 </i18n>

--- a/src/components/form/checklist.vue
+++ b/src/components/form/checklist.vue
@@ -495,6 +495,53 @@ export default {
         ]
       }
     ]
+  },
+  "sw": {
+    "clickForInfo": "Bonyeza hapa kujua zaidi",
+    "steps": [
+      {
+        "title": "Chapisha Rasimu ya toleo lako la kwanza",
+        "body": [
+          "Kazi nzuri!",
+          "Umechapisha Fomu yako. Iko tayari kukubali Mawasilisho. Ikiwa ungependa kufanya mabadiliko kwenye Fomu au Faili zake za Midia, unaweza kutengeneza Rasimu mpya."
+        ]
+      },
+      {
+        "title": "Pakua Fomu ya wateja wa uchunguzi na uwasilishe data",
+        "body": [
+          {
+            "none": "Bado hakuna mtu aliyewasilisha data yoyote kwa Fomu hii",
+            "any": "Jumla ya wasilisho {count} imewasilishwa. | Jumla ya Mawasilisho {count} yamewasilishwa."
+          },
+          {
+            "full": "{clickHere} ili kupata maelezo kuhusu njia tofauti za kuwasilisha data",
+            "clickHere": "Bonyeza hapa"
+          }
+        ]
+      },
+      {
+        "title": "Tathmini na uchanganue data iliyowasilishwa",
+        "body": [
+          {
+            "none": "Baada ya kupata data ya Fomu hii, unaweza kuihamisha au kuisawazisha ili kufuatilia na kuchambua data kwa ubora na matokeo.",
+            "any": "Unaweza kuhamisha au kusawazisha {count} wasilisho kwenye Fomu hii ili kuyafuatilia na kuyachanganua kwa ubora na matokeo. | Unaweza kuhamisha au kusawazisha {count} Mawasilisho kwenye Fomu hii ili kuyafuatilia na kuyachanganua kwa ubora na matokeo."
+          },
+          {
+            "full": "Unaweza kufanya hivyo kwa vibonye vya Kupakua na Kuchanganua kwenye {submissionsTab}",
+            "submissionsTab": "Kichupo cha mawasilisho"
+          }
+        ]
+      },
+      {
+        "title": "Dhibiti kustaafu kwa Fomu",
+        "body": [
+          {
+            "full": "Unapofika mwisho wa ukusanyaji wako wa data, unaweza kutumia vidhibiti vya Hali ya Fomu kwenye {formAccessTab} ili kudhibiti kama, kwa mfano, Watumiaji wa Programu wataweza kuona au kuunda Mawasilisho mapya kwa Fomu hii.",
+            "formAccessTab": "Kichupo cha Ufikiaji wa Fomu cha ukurasa wa Mradi"
+          }
+        ]
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/form/delete.vue
+++ b/src/components/form/delete.vue
@@ -123,6 +123,13 @@ export default {
   },
   "ja": {
     "title": "フォームの削除"
+  },
+  "sw": {
+    "title": "Futa Fomu",
+    "introduction": [
+      "Je, una uhakika ungependa kufuta Fomu ya {name} na Mawasilisho yake yote?",
+      "kitendo hiki kitahamisha Fomu hadi kwenye Tupio. Baada ya siku 30 kwenye Tupio, itasafishwa kabisa, lakini inaweza kufutwa kabla ya wakati huo."
+    ]
   }
 }
 </i18n>

--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -356,6 +356,22 @@ $tab-li-margin-top: 5px;
         "create": "新規下書きの作成"
       }
     }
+  },
+  "sw": {
+    "projectNav": {
+      "action": {
+        "back": "Rudi kwa Muhtasari wa Mradi"
+      }
+    },
+    "formNav": {
+      "tabTitle": "Vipengele hivi vitapatikana mara tu utakapochapisha Rasimu ya Fomu yako"
+    },
+    "draftNav": {
+      "title": "Rasimu",
+      "action": {
+        "create": "Unda Rasimu mpya"
+      }
+    }
   }
 }
 </i18n>

--- a/src/components/form/list.vue
+++ b/src/components/form/list.vue
@@ -165,6 +165,16 @@ export default {
     "alert": {
       "create": "新規フォーム\"{name}\"が下書きとして作成されました。以下のチェックリストを参考にして、準備が整ったらフォームを公開して使用できます。"
     }
+  },
+  "sw": {
+    "title": "Fomu",
+    "action": {
+      "create": "Mpya"
+    },
+    "emptyTable": "hakuna Fomu za kuonyesha",
+    "alert": {
+      "create": "Fomu yako mpya \"{name}\" imeundwa kama Rasimu. Angalia orodha hapa chini, na unapohisi iko tayari, unaweza kuchapisha Fomu kwa matumizi."
+    }
   }
 }
 </i18n>

--- a/src/components/form/new.vue
+++ b/src/components/form/new.vue
@@ -591,6 +591,47 @@ $drop-zone-vpadding: 15px;
         "update": "これら問題が無視できると判断した場合、ボタンをクリックして下書きを更新して下さい。"
       }
     ]
+  },
+  "sw": {
+    "title": {
+      "create": "unda fomu",
+      "update": "Pakia Ufafanuzi wa Fomu Mpya"
+    },
+    "introduction": [
+      {
+        "create": "Ili kuunda Fomu, pakia faili ya XForms XML au faili ya XLSForm Excel.",
+        "update": "Ili kusasisha Rasimu, pakia faili ya XForms XML au faili ya XLSForm Excel."
+      },
+      {
+        "full": "Ikiwa tayari huna, kuna {tools} za kukusaidia kuunda Fomu yako.",
+        "tools": "zana zinazopatikana"
+      },
+      "Ikiwa una media, utaweza kuipakia kwenye ukurasa unaofuata, baada ya kuunda Fomu."
+    ],
+    "dropZone": {
+      "full": "Dondosha faili hapa, au {chooseOne} ili upakie.",
+      "chooseOne": "Chagua moja"
+    },
+    "action": {
+      "upload": "pakia",
+      "uploadAnyway": "Pakia hata hivyo"
+    },
+    "alert": {
+      "fileRequired": "Tafadhali chagua faili."
+    },
+    "problem": {
+      "400_8": "Ufafanuzi wa Fomu uliyopakia hauonekani kuwa wa Fomu hii. Ina formId isiyo sahihi (expected \"{expected}\", imepata \"{actual}\").",
+      "400_15": "XLSForm haikuweza kubadilishwa: {error}",
+      "409_3": "Tayari kuna Fomu katika Mradi huu yenye Kitambulisho cha Fomu ya “{xmlFormId}”."
+    },
+    "warningsText": [
+      "Faili hii ya XLSForm inaweza kutumika, lakini ina matatizo yafuatayo yanayowezekana (maonyo ya ubadilishaji).",
+      "Tafadhali sahihisha matatizo na ujaribu tena",
+      {
+        "create": "Ikiwa una uhakika kuwa matatizo haya yanaweza kupuuzwa, bofya kitufe ili kuunda Fomu hata hivyo:",
+        "update": "ikiwa una uhakika matatizo haya yanaweza kupuuzwa, bofya kitufe ili kusasisha Rasimu hata hivyo:"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/form/overview.vue
+++ b/src/components/form/overview.vue
@@ -274,6 +274,21 @@ export default {
         }
       }
     }
+  },
+  "sw": {
+    "checklist": "Orodha ya ukaguzi",
+    "draft": {
+      "none": {
+        "title": "Hakuna Rasimu ya Sasa",
+        "body": "Kwa sasa hakuna Rasimu ya toleo la Fomu hii. Ikiwa ungependa kufanya mabadiliko kwenye Fomu au Faili zake za Midia, anza kwa kuunda Rasimu kwa kutumia kitufe kilicho hapo juu"
+      },
+      "any": {
+        "versionCaption": {
+          "full": "{draftVersion} ya Fomu hii",
+          "draftVersion": "Toleo la rasimu"
+        }
+      }
+    }
   }
 }
 </i18n>

--- a/src/components/form/overview/right-now.vue
+++ b/src/components/form/overview/right-now.vue
@@ -263,6 +263,24 @@ export default {
       ],
       "submissions": "提出"
     }
+  },
+  "sw": {
+    "version": {
+      "full": "{publishedVersion} ya Fomu hii.",
+      "publishedVersion": "Toleo lililochapishwa"
+    },
+    "stateCaption": {
+      "open": "Fomu hii inaweza kupakuliwa na inakubali Mawasilisho.",
+      "closing": "Fomu hii haiwezi kupakuliwa lakini bado inakubali Mawasilisho.",
+      "closed": "Fomu hii haiwezi kupakuliwa na haikubali Mawasilisho."
+    },
+    "submissions": {
+      "full": [
+        "{submissions} zimehifadhiwa kwa Fomu hii.",
+        "{submissions} zimehifadhiwa kwa Fomu hii."
+      ],
+      "submissions": "Wasilisho | Mawasilisho"
+    }
   }
 }
 </i18n>

--- a/src/components/form/restore.vue
+++ b/src/components/form/restore.vue
@@ -125,6 +125,14 @@ export default {
       "Il Formulario verrà ripristinato allo stato precedente, inclusi tutti i dati, le impostazioni e le autorizzazioni.",
       "Se il Formulario viene nuovamente eliminato, ci vorranno altri 30 giorni prima che venga rimosso."
     ]
+  },
+  "sw": {
+    "title": "Ondoa kufuta fomu",
+    "introduction": [
+      "Je, una uhakika unataka kutengua Fomu ya {name}?",
+      "Fomu itarejeshwa katika hali yake ya awali, ikijumuisha data, mipangilio na ruhusa zote.",
+      "Ikiwa Fomu itafutwa tena, itapita siku 30 kabla ya kuondolewa."
+    ]
   }
 }
 </i18n>

--- a/src/components/form/row.vue
+++ b/src/components/form/row.vue
@@ -246,6 +246,14 @@ export default {
     "formClosedTip": "このフォームは終了しています。ダウンロードやフォームの提出は出来ません。",
     "formClosingTip": "このフォームはクロージング状態です。ダウンロードは出来ませんが、フォームの提出は受け付けています。",
     "formUnpublishedTip": "このフォームは公開バージョンがまだありません。"
+  },
+  "sw": {
+    "action": {
+      "fill": "Jaza Fomu"
+    },
+    "formClosedTip": "Fomu Hii Imefungwa. Haiwezi kupakuliwa na haikubali Mawasilisho.",
+    "formClosingTip": "Fomu Hii Inafungwa. Haiwezi kupakuliwa lakini bado inakubali Mawasilisho.",
+    "formUnpublishedTip": "Fomu hii bado haina toleo lililochapishwa."
   }
 }
 </i18n>

--- a/src/components/form/settings.vue
+++ b/src/components/form/settings.vue
@@ -216,6 +216,21 @@ export default {
     "alert": {
       "delete": "フォーム\"{name}\"は削除されました。"
     }
+  },
+  "sw": {
+    "state": {
+      "title": "Jimbo la Fomu",
+      "body": {
+        "full": "Ili kuweka hali ya Fomu hii, tafadhali tembelea Project {formAccessSettings}.",
+        "formAccessSettings": "Mipangilio ya Ufikiaji wa Fomu"
+      }
+    },
+    "action": {
+      "delete": "Futa Fomu hii"
+    },
+    "alert": {
+      "delete": "Fomu \"{name}\" ilifutwa."
+    }
   }
 }
 </i18n>

--- a/src/components/form/table.vue
+++ b/src/components/form/table.vue
@@ -110,6 +110,11 @@ export default {
     "header": {
       "idAndVersion": "フォームIDとバージョン"
     }
+  },
+  "sw": {
+    "header": {
+      "idAndVersion": "Kitambulisho na Toleo"
+    }
   }
 }
 </i18n>

--- a/src/components/form/trash-list.vue
+++ b/src/components/form/trash-list.vue
@@ -192,6 +192,14 @@ export default {
       "restore": "Il formulario “{name}” è stato ripristinato."
     },
     "message": "I formulari e i dati relativi ai formulari vengono eliminati dopo 30 giorni nel Cestino"
+  },
+  "sw": {
+    "title": "Takataka",
+    "trashCount": "({count})",
+    "alert": {
+      "restore": "Fomu \"{name}\" imetenguliwa"
+    },
+    "message": "Fomu na data inayohusiana na Fomu hufutwa baada ya siku 30 kwenye Tupio"
   }
 }
 </i18n>

--- a/src/components/form/trash-row.vue
+++ b/src/components/form/trash-row.vue
@@ -202,6 +202,15 @@ export default {
     "disabled": {
       "conflict": "Questo formulario non può essere ripristinato perché esiste un formulario attivo con lo stesso ID."
     }
+  },
+  "sw": {
+    "action": {
+      "restore": "Ondoa kufuta"
+    },
+    "deletedDate": "Imefutwa {dateTime}",
+    "disabled": {
+      "conflict": "Fomu hii haiwezi kufutwa kwa sababu kuna Fomu inayotumika yenye kitambulisho sawa."
+    }
   }
 }
 </i18n>

--- a/src/components/loading.vue
+++ b/src/components/loading.vue
@@ -64,6 +64,9 @@ export default {
   },
   "ja": {
     "text": "読み込み中..."
+  },
+  "sw": {
+    "text": "Inapakia..."
   }
 }
 </i18n>

--- a/src/components/markdown/textarea.vue
+++ b/src/components/markdown/textarea.vue
@@ -182,6 +182,10 @@ export default {
   "ja": {
     "markdownSupported": "マークダウンがサポートされています。",
     "preview": "プレビュー"
+  },
+  "sw": {
+    "markdownSupported": "Markdown inatumika",
+    "preview": "Hakiki"
   }
 }
 </i18n>

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -301,6 +301,12 @@ $border-height: 3px;
       "toggle": "ナビゲーションを有効化"
     },
     "analyticsNotice": "Centralの改善を支援！"
+  },
+  "sw": {
+    "action": {
+      "toggle": "Geuza urambazaji"
+    },
+    "analyticsNotice": "Saidia kuboresha Central"
   }
 }
 </i18n>

--- a/src/components/navbar/actions.vue
+++ b/src/components/navbar/actions.vue
@@ -151,6 +151,15 @@ export default {
     "alert": {
       "logOut": "ログアウトに成功しました。"
     }
+  },
+  "sw": {
+    "notLoggedIn": "Hujaingia",
+    "action": {
+      "logOut": "toka kwenye ukurasa"
+    },
+    "alert": {
+      "logOut": "Umetoka kwenye ukurasa kwa mafanikio."
+    }
   }
 }
 </i18n>

--- a/src/components/navbar/help-dropdown.vue
+++ b/src/components/navbar/help-dropdown.vue
@@ -89,6 +89,11 @@ export default {
     "docs": "Docs",
     "forum": "フォーラム",
     "version": "バージョン"
+  },
+  "sw": {
+    "docs": "hati",
+    "forum": "Jukwaa",
+    "version": "Toleo"
   }
 }
 </i18n>

--- a/src/components/navbar/links.vue
+++ b/src/components/navbar/links.vue
@@ -107,6 +107,9 @@ export default {
   },
   "ja": {
     "current": "現在"
+  },
+  "sw": {
+    "current": "sasa"
   }
 }
 </i18n>

--- a/src/components/navbar/locale-dropdown.vue
+++ b/src/components/navbar/locale-dropdown.vue
@@ -100,6 +100,9 @@ export default {
   },
   "ja": {
     "helpTranslate": "Centralの翻訳に貢献する"
+  },
+  "sw": {
+    "helpTranslate": "Saidia kutafsiri Central"
   }
 }
 </i18n>

--- a/src/components/not-found.vue
+++ b/src/components/not-found.vue
@@ -61,6 +61,9 @@ export default {
   },
   "ja": {
     "body": "リクエストされたページは見つかりません。"
+  },
+  "sw": {
+    "body": "Ukurasa ulioomba haukupatikana."
   }
 }
 </i18n>

--- a/src/components/project/archive.vue
+++ b/src/components/project/archive.vue
@@ -170,6 +170,16 @@ export default {
         "noUndo": "この操作は取り消しできません。"
       }
     ]
+  },
+  "sw": {
+    "title": "Mradi wa Kuhifadhi kumbukumbu",
+    "introduction": [
+      "Unakaribia kuweka Mradi \"{name}\" kwenye kumbukumbu. Bado itafanya kazi kama inavyofanya sasa, lakini itapangwa hadi chini ya Orodha ya Mradi kwenye ukurasa wa nyumbani wa Central",
+      {
+        "full": "{noUndo}, lakini uwezo wa kutoa Mradi kwenye kumbukumbu umepangwa kutolewa siku zijazo.",
+        "noUndo": "Kitendo hiki hakiwezi kutenduliwa"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/project/edit.vue
+++ b/src/components/project/edit.vue
@@ -149,6 +149,15 @@ export default {
     "alert": {
       "success": "プロジェクト設定の保存完了！"
     }
+  },
+  "sw": {
+    "title": "Maelezo ya Msingi",
+    "field": {
+      "name": "Jina la mradi"
+    },
+    "alert": {
+      "success": "Mipangilio ya mradi imehifadhiwa!"
+    }
   }
 }
 </i18n>

--- a/src/components/project/enable-encryption.vue
+++ b/src/components/project/enable-encryption.vue
@@ -699,6 +699,62 @@ export default {
     "field": {
       "hint": "パスフレーズのヒント（任意）"
     }
+  },
+  "sw": {
+    "title": "Washa Usimbaji",
+    "steps": [
+      {
+        "introduction": [
+          [
+            "Ukiwezesha usimbaji fiche, mambo yafuatayo yatafanyika:",
+            "Data iliyokamilishwa ya Uwasilishaji itasimbwa kwa njia fiche kwenye vifaa vya mkononi.",
+            "Data ya uwasilishaji imesalia itasimbwa kwa njia fiche kwenye seva ya Central",
+            [
+              "Fomu zilizosanidiwa kwa funguo za mwongozo za {submission} zitaendelea kutumia funguo hizo, na lazima zisimbuwe wewe mwenyewe",
+              "li kutumia mchakato wa usimbaji fiche wa Kati kiotomatiki kwenye Fomu hizi, ondoa usanidi wa {base64RsaPublicKey}."
+            ],
+            "Hutaweza tena kuhakiki data ya Wasilisho mtandaoni.",
+            "Hutaweza tena kuunganisha kwa data kupitia OData.",
+            "Hutaweza tena kuhariri Mawasilisho katika kivinjari chako cha wavuti."
+          ],
+          [
+            "kwa kuongeza, yafuatayo ni kweli katika toleo hili la ODK Central:",
+            [
+              "Mawasilisho yaliyopo yatasalia kuwa hayajasimbwa.",
+              "katika toleo la baadaye, utakuwa na chaguo la kusimba data iliyopo"
+            ],
+            [
+              "Usimbaji fiche hauwezi kuzimwa baada ya kuwezeshwa",
+              "Katika toleo la baadaye, utaweza kuzima usimbaji fiche, ambao utaondoa usimbaji fiche wa data yako. Hii itakuwa kweli hata ukiwezesha usimbaji fiche sasa."
+            ]
+          ],
+          {
+            "full": "Unaweza kupata maelezo zaidi kuhusu usimbaji fiche {here}. Ikiwa hii inaonekana kama kitu unachotaka, bonyeza Ifuatayo ili kuendelea.",
+            "here": "hapa"
+          }
+        ]
+      },
+      {
+        "introduction": [
+          "Kwanza, utahitaji kuchagua neno la siri. Kaulisiri hii itahitajika ili kusimbua Mawasilisho yako. Kwa faragha yako, seva haitakumbuka kaulisiri hii: watu walio na kaulisiri pekee wataweza kusimbua na kusoma data yako ya Wasilisho.",
+          {
+            "full": "Hakuna urefu au vizuizi vya maudhui kwenye kaulisiri, lakini ukiipoteza, hakuna njia {no} ya kuirejesha au data yako!",
+            "no": "Hapana"
+          }
+        ]
+      },
+      {
+        "introduction": [
+          "Usimbaji fiche umesanidiwa kwa Mradi huu. Kifaa chochote cha rununu kitalazimika kuleta au kuleta tena Fomu za hivi punde zaidi ili usimbaji fiche ufanyike."
+        ]
+      }
+    ],
+    "field": {
+      "hint": "Kidokezo cha kaulisiri (si lazima)"
+    },
+    "alert": {
+      "passphraseTooShort": "Tafadhali weka kaulisiri yenye urefu wa angalau vibambo 10."
+    }
   }
 }
 </i18n>

--- a/src/components/project/form-access.vue
+++ b/src/components/project/form-access.vue
@@ -332,6 +332,15 @@ export default {
     "alert": {
       "success": "変更が保存されました。"
     }
+  },
+  "sw": {
+    "heading": [
+      "Watumiaji wa Programu wanaweza tu kuona na kujaza Fomu ambazo wamepewa ufikiaji wa uwazi katika jedwali lililo hapa chini. Wasimamizi wa Miradi na Wakusanyaji Data wanaweza kutumia kivinjari cha wavuti kujaza Fomu yoyote katika Mradi ambayo iko katika hali ya Wazi."
+    ],
+    "emptyTable": "Hakuna Fomu za kuonyesha.",
+    "alert": {
+      "success": "Mabadiliko yako yamehifadhiwa!"
+    }
   }
 }
 </i18n>

--- a/src/components/project/form-access/row.vue
+++ b/src/components/project/form-access/row.vue
@@ -197,6 +197,13 @@ export default {
       "state": "状態",
       "appUserAccess": "アプリユーザーのアクセス"
     }
+  },
+  "sw": {
+    "draftTitle": "Fomu hii bado haina toleo lililochapishwa. Haitaonekana kwenye vifaa hadi Rasimu itakapochapishwa. Ukishachapisha Fomu, mipangilio iliyoonyeshwa hapa itatumika",
+    "field": {
+      "state": "Hali",
+      "appUserAccess": "Ufikiaji wa Mtumiaji wa Programu"
+    }
   }
 }
 </i18n>

--- a/src/components/project/form-access/states.vue
+++ b/src/components/project/form-access/states.vue
@@ -237,6 +237,27 @@ export default {
         "not2": "ません"
       }
     ]
+  },
+  "sw": {
+    "title": "Hali ya fomu",
+    "introduction": [
+      "Hali ya Fomu hudhibiti hali ya mzunguko wa maisha ya kila Fomu. Kwa kawaida, lakini si mara zote, Fomu itaanza Fungua na kuendelea na Kufunga hadi Kufungwa wakati haihitajiki tena.",
+      {
+        "full": "{open} Fomu zinapatikana kwa kupakuliwa na zitakubali Mawasilisho mapya.",
+        "open": "Fungua"
+      },
+      {
+        "full": "{closing} Fomu zitakubali Mawasilisho mapya, lakini si {not} kupakuliwa.",
+        "closing": "Kufunga",
+        "not": "sivyo"
+      },
+      {
+        "full": "{closed} Fomu {not1} kupakuliwa na {not2} hazitakubali Mawasilisho mapya",
+        "closed": "Imefungwa",
+        "not1": "Sivyo",
+        "not2": "Sivyo"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/project/form-access/table.vue
+++ b/src/components/project/form-access/table.vue
@@ -260,6 +260,12 @@ export default {
       "form": "フォーム",
       "state": "状態"
     }
+  },
+  "sw": {
+    "header": {
+      "form": "fomu",
+      "state": "hali"
+    }
   }
 }
 </i18n>

--- a/src/components/project/introduction.vue
+++ b/src/components/project/introduction.vue
@@ -102,6 +102,12 @@ export default {
     "introduction": [
       "プロジェクトでは、関連のあるフォームやユーザーをグループ化できます。Webユーザーには役割が与えられ、ブラウザでのフォーム入力など、プロジェクト内で特定の操作が可能です。プロジェクトのアプリユーザーは、自分がアクセス権のあるプロジェクト内のフォームのみ閲覧できます。"
     ]
+  },
+  "sw": {
+    "title": "Miradi ni nini?",
+    "introduction": [
+      "Miradi hukuruhusu kupanga Fomu na Watumiaji zinazohusiana. Watumiaji wa Wavuti wanaweza kupewa Majukumu ambayo huwaruhusu kutekeleza vitendo fulani ndani ya Mradi, ikijumuisha kutumia kivinjari cha wavuti kujaza Fomu. Watumiaji wa Programu za Mradi wanaweza tu kuona Fomu katika Mradi ambao wanaweza kufikia."
+    ]
   }
 }
 </i18n>

--- a/src/components/project/list.vue
+++ b/src/components/project/list.vue
@@ -635,6 +635,53 @@ export default {
     "alert": {
       "create": "新規プロジェクトは正しく作成されました。"
     }
+  },
+  "sw": {
+    "heading": [
+      "Karibu Central.",
+      "Hebu tufanye baadhi ya mambo."
+    ],
+    "gettingStarted": {
+      "title": "Kuanza",
+      "body": [
+        {
+          "full": "Iwapo huna uhakika pa kuanzia, kuna mwongozo wa kuanza na hati za mtumiaji zinazopatikana kwenye {docsWebsite}.",
+          "docsWebsite": "Tovuti ya Hati za ODK"
+        },
+        {
+          "full": "Kwa kuongeza, unaweza kupata usaidizi kutoka kwa wengine kwenye {forum} wakati wowote, ambapo unaweza kutafuta maswali ya awali au kuuliza moja yako mwenyewe.",
+          "forum": "ODK jamii forum"
+        }
+      ]
+    },
+    "news": "Habari",
+    "rightNow": {
+      "users": {
+        "full": [
+          "{webUsers} ambaye anaweza kusimamia Miradi kupitia tovuti hii.",
+          "{webUsers} ambao wanaweza kusimamia Miradi kupitia tovuti hii."
+        ],
+        "webUsers": "Mtumiaji wa Mtandao | Watumiaji wa Mtandao"
+      },
+      "projects": {
+        "full": [
+          "{projects} ambayo inaweza kupanga Fomu na Watumiaji wa Programu kwa ajili ya kusambaza kifaa.",
+          "{projects} ambayo inaweza kupanga Fomu na Watumiaji wa Programu kwa ajili ya kusambaza kifaa."
+        ],
+        "projects": "Mradi | Miradi"
+      }
+    },
+    "projectsTitle": "Miradi",
+    "action": {
+      "create": "Mpya"
+    },
+    "header": {
+      "forms": "Fomu"
+    },
+    "emptyTable": "Hakuna Miradi kwako kuona.",
+    "alert": {
+      "create": "Mradi wako mpya umeundwa."
+    }
   }
 }
 </i18n>

--- a/src/components/project/new.vue
+++ b/src/components/project/new.vue
@@ -137,6 +137,12 @@ export default {
     "introduction": [
       "プロジェクトでは、フォームやアプリユーザーをグループ化して、このWebサイトとデータ収集デバイスの両方で、整理と管理を簡易化します。"
     ]
+  },
+  "sw": {
+    "title": "Unda Mradi",
+    "introduction": [
+      "Miradi huweka pamoja Fomu na Watumiaji wa Programu ili kurahisisha kupanga na kudhibiti, kwenye tovuti hii na kwenye kifaa chako cha kukusanya data."
+    ]
   }
 }
 </i18n>

--- a/src/components/project/overview/about.vue
+++ b/src/components/project/overview/about.vue
@@ -163,6 +163,19 @@ export default {
         "forumThread": "フォーラムのスレッド"
       }
     ]
+  },
+  "sw": {
+    "title": "Kuhusu Miradi",
+    "body": [
+      {
+        "full": "Miradi hukuruhusu kupanga Fomu na Watumiaji zinazohusiana. Watumiaji wa Wavuti wanaweza kupewa Majukumu ambayo huwaruhusu kutekeleza vitendo fulani ndani ya Mradi huu, ikijumuisha kutumia kivinjari cha wavuti kujaza Fomu. Watumiaji wa Programu za Mradi huu wanaweza tu kuona Fomu katika Mradi huu ambao wana {accessTo}",
+        "accessTo": "upatikanaji wa"
+      },
+      {
+        "full": "ikiwa una maoni yoyote, tafadhali tembelea {forumThread}.",
+        "forumThread": "hii thread ya jukwaa"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/project/overview/right-now.vue
+++ b/src/components/project/overview/right-now.vue
@@ -200,6 +200,22 @@ export default {
       ],
       "forms": "フォーム"
     }
+  },
+  "sw": {
+    "appUsers": {
+      "full": [
+        "{appUsers} ambao wanaweza kutumia mteja wa kukusanya data kupakua na kuwasilisha data ya Fomu kwa Mradi huu",
+        "{appUsers} ambao wanaweza kutumia mteja wa kukusanya data kupakua na kuwasilisha data ya Fomu kwa Mradi huu"
+      ],
+      "appUsers": "Mtumiaji wa Programu | Watumiaji wa Programu"
+    },
+    "forms": {
+      "full": [
+        "{forms} ambazo zinaweza kupakuliwa na kutolewa kama tafiti.",
+        "{forms} ambazo zinaweza kupakuliwa na kutolewa kama tafiti."
+      ],
+      "forms": "Fomu | Fomu"
+    }
   }
 }
 </i18n>

--- a/src/components/project/row.vue
+++ b/src/components/project/row.vue
@@ -134,6 +134,11 @@ export default {
     "help": "プロジェクトとは？",
     "noSubmission": "（なし）",
     "encryptionTip": "このプロジェクトは管理された暗号化を使用しています。"
+  },
+  "sw": {
+    "help": "Miradi ni nini?",
+    "noSubmission": "(Hakuna)",
+    "encryptionTip": "Mradi huu unatumia usimbaji fiche unaodhibitiwa"
   }
 }
 </i18n>

--- a/src/components/project/settings.vue
+++ b/src/components/project/settings.vue
@@ -395,6 +395,38 @@ export default {
     "alert": {
       "archive": "プロジェクト\"{name}\"はアーカイブされました。"
     }
+  },
+  "sw": {
+    "encryption": {
+      "title": "Usimbaji fiche",
+      "body": {
+        "unencrypted": [
+          "Usimbaji fiche wa data ya uwasilishaji haujawezeshwa kwa Mradi huu."
+        ],
+        "encrypted": [
+          {
+            "full": "Usimbaji fiche wa data ya uwasilishaji {enabled} kwa Mradi huu.",
+            "enabled": "imewezeshwa"
+          },
+          "Katika toleo hili la ODK Central, huwezi kuzima usimbaji fiche mara tu inapowashwa."
+        ]
+      },
+      "action": {
+        "enableEncryption": "Washa usimbaji fiche"
+      }
+    },
+    "dangerZone": {
+      "action": {
+        "archive": "Hifadhi Mradi huu kwenye kumbukumbu"
+      },
+      "archived": [
+        "Mradi huu umewekwa kwenye kumbukumbu.",
+        "Katika toleo hili la ODK Central, unaweza usiondoe Mradi kwenye kumbukumbu. Hata hivyo, uwezo wa kufuta Mradi umepangwa kwa ajili ya kutolewa siku zijazo."
+      ]
+    },
+    "alert": {
+      "archive": "Mradi \"{name}\" uliwekwa kwenye kumbukumbu."
+    }
   }
 }
 </i18n>

--- a/src/components/project/submission-options.vue
+++ b/src/components/project/submission-options.vue
@@ -252,6 +252,25 @@ export default {
         "dataCollector": "データ収集者"
       }
     ]
+  },
+  "sw": {
+    "title": "Chaguzi za Uwasilishaji",
+    "introduction": [
+      "Kuna chaguo kadhaa za kuwasilisha data kwa ODK Central:",
+      {
+        "full": "Unda {appUsers} na utumie programu ya Android ya {collect}. Hii inafaa zaidi wakati wakusanyaji wa data wanahitaji ufikiaji wa Fomu nyingi, wako nje ya mtandao, au una Fomu ngumu",
+        "appUsers": "Watumiaji wa Programu"
+      },
+      {
+        "full": "Unda {publicLinks} moja au zaidi ili kushiriki na waliojibu ambao watajiripoti.",
+        "publicLinks": "Viungo vya Ufikiaji wa Umma"
+      },
+      {
+        "full": "Unda {webUser} na Jukumu la {dataCollector} kwa kila mtu ambaye atakuwa akikusanya data. Watumiaji hawa wataingia katika Kituo Kikuu ili kujaza Fomu hii katika kivinjari cha wavuti. Wasimamizi wa Miradi wanaweza pia kuunda Mawasilisho kutoka kwa kivinjari cha wavuti.",
+        "webUser": "Mtumiaji wa Mtandao",
+        "dataCollector": "Mkusanya Data"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/project/user/list.vue
+++ b/src/components/project/user/list.vue
@@ -557,6 +557,42 @@ export default {
       "assignRole": "成功です！\"{displayName}\"には、このプロジェクトで\"{roleName}\"の役割が割当てられました。",
       "unassignRole": "成功です！\"{displayName}\"はこのプロジェクトから除外されました。"
     }
+  },
+  "sw": {
+    "heading": [
+      "Wasimamizi wa Tovuti nzima wanazingatiwa kiotomatiki Wasimamizi wa kila Mradi. Watumiaji Wengine wanaweza kuwa na Majukumu mahususi kwa Mradi huu",
+      {
+        "full": "{projectManagers} inaweza kutekeleza kazi yoyote ya usimamizi inayohusiana na Mradi huu na inaweza kujaza Fomu katika kivinjari cha wavuti.",
+        "projectManagers": "Wasimamizi wa Mradi"
+      },
+      {
+        "full": "{projectViewers} inaweza kufikia na kupakua data yote ya Fomu katika Mradi huu, lakini haiwezi kufanya mabadiliko yoyote kwenye mipangilio au data",
+        "projectViewers": "Watazamaji wa Mradi"
+      },
+      {
+        "full": "{dataCollectors} inaweza kujaza Fomu katika kivinjari, lakini haiwezi kuona au kubadilisha data au mipangilio",
+        "dataCollectors": "Wakusanyaji Data"
+      }
+    ],
+    "action": {
+      "clearSearch": "Futa utafutaji"
+    },
+    "field": {
+      "q": {
+        "canList": "Tafuta mtumiaji...",
+        "cannotList": "Weka barua pepe kamili ya mtumiaji..."
+      }
+    },
+    "header": {
+      "user": "Mtumiaji",
+      "projectRole": "Jukumu la Mradi"
+    },
+    "emptyTable": "Bado hakuna watumiaji waliokabidhiwa kwa Mradi huu. Ili kuongeza moja, tafuta mtumiaji hapo juu.",
+    "alert": {
+      "unassignWithoutReassign": "Hitilafu fulani imetokea. \"{displayName}\" imeondolewa kwenye Mradi.",
+      "assignRole": "Mafanikio! \"{displayName}\" imepewa Jukumu la \"{roleName}\" kwenye Mradi huu.",
+      "unassignRole": "Mafanikio! \"{displayName}\" imeondolewa kwenye Mradi huu."
+    }
   }
 }
 </i18n>

--- a/src/components/project/user/row.vue
+++ b/src/components/project/user/row.vue
@@ -205,6 +205,12 @@ export default {
     "field": {
       "projectRole": "プロジェクトでの役割"
     }
+  },
+  "sw": {
+    "cannotAssignRole": "Huenda usihariri Jukumu lako la Mradi.",
+    "field": {
+      "projectRole": "Jukumu la Mradi"
+    }
   }
 }
 </i18n>

--- a/src/components/public-link/create.vue
+++ b/src/components/public-link/create.vue
@@ -189,6 +189,16 @@ export default {
       "once": "一回限りのデータ提出機能"
     },
     "onceHelp": "各プラウザから一回しかフォームの提出を受け付けない。"
+  },
+  "sw": {
+    "title": "Unda Kiungo cha Ufikiaji wa Umma",
+    "introduction": [
+      "Mtu yeyote aliye na Kiungo hiki ataweza kujaza Fomu hii katika kivinjari. Tumia jina la onyesho ili kujikumbusha mahali ulipoichapisha, ulishiriki na nani, wakati inakusudiwa kutumika, na kadhalika"
+    ],
+    "field": {
+      "once": "Uwasilishaji Mmoja"
+    },
+    "onceHelp": "Ruhusu Uwasilishaji mmoja tu kutoka kwa kila kivinjari."
   }
 }
 </i18n>

--- a/src/components/public-link/list.vue
+++ b/src/components/public-link/list.vue
@@ -311,6 +311,26 @@ export default {
       "create": "成功です！一般公開リンクが作成され、利用可能です。 以下をコピーして配布できます。",
       "revoke": "一般公開リンク\"{displayName}\"の無効化に成功しました。以後、このリンクでのサフォームの提出は受付られません。"
     }
+  },
+  "sw": {
+    "action": {
+      "create": "Unda Kiungo cha Ufikiaji wa Umma"
+    },
+    "heading": [
+      {
+        "full": "Mtu yeyote aliye na Kiungo cha Ufikiaji wa Umma anaweza kujaza Fomu hii katika kivinjari. Unaweza kuunda Viungo vingi ili kufuatilia usambazaji tofauti wa Fomu, kuweka kikomo muda ambao kikundi mahususi cha watu kinaweza kufikia Fomu, na zaidi. Viungo hivi vitafanya kazi ikiwa tu Fomu iko katika {state} la Wazi.",
+        "state": "Hali"
+      },
+      {
+        "full": "Viungo vya Umma vimekusudiwa kujiripoti. Ikiwa unafanya kazi na wakusanyaji data ambao wanahitaji kuwasilisha Fomu sawa mara nyingi, {clickHere} kwa chaguo zingine.",
+        "clickHere": "Bonyeza hapa"
+      }
+    ],
+    "emptyTable": "Hakuna Viungo vya Ufikiaji wa Umma vya Fomu hii.",
+    "alert": {
+      "create": "Mafanikio! Kiungo chako cha Kufikia Umma kimeundwa na sasa kinapatikana. Nakili hapa chini ili kuisambaza.",
+      "revoke": "Kiungo cha Ufikiaji wa Umma \"{displayName}\" kimebatilishwa. Hakuna Mawasilisho Zaidi yatakubaliwa kwa kutumia Kiungo hiki."
+    }
   }
 }
 </i18n>

--- a/src/components/public-link/revoke.vue
+++ b/src/components/public-link/revoke.vue
@@ -126,6 +126,12 @@ export default {
     "introduction": [
       "一般公開リンクを無効化しようとしています。これにより、この一般公開リンクを用いた全てのデータの提出が出来なくなります。これには現在すでに入力が開始されたフォームの提出も含まれます。"
     ]
+  },
+  "sw": {
+    "title": "Batilisha Kiungo cha Ufikiaji wa Umma",
+    "introduction": [
+      "Unakaribia kubatilisha Kiungo hiki cha Ufikiaji wa Umma. Hii ina maana kwamba majaribio yote ya kuwasilisha data kwa kutumia kiungo yatakataliwa, ikiwa ni pamoja na rekodi ambazo tayari zimeanzishwa"
+    ]
   }
 }
 </i18n>

--- a/src/components/public-link/row.vue
+++ b/src/components/public-link/row.vue
@@ -177,6 +177,16 @@ export default {
       "text": "まだ利用できません。",
       "title": "一般公開リンクはまだ利用できません。処理が終了していません。後ほどページを更新し、もう一度試して下さい。"
     }
+  },
+  "sw": {
+    "action": {
+      "revoke": "Batilisha"
+    },
+    "revoked": "Imebatilishwa",
+    "unavailable": {
+      "text": "Haipatikani bado",
+      "title": "Kiungo cha Ufikiaji wa Umma bado hakipatikani. Haijamaliza kuchakatwa. Tafadhali onyesha upya baadaye na ujaribu tena."
+    }
   }
 }
 </i18n>

--- a/src/components/public-link/table.vue
+++ b/src/components/public-link/table.vue
@@ -110,6 +110,12 @@ export default {
       "once": "一回限りのデータ提出機能",
       "accessLink": "アクセスリンク"
     }
+  },
+  "sw": {
+    "header": {
+      "once": "Uwasilishaji Mmoja",
+      "accessLink": "Kiungo cha Ufikiaji"
+    }
   }
 }
 </i18n>

--- a/src/components/submission/analyze.vue
+++ b/src/components/submission/analyze.vue
@@ -452,6 +452,39 @@ export default {
         "article": "こちら"
       }
     }
+  },
+  "sw": {
+    "title": "Kwa kutumia OData",
+    "introduction": [
+      "OData ni kiwango kipya cha kuhamisha data kati ya zana na huduma. Zana za uchanganuzi zisizolipishwa na zenye nguvu kama vile Excel, {powerBi} na {r} zinaweza kuleta data kupitia OData kwa uchanganuzi.",
+      "Kuna faida nyingi kwa OData, lakini muhimu zaidi inaauni uhamishaji wa uaminifu kamili wa aina ngumu kama vile nambari na data ya kijiografia, na huwezesha toleo jipya zaidi la data yako kusawazisha kwa urahisi na zana zozote zinazoitumia.",
+      "Ili kuanza kutumia OData, chagua zana yako na unakili kiungo ndani yake."
+    ],
+    "tab": {
+      "microsoft": "Excel/Power BI",
+      "other": "Nyingine"
+    },
+    "help": {
+      "microsoft": {
+        "full": "Kwa usaidizi wa kutumia OData na Excel, angalia {pageForExcel}. Kwa usaidizi wa Power BI, angalia {pageForPowerBi}.",
+        "pageForExcel": "ukurasa huu",
+        "pageForPowerBi": "ukurasa huu"
+      },
+      "r": [
+        {
+          "full": "Ili kufikia data ya Kati kutoka kwa {r}, tunapendekeza utumie {ruODK}. Tazama vignette za ruODK kwa mifano ya kutumia API ya {oData} na {restful}.",
+          "restful": "Tulivu"
+        },
+        {
+          "full": "kama vile ODK yenyewe, ruODK inatengenezwa na kuungwa mkono na wanajamii. Ikiwa ungependa kusaidia kuiboresha, unaweza kupata maelezo {here}.",
+          "here": "Hapa"
+        }
+      ],
+      "other": {
+        "full": "Kwa maelezo kamili ya usaidizi wetu wa OData, tafadhali angalia {article}.",
+        "article": "Makala hii"
+      }
+    }
   }
 }
 </i18n>

--- a/src/components/submission/basic-details.vue
+++ b/src/components/submission/basic-details.vue
@@ -215,6 +215,16 @@ export default {
     "present": "{count}件の提出済メディアファイル",
     "expected": "{count}件の期待されるメディアファイル数",
     "attachmentSummary": "{present} / {expected}"
+  },
+  "sw": {
+    "reviewState": "Kagua hali",
+    "formVersion": "Toleo la fomu",
+    "deviceId": "Kitambulisho cha Kifaa",
+    "userAgent": "Wakala wa mtumiaji",
+    "attachments": "Faili za media",
+    "present": "faili {count} | faili {count}",
+    "expected": "{count} inatarajiwa | {count} inatarajiwa",
+    "attachmentSummary": "{present} / {expected}"
   }
 }
 </i18n>

--- a/src/components/submission/comment.vue
+++ b/src/components/submission/comment.vue
@@ -156,6 +156,9 @@ export default {
   },
   "ja": {
     "editWithoutComment": "データが編集されました。あなたが実施した変更について説明して下さい。"
+  },
+  "sw": {
+    "editWithoutComment": "Umefanya mabadiliko kwenye data hii. Tafadhali eleza mabadiliko uliyofanya."
   }
 }
 </i18n>

--- a/src/components/submission/data-access.vue
+++ b/src/components/submission/data-access.vue
@@ -119,6 +119,13 @@ export default {
       "analyze": "OData経由で解析"
     },
     "analyzeDisabled": "フォームの暗号化のため、ODataによるアクセスは利用できません"
+  },
+  "sw": {
+    "action": {
+      "apiAccess": "Ufikiaji wa API",
+      "analyze": "Changanua kupitia OData"
+    },
+    "analyzeDisabled": "Ufikiaji wa OData haupatikani kwa sababu ya usimbaji fiche wa Fomu"
   }
 }
 </i18n>

--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -484,6 +484,33 @@ $label-icon-max-width: 15px;
     "alert": {
       "submit": "データダウンロードはすぐに始まります。始まり次第、このボックスを閉じて構いません。開始されない場合は、もう一度試して下さい。"
     }
+  },
+  "sw": {
+    "title": "Pakua Mawasilisho",
+    "exportOptions": "Chaguzi za export",
+    "field": {
+      "splitSelectMultiples": "Gawanya chaguo za \"chagua nyingi\" kwenye safu wima",
+      "removeGroupNames": "Ondoa majina ya kikundi",
+      "deletedFields": "Jumuisha sehemu za Fomu zilizofutwa hapo awali"
+    },
+    "noSelectMultiple": "Fomu hii haina sehemu nyingi zilizochaguliwa",
+    "encryptedForm": "Fomu Zilizosimbwa kwa njia fiche haziwezi kuchakatwa kwa njia hii",
+    "introduction": [
+      "Ili kupakua data hii, utahitaji kutoa neno lako la siri. Kauli yako ya siri itatumika tu kusimbua data yako kwa ajili ya kupakua, na kisha seva itaisahau tena."
+    ],
+    "hint": "Kidokezo: {hint}",
+    "noRepeat": "Fomu hii haina marudio",
+    "action": {
+      "download": {
+        "mainTable": "Jedwali kuu la data (hakuna marudio)",
+        "allTables": "Jedwali zote za data",
+        "withMedia": "Data zote na faili za midia"
+      }
+    },
+    "alert": {
+      "unavailable": "Upakuaji wa data bado haupatikani. Tafadhali jaribu tena baada ya muda mfupi",
+      "submit": "Upakuaji wa data yako unapaswa kuanza hivi karibuni. Mara tu inapoanza, unaweza kufunga kisanduku hiki. Ikiwa umekuwa ukingoja na haijaanza, tafadhali jaribu tena."
+    }
   }
 }
 </i18n>

--- a/src/components/submission/diff-item.vue
+++ b/src/components/submission/diff-item.vue
@@ -341,6 +341,13 @@ export default {
       "deleted": "（削除済み）"
     },
     "empty": "空"
+  },
+  "sw": {
+    "editCaption": {
+      "added": "(imeongezwa)",
+      "deleted": "(imefutwa)"
+    },
+    "empty": "tupu"
   }
 }
 </i18n>

--- a/src/components/submission/download-dropdown.vue
+++ b/src/components/submission/download-dropdown.vue
@@ -147,6 +147,17 @@ export default {
         }
       }
     }
+  },
+  "sw": {
+    "action": {
+      "download": {
+        "unfiltered": "Pakua rekodi {count} | Pakua rekodi {count}",
+        "filtered": {
+          "withoutCount": "Pakua rekodi zinazolingana",
+          "withCount": "Pakua rekodi {count} zinazolingana | Pakua rekodi {count} zinazolingana"
+        }
+      }
+    }
   }
 }
 </i18n>

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -450,6 +450,34 @@ Comment • {name} */
       },
       "comment": "{name}によるコメント"
     }
+  },
+  "sw": {
+    "title": {
+      "create": "Imewasilishwa na {name}",
+      "updateReviewState": {
+        "null": {
+          "full": "{reviewState} kwa {name}",
+          "reviewState": "Imepokelewa"
+        },
+        "hasIssues": {
+          "full": "{reviewState} kwa {name}",
+          "reviewState": "Ina Masuala"
+        },
+        "edited": {
+          "full": "{reviewState} kwa {name}",
+          "reviewState": "Imehaririwa"
+        },
+        "approved": {
+          "full": "{reviewState} kwa {name}",
+          "reviewState": "Imeidhinishwa"
+        },
+        "rejected": {
+          "full": "{reviewState} kwa {name}",
+          "reviewState": "Imekataliwa"
+        }
+      },
+      "comment": "Maoni kutoka kwa {name}"
+    }
   }
 }
 </i18n>

--- a/src/components/submission/field-dropdown.vue
+++ b/src/components/submission/field-dropdown.vue
@@ -421,6 +421,21 @@ export default {
         "none": "なし"
       }
     }
+  },
+  "sw": {
+    "placeholder": "{selected} kati ya {total}",
+    "field": {
+      "columns": "Safu wima zimeonyeshwa",
+      "search": "Tafuta safu wima..."
+    },
+    "disabled": "Haiwezi kuchagua zaidi ya safu wima 100.",
+    "action": {
+      "select": {
+        "full": "Chagua {all} / {none}",
+        "all": "zote",
+        "none": "hakuna"
+      }
+    }
   }
 }
 </i18n>

--- a/src/components/submission/filters.vue
+++ b/src/components/submission/filters.vue
@@ -102,6 +102,11 @@ export default {
     "field": {
       "submissionDate": "フォームの送信日"
     }
+  },
+  "sw": {
+    "field": {
+      "submissionDate": "Imewasilishwa kwa"
+    }
   }
 }
 </i18n>

--- a/src/components/submission/filters/review-state.vue
+++ b/src/components/submission/filters/review-state.vue
@@ -71,6 +71,9 @@ export default {
   },
   "it": {
     "anyState": "(Qualsiasi Stato)"
+  },
+  "sw": {
+    "anyState": "(hali lolote)"
   }
 }
 </i18n>

--- a/src/components/submission/filters/submitter.vue
+++ b/src/components/submission/filters/submitter.vue
@@ -97,6 +97,11 @@ export default {
     "field": {
       "submitter": "フォーム送信者"
     }
+  },
+  "sw": {
+    "field": {
+      "submitter": "Iliyowasilishwa na"
+    }
   }
 }
 </i18n>

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -577,6 +577,28 @@ export default {
     },
     "emptyTable": "表示できる提出済フォームはありません。",
     "noMatching": "照合できる提出済フォームはありません。"
+  },
+  "sw": {
+    "loading": {
+      "withoutCount": "Inapakia Mawasilisho...",
+      "all": "Inapakia Mawasilisho {count}... | Inapakia Mawasilisho {count}...",
+      "first": "Inapakia {top} ya kwanza kati ya Mawasilisho {count}... | Inapakia {top} ya kwanza kati ya Mawasilisho {count}...",
+      "middle": "Inapakia {top} zaidi ya Mawasilisho {count} yaliyosalia... | Inapakia {top} zaidi ya Mawasilisho {count} yaliyosalia...",
+      "last": {
+        "multiple": "Inapakia Mawasilisho {count} ya mwisho... | Inapakia Mawasilisho {count} ya mwisho...",
+        "one": "Inapakia Wasilisho la mwisho..."
+      },
+      "filtered": {
+        "withoutCount": "Inapakia Mawasilisho yanayolingana...",
+        "middle": "Inapakia {top} zaidi ya Mawasilisho {count} yanayolingana... | Inapakia {top} zaidi ya Mawasilisho {count} yanayolingana...",
+        "last": {
+          "multiple": "Inapakia Mawasilisho {count} ya mwisho yanayolingana... | Inapakia Mawasilisho {count} ya mwisho yanayolingana...",
+          "one": "Inapakia Wasilisho linalolingana la mwisho..."
+        }
+      }
+    },
+    "emptyTable": "Bado hakuna Mawasilisho.",
+    "noMatching": "Hakuna Mawasilisho yanayolingana."
   }
 }
 </i18n>

--- a/src/components/submission/show.vue
+++ b/src/components/submission/show.vue
@@ -242,6 +242,12 @@ export default {
       "title": "提出フォームの詳細",
       "back": "提出フォームの一覧に戻る"
     }
+  },
+  "sw": {
+    "back": {
+      "title": "Maelezo ya Uwasilishaji",
+      "back": "Rudi kwenye Jedwali la Mawasilisho"
+    }
   }
 }
 </i18n>

--- a/src/components/submission/table.vue
+++ b/src/components/submission/table.vue
@@ -250,6 +250,11 @@ export default {
     "header": {
       "stateAndActions": "レビュー・ステータスと操作"
     }
+  },
+  "sw": {
+    "header": {
+      "stateAndActions": "Hali na vitendo"
+    }
   }
 }
 </i18n>

--- a/src/components/submission/update-review-state.vue
+++ b/src/components/submission/update-review-state.vue
@@ -206,6 +206,12 @@ export default {
     "field": {
       "notes": "メモとコメント（任意）"
     }
+  },
+  "sw": {
+    "title": "Sasisha Uhakiki wa hali",
+    "field": {
+      "notes": "Vidokezo na maoni (si lazima)"
+    }
   }
 }
 </i18n>

--- a/src/components/time-and-user.vue
+++ b/src/components/time-and-user.vue
@@ -87,6 +87,9 @@ export default {
   },
   "ja": {
     "text": "{displayName}が{dateTime}の時点で実施"
+  },
+  "sw": {
+    "text": "{dateTime} na {displayName}"
   }
 }
 </i18n>

--- a/src/components/user/edit/basic-details.vue
+++ b/src/components/user/edit/basic-details.vue
@@ -158,6 +158,15 @@ export default {
     "alert": {
       "success": "ユーザー詳細の保存完了！"
     }
+  },
+  "sw": {
+    "title": "Maelezo ya Msingi",
+    "action": {
+      "update": "Sasisha maelezo"
+    },
+    "alert": {
+      "success": "Maelezo ya mtumiaji yamehifadhiwa!"
+    }
   }
 }
 </i18n>

--- a/src/components/user/edit/password.vue
+++ b/src/components/user/edit/password.vue
@@ -199,6 +199,17 @@ export default {
       "mismatch": "新しいパスワードが一致することを確認して下さい。",
       "success": "成功です！パスワードが更新されました。"
     }
+  },
+  "sw": {
+    "title": "Badilisha neno la siri",
+    "action": {
+      "change": "Badilisha neno la siri"
+    },
+    "cannotChange": "Ni mmiliki wa akaunti pekee ndiye anayeweza kuweka nenosiri lake moja kwa moja.",
+    "alert": {
+      "mismatch": "Ni mmiliki wa akaunti pekee ndiye anayeweza kuweka nenosiri lake moja kwa moja.",
+      "success": "Mafanikio! Nenosiri lako limesasishwa."
+    }
   }
 }
 </i18n>

--- a/src/components/user/home.vue
+++ b/src/components/user/home.vue
@@ -131,6 +131,14 @@ export default {
       "roles": "役割設定"
     },
     "comingSoon": "（近日公開）"
+  },
+  "sw": {
+    "title": "Mipangilio ya Mtumiaji",
+    "tab": {
+      "users": "Watumiaji wa Mtandao",
+      "roles": "Mipangilio ya Wajibu"
+    },
+    "comingSoon": "(inakuja hivi karibuni)"
   }
 }
 </i18n>

--- a/src/components/user/list.vue
+++ b/src/components/user/list.vue
@@ -339,6 +339,23 @@ export default {
       "resetPassword": "\"{displayName}\"のパスワードが無効です。{email}宛に、今後の対応についての手続き方法を記載したメールが送信されました。",
       "retire": "ユーザー\"{displayName}\"を除外しました。"
     }
+  },
+  "sw": {
+    "action": {
+      "create": "Unda Mtumiaji wa Wavuti"
+    },
+    "heading": [
+      "Watumiaji Wavuti wana akaunti kwenye tovuti hii ili kusimamia na kusimamia Miradi kwenye seva hii. Wasimamizi wanaweza kudhibiti chochote kwenye tovuti. Watumiaji wasio na Jukumu la Tovuti Pote wanaweza kupewa Jukumu kwenye Mradi wowote, kutoka kwa mipangilio ya Mradi huo. Wasimamizi wa Tovuti nzima na baadhi ya Majukumu ya Mradi wanaweza kutumia kivinjari cha wavuti kujaza Fomu. Ili kuwasilisha data kupitia programu kama vile {collect}, unda Watumiaji wa Programu kwa kila Mradi."
+    ],
+    "header": {
+      "sitewideRole": "Jukumu la Tovuti nzima"
+    },
+    "alert": {
+      "create": "Mtumiaji ameundwa kwa ajili ya \"{displayName}\".",
+      "assignRole": "Mafanikio! \"{displayName}\" imepewa Jukumu la Eneo Lote la \"{roleName}\".",
+      "resetPassword": "Nenosiri la \"{displayName}\" limebatilishwa. Barua pepe imetumwa kwa {email} ikiwa na maagizo ya jinsi ya kuendelea.",
+      "retire": "Mtumiaji \"{displayName}\" amestaafu."
+    }
   }
 }
 </i18n>

--- a/src/components/user/new.vue
+++ b/src/components/user/new.vue
@@ -139,6 +139,12 @@ export default {
     "introduction": [
       "このアカウントを作成すると、登録したメールアドレスにパスワード設定方法と今後の手順を記載したメールが送信されます。"
     ]
+  },
+  "sw": {
+    "title": "Unda Mtumiaji wa Wavuti",
+    "introduction": [
+      "Ukishafungua akaunti hii, barua pepe utakayotoa itatumiwa maelekezo ya jinsi ya kuweka nenosiri na kuendelea."
+    ]
   }
 }
 </i18n>

--- a/src/components/user/reset-password.vue
+++ b/src/components/user/reset-password.vue
@@ -136,6 +136,13 @@ export default {
       "full": "次の{resetPassword}クリックすると、ユーザー\"{displayName}\"\u003c{email}>のパスワードが今すぐ無効化されます。その際、{email}に今後の手順を記載したメールが送信されます。",
       "resetPassword": "パスワードのリセット"
     }
+  },
+  "sw": {
+    "title": "Weka upya Nenosiri",
+    "introduction": {
+      "full": "Ukibofya {resetPassword} hapa chini, nenosiri la mtumiaji “{displayName}” \u003c{email}> litabatilishwa mara moja. Barua pepe itatumwa kwa {email} ikiwa na maagizo ya jinsi ya kuendelea.",
+      "resetPassword": "Weka upya nenosiri"
+    }
   }
 }
 </i18n>

--- a/src/components/user/retire.vue
+++ b/src/components/user/retire.vue
@@ -161,6 +161,16 @@ export default {
         "noUndo": "この操作は取り消しできません"
       }
     ]
+  },
+  "sw": {
+    "title": "Mtumiaji Anayestaafu",
+    "introduction": [
+      "Unakaribia kustaafu akaunti ya mtumiaji \"{displayName}\" \u003c{email}>. Mtumiaji huyo atazuiwa mara moja kufanya vitendo vyovyote na kuondoka",
+      {
+        "full": "{noUndo}, lakini akaunti mpya inaweza kufunguliwa kwa ajili ya mtu huyo kwa kutumia anwani sawa ya barua pepe.",
+        "noUndo": "Kitendo hiki hakiwezi kutenduliwa"
+      }
+    ]
   }
 }
 </i18n>

--- a/src/components/user/row.vue
+++ b/src/components/user/row.vue
@@ -247,6 +247,16 @@ export default {
     "action": {
       "retire": "ユーザーの除外"
     }
+  },
+  "sw": {
+    "cannotAssignRole": "Huenda usihariri Jukumu lako la Tovuti nzima.",
+    "field": {
+      "sitewideRole": "Jukumu la Tovuti nzima"
+    },
+    "cannotRetire": "Huenda usistaafu mwenyewe.",
+    "action": {
+      "retire": "Staafu mtumiaji"
+    }
   }
 }
 </i18n>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -23,7 +23,8 @@ export const locales = new Map()
   .set('fr', 'Français')
   .set('id', 'Bahasa Indonesia')
   .set('it', 'Italiano')
-  .set('ja', '日本語');
+  .set('ja', '日本語')
+  .set('sw', 'Kiswahili');
 
 const fallbackLocale = 'en';
 

--- a/src/locales/sw.json
+++ b/src/locales/sw.json
@@ -1,0 +1,295 @@
+{
+  "title": {
+    "resetPassword": "Weka upya neno siri",
+    "setPassword": "Weka neno siri",
+    "editProfile": "Hariri Wasifu",
+    "download": "Pakua",
+    "pageNotFound": "Ukurasa Haupatikani",
+    "details": "Maelezo"
+  },
+  "projectShow": {
+    "tab": {
+      "formAccess": "Ufikiaji wa Fomu"
+    }
+  },
+  "formHead": {
+    "tab": {
+      "versions": "Matoleo",
+      "publicAccess": "Ufikiaji wa Umma"
+    },
+    "draftNav": {
+      "tab": {
+        "status": "Hali",
+        "attachments": "Faili za media",
+        "testing": "Upimaji"
+      }
+    }
+  },
+  "systemHome": {
+    "title": "Usimamizi wa mfumo",
+    "tab": {
+      "backups": "Hifadhi rudufu",
+      "audits": "Kumbukumbu za ukaguzi wa seva",
+      "analytics": "Ripoti ya matumizi"
+    }
+  },
+  "role": {
+    "none": "Hakuna",
+    "admin": "Msimamizi",
+    "manager": "Meneja wa mradi",
+    "viewer": "Mtazamaji wa mradi",
+    "formfill": "Mkusanyaji wa data"
+  },
+  "formState": {
+    "open": "Fungua",
+    "closing": "Kufunga",
+    "closed": "imefungwa"
+  },
+  "reviewState": {
+    "received": "Imepokelewa",
+    "hasIssues": "Ina masuala",
+    "edited": "Imehaririwa",
+    "approved": "Imeidhinishwa",
+    "rejected": "Imekataliwa",
+    "null": "@:reviewState.received"
+  },
+  "audit": {
+    "category": {
+      "nonverbose": "vitendo vyote",
+      "user": "vitendo vya mtumiaji wa wavuti",
+      "project": "hatua za mradi",
+      "form": "Vitendo vya fomu",
+      "field_key": "Vitendo vya mtumiaji wa programu",
+      "public_link": "vitendo vya kiungo cha ufikiaji wa umma",
+      "config": "vitendo vya usanidi wa seva",
+      "upgrade": "uboreshaji wa seva"
+    },
+    "action": {
+      "default": {
+        "create": "Unda",
+        "update": "sasisha maelezo",
+        "session_end": "batilisha",
+        "delete": "kufuta"
+      },
+      "analytics": "Ripoti matumizi",
+      "backup": "Hifadhi nakala",
+      "config": {
+        "set": "weka"
+      },
+      "field_key": {
+        "assignment_create": "kutoa ufikiaji",
+        "assignment_delete": "Ondoa ufikiaji",
+        "create": "@:audit.action.default.create",
+        "session_end": "@:audit.action.default.session_end",
+        "delete": "@:audit.action.default.delete"
+      },
+      "form": {
+        "update_draft_set": "Unda rasimu",
+        "update_publish": "Chapisha rasimu",
+        "update_draft_delete": "Acha rasimu",
+        "attachment_update": "Sasisha Viambatisho",
+        "submission_export": "Pakua mawasilisho",
+        "restore": "futa kufuta",
+        "purge": "Safisha",
+        "create": "@:audit.action.default.create",
+        "update": "@:audit.action.default.update",
+        "delete": "@:audit.action.default.delete"
+      },
+      "public_link": {
+        "assignment_create": "Peana ufikiaji",
+        "assignment_delete": "Ondoa ufikiaji",
+        "create": "@:audit.action.default.create",
+        "session_end": "@:audit.action.default.session_end",
+        "delete": "@:audit.action.default.delete"
+      },
+      "upgrade": {
+        "process_form": "Chakata Fomu",
+        "process_form_draft": "Rasimu ya fomu ya mchakato"
+      },
+      "user": {
+        "assignment_create": "Panga jukumu",
+        "assignment_delete": "Batilisha jukumu",
+        "delete": "staafu",
+        "create": "@:audit.action.default.create",
+        "update": "@:audit.action.default.update",
+        "session_create": "@:action.logIn"
+      },
+      "project": {
+        "create": "@:audit.action.default.create",
+        "update": "@:audit.action.default.update",
+        "delete": "@:audit.action.default.delete"
+      }
+    }
+  },
+  "action": {
+    "cancel": "Ghairi",
+    "clear": "Safisha",
+    "close": "Funga",
+    "comment": "Maoni",
+    "create": "Unda",
+    "createSubmission": "Mpya",
+    "done": "Imekamilika",
+    "download": "Pakua",
+    "edit": "Hariri",
+    "editProfile": "Hariri wasifu",
+    "logIn": "Ingia",
+    "looksGood": "Inaonekana vizuri, endelea",
+    "more": "Zaidi",
+    "neverMind": "Usijali, ghairi",
+    "next": "Inayofuata",
+    "noCancel": "Hapana, ghairi",
+    "ok": "sawa",
+    "proceed": "Endelea",
+    "refresh": "Onyesha upya",
+    "resetPassword": "Weka upya nenosiri",
+    "review": "hakiki",
+    "save": "hifadhi",
+    "saveSettings": "hifadhi mipangilio",
+    "update": "sasisha",
+    "yesProceed": "Ndio,endelea",
+    "showPreview": "Hakiki",
+    "hidePreview": "Ficha hakiki"
+  },
+  "field": {
+    "comment": "Acha Maoni",
+    "dateRange": "Muda wa tarehe",
+    "displayName": "Onyesha jina",
+    "email": "Barua pepe",
+    "name": "Jina",
+    "newPassword": "Password mpya",
+    "oldPassword": "Password ya zamani",
+    "passphrase": "Nenosiri",
+    "password": "Password",
+    "passwordConfirm": "Password mpya (thibitisha)",
+    "reviewState": "Kagua hali",
+    "type": "Aina"
+  },
+  "header": {
+    "actions": "Vitendo",
+    "created": "Imeundwa",
+    "createdBy": "Imeundwa na",
+    "displayName": "Onyesha jina",
+    "email": "Barua pepe",
+    "instanceId": "Kitambulisho cha Mfano",
+    "lastSubmission": "uwasilishaji wa hivi karibuni",
+    "name": "Jina",
+    "submitterName": "iliyowasilishwa na",
+    "submissionDate": "imewasilishwa kwa",
+    "time": "Muda",
+    "type": "Aina"
+  },
+  "plural": {
+    "appUser": "mtumiaji wa programu | Watumiaji wa programu",
+    "form": "Fomu | Fomu",
+    "project": "Mradi | Miradi",
+    "submission": "Uwasilishaji | Mawasilisho",
+    "webUser": "mtumiaji wa wavuti | watumiaji wa mtandao"
+  },
+  "count": {
+    "appUser": "{count} Mtumiaji wa Programu | {count} Watumiaji wa Programu",
+    "form": "{count} Fomu | {count} Fomu",
+    "submission": "{count} wasilisho | {count} Mawasilisho"
+  },
+  "resource": {
+    "appUser": "mtumiaji wa programu",
+    "appUsers": "watumiaji wa programu",
+    "config": "usanidi wa seva",
+    "form": "Fomu",
+    "forms": "fomu",
+    "project": "Mradi",
+    "projects": "miradi",
+    "publicLink": "Kiungo cha ufikiaji wa umma",
+    "user": "mtumiaji",
+    "users": "Watumiaji",
+    "webUser": "mtumiaji wa wavuti",
+    "webUsers": "watumiaji wa mtandao",
+    "session": "kipindi",
+    "submissions": "mawasilisho",
+    "projectRoles": "majukumu ya mradi"
+  },
+  "alert": {
+    "passwordTooShort": "Tafadhali weka nenosiri lenye urefu wa angalau vibambo 10.",
+    "updateReviewState": "Kagua Jimbo limehifadhiwa!"
+  },
+  "moreInfo": {
+    "clickHere": {
+      "full": "For more information, {clickHere}.",
+      "clickHere": "bonyeza hapa"
+    },
+    "helpArticle": {
+      "full": "Kwa maelezo zaidi, tafadhali angalia {helpArticle}.",
+      "helpArticle": "Makala hii ya msaada"
+    },
+    "learnMore": "Jifunze zaidi"
+  },
+  "analytics": {
+    "alwaysImprove": "Daima tunajaribu kuboresha ODK Central.",
+    "needFeedback": {
+      "full": "Ili kufanya hivi, tunahitaji maoni yako {your}, ili tuweze kuelewa jinsi unavyotumia Central, na jinsi inavyoweza kuwa bora zaidi kwako.",
+      "your": "yako"
+    }
+  },
+  "submission": {
+    "missingMedia": "Vyombo vya habari vinavyokosekana",
+    "action": {
+      "edit": "Hariri ({count})"
+    },
+    "editDisabled": "Huwezi kuhariri mawasilisho yaliyosimbwa kwa njia fiche",
+    "binaryLinkTitle": "Faili iliwasilishwa. Bofya ili kupakua.",
+    "encryptionMessage": "Onyesho la kukagua data halipatikani kwa sababu ya usimbaji fiche"
+  },
+  "common": {
+    "activity": "shughuli",
+    "anybody": "(Mtu yeyote)",
+    "areYouSure": "Je, una uhakika ungependa kuendelea?",
+    "basicInfo": "Taarifa za Msingi",
+    "currentDraft": "Rasimu Yako ya Sasa",
+    "dangerZone": "Eneo la Hatari",
+    "filter": "chujio",
+    "no": "Hapana",
+    "noResults": "Hakuna majibu",
+    "rightNow": "Sasaivi",
+    "success": "Mafanikio!",
+    "system": "mfumo",
+    "yes": "Ndiyo",
+    "tab": {
+      "settings": "mipangilio",
+      "overview": "muhtasari"
+    },
+    "total": "jumla",
+    "lastSubmission": "(mwisho {dateTime})"
+  },
+  "mixin": {
+    "request": {
+      "alert": {
+        "fileSize": "faili \"{name}\" ambayo unajaribu kupakia ni kubwa kuliko kikomo cha MB 100"
+      }
+    }
+  },
+  "presenter": {
+    "Project": {
+      "nameWithArchived": "{name} (iliyohifadhiwa)"
+    }
+  },
+  "util": {
+    "dateTime": {
+      "today": "leo",
+      "yesterday": "jana"
+    },
+    "request": {
+      "noRequest": "Hitilafu fulani imetokea: hakukuwa na ombi.",
+      "noResponse": "Hitilafu fulani imetokea: hakukuwa na jibu kwa ombi lako.",
+      "errorNotProblem": "Hitilafu fulani imetokea: msimbo wa hitilafu {status}."
+    },
+    "session": {
+      "alert": {
+        "expiresSoon": "Muda wa kipindi chako utaisha baada ya dakika 2, na utaondolewa kiotomatiki.",
+        "expired": "Muda wa kipindi chako umeisha. Ili kuendelea kufanya kazi, tafadhali ingia tena.",
+        "logoutError": "Kulikuwa na tatizo, na hukuwa umetoka nje kikamilifu. Tafadhali onyesha upya ukurasa na ujaribu kutoka tena. {message}"
+      }
+    }
+  },
+  "router": {
+    "unsavedChanges": "Je, una uhakika unataka kuondoka kwenye ukurasa huu? Mabadiliko yako huenda yasihifadhiwe."
+  }
+}

--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -13,68 +13,26 @@ import Vue from 'vue';
 
 import i18n, { locales } from '../i18n';
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-// FLATPICKR
-
-// Note that when we load a flatpickr locale, flatpickr itself may or may not be
-// imported yet. Thus, rather than using flatpickr immediately (for example, by
-// calling flatpickr.localize()), we simply store the locale for DateRangePicker
-// to use.
-
-// flatpickrLocales does not have a property for the fallback locale, because
-// DateRangePicker bundles that locale.
-export const flatpickrLocales = {};
-
-const loadFlatpickrLocale = (locale) => {
-  // flatpickr bundles the flatpickr locale for en.
-  if (flatpickrLocales[locale] != null || locale === 'en')
-    return Promise.resolve();
-  return import(
-    /* webpackExclude: /(default|index)\.js$/ */
-    /* webpackChunkName: "flatpickr-locale-[request]" */
-    `flatpickr/dist/l10n/${locale}.js`
-  )
-    .then(m => {
-      flatpickrLocales[locale] = m.default[locale];
-    });
-};
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// loadLocale()
-
-// We bundle the messages for the fallback locale.
-const loaded = new Set([i18n.fallbackLocale]);
-
 const setLocale = (locale) => {
   i18n.locale = locale;
   document.querySelector('html').setAttribute('lang', locale);
 };
 
-const loadMessages = (locale) => {
-  if (i18n.messages[locale] != null) return Promise.resolve();
+// Loads a locale asynchronously.
+export const loadLocale = (locale) => {
+  if (!locales.has(locale)) return Promise.reject(new Error('unknown locale'));
+
+  if (i18n.messages[locale] != null) {
+    if (locale !== i18n.locale) setLocale(locale);
+    return Promise.resolve();
+  }
+
   return import(
     /* webpackChunkName: "i18n-[request]" */
     `../locales/${locale}.json`
   )
     .then(m => {
       i18n.setLocaleMessage(locale, m.default);
-    });
-};
-
-// Loads a locale asynchronously.
-export const loadLocale = (locale) => {
-  if (loaded.has(locale)) {
-    if (locale !== i18n.locale) setLocale(locale);
-    return Promise.resolve();
-  }
-  if (!locales.has(locale)) return Promise.reject();
-  return Promise.all([loadMessages(locale), loadFlatpickrLocale(locale)])
-    .then(() => {
-      loaded.add(locale);
       setLocale(locale);
     })
     .catch(e => {

--- a/test/components/date-range-picker.spec.js
+++ b/test/components/date-range-picker.spec.js
@@ -278,16 +278,21 @@ describe('DateRangePicker', () => {
   });
 
   describe('i18n', () => {
-    it('does not specify a flatpickr locale if the i18n locale is en', () => {
-      should.not.exist(mountComponent().vm.config.locale);
+    afterEach(() => loadLocale('en'));
+
+    it('renders correctly for en', async () => {
+      const component = mountComponent({ attachTo: document.body });
+      await component.get('input').trigger('click');
+      const text = document.querySelector('.flatpickr-weekday').textContent.trim();
+      text.should.equal('Sun');
     });
 
-    it('specifies a flatpickr locale if the i18n locale is es', () =>
-      loadLocale('es')
-        .then(() => {
-          const { locale } = mountComponent().vm.config;
-          locale.weekdays.longhand[0].should.equal('Domingo');
-        })
-        .finally(() => loadLocale('en')));
+    it('renders correctly for es', async () => {
+      await loadLocale('es');
+      const component = mountComponent({ attachTo: document.body });
+      await component.get('input').trigger('click');
+      const text = document.querySelector('.flatpickr-weekday').textContent.trim();
+      text.should.equal('Lun');
+    });
   });
 });

--- a/test/components/date-range-picker.spec.js
+++ b/test/components/date-range-picker.spec.js
@@ -294,5 +294,14 @@ describe('DateRangePicker', () => {
       const text = document.querySelector('.flatpickr-weekday').textContent.trim();
       text.should.equal('Lun');
     });
+
+    // There is not a flatpickr localization for sw.
+    it('renders correctly for sw', async () => {
+      await loadLocale('sw');
+      const component = mountComponent({ attachTo: document.body });
+      await component.get('input').trigger('click');
+      const text = document.querySelector('.flatpickr-weekday').textContent.trim();
+      text.should.equal('Sun');
+    });
   });
 });

--- a/test/unit/i18n.spec.js
+++ b/test/unit/i18n.spec.js
@@ -1,5 +1,6 @@
 import i18n from '../../src/i18n';
-import { flatpickrLocales, loadLocale } from '../../src/util/i18n';
+import { loadLocale } from '../../src/util/i18n';
+
 import { i18nProps } from '../util/i18n';
 
 describe('util/i18n', () => {
@@ -20,13 +21,8 @@ describe('util/i18n', () => {
         document.querySelector('html').getAttribute('lang').should.equal('es');
       }));
 
-    it('loads the flatpickr locale', () =>
-      loadLocale('es').then(() => {
-        flatpickrLocales.es.weekdays.longhand[0].should.equal('Domingo');
-      }));
-
-    it('returns a rejected promise for a locale that is not defined', () =>
-      loadLocale('la').should.be.rejected());
+    it('returns a rejected promise for a locale that is not supported', () =>
+      loadLocale('la').should.be.rejectedWith('unknown locale'));
   });
 
   describe('pluralization rules', () => {

--- a/transifex/strings_sw.json
+++ b/transifex/strings_sw.json
@@ -1,0 +1,3837 @@
+{
+  "title": {
+    "resetPassword": {
+      "string": "Weka upya neno siri",
+      "developer_comment": "This is the text shown as the title of a page including in the browser tab."
+    },
+    "setPassword": {
+      "string": "Weka neno siri",
+      "developer_comment": "This is the text shown as the title of a page including in the browser tab."
+    },
+    "editProfile": {
+      "string": "Hariri Wasifu",
+      "developer_comment": "This is the text shown as the title of a page including in the browser tab."
+    },
+    "download": {
+      "string": "Pakua",
+      "developer_comment": "This is the text shown as the title of a page including in the browser tab."
+    },
+    "pageNotFound": {
+      "string": " Ukurasa Haupatikani",
+      "developer_comment": "This is the text shown as the title of a page including in the browser tab."
+    },
+    "details": {
+      "string": "Maelezo",
+      "developer_comment": "This is the text shown as the title of a page including in the browser tab."
+    }
+  },
+  "projectShow": {
+    "tab": {
+      "formAccess": {
+        "string": "Ufikiaji wa Fomu",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      }
+    }
+  },
+  "formHead": {
+    "tab": {
+      "versions": {
+        "string": "Matoleo",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      },
+      "publicAccess": {
+        "string": "Ufikiaji wa Umma",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      }
+    },
+    "draftNav": {
+      "tab": {
+        "status": {
+          "string": "Hali",
+          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+        },
+        "attachments": {
+          "string": "Faili za media",
+          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+        },
+        "testing": {
+          "string": " Upimaji",
+          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+        }
+      }
+    }
+  },
+  "systemHome": {
+    "title": {
+      "string": "Usimamizi wa mfumo",
+      "developer_comment": "This is the title of the page for managing backups, audit logs, and other system-level functions."
+    },
+    "tab": {
+      "backups": {
+        "string": "Hifadhi rudufu",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      },
+      "audits": {
+        "string": "Kumbukumbu za ukaguzi wa seva",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      },
+      "analytics": {
+        "string": "Ripoti ya matumizi",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      }
+    }
+  },
+  "role": {
+    "none": {
+      "string": "Hakuna",
+      "developer_comment": "This is shown when a user does not have a Role."
+    },
+    "admin": {
+      "string": "Msimamizi",
+      "developer_comment": "This is the name of a user Role."
+    },
+    "manager": {
+      "string": "Meneja wa mradi",
+      "developer_comment": "This is the name of a user Role."
+    },
+    "viewer": {
+      "string": "Mtazamaji wa mradi",
+      "developer_comment": "This is the name of a user Role."
+    },
+    "formfill": {
+      "string": "Mkusanyaji wa data",
+      "developer_comment": "This is the name of a user Role."
+    }
+  },
+  "formState": {
+    "open": {
+      "string": "Fungua",
+      "developer_comment": "Form States control the lifecycle state of each Form. \"Open\" is one Form State."
+    },
+    "closing": {
+      "string": "Kufunga",
+      "developer_comment": "Form States control the lifecycle state of each Form. \"Closing\" is one Form State."
+    },
+    "closed": {
+      "string": "imefungwa",
+      "developer_comment": "Form States control the lifecycle state of each Form. \"Closed\" is one Form State."
+    }
+  },
+  "reviewState": {
+    "received": {
+      "string": "Imepokelewa",
+      "developer_comment": "This is a possible Review State for a Submission."
+    },
+    "hasIssues": {
+      "string": "Ina masuala",
+      "developer_comment": "This is a possible Review State for a Submission."
+    },
+    "edited": {
+      "string": "Imehaririwa",
+      "developer_comment": "This is a possible Review State for a Submission."
+    },
+    "approved": {
+      "string": "Imeidhinishwa",
+      "developer_comment": "This is a possible Review State for a Submission."
+    },
+    "rejected": {
+      "string": "Imekataliwa",
+      "developer_comment": "This is a possible Review State for a Submission."
+    }
+  },
+  "audit": {
+    "category": {
+      "nonverbose": {
+        "string": "vitendo vyote",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "user": {
+        "string": "vitendo vya mtumiaji wa wavuti",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "project": {
+        "string": "hatua za mradi",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "form": {
+        "string": "Vitendo vya fomu",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "field_key": {
+        "string": "Vitendo vya mtumiaji wa programu",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "public_link": {
+        "string": "vitendo vya kiungo cha ufikiaji wa umma",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "config": {
+        "string": "vitendo vya usanidi wa seva",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
+      "upgrade": {
+        "string": "uboreshaji wa seva",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      }
+    },
+    "action": {
+      "default": {
+        "create": {
+          "string": "Unda",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action."
+        },
+        "update": {
+          "string": "sasisha maelezo",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action."
+        },
+        "session_end": {
+          "string": "batilisha",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action."
+        },
+        "delete": {
+          "string": "kufuta",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action."
+        }
+      },
+      "analytics": {
+        "string": "Ripoti matumizi",
+        "developer_comment": "This is shown in the log of actions performed on the server."
+      },
+      "backup": {
+        "string": "Hifadhi nakala",
+        "developer_comment": "This is shown in the log of actions performed on the server."
+      },
+      "config": {
+        "set": {
+          "string": "weka",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Server Configuration."
+        }
+      },
+      "field_key": {
+        "assignment_create": {
+          "string": "kutoa ufikiaji",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on an App User."
+        },
+        "assignment_delete": {
+          "string": "Ondoa ufikiaji",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on an App User."
+        }
+      },
+      "form": {
+        "update_draft_set": {
+          "string": "Unda rasimu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        },
+        "update_publish": {
+          "string": "Chapisha rasimu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        },
+        "update_draft_delete": {
+          "string": "Acha rasimu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        },
+        "attachment_update": {
+          "string": "Sasisha Viambatisho",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        },
+        "submission_export": {
+          "string": "Pakua mawasilisho",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        },
+        "restore": {
+          "string": "futa kufuta",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        },
+        "purge": {
+          "string": "Safisha",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Form."
+        }
+      },
+      "public_link": {
+        "assignment_create": {
+          "string": "Peana ufikiaji",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Public Access Link."
+        },
+        "assignment_delete": {
+          "string": "Ondoa ufikiaji",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Public Access Link."
+        }
+      },
+      "upgrade": {
+        "process_form": {
+          "string": " Chakata Fomu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that the server performs when it is upgraded."
+        },
+        "process_form_draft": {
+          "string": "Rasimu ya fomu ya mchakato",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that the server performs when it is upgraded."
+        }
+      },
+      "user": {
+        "assignment_create": {
+          "string": "Panga jukumu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on or for a Web User."
+        },
+        "assignment_delete": {
+          "string": "Batilisha jukumu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on or for a Web User."
+        },
+        "delete": {
+          "string": "staafu",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on or for a Web User."
+        }
+      }
+    }
+  },
+  "action": {
+    "cancel": {
+      "string": "Ghairi",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "clear": {
+      "string": "Safisha",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "close": {
+      "string": "Funga",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "comment": {
+      "string": "Maoni",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "create": {
+      "string": "Unda",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "createSubmission": {
+      "string": "Mpya",
+      "developer_comment": "This is the text of a button that is used to fill out a new Submission. It is shown next to a heading whose text is \"Submissions\"."
+    },
+    "done": {
+      "string": "Imekamilika",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "download": {
+      "string": "Pakua",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "edit": {
+      "string": "Hariri",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "editProfile": {
+      "string": "Hariri wasifu",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "logIn": {
+      "string": "Ingia",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "looksGood": {
+      "string": "Inaonekana vizuri, endelea",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "more": {
+      "string": "Zaidi",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "neverMind": {
+      "string": "Usijali, ghairi",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "next": {
+      "string": "Inayofuata",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "noCancel": {
+      "string": "Hapana, ghairi",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "ok": {
+      "string": "sawa",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "proceed": {
+      "string": "Endelea",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "refresh": {
+      "string": "Onyesha upya",
+      "developer_comment": "This is the text of a button that refreshes data."
+    },
+    "resetPassword": {
+      "string": "Weka upya nenosiri",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "review": {
+      "string": "hakiki",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "save": {
+      "string": "hifadhi",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "saveSettings": {
+      "string": "hifadhi mipangilio",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "update": {
+      "string": "sasisha",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "yesProceed": {
+      "string": "Ndio,endelea",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
+    "showPreview": {
+      "string": "Hakiki",
+      "developer_comment": "This text is shown on a button that the user clicks to show a preview of something"
+    },
+    "hidePreview": {
+      "string": "Ficha hakiki",
+      "developer_comment": "This text is shown on a button that the user clicks to hide a preview of something"
+    }
+  },
+  "field": {
+    "comment": {
+      "string": "Acha Maoni",
+      "developer_comment": "This is the text of a form field."
+    },
+    "dateRange": {
+      "string": "Muda wa tarehe",
+      "developer_comment": "This is the text of a form field."
+    },
+    "displayName": {
+      "string": " Onyesha jina",
+      "developer_comment": "This is the text of a form field."
+    },
+    "email": {
+      "string": "Barua pepe",
+      "developer_comment": "This is the text of a form field."
+    },
+    "name": {
+      "string": "Jina",
+      "developer_comment": "This is the text of a form field."
+    },
+    "newPassword": {
+      "string": "Password mpya",
+      "developer_comment": "This is the text of a form field."
+    },
+    "oldPassword": {
+      "string": "Password ya zamani",
+      "developer_comment": "This is the text of a form field."
+    },
+    "passphrase": {
+      "string": " Nenosiri",
+      "developer_comment": "This is the text of a form field."
+    },
+    "password": {
+      "string": "Password",
+      "developer_comment": "This is the text of a form field."
+    },
+    "passwordConfirm": {
+      "string": "Password mpya (thibitisha)",
+      "developer_comment": "This is the text of a form field."
+    },
+    "reviewState": {
+      "string": "Kagua hali",
+      "developer_comment": "This is the text of a form field."
+    },
+    "type": {
+      "string": "Aina",
+      "developer_comment": "This is the text of a form field."
+    }
+  },
+  "header": {
+    "actions": {
+      "string": "Vitendo",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "created": {
+      "string": "Imeundwa",
+      "developer_comment": "This is the text of a table column header. The column shows who created the resource and possibly also when they did so."
+    },
+    "createdBy": {
+      "string": "Imeundwa na",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "displayName": {
+      "string": "Onyesha jina",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "email": {
+      "string": "Barua pepe",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "instanceId": {
+      "string": "Kitambulisho cha Mfano",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "lastSubmission": {
+      "string": "uwasilishaji wa hivi karibuni",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "name": {
+      "string": "Jina",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "submitterName": {
+      "string": "iliyowasilishwa na",
+      "developer_comment": "This is the text of a table column header."
+    },
+    "submissionDate": {
+      "string": "imewasilishwa kwa",
+      "developer_comment": "This is the text of a table column header. The column indicates when each Submission was submitted."
+    },
+    "time": {
+      "string": "Muda",
+      "developer_comment": "This is the text of a table column header for a column that shows dates and times."
+    },
+    "type": {
+      "string": "Aina",
+      "developer_comment": "This is the text of a table column header."
+    }
+  },
+  "plural": {
+    "appUser": {
+      "string": "{count, plural, one {mtumiaji wa programu} other {Watumiaji wa programu}}"
+    },
+    "form": {
+      "string": "{count, plural, one {Fomu} other {Fomu}}"
+    },
+    "project": {
+      "string": "{count, plural, one {Mradi} other {Miradi}}"
+    },
+    "submission": {
+      "string": "{count, plural, one {Uwasilishaji} other {Mawasilisho}}"
+    },
+    "webUser": {
+      "string": "{count, plural, one {mtumiaji wa wavuti} other {watumiaji wa mtandao}}"
+    }
+  },
+  "count": {
+    "appUser": {
+      "string": "{count, plural, one {{count} Mtumiaji wa Programu} other {{count} Watumiaji wa Programu}}",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence."
+    },
+    "form": {
+      "string": "{count, plural, one {{count} Fomu} other {{count} Fomu}}",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence."
+    },
+    "submission": {
+      "string": "{count, plural, one {{count} wasilisho} other {{count} Mawasilisho}}",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence."
+    }
+  },
+  "resource": {
+    "appUser": {
+      "string": "mtumiaji wa programu",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "appUsers": {
+      "string": "watumiaji wa programu",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "config": {
+      "string": "usanidi wa seva",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "form": {
+      "string": "Fomu",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "forms": {
+      "string": "fomu",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "project": {
+      "string": "Mradi",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "projects": {
+      "string": "miradi",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "publicLink": {
+      "string": "Kiungo cha ufikiaji wa umma",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "user": {
+      "string": "mtumiaji",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "users": {
+      "string": "Watumiaji",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "webUser": {
+      "string": "mtumiaji wa wavuti",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "webUsers": {
+      "string": "watumiaji wa mtandao",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "session": {
+      "string": "kipindi",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "submissions": {
+      "string": "mawasilisho",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "projectRoles": {
+      "string": "majukumu ya mradi",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    }
+  },
+  "alert": {
+    "passwordTooShort": {
+      "string": "Tafadhali weka nenosiri lenye urefu wa angalau vibambo 10."
+    },
+    "updateReviewState": {
+      "string": "Kagua Jimbo limehifadhiwa!"
+    }
+  },
+  "moreInfo": {
+    "clickHere": {
+      "full": {
+        "string": "For more information, {clickHere}.",
+        "developer_comment": "{clickHere} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nclick here"
+      },
+      "clickHere": {
+        "string": "bonyeza hapa",
+        "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {clickHere} is in the following text:\n\nFor more information, {clickHere}."
+      }
+    },
+    "helpArticle": {
+      "full": {
+        "string": "Kwa maelezo zaidi, tafadhali angalia {helpArticle}.",
+        "developer_comment": "{helpArticle} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthis help article"
+      },
+      "helpArticle": {
+        "string": "Makala hii ya msaada",
+        "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {helpArticle} is in the following text:\n\nFor more information, please see {helpArticle}."
+      }
+    },
+    "learnMore": {
+      "string": "Jifunze zaidi",
+      "developer_comment": "This is a link to more information."
+    }
+  },
+  "analytics": {
+    "alwaysImprove": {
+      "string": "Daima tunajaribu kuboresha ODK Central."
+    },
+    "needFeedback": {
+      "full": {
+        "string": "Ili kufanya hivi, tunahitaji maoni yako  {your}, ili tuweze kuelewa jinsi unavyotumia Central, na jinsi inavyoweza kuwa bora zaidi kwako.",
+        "developer_comment": "\"This\" refers to improving Central.\n\n{your} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nyour"
+      },
+      "your": {
+        "string": "yako",
+        "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {your} is in the following text:\n\nTo do this, we need {your} feedback, so that we can understand how you are using Central, and how it could be better for you."
+      }
+    }
+  },
+  "submission": {
+    "missingMedia": {
+      "string": "Vyombo vya habari vinavyokosekana",
+      "developer_comment": "This is a possible state for a Submission."
+    },
+    "action": {
+      "edit": {
+        "string": "Hariri ({count})",
+        "developer_comment": "{count} is the number of previous edits."
+      }
+    },
+    "editDisabled": {
+      "string": "Huwezi kuhariri mawasilisho yaliyosimbwa kwa njia fiche",
+      "developer_comment": "This is shown when the Edit button is disabled."
+    },
+    "binaryLinkTitle": {
+      "string": "Faili iliwasilishwa. Bofya ili kupakua."
+    },
+    "encryptionMessage": {
+      "string": "Onyesho la kukagua data halipatikani kwa sababu ya usimbaji fiche"
+    }
+  },
+  "common": {
+    "activity": {
+      "string": "shughuli",
+      "developer_comment": "This is a title shown above a section of the page."
+    },
+    "anybody": {
+      "string": "(Mtu yeyote)",
+      "developer_comment": "This is shown in a dropdown that allows the user to filter to only show data for particular users."
+    },
+    "areYouSure": {
+      "string": "Je, una uhakika ungependa kuendelea?",
+      "developer_comment": "Here we ask the user to confirm that they wish to complete an action that they have initiated."
+    },
+    "basicInfo": {
+      "string": "Taarifa za Msingi",
+      "developer_comment": "This is a title shown above a section of the page."
+    },
+    "currentDraft": {
+      "string": "Rasimu Yako ya Sasa",
+      "developer_comment": "This is a title shown above a section of the page."
+    },
+    "dangerZone": {
+      "string": "Eneo la Hatari",
+      "developer_comment": "This is a title shown above a section of the page."
+    },
+    "filter": {
+      "string": "chujio",
+      "developer_comment": "This text is shown next to options for filtering a table."
+    },
+    "no": {
+      "string": "Hapana"
+    },
+    "noResults": {
+      "string": "Hakuna majibu",
+      "developer_comment": "This is shown if a search returned no results."
+    },
+    "rightNow": {
+      "string": "Sasaivi",
+      "developer_comment": "This is the title of a section that shows status information for the entire server such as project count."
+    },
+    "success": {
+      "string": "Mafanikio!"
+    },
+    "system": {
+      "string": "mfumo",
+      "developer_comment": "\"System\" refers to the server and how it is configured. It may be shown as a title, for example, at the top of the page."
+    },
+    "yes": {
+      "string": "Ndiyo"
+    },
+    "tab": {
+      "settings": {
+        "string": "mipangilio",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      },
+      "overview": {
+        "string": "muhtasari",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      }
+    },
+    "total": {
+      "string": "jumla"
+    },
+    "lastSubmission": {
+      "string": "(mwisho {dateTime})",
+      "developer_comment": "This text shows when the last Submission was received. {dateTime} shows the date and time, for example: \"2020/01/01 01:23\". It may show a formatted date like \"2020/01/01\", or it may use a word like \"today\", \"yesterday\", or \"Sunday\"."
+    }
+  },
+  "mixin": {
+    "request": {
+      "alert": {
+        "fileSize": {
+          "string": "faili \"{name}\" ambayo unajaribu kupakia ni kubwa kuliko kikomo cha MB 100"
+        }
+      }
+    }
+  },
+  "presenter": {
+    "Project": {
+      "nameWithArchived": {
+        "string": "{name} (iliyohifadhiwa)",
+        "developer_comment": "{name} is the name of a Project. We append \"(archived)\" to the name if the Project is archived."
+      }
+    }
+  },
+  "util": {
+    "dateTime": {
+      "today": {
+        "string": "leo",
+        "developer_comment": "This will be part of a longer string that shows the date and time, for example: \"today 01:23\". The string may appear on its own or be part of a sentence."
+      },
+      "yesterday": {
+        "string": "jana",
+        "developer_comment": "This will be part of a longer string that shows the date and time, for example: \"yesterday 01:23\". The string may appear on its own or be part of a sentence."
+      }
+    },
+    "request": {
+      "noRequest": {
+        "string": "Hitilafu fulani imetokea: hakukuwa na ombi."
+      },
+      "noResponse": {
+        "string": "Hitilafu fulani imetokea: hakukuwa na jibu kwa ombi lako."
+      },
+      "errorNotProblem": {
+        "string": "Hitilafu fulani imetokea: msimbo wa hitilafu {status}.",
+        "developer_comment": "{status} is an HTTP status code, for example, 404."
+      }
+    },
+    "session": {
+      "alert": {
+        "expiresSoon": {
+          "string": "Muda wa kipindi chako utaisha baada ya dakika 2, na utaondolewa kiotomatiki."
+        },
+        "expired": {
+          "string": "Muda wa kipindi chako umeisha. Ili kuendelea kufanya kazi, tafadhali ingia tena."
+        },
+        "logoutError": {
+          "string": "Kulikuwa na tatizo, na hukuwa umetoka nje kikamilifu. Tafadhali onyesha upya ukurasa na ujaribu kutoka tena. {message}",
+          "developer_comment": "{message} is a more detailed error message."
+        }
+      }
+    }
+  },
+  "router": {
+    "unsavedChanges": {
+      "string": "Je, una uhakika unataka kuondoka kwenye ukurasa huu? Mabadiliko yako huenda yasihifadhiwe."
+    }
+  },
+  "component": {
+    "AccountClaim": {
+      "action": {
+        "set": {
+          "string": "Weka nenosiri",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "problem": {
+        "401_2": {
+          "string": "{message} Huenda muda wa kiungo katika barua pepe yako umeisha, na huenda barua pepe mpya ikatumwa.",
+          "developer_comment": "{message} is an error message from the server."
+        }
+      },
+      "alert": {
+        "success": {
+          "string": "Nenosiri limewekwa upya."
+        }
+      }
+    },
+    "AccountLogin": {
+      "alert": {
+        "alreadyLoggedIn": {
+          "string": "Mtumiaji tayari ameingia. Tafadhali onyesha upya ukurasa ili kuendelea."
+        },
+        "changePassword": {
+          "string": "Nenosiri lako ni fupi kuliko vibambo 10. Ili kulinda akaunti yako, tafadhali badilisha nenosiri lako ili kuifanya iwe ndefu."
+        }
+      },
+      "problem": {
+        "401_2": {
+          "string": "Anwani ya barua pepe na/au nenosiri si sahihi."
+        }
+      }
+    },
+    "AccountResetPassword": {
+      "alert": {
+        "success": {
+          "string": "Barua pepe imetumwa kwa {email} ikiwa na maagizo zaidi."
+        }
+      }
+    },
+    "AnalyticsForm": {
+      "enabled": {
+        "null": {
+          "0": {
+            "string": "Tukumbushe baadaye"
+          },
+          "1": {
+            "string": "Wasimamizi wataendelea kuona ujumbe juu ya skrini"
+          }
+        },
+        "true": {
+          "0": {
+            "full": {
+              "string": "{weWillShare} na tunakubali {termsOfService} na {privacyPolicy}.",
+              "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {weWillShare} has the text: We are willing to share anonymous usage data monthly with the Central team,\n- {termsOfService} has the text: Terms of Service\n- {privacyPolicy} has the text: Privacy Policy"
+            },
+            "weWillShare": {
+              "string": "Tuko tayari kushiriki data ya matumizi isiyojulikana kila mwezi na timu ya Kati",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {weWillShare} is in the following text:\n\n{weWillShare} and we accept the {termsOfService} and {privacyPolicy}."
+            },
+            "termsOfService": {
+              "string": "Masharti ya Huduma",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {termsOfService} is in the following text:\n\n{weWillShare} and we accept the {termsOfService} and {privacyPolicy}."
+            },
+            "privacyPolicy": {
+              "string": "Sera ya Faragha",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {privacyPolicy} is in the following text:\n\n{weWillShare} and we accept the {termsOfService} and {privacyPolicy}."
+            }
+          },
+          "1": {
+            "string": "Ni vipimo gani vinatumwa?"
+          }
+        },
+        "false": {
+          "0": {
+            "string": "Hatutashiriki habari yoyote."
+          },
+          "1": {
+            "string": "hutaona kikumbusho kuhusu hili tena"
+          }
+        }
+      },
+      "contact": {
+        "0": {
+          "string": "Niko tayari kujumuisha maelezo yangu ya mawasiliano na ripoti"
+        },
+        "1": {
+          "string": "Tunaweza kuwasiliana nawe ili kupata maelezo zaidi kuhusu matumizi yako ya Central"
+        }
+      },
+      "field": {
+        "workEmail": {
+          "string": "Anwani ya barua pepe ya kazini",
+          "developer_comment": "This is the text of a form field."
+        },
+        "organization": {
+          "string": "Jina la shirika",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "alert": {
+        "success": {
+          "string": "Mipangilio imehifadhiwa!"
+        }
+      }
+    },
+    "AnalyticsIntroduction": {
+      "title": {
+        "string": "Saidia Kuboresha Central!",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "full": {
+            "string": "Katika kichupo cha {usageReporting} katika Mipangilio ya Mfumo, unaweza kuchagua kushiriki data ya matumizi isiyojulikana au maelezo ya mawasiliano na timu ya Kati.",
+            "developer_comment": "{usageReporting} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nUsage Reporting"
+          },
+          "usageReporting": {
+            "string": "Ripoti ya Matumizi",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {usageReporting} is in the following text:\n\nIn the {usageReporting} tab in System Settings, you can choose to share anonymized usage data or contact information with the Central team."
+          }
+        },
+        "1": {
+          "string": "Huko, unaweza pia kuchagua kutouona ujumbe huu tena"
+        }
+      },
+      "action": {
+        "improveCentral": {
+          "string": "Boresha Central",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      }
+    },
+    "AnalyticsList": {
+      "heading": {
+        "0": {
+          "string": "Hapo chini, unaweza kuchagua kama seva hii ya Central itashiriki maelezo ya matumizi yasiyokutambulisha na timu ya Central. Mpangilio huu unaathiri seva nzima"
+        }
+      },
+      "auditsTitle": {
+        "string": "Ripoti za Matumizi ya Hivi Punde",
+        "developer_comment": "This is a title shown above a section of the page."
+      }
+    },
+    "AnalyticsMetricsTable": {
+      "recent": {
+        "string": "katika siku 45 zilizopita"
+      },
+      "fields": {
+        "num_admins": {
+          "string": "Idadi ya Wasimamizi"
+        },
+        "num_projects_encryption": {
+          "string": "Idadi ya Miradi ambayo usimbaji fiche umewezeshwa"
+        },
+        "num_questions_biggest_form": {
+          "string": "Idadi ya maswali katika kidato kikubwa zaidi"
+        },
+        "num_audit_log_entries": {
+          "string": "Idadi ya maingizo ya Kumbukumbu ya Ukaguzi"
+        },
+        "backups_configured": {
+          "string": "Hifadhi rudufu zilizosanidiwa"
+        },
+        "database_size": {
+          "string": "Saizi ya hifadhidata ya mfumo"
+        },
+        "num_managers": {
+          "string": "Idadi ya wasimamizi wa miradi"
+        },
+        "num_viewers": {
+          "string": "Idadi ya watazamaji wa mradi"
+        },
+        "num_data_collectors": {
+          "string": "Idadi ya wakusanyaji data"
+        },
+        "num_app_users": {
+          "string": "Idadi ya watumiaji wa programu"
+        },
+        "num_device_ids": {
+          "string": "Idadi ya vitambulisho vya kifaa"
+        },
+        "num_public_access_links": {
+          "string": "Idadi ya viungo vya ufikiaji wa umma"
+        },
+        "num_forms": {
+          "string": "Idadi ya Fomu"
+        },
+        "num_forms_with_repeats": {
+          "string": "Idadi ya Fomu zilizo na marudio"
+        },
+        "num_forms_with_geospatial": {
+          "string": "Idadi ya Fomu zilizo na jiografia"
+        },
+        "num_forms_with_encryption": {
+          "string": "Idadi ya Fomu zilizo na usimbaji fiche"
+        },
+        "num_forms_with_audits": {
+          "string": "Idadi ya Fomu zilizo na ukaguzi\n "
+        },
+        "num_submissions_received": {
+          "string": "Idadi ya Mawasilisho - Yaliyopokelewa"
+        },
+        "num_submissions_approved": {
+          "string": "Idadi ya Mawasilisho - Yameidhinishwa"
+        },
+        "num_submissions_has_issues": {
+          "string": "Idadi ya Mawasilisho - Ina Masuala"
+        },
+        "num_submissions_rejected": {
+          "string": "Idadi ya Mawasilisho - Yamekataliwa"
+        },
+        "num_submissions_edited": {
+          "string": "Idadi ya Mawasilisho - Yaliyohaririwa"
+        },
+        "num_submissions_with_edits": {
+          "string": "Idadi ya Mawasilisho yenye mabadiliko"
+        },
+        "num_submissions_with_comments": {
+          "string": "Idadi ya Mawasilisho yenye maoni"
+        },
+        "num_submissions_from_app_users": {
+          "string": "Idadi ya Mawasilisho kutoka kwa Watumiaji wa Programu"
+        },
+        "num_submissions_from_public_links": {
+          "string": "Idadi ya Mawasilisho kutoka kwa Viungo vya Umma"
+        },
+        "num_submissions_from_web_users": {
+          "string": "Idadi ya Mawasilisho kutoka kwa Watumiaji wa Wavuti"
+        }
+      }
+    },
+    "AnalyticsPreview": {
+      "title": {
+        "string": "Ripoti ya Matumizi Isiyojulikana",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Asante kwa kufikiria kutuma habari ya matumizi. Data hii itatusaidia kutanguliza mahitaji yako!"
+        },
+        "1": {
+          "string": "Inayoonyeshwa hapa ni ripoti tunayokusanya kwa sasa. Ili kukabiliana na vipengele na mahitaji mapya, wakati mwingine tutabadilisha kile kinachoripotiwa, lakini tutawahi tu kukusanya wastani wa muhtasari kama unavyoona hapa."
+        },
+        "2": {
+          "string": "Unaweza kuja hapa kila wakati ili kuona kile kinachokusanywa."
+        }
+      },
+      "projects": {
+        "title": {
+          "string": "Muhtasari wa Mradi",
+          "developer_comment": "This is the title shown above a series of metrics about Project usage."
+        },
+        "subtitle": {
+          "string": "{count, plural, one {(Inaonyesha Mradi amilifu zaidi wa Mradi ya {count})} other {(Inaonyesha Mradi amilifu zaidi wa Miradi ya {count})}}"
+        }
+      },
+      "submissionStates": {
+        "string": "Nchi za Uwasilishaji",
+        "developer_comment": "This is the title of a single table in the analytics metrics report of metrics about submission state (approved, rejected, etc)"
+      }
+    },
+    "App": {
+      "alert": {
+        "versionChange": {
+          "string": "Seva imesasishwa. Tafadhali onyesha upya ukurasa ili kuepuka yasiyotabirika."
+        }
+      }
+    },
+    "AsyncRoute": {
+      "alert": {
+        "loadError": {
+          "string": "ukurasa ulioomba haukuweza kupakiwa. Tafadhali onyesha upya ukurasa na ujaribu tena"
+        }
+      }
+    },
+    "AuditList": {
+      "heading": {
+        "0": {
+          "string": "Hapa utapata logi ya vitendo muhimu vilivyofanywa kwenye seva hii. Mabadiliko yaliyofanywa kwa mipangilio ya mtumiaji, Mradi, au Fomu yanaweza kupatikana hapa."
+        }
+      },
+      "emptyTable": {
+        "string": "Hakuna maingizo ya kumbukumbu ya ukaguzi yanayolingana"
+      }
+    },
+    "AuditRow": {
+      "deletedMessage": {
+        "string": "Rasimali hii imefutwa",
+        "developer_comment": "This shows as a tool tip in the audit log explaining that a resource has been deleted."
+      },
+      "purgedMessage": {
+        "string": "Rasilimali hii imesafishwa.",
+        "developer_comment": "This shows as a tool tip in the audit log explaining that a resource has been purged (deleted forever)."
+      }
+    },
+    "AuditTable": {
+      "header": {
+        "initiator": {
+          "string": "Mwanzilishi",
+          "developer_comment": "This is the text of a table column header."
+        },
+        "target": {
+          "string": "Lengo",
+          "developer_comment": "This is the text of a table column header."
+        },
+        "details": {
+          "string": "Maelezo",
+          "developer_comment": "This is the text of a table column header."
+        }
+      }
+    },
+    "BackupList": {
+      "auditsTitle": {
+        "string": "Hifadhi Nakala za Hivi Punde",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "alert": {
+        "create": {
+          "string": "Mafanikio! Hifadhi rudufu za kiotomatiki sasa zimesanidiwa."
+        },
+        "terminate": {
+          "string": "Nakala zako za kiotomatiki zimekatishwa. Inapendekezwa kuwa usanidi mpya haraka iwezekanavyo"
+        }
+      }
+    },
+    "BackupNew": {
+      "title": {
+        "string": "Sanidi Hifadhi Nakala",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "steps": {
+        "0": {
+          "warning": {
+            "full": {
+              "string": "Hifadhi rudufu hii kwa sasa haijumuishi viungo vya Fomu ya Wavuti. Ukishiriki Viungo vya Ufikiaji wa Umma au kuunganisha kwa nje moja kwa moja kwa Fomu za Wavuti kwa ajili ya kufanya Mawasilisho mapya, tunapendekeza kwa dhati kwamba ufanye hifadhi kamili ya mfumo hadi hili lishughulikiwe. Iwapo itabidi urejeshe kutoka kwa nakala na uishie na viungo vilivyovunjika vya Onyesho la Kuchungulia, tafadhali ichapishe kwenye {forum} ili upate usaidizi.",
+              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
+            },
+            "forum": {
+              "string": "jukwaa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
+            }
+          },
+          "introduction": {
+            "0": {
+              "string": "Ukipenda, unaweza kusanidi kaulisiri ya usimbaji ambayo lazima itumike kufungua nakala rudufu."
+            },
+            "1": {
+              "string": "Hakuna njia ya kurejesha kaulisiri ikiwa utaipoteza!"
+            },
+            "2": {
+              "string": "Hakikisha umechagua kitu ambacho utakumbuka, au uandike mahali salama"
+            }
+          }
+        },
+        "1": {
+          "introduction": {
+            "0": {
+              "full": {
+                "string": "Kwa usalama, seva hutuma data yako kwenye Hifadhi ya Google. Unaweza kujiandikisha kwa akaunti isiyolipishwa {here}",
+                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
+              },
+              "here": {
+                "string": "hapa",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
+              }
+            },
+            "1": {
+              "string": "Unapobofya inayofuata, Google itathibitisha kwamba ungependa kuruhusu seva kufikia akaunti yako. Kitu pekee ambacho seva itaruhusiwa kugusa ni faili za chelezo inazounda"
+            },
+            "2": {
+              "string": "Ukishathibitisha hili, utaombwa kunakili na kubandika maandishi hapa nyuma."
+            }
+          }
+        },
+        "2": {
+          "introduction": {
+            "0": {
+              "full": {
+                "string": "Karibu tena! Je, umepata maandishi ya kunakili na kubandika? Ikiwa sivyo, bofya {here} ili kujaribu tena.",
+                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
+              },
+              "here": {
+                "string": "hapa",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
+              }
+            },
+            "1": {
+              "string": "Vinginevyo, bandika hapa chini na umemaliza!"
+            }
+          }
+        }
+      },
+      "field": {
+        "passphrase": {
+          "string": "Nenosiri (hiari)",
+          "developer_comment": "This is the text of a form field."
+        },
+        "confirmationText": {
+          "string": "Maandishi ya uthibitisho",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "problem": {
+        "verify": {
+          "string": "Tafadhali jaribu tena, na uende kwenye jamii forum tatizo likiendelea."
+        }
+      }
+    },
+    "BackupStatus": {
+      "getHelp": {
+        "full": {
+          "string": "Ikiwa unatatizika, tafadhali jaribu {forum}.",
+          "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ncommunity forum"
+        },
+        "forum": {
+          "string": "jamii forum",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nIf you are having trouble, please try the {forum}."
+        }
+      },
+      "notConfigured": {
+        "0": {
+          "string": "Hifadhi rudufu hazijasanidiwa."
+        },
+        "1": {
+          "string": "Seva ya data haijawekwa ili kuhifadhi nakala kiotomatiki data yake popote pale."
+        },
+        "2": {
+          "full": {
+            "string": "Isipokuwa umeweka aina nyingine ya kuhifadhi nakala ya data ambayo seva haijui, {recommended} ufanye hivi sasa. Ikiwa huna uhakika, ni bora kufanya hivyo ili tu kuwa salama.",
+            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
+          },
+          "recommended": {
+            "string": "inapendekezwa sana",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
+          }
+        },
+        "3": {
+          "string": "Hifadhi rudufu za data otomatiki hufanyika kupitia mfumo huu mara moja kwa siku. Data yako yote imesimbwa kwa njia fiche kwa nenosiri ulilotoa ili wewe tu uweze kulifungua."
+        }
+      },
+      "neverRun": {
+        "0": {
+          "string": "Hifadhi rudufu iliyosanidiwa bado haijatekelezwa"
+        },
+        "1": {
+          "string": "Ikiwa umesanidi nakala rudufu ndani ya siku chache zilizopita, hii ni kawaida. Vinginevyo, kitu kimeenda vibaya."
+        },
+        "2": {
+          "full": {
+            "string": "Katika hali hiyo, marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma.",
+            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
+          },
+          "terminate": {
+            "string": "sitisha",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
+          }
+        }
+      },
+      "somethingWentWrong": {
+        "0": {
+          "string": "Kuna kitu hakiko sawa"
+        },
+        "1": {
+          "full": {
+            "string": "Hifadhi rudufu ya hivi punde iliyokamilika kwa ufanisi ilikuwa {moreThanThreeDaysAgo}.",
+            "developer_comment": "{moreThanThreeDaysAgo} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nmore than three days ago"
+          },
+          "moreThanThreeDaysAgo": {
+            "string": "zaidi ya siku tatu zilizopita",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {moreThanThreeDaysAgo} is in the following text:\n\nThe latest backup that completed successfully was {moreThanThreeDaysAgo}."
+          }
+        },
+        "2": {
+          "full": {
+            "string": "Marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma",
+            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
+          },
+          "terminate": {
+            "string": "sitisha",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
+          }
+        }
+      },
+      "success": {
+        "0": {
+          "string": "Hifadhi rudufu inafanya kazi.",
+          "developer_comment": "This text is displayed if the latest backup attempt was successful. It indicates that the backup process is working."
+        },
+        "1": {
+          "string": "Hifadhi rudufu ya mwisho ilikamilika {dateTime}.",
+          "developer_comment": "{dateTime} shows the date and time at which the last backup completed, for example: \"2020/01/01 01:23\". It may show a formatted date like \"2020/01/01\", or it may use a word like \"today\", \"yesterday\", or \"Sunday\". {dateTime} is formatted in bold."
+        }
+      },
+      "action": {
+        "setUp": {
+          "string": "Sanidi sasa",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        },
+        "download": {
+          "string": "Pakua nakala rudufu sasa",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        },
+        "terminate": {
+          "string": "Sitisha",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "alert": {
+        "download": {
+          "string": "Hifadhi rudufu inaendelea sasa, na itasimbwa kwa njia fiche na kupakuliwa kwenye kompyuta yako. Hii inaweza kuchukua muda. Mara tu upakuaji unapoanza, unaweza kuondoka kwenye ukurasa huu."
+        }
+      }
+    },
+    "BackupTerminate": {
+      "title": {
+        "string": "Sitisha Hifadhi Nakala za Kiotomatiki",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Je, una uhakika kuwa ungependa kusitisha hifadhi rudufu zako otomatiki?"
+        },
+        "1": {
+          "string": "Utalazimika kuzisanidi tena kutoka mwanzo ili kuzianzisha tena, na kitendo hiki hakiwezi kutenduliwa"
+        }
+      }
+    },
+    "Download": {
+      "body": {
+        "string": "{filename} itaanza kupakuliwa hivi karibuni. Mara tu upakuaji unapoanza, unaweza kuondoka kwenye ukurasa huu"
+      }
+    },
+    "EnketoFill": {
+      "disabled": {
+        "processing": {
+          "string": "Fomu ya Wavuti bado haipatikani. Haijamaliza kuchakatwa. Tafadhali onyesha upya baadaye na ujaribu tena"
+        },
+        "notOpen": {
+          "string": "Fomu hii haikubali Mawasilisho mapya kwa sasa"
+        }
+      }
+    },
+    "EnketoPreview": {
+      "disabled": {
+        "processing": {
+          "string": "Onyesho la kuchungulia halijamaliza kuchakata Fomu hii. Tafadhali onyesha upya baadaye na ujaribu tena."
+        },
+        "notOpen": {
+          "string": "Katika toleo hili la ODK Central, onyesho la kukagua linapatikana kwa Fomu zilizo katika \"OPEN STATE\""
+        }
+      }
+    },
+    "FieldKeyList": {
+      "action": {
+        "create": {
+          "string": "Unda Mtumiaji wa Programu",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "heading": {
+        "0": {
+          "full": {
+            "string": "Watumiaji wa Programu hutumiwa kukusanya data kutoka kwa programu kama vile {collect}. Kwa kawaida huwakilisha jukumu la pamoja kama vile \"Chanjo\" lakini pia zinaweza kuwakilisha watu binafsi. Watumiaji wa Programu katika Mradi huu wanaweza kupakua na kutumia Fomu ndani ya Mradi huu pekee. Unapounda Mtumiaji mpya wa Programu, haitakuwa na ufikiaji wa Fomu zozote mwanzoni. Ili kuweka Fomu ambazo kila Mtumiaji wa Programu anaweza kufikia, tumia kichupo cha {formAccess}.",
+            "developer_comment": "{collect} is a link whose text is \"ODK Collect\".\n\n{formAccess} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nForm Access"
+          },
+          "formAccess": {
+            "string": "Ufikiaji wa Fomu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {formAccess} is in the following text:\n\nApp Users are used to collect data from an application such as {collect}. They typically represent a shared role such as “Vaccinator” but may also represent individuals. App Users in this Project can only download and use Forms within this Project. When you create a new App User, it will not have access to any Forms at first. To set the Forms each App User may access, use the {formAccess} tab."
+          }
+        },
+        "1": {
+          "full": {
+            "string": "Watumiaji wa Programu wanafaa zaidi wakati wakusanyaji wa data wanahitaji ufikiaji wa Fomu nyingi, wako nje ya mtandao, au una Fomu ngumu. Ikiwa unahitaji watu waliojibu kuripoti binafsi au kuwa na fomu ya mtandaoni pekee, {clickHere} kwa chaguo zingine.",
+            "developer_comment": "{clickHere} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nclick here"
+          },
+          "clickHere": {
+            "string": "bonyeza hapa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {clickHere} is in the following text:\n\nApp Users are most appropriate when data collectors need access to multiple Forms, are offline, or you have a complex Form. If you need respondents to self-report or have an online-only form, {clickHere} for other options."
+          }
+        }
+      },
+      "header": {
+        "lastUsed": {
+          "string": "Iliyotumika Mwisho",
+          "developer_comment": "This is the text of a table column header."
+        },
+        "configureClient": {
+          "string": "Sanidi Mteja",
+          "developer_comment": "Header for the table column that shows QR codes to configure data collection clients such as ODK Collect."
+        }
+      },
+      "emptyTable": {
+        "string": "Bado hakuna Watumiaji wa Programu. Utahitaji kuunda baadhi ili kupakua Fomu na kuwasilisha data kutoka kwa kifaa chako"
+      },
+      "alert": {
+        "create": {
+          "string": "Mtumiaji wa Programu \"{displayName}\" ameundwa."
+        },
+        "revoke": {
+          "string": "Ufikiaji umebatilishwa kwa Mtumiaji wa Programu \"{displayName}\"."
+        }
+      }
+    },
+    "FieldKeyNew": {
+      "title": {
+        "string": "Unda Mtumiaji wa Programu",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Mtumiaji huyu hatakuwa na ufikiaji wa Fomu zozote mwanzoni. Utaweza kukabidhi Fomu baada ya mtumiaji kuunda."
+        }
+      },
+      "success": {
+        "0": {
+          "string": "Mtumiaji wa Programu \"{displayName}\" ameundwa."
+        },
+        "1": {
+          "string": "Unaweza kusanidi kifaa cha mkononi kwa ajili ya \"{displayName}\" sasa hivi, au unaweza kuifanya baadaye kwenye jedwali la Watumiaji wa Programu kwa kubofya \"Angalia nambari ya kuthibitisha.\"",
+          "developer_comment": "Clicking \"See code\" displays a QR code."
+        },
+        "2": {
+          "full": {
+            "string": "Unaweza kutaka kutembelea {formAccessSettings} za Mradi huu ili kumpa mtumiaji huyu idhini ya kufikia Fomu.",
+            "developer_comment": "{formAccessSettings} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nForm Access settings"
+          },
+          "formAccessSettings": {
+            "string": "Mipangilio ya Ufikiaji wa Fomu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {formAccessSettings} is in the following text:\n\nYou may wish to visit this Project’s {formAccessSettings} to give this user access to Forms."
+          }
+        }
+      },
+      "action": {
+        "createAnother": {
+          "string": "Unda nyingine",
+          "developer_comment": "This is the text of a button that is used to create another App User."
+        }
+      }
+    },
+    "FieldKeyQrPanel": {
+      "title": {
+        "managed": {
+          "string": "Msimbo wa Usanidi wa Mteja",
+          "developer_comment": "This is the title at the top of a pop-up. \"Client\" refers to a data collection client like ODK Collect. \"Code\" refers to a QR code."
+        },
+        "legacy": {
+          "string": "Msimbo wa Usanidi wa Mteja wa Urithi",
+          "developer_comment": "This is the title at the top of a pop-up. \"Client\" refers to a data collection client like ODK Collect. \"Code\" refers to a QR code."
+        }
+      },
+      "body": {
+        "0": {
+          "managed": {
+            "full": {
+              "string": "Hii ni {managedCode}",
+              "developer_comment": "{managedCode} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nManaged QR Code"
+            },
+            "managedCode": {
+              "string": "Msimbo wa QR unaosimamiwa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {managedCode} is in the following text:\n\nThis is a {managedCode}."
+            }
+          },
+          "legacy": {
+            "full": {
+              "string": "Hii ni {legacyCode}.",
+              "developer_comment": "{legacyCode} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nLegacy QR Code"
+            },
+            "legacyCode": {
+              "string": "Msimbo wa QR wa urithi",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {legacyCode} is in the following text:\n\nThis is a {legacyCode}."
+            }
+          }
+        },
+        "1": {
+          "managed": {
+            "string": "Mkusanyiko utalingana kabisa na Fomu zinazopatikana kwa \"{displayName}\" ikijumuisha kutumia masasisho kiotomatiki. Watumiaji hawatahitaji Kujipatia Fomu tupu. Zaidi ya hayo, Fomu zilizokamilishwa zitatumwa kiotomatiki mara tu muunganisho utakapopatikana.",
+            "developer_comment": "\"Get Blank Form\" is the text of a button in ODK Collect."
+          },
+          "legacy": {
+            "string": "Watumiaji watalazimika Kupata mwenyewe Fomu tupu kwenye kifaa na kuamua ni Fomu zipi za kusasisha. Pia watahitaji Kutuma mwenyewe Fomu Zilizokamilishwa",
+            "developer_comment": "\"Get Blank Form\" and \"Send Finalized Form\" are the text of buttons in ODK Collect."
+          }
+        },
+        "2": {
+          "managed": {
+            "full": {
+              "string": "Kwa tabia ya zamani, {switchToLegacy}",
+              "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {switchToLegacy} has the text: switch to a {legacyCode}\n- {legacyCode} has the text: Legacy QR Code"
+            },
+            "switchToLegacy": {
+              "string": "badilisha hadi {legacyCode}",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {switchToLegacy} is in the following text:\n\nFor the old behavior, {switchToLegacy}.\n\nNote that {legacyCode} is a separate string that will be translated below. Its text is:\n\nLegacy QR Code"
+            },
+            "legacyCode": {
+              "string": "Msimbo wa QR wa urithi",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {legacyCode} is in the following text:\n\nFor the old behavior, switch to a {legacyCode}."
+            }
+          },
+          "legacy": {
+            "full": {
+              "string": "Kwa mchakato unaodhibitiwa zaidi na usiofaa, {switchToManaged}",
+              "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {switchToManaged} has the text: switch to a {managedCode}\n- {managedCode} has the text: Managed QR Code"
+            },
+            "switchToManaged": {
+              "string": "badilisha hadi {managedCode}",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {switchToManaged} is in the following text:\n\nFor a more controlled and foolproof process, {switchToManaged}.\n\nNote that {managedCode} is a separate string that will be translated below. Its text is:\n\nManaged QR Code"
+            },
+            "managedCode": {
+              "string": "Msimbo wa QR unaosimamiwa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {managedCode} is in the following text:\n\nFor a more controlled and foolproof process, switch to a {managedCode}."
+            }
+          }
+        },
+        "3": {
+          "string": "Changanua msimbo huu wa QR ili kusanidi kifaa kilicho na akaunti \"{displayName}\"."
+        }
+      }
+    },
+    "FieldKeyRevoke": {
+      "title": {
+        "string": "Batilisha Ufikiaji wa Mtumiaji",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Je, una uhakika unataka kubatilisha ufikiaji kutoka kwa Mtumiaji wa Programu {displayName}?",
+          "developer_comment": "{displayName} is formatted in bold."
+        },
+        "1": {
+          "string": "Mawasilisho yaliyopo kutoka kwa mtumiaji huyu yatasalia, lakini mtu yeyote anayemtegemea mtumiaji huyu atalazimika kuunda upya ili kuendelea kupakua Fomu au kupakia Mawasilisho"
+        },
+        "2": {
+          "string": "Kitendo hiki hakiwezi kutenduliwa"
+        }
+      }
+    },
+    "FieldKeyRow": {
+      "seeCode": {
+        "string": "Angalia msimbo",
+        "developer_comment": "Clicking on this text displays an App User QR code for configuring ODK Collect."
+      },
+      "accessRevoked": {
+        "string": "Ufikiaji umebatilishwa",
+        "developer_comment": "This text is shown for an App User whose access has been revoked."
+      },
+      "action": {
+        "revokeAccess": {
+          "string": "Batilisha ufikiaji",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      }
+    },
+    "FormAttachmentList": {
+      "action": {
+        "upload": {
+          "string": "Pakia faili",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "heading": {
+        "0": {
+          "string": "Kulingana na Fomu uliyopakia, faili zifuatazo zinatarajiwa. Unaweza kuona ni zipi zimepakiwa au bado hazipo."
+        },
+        "1": {
+          "string": "Ili kupakia faili, buruta na udondoshe faili moja au zaidi kwenye ukurasa"
+        }
+      },
+      "header": {
+        "uploaded": {
+          "string": "Imepakiwa",
+          "developer_comment": "This is the text of a table column header. The column shows when each Media File was uploaded."
+        }
+      },
+      "problem": {
+        "noneUploaded": {
+          "string": "{message} Hakuna faili zilizopakiwa.",
+          "developer_comment": "{message} is an error message from the server."
+        },
+        "someUploaded": {
+          "string": "{count, plural, one {{message} {uploaded} pekee kati ya faili {total} ndizo zilizopakiwa.} other {{message} {uploaded} pekee kati ya faili {total} ndizo zilizopakiwa.}}",
+          "developer_comment": "This string is an error message. It is shown only if the user tried to upload multiple files. {message} is an error message from the server. {uploaded} and {total} are numbers. {uploaded} is at least 1, and {total} is at least 2. The string will be pluralized based on {uploaded}."
+        }
+      },
+      "alert": {
+        "readError": {
+          "string": "Hitilafu fulani imetokea wakati wa kusoma \"{filename}\""
+        },
+        "success": {
+          "string": "{count, plural, one {faili {count} imepakiwa.} other {faili {count} zimepakiwa.}}"
+        }
+      }
+    },
+    "FormAttachmentNameMismatch": {
+      "title": {
+        "upload": {
+          "string": "Pakia Faili",
+          "developer_comment": "This is the title at the top of a pop-up."
+        },
+        "replace": {
+          "string": "Badilisha Faili",
+          "developer_comment": "This is the title at the top of a pop-up."
+        }
+      },
+      "introduction": {
+        "0": {
+          "string": "Je, una uhakika unataka kupakia {filename} kama {attachmentName}?",
+          "developer_comment": "{filename} and {attachmentName} are formatted in bold."
+        },
+        "1": {
+          "string": "Tunakagua mara mbili kwa sababu majina ya faili hayalingani"
+        }
+      }
+    },
+    "FormAttachmentPopups": {
+      "title": {
+        "string": "Pakia Faili",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "duringDragover": {
+        "dropToUpload": {
+          "string": "Dondosha sasa ili upakie faili hii kama {attachmentName}.",
+          "developer_comment": "{attachmentName} is formatted in bold."
+        },
+        "dragover": {
+          "string": "Buruta juu ya ingizo la faili unalotaka kubadilisha na faili na uangushe ili kupakia"
+        },
+        "dropToPrepare": {
+          "full": {
+            "string": "Dondosha sasa ili kuandaa {countOfFiles} kwa ajili ya kupakiwa kwenye Fomu hii.",
+            "developer_comment": "{countOfFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} files"
+          },
+          "countOfFiles": {
+            "string": "{count, plural, one {faili {count}} other {faili {count}}}",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {countOfFiles} is in the following text:\n\nDrop now to prepare {countOfFiles} for upload to this Form."
+          }
+        }
+      },
+      "afterSelection": {
+        "matched": {
+          "full": {
+            "string": "{count, plural, one {{countOfFiles} tayari kupakiwa.} other {{countOfFiles} tayari kupakiwa.}}",
+            "developer_comment": "{countOfFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} files"
+          },
+          "countOfFiles": {
+            "string": "{count, plural, one {faili {count}} other {faili {count}}}",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {countOfFiles} is in the following text. (The plural form of the text is shown.)\n\n{countOfFiles} ready for upload."
+          }
+        },
+        "someUnmatched": {
+          "full": {
+            "string": "{count, plural, one {{countOfFiles} wana jina ambalo hatulitambui na tutapuuzwa. Ili kuzipakia, zipe jina jipya au ziburute kibinafsi hadi kwenye malengo yao} other {{countOfFiles} wana jina ambalo hatulitambui na tutapuuzwa. Ili kuzipakia, zipe jina jipya au ziburute kibinafsi hadi kwenye malengo yao.}}",
+            "developer_comment": "{countOfFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} files"
+          },
+          "countOfFiles": {
+            "string": "{count, plural, one {faili {count}} other {faili {count}}}",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {countOfFiles} is in the following text. (The plural form of the text is shown.)\n\n{countOfFiles} have a name we don’t recognize and will be ignored. To upload them, rename them or drag them individually onto their targets."
+          }
+        },
+        "noneMatched": {
+          "string": "{count, plural, one {Hatutambui faili zozote unazojaribu kupakia. Tafadhali zipe jina jipya ili zilingane na majina yaliyoorodheshwa hapo juu, au ziburute moja moja hadi kwenye malengo yao} other {Hatutambui faili zozote unazojaribu kupakia. Tafadhali zipe jina jipya ili zilingane na majina yaliyoorodheshwa hapo juu, au ziburute moja moja hadi kwenye malengo yao}}"
+        }
+      },
+      "duringUpload": {
+        "total": {
+          "string": "{count, plural, one {Tafadhali subiri,  faili yako inapakiwa {count}:} other {Tafadhali subiri,  faili zako zinapakiwa {count}:}}"
+        },
+        "current": {
+          "string": "Inatuma {filename} ({percentUploaded})",
+          "developer_comment": "Displayed in a pop-up to indicate a Media File that is currently being uploaded to be attached to a Form."
+        },
+        "remaining": {
+          "beforeLast": {
+            "string": "{count, plural, one {faili {count} itasalia.} other {faili {count} zitasalia.}}"
+          },
+          "last": {
+            "string": "Hili ndilo faili la mwisho."
+          }
+        }
+      }
+    },
+    "FormAttachmentRow": {
+      "type": {
+        "image": {
+          "string": "Picha",
+          "developer_comment": "This is a type of Media File."
+        },
+        "audio": {
+          "string": "Sauti",
+          "developer_comment": "This is a type of Media File."
+        },
+        "video": {
+          "string": "Video",
+          "developer_comment": "This is a type of Media File."
+        },
+        "file": {
+          "string": "Faili ya Data",
+          "developer_comment": "This is a type of Media File."
+        }
+      },
+      "replace": {
+        "string": "Badilisha",
+        "developer_comment": "This is a label that is shown next to a Media File that would be replaced if the selected files were uploaded."
+      },
+      "notUploaded": {
+        "text": {
+          "string": "Bado haijapakiwa",
+          "developer_comment": "This is shown for a Media File that has not been uploaded."
+        },
+        "title": {
+          "string": "Ili kupakia faili, buruta na udondoshe faili moja au zaidi kwenye ukurasa huu"
+        }
+      }
+    },
+    "FormAttachmentUploadFiles": {
+      "title": {
+        "string": "Pakia Faili",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "full": {
+            "string": "Ili kupakia faili, unaweza {dragAndDrop} faili moja au zaidi kwenye jedwali kwenye ukurasa huu.",
+            "developer_comment": "{dragAndDrop} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ndrag and drop"
+          },
+          "dragAndDrop": {
+            "string": "buruta na udondoshe",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {dragAndDrop} is in the following text:\n\nTo upload files, you can {dragAndDrop} one or more files onto the table on this page."
+          }
+        },
+        "1": {
+          "full": {
+            "string": "ikiwa ungependa kuchagua faili kutoka kwa haraka, hakikisha kwamba majina yao yanalingana na yale yaliyo kwenye jedwali kisha {clickHere}",
+            "developer_comment": "{clickHere} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nclick here to choose"
+          },
+          "clickHere": {
+            "string": "bonyeza hapa kuchagua",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {clickHere} is in the following text:\n\nIf you would rather select files from a prompt, ensure that their names match the ones in the table and then {clickHere}."
+          }
+        }
+      }
+    },
+    "FormChecklist": {
+      "clickForInfo": {
+        "string": "Bonyeza hapa kujua zaidi"
+      },
+      "steps": {
+        "0": {
+          "title": {
+            "string": "Chapisha Rasimu ya toleo lako la kwanza",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "string": "Kazi nzuri!"
+            },
+            "1": {
+              "string": "Umechapisha Fomu yako. Iko tayari kukubali Mawasilisho. Ikiwa ungependa kufanya mabadiliko kwenye Fomu au Faili zake za Midia, unaweza kutengeneza Rasimu mpya."
+            }
+          }
+        },
+        "1": {
+          "title": {
+            "string": "Pakua Fomu ya wateja wa uchunguzi na uwasilishe data",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "none": {
+                "string": "Bado hakuna mtu aliyewasilisha data yoyote kwa Fomu hii"
+              },
+              "any": {
+                "string": "{count, plural, one {Jumla ya wasilisho {count} imewasilishwa.} other {Jumla ya Mawasilisho {count} yamewasilishwa.}}"
+              }
+            },
+            "1": {
+              "full": {
+                "string": "{clickHere} ili kupata maelezo kuhusu njia tofauti za kuwasilisha data",
+                "developer_comment": "{clickHere} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nClick here"
+              },
+              "clickHere": {
+                "string": "Bonyeza hapa",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {clickHere} is in the following text:\n\n{clickHere} to learn about the different ways to submit data."
+              }
+            }
+          }
+        },
+        "2": {
+          "title": {
+            "string": "Tathmini na uchanganue data iliyowasilishwa",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "none": {
+                "string": "Baada ya kupata data ya Fomu hii, unaweza kuihamisha au kuisawazisha ili kufuatilia na kuchambua data kwa ubora na matokeo."
+              },
+              "any": {
+                "string": "{count, plural, one {Unaweza kuhamisha au kusawazisha {count} wasilisho kwenye Fomu hii ili kuyafuatilia na kuyachanganua kwa ubora na matokeo.} other {Unaweza kuhamisha au kusawazisha {count} Mawasilisho kwenye Fomu hii ili kuyafuatilia na kuyachanganua kwa ubora na matokeo.}}"
+              }
+            },
+            "1": {
+              "full": {
+                "string": "Unaweza kufanya hivyo kwa vibonye vya Kupakua na Kuchanganua kwenye {submissionsTab}",
+                "developer_comment": "{submissionsTab} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nSubmissions tab"
+              },
+              "submissionsTab": {
+                "string": "Kichupo cha mawasilisho",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {submissionsTab} is in the following text:\n\nYou can do this with the Download and Analyze buttons on the {submissionsTab}."
+              }
+            }
+          }
+        },
+        "3": {
+          "title": {
+            "string": "Dhibiti kustaafu kwa Fomu",
+            "developer_comment": "This is the title of a checklist item. \"Retirement\" refers to reducing access to the form. For example, removing the ability to download the form or to submit to it."
+          },
+          "body": {
+            "0": {
+              "full": {
+                "string": "Unapofika mwisho wa ukusanyaji wako wa data, unaweza kutumia vidhibiti vya Hali ya Fomu kwenye {formAccessTab} ili kudhibiti kama, kwa mfano, Watumiaji wa Programu wataweza kuona au kuunda Mawasilisho mapya kwa Fomu hii.",
+                "developer_comment": "{formAccessTab} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nForm Access tab of the Project page"
+              },
+              "formAccessTab": {
+                "string": "Kichupo cha Ufikiaji wa Fomu cha ukurasa wa Mradi",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {formAccessTab} is in the following text:\n\nAs you come to the end of your data collection, you can use the Form State controls on the {formAccessTab} to control whether, for example, App Users will be able to see or create new Submissions to this Form."
+              }
+            }
+          }
+        }
+      }
+    },
+    "FormDelete": {
+      "title": {
+        "string": "Futa Fomu",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Je, una uhakika ungependa kufuta Fomu ya {name} na Mawasilisho yake yote?"
+        },
+        "1": {
+          "string": "kitendo hiki kitahamisha Fomu hadi kwenye Tupio. Baada ya siku 30 kwenye Tupio, itasafishwa kabisa, lakini inaweza kufutwa kabla ya wakati huo."
+        }
+      }
+    },
+    "FormDraftAbandon": {
+      "title": {
+        "abandon": {
+          "string": "acha rasimu",
+          "developer_comment": "This is the title at the top of a pop-up."
+        },
+        "deleteForm": {
+          "string": "Achana na Rasimu na ufute Fomu",
+          "developer_comment": "This is the title at the top of a pop-up."
+        }
+      },
+      "introduction": {
+        "abandon": {
+          "0": {
+            "string": "Unakaribia kufuta kabisa Rasimu ya toleo la Fomu hii. Hii inamaanisha kuwa rasimu ya ufafanuzi wa Fomu, rasimu ya Faili zozote za Midia ulizopakia na Mawasilisho yote ya majaribio yataondolewa."
+          },
+          "1": {
+            "string": "Ufafanuzi wako wa Fomu uliochapishwa, Faili zake za Midia na Mawasilisho hayataathiriwa"
+          }
+        },
+        "deleteForm": {
+          "0": {
+            "string": "Unakaribia kufuta rasimu hii ya ufafanuzi wa Fomu, pamoja na rasimu ya Faili zozote za Midia ambazo umepakia, na Mawasilisho yote ya majaribio. Kwa sababu bado hujaichapisha, Fomu hii yote itafutwa na kuhamishiwa kwenye Tupio."
+          }
+        }
+      },
+      "action": {
+        "abandon": {
+          "string": "Achana",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      }
+    },
+    "FormDraftChecklist": {
+      "clickForInfo": {
+        "string": "Bonyeza hapa kujua zaidi"
+      },
+      "steps": {
+        "0": {
+          "title": {
+            "string": "Pakia ufafanuzi wa awali wa Fomu",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "string": "Kazi nzuri!"
+            },
+            "1": {
+              "string": "Muundo wako wa Fomu umepakiwa."
+            }
+          }
+        },
+        "1": {
+          "title": {
+            "string": "Pakia ufafanuzi wa Fomu uliorekebishwa (si lazima)",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "status": {
+                "string": "Ikiwa umefanya mabadiliko kwenye Fomu yenyewe, ikijumuisha maandishi ya swali au sheria za mantiki, sasa ni wakati wa kupakia XML au XLSForm mpya kwa kutumia kitufe kilicho kulia.",
+                "developer_comment": "This refers to changes to the Form definition as opposed to just the media associated with the Form. The word \"XLSForm\" should not be translated."
+              },
+              "link": {
+                "full": {
+                  "string": "Ikiwa umefanya mabadiliko kwenye Fomu yenyewe, ikijumuisha maandishi ya swali au sheria za mantiki, sasa ni wakati wa {upload} XML au XLSForm mpya.",
+                  "developer_comment": "This refers to changes to the Form definition as opposed to just the media associated with the Form. The word \"XLSForm\" should not be translated.\n\n{upload} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nupload"
+                },
+                "upload": {
+                  "string": "pakia",
+                  "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {upload} is in the following text:\n\nIf you have made changes to the Form itself, including question text or logic rules, now is the time to {upload} the new XML or XLSForm."
+                }
+              }
+            }
+          }
+        },
+        "2": {
+          "title": {
+            "string": "Pakia Faili za Midia ya Fomu",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "full": {
+                "string": "Usanifu wa Fomu yako unarejelea faili ambazo zinahitajika ili kuwasilisha Fomu yako. Unaweza kupakia nakala mpya au zilizosasishwa za hizi kwa usambazaji chini ya kichupo cha {mediaFiles}",
+                "developer_comment": "{mediaFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nMedia Files"
+              },
+              "mediaFiles": {
+                "string": "Faili za Midia",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {mediaFiles} is in the following text:\n\nYour Form design references files that are needed in order to present your Form. You can upload new or updated copies of these for distribution under the {mediaFiles} tab."
+              }
+            }
+          }
+        },
+        "3": {
+          "title": {
+            "string": "Jaribu Fomu kwa kuunda Wasilisho",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "full": {
+                "string": "Unaweza {test} Fomu ili kuhakikisha kuwa inafanya kazi jinsi unavyotarajia. Mawasilisho ya Jaribio hayajumuishwi katika data yako ya mwisho.",
+                "developer_comment": "{test} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntest"
+              },
+              "test": {
+                "string": "Jaribia",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {test} is in the following text:\n\nYou can {test} a Form to be sure it works the way you expect. Test Submissions are not included in your final data."
+              }
+            }
+          }
+        },
+        "4": {
+          "title": {
+            "string": "Chapisha Rasimu",
+            "developer_comment": "This is the title of a checklist item."
+          },
+          "body": {
+            "0": {
+              "status": {
+                "string": "Unapokuwa na uhakika kuwa Rasimu yako iko tayari na ungependa kuisambaza kwa vifaa vyako kwenye uga, unaweza kuichapisha kwa kutumia kitufe kilicho kulia."
+              },
+              "link": {
+                "full": {
+                  "string": "Unapokuwa na uhakika kuwa Rasimu yako iko tayari na ungependa kuisambaza kwa vifaa vyako kwenye uga, unaweza {publish}.",
+                  "developer_comment": "{publish} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\npublish"
+                },
+                "publish": {
+                  "string": "Chapisha",
+                  "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {publish} is in the following text:\n\nWhen you are sure your Draft is ready and you wish to roll it out to your devices in the field, you can {publish} it."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "FormDraftPublish": {
+      "title": {
+        "string": "Chapisha Rasimu",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "warnings": {
+        "attachments": {
+          "full": {
+            "string": "Hujatoa {mediaFiles} zote ambazo Fomu yako inahitaji. Unaweza kupuuza hili ukipenda, lakini utahitaji kutengeneza toleo jipya la Rasimu ili kupakia faili hizo baadaye.",
+            "developer_comment": "This is a warning shown to the user.\n\n{mediaFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nMedia Files"
+          },
+          "mediaFiles": {
+            "string": "Faili za Midia",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {mediaFiles} is in the following text:\n\nYou have not provided all the {mediaFiles} that your Form requires. You can ignore this if you wish, but you will need to make a new Draft version to upload those files later."
+          }
+        },
+        "testing": {
+          "full": {
+            "string": "Bado huja {tested} kwa kupakia Wasilisho la jaribio. Sio lazima kufanya hivi, lakini inashauriwa sana.",
+            "developer_comment": "This is a warning shown to the user.\n\n{tested} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntested this Form"
+          },
+          "tested": {
+            "string": "Fomu hii imejaribiwa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tested} is in the following text:\n\nYou have not yet {tested} by uploading a test Submission. You do not have to do this, but it is highly recommended."
+          }
+        }
+      },
+      "introduction": {
+        "0": {
+          "string": "Unakaribia kuifanya Rasimu hii kuwa toleo lililochapishwa la Fomu yako. Hii itakamilisha mabadiliko yoyote ambayo umefanya kwa ufafanuzi wa Fomu na Faili zake za Midia zilizoambatishwa"
+        },
+        "1": {
+          "string": "Mawasilisho ya Fomu Yaliyopo hayataathiriwa, lakini Mawasilisho yote ya Rasimu ya majaribio yataondolewa"
+        },
+        "2": {
+          "string": "Kila toleo la Fomu linahitaji jina la toleo la kipekee. Kwa sasa, Rasimu ya Fomu yako ina jina la toleo sawa na toleo lililochapishwa hapo awali. Unaweza kuweka mpya kwa kupakia ufafanuzi wa Fomu kwa jina unalotaka, au unaweza kuandika mpya hapa chini na seva itakubadilisha."
+        }
+      },
+      "field": {
+        "version": {
+          "string": "Toleo",
+          "developer_comment": "This is the text of a form field. It is used to specify a unique version name for the version of the Form that is about to be published."
+        }
+      },
+      "problem": {
+        "409_6": {
+          "string": "Jina la toleo la Rasimu hii linakinzana na toleo la awali la Fomu hii au Fomu iliyofutwa. Tafadhali tumia sehemu iliyo hapa chini ili kuibadilisha hadi kitu kipya au kupakia ufafanuzi mpya wa Fomu"
+        }
+      }
+    },
+    "FormDraftStatus": {
+      "draftChecklist": {
+        "title": {
+          "string": " Orodha ya rasimu",
+          "developer_comment": "This is a title shown above a section of the page."
+        }
+      },
+      "currentDraft": {
+        "versionCaption": {
+          "full": {
+            "string": "{draftVersion} ya Fomu hii.",
+            "developer_comment": "{draftVersion} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nDraft version"
+          },
+          "draftVersion": {
+            "string": "Toleo la rasimu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {draftVersion} is in the following text:\n\n{draftVersion} of this Form."
+          }
+        },
+        "action": {
+          "upload": {
+            "string": "Pakia ufafanuzi mpya",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        }
+      },
+      "actions": {
+        "title": {
+          "string": "Vitendo",
+          "developer_comment": "This is a title shown above a section of the page."
+        },
+        "action": {
+          "publish": {
+            "string": "Chapisha Rasimu",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          },
+          "abandon": {
+            "string": "Achana na Rasimu",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        }
+      },
+      "alert": {
+        "upload": {
+          "string": "Mafanikio! Ufafanuzi mpya wa Fomu umehifadhiwa kama Rasimu yako"
+        },
+        "publish": {
+          "string": "Rasimu yako sasa imechapishwa. Kifaa chochote kinachorejesha Fomu za Mradi huu sasa kitapokea ufafanuzi mpya wa Fomu na Faili za Midia"
+        },
+        "abandon": {
+          "string": "Toleo la Rasimu la Fomu hii limefutwa kwa ufanisi."
+        },
+        "delete": {
+          "string": "Fomu \"{name}\" ilifutwa."
+        }
+      }
+    },
+    "FormDraftTesting": {
+      "title": {
+        "string": "Mtihani wa Rasimu",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "body": {
+        "0": {
+          "string": "Unaweza kutumia msimbo wa usanidi ulio kulia ili kusanidi kifaa cha mkononi ili kupakua Rasimu hii. Unaweza pia kubofya kitufe kipya hapo juu ili kuunda Wasilisho jipya kutoka kwa kivinjari chako cha wavuti."
+        },
+        "1": {
+          "string": "Rasimu ya Mawasilisho huenda kwenye jedwali la majaribio hapa chini, ambapo unaweza kuhakiki na kupakua. Unapochapisha Rasimu ya Fomu hii, Mawasilisho yake ya majaribio yataondolewa kabisa."
+        }
+      },
+      "collectProjectName": {
+        "string": "[Rasimu] {name}",
+        "developer_comment": "This text will be shown in ODK Collect when testing a Draft Form. {name} is the title of the Draft Form."
+      }
+    },
+    "FormHead": {
+      "projectNav": {
+        "action": {
+          "back": {
+            "string": "Rudi kwa Muhtasari wa Mradi",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        }
+      },
+      "formNav": {
+        "tabTitle": {
+          "string": "Vipengele hivi vitapatikana mara tu utakapochapisha Rasimu ya Fomu yako",
+          "developer_comment": "Tooltip text that will be shown when hovering over tabs for Form Overview, Submissions, etc."
+        }
+      },
+      "draftNav": {
+        "title": {
+          "string": "Rasimu",
+          "developer_comment": "This is shown above the navigation tabs for the Form Draft."
+        },
+        "action": {
+          "create": {
+            "string": "Unda Rasimu mpya",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        }
+      }
+    },
+    "FormList": {
+      "title": {
+        "string": "Fomu",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "action": {
+        "create": {
+          "string": "Mpya",
+          "developer_comment": "This is the text of a button that is used to create a new Form."
+        }
+      },
+      "emptyTable": {
+        "string": "hakuna Fomu za kuonyesha"
+      },
+      "alert": {
+        "create": {
+          "string": "Fomu yako mpya \"{name}\" imeundwa kama Rasimu. Angalia orodha hapa chini, na unapohisi iko tayari, unaweza kuchapisha Fomu kwa matumizi."
+        }
+      }
+    },
+    "FormNew": {
+      "title": {
+        "create": {
+          "string": "unda fomu",
+          "developer_comment": "This is the title at the top of a pop-up."
+        },
+        "update": {
+          "string": "Pakia Ufafanuzi wa Fomu Mpya",
+          "developer_comment": "This is the title at the top of a pop-up."
+        }
+      },
+      "introduction": {
+        "0": {
+          "create": {
+            "string": "Ili kuunda Fomu, pakia faili ya XForms XML au faili ya XLSForm Excel.",
+            "developer_comment": "The words \"XForms\" and \"XLSForm\" should not be translated."
+          },
+          "update": {
+            "string": "Ili kusasisha Rasimu, pakia faili ya XForms XML au faili ya XLSForm Excel.",
+            "developer_comment": "The words \"XForms\" and \"XLSForm\" should not be translated."
+          }
+        },
+        "1": {
+          "full": {
+            "string": "Ikiwa tayari huna, kuna {tools} za kukusaidia kuunda Fomu yako.",
+            "developer_comment": "{tools} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ntools available"
+          },
+          "tools": {
+            "string": "zana zinazopatikana",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {tools} is in the following text:\n\nIf you don’t already have one, there are {tools} to help you design your Form."
+          }
+        },
+        "2": {
+          "string": "Ikiwa una media, utaweza kuipakia kwenye ukurasa unaofuata, baada ya kuunda Fomu."
+        }
+      },
+      "dropZone": {
+        "full": {
+          "string": "Dondosha faili hapa, au {chooseOne} ili upakie.",
+          "developer_comment": "{chooseOne} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nchoose one"
+        },
+        "chooseOne": {
+          "string": "Chagua moja",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {chooseOne} is in the following text:\n\nDrop a file here, or {chooseOne} to upload."
+        }
+      },
+      "action": {
+        "upload": {
+          "string": "pakia",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        },
+        "uploadAnyway": {
+          "string": "Pakia hata hivyo",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "alert": {
+        "fileRequired": {
+          "string": "Tafadhali chagua faili."
+        }
+      },
+      "problem": {
+        "400_8": {
+          "string": "Ufafanuzi wa Fomu uliyopakia hauonekani kuwa wa Fomu hii. Ina formId isiyo sahihi (expected \"{expected}\", imepata \"{actual}\")."
+        },
+        "400_15": {
+          "string": "XLSForm haikuweza kubadilishwa: {error}",
+          "developer_comment": "The word \"XLSForm\" should not be translated."
+        },
+        "409_3": {
+          "string": "Tayari kuna Fomu katika Mradi huu yenye Kitambulisho cha Fomu ya “{xmlFormId}”."
+        }
+      },
+      "warningsText": {
+        "0": {
+          "string": "Faili hii ya XLSForm inaweza kutumika, lakini ina matatizo yafuatayo yanayowezekana (maonyo ya ubadilishaji).",
+          "developer_comment": "The word \"XLSForm\" should not be translated."
+        },
+        "1": {
+          "string": "Tafadhali sahihisha matatizo na ujaribu tena"
+        },
+        "2": {
+          "create": {
+            "string": "Ikiwa una uhakika kuwa matatizo haya yanaweza kupuuzwa, bofya kitufe ili kuunda Fomu hata hivyo:"
+          },
+          "update": {
+            "string": "ikiwa una uhakika matatizo haya yanaweza kupuuzwa, bofya kitufe ili kusasisha Rasimu hata hivyo:"
+          }
+        }
+      }
+    },
+    "FormOverview": {
+      "checklist": {
+        "string": "Orodha ya ukaguzi",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "draft": {
+        "none": {
+          "title": {
+            "string": "Hakuna Rasimu ya Sasa",
+            "developer_comment": "This is a title shown above a section of the page."
+          },
+          "body": {
+            "string": "Kwa sasa hakuna Rasimu ya toleo la Fomu hii. Ikiwa ungependa kufanya mabadiliko kwenye Fomu au Faili zake za Midia, anza kwa kuunda Rasimu kwa kutumia kitufe kilicho hapo juu"
+          }
+        },
+        "any": {
+          "versionCaption": {
+            "full": {
+              "string": "{draftVersion} ya Fomu hii",
+              "developer_comment": "{draftVersion} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nDraft version"
+            },
+            "draftVersion": {
+              "string": "Toleo la rasimu",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {draftVersion} is in the following text:\n\n{draftVersion} of this Form."
+            }
+          }
+        }
+      }
+    },
+    "FormOverviewRightNow": {
+      "version": {
+        "full": {
+          "string": "{publishedVersion} ya Fomu hii.",
+          "developer_comment": "{publishedVersion} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nPublished version"
+        },
+        "publishedVersion": {
+          "string": "Toleo lililochapishwa",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {publishedVersion} is in the following text:\n\n{publishedVersion} of this Form."
+        }
+      },
+      "stateCaption": {
+        "open": {
+          "string": "Fomu hii inaweza kupakuliwa na inakubali Mawasilisho."
+        },
+        "closing": {
+          "string": "Fomu hii haiwezi kupakuliwa lakini bado inakubali Mawasilisho."
+        },
+        "closed": {
+          "string": "Fomu hii haiwezi kupakuliwa na haikubali Mawasilisho."
+        }
+      },
+      "submissions": {
+        "full": {
+          "string": "{count, plural, one {{submissions} zimehifadhiwa kwa Fomu hii.} other {{submissions} zimehifadhiwa kwa Fomu hii.}}",
+          "developer_comment": "The count of Submissions is shown separately above this text.\n\n{submissions} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nSubmissions"
+        },
+        "submissions": {
+          "string": "{count, plural, one {Wasilisho} other {Mawasilisho}}",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {submissions} is in the following text. (The plural form of the text is shown.)\n\n{submissions} have been saved for this Form."
+        }
+      }
+    },
+    "FormRestore": {
+      "title": {
+        "string": "Ondoa kufuta fomu",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Je, una uhakika unataka kutengua Fomu ya {name}?"
+        },
+        "1": {
+          "string": "Fomu itarejeshwa katika hali yake ya awali, ikijumuisha data, mipangilio na ruhusa zote."
+        },
+        "2": {
+          "string": "Ikiwa Fomu itafutwa tena, itapita siku 30 kabla ya kuondolewa."
+        }
+      }
+    },
+    "FormRow": {
+      "action": {
+        "fill": {
+          "string": "Jaza Fomu",
+          "developer_comment": "This text shows when the last Submission was received. {dateTime} shows the date and time, for example: \"2020/01/01 01:23\". It may show a formatted date like \"2020/01/01\", or it may use a word like \"today\", \"yesterday\", or \"Sunday\"."
+        }
+      },
+      "formClosedTip": {
+        "string": "Fomu Hii Imefungwa. Haiwezi kupakuliwa na haikubali Mawasilisho."
+      },
+      "formClosingTip": {
+        "string": "Fomu Hii Inafungwa. Haiwezi kupakuliwa lakini bado inakubali Mawasilisho."
+      },
+      "formUnpublishedTip": {
+        "string": "Fomu hii bado haina toleo lililochapishwa."
+      }
+    },
+    "FormSettings": {
+      "state": {
+        "title": {
+          "string": "Jimbo la Fomu",
+          "developer_comment": "This is a title shown above a section of the page."
+        },
+        "body": {
+          "full": {
+            "string": "Ili kuweka hali ya Fomu hii, tafadhali tembelea Project {formAccessSettings}.",
+            "developer_comment": "{formAccessSettings} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nForm Access settings"
+          },
+          "formAccessSettings": {
+            "string": "Mipangilio ya Ufikiaji wa Fomu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {formAccessSettings} is in the following text:\n\nTo set this Form’s state, please visit the Project {formAccessSettings}."
+          }
+        }
+      },
+      "action": {
+        "delete": {
+          "string": "Futa Fomu hii",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "alert": {
+        "delete": {
+          "string": "Fomu \"{name}\" ilifutwa."
+        }
+      }
+    },
+    "FormTable": {
+      "header": {
+        "idAndVersion": {
+          "string": "Kitambulisho na Toleo",
+          "developer_comment": "This is the text of a column header in a table of Forms. The column shows the ID of each Form, as well as the name of its primary version."
+        }
+      }
+    },
+    "FormTrashList": {
+      "title": {
+        "string": "Takataka"
+      },
+      "trashCount": {
+        "string": "({count})",
+        "developer_comment": "{count} is the number of Forms in the trash."
+      },
+      "alert": {
+        "restore": {
+          "string": "Fomu \"{name}\" imetenguliwa"
+        }
+      },
+      "message": {
+        "string": "Fomu na data inayohusiana na Fomu hufutwa baada ya siku 30 kwenye Tupio"
+      }
+    },
+    "FormTrashRow": {
+      "action": {
+        "restore": {
+          "string": "Ondoa kufuta",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "deletedDate": {
+        "string": "Imefutwa {dateTime}",
+        "developer_comment": "This text shows when the Form was deleted. {dateTime} shows the date and time, for example: \"2020/01/01 01:23\". It may show a formatted date like \"2020/01/01\", or it may use a word like \"today\", \"yesterday\", or \"Sunday\"."
+      },
+      "disabled": {
+        "conflict": {
+          "string": "Fomu hii haiwezi kufutwa kwa sababu kuna Fomu inayotumika yenye kitambulisho sawa."
+        }
+      }
+    },
+    "FormVersionDefDropdown": {
+      "action": {
+        "def": {
+          "string": "Ufafanuzi",
+          "developer_comment": "This is the text of a button. \"Definition\" refers to a Form definition."
+        },
+        "viewXml": {
+          "string": "Tazama XML kwenye kivinjari",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        },
+        "downloadXForm": {
+          "string": "Pakua kama XForm (.xml)",
+          "developer_comment": "This is the text of a link to download a Form definition. The word \"XForm\" should not be translated."
+        },
+        "downloadXlsForm": {
+          "string": "Pakua kama XLSForm ({extension})",
+          "developer_comment": "This is the text of a link to download a Form definition. {extension} is either .xls or .xlsx. The word \"XLSForm\" should not be translated."
+        }
+      }
+    },
+    "FormVersionString": {
+      "blank": {
+        "string": "(tupu)",
+        "developer_comment": "This is shown for a Form with a blank version name."
+      }
+    },
+    "FormVersionTable": {
+      "header": {
+        "published": {
+          "string": "Imechapishwa",
+          "developer_comment": "This is the text of a table column header. The column shows who published the version of the Form, as well as when they did so."
+        },
+        "definition": {
+          "string": "Ufafanuzi",
+          "developer_comment": "This is the text of a table column header. \"Definition\" refers to a Form definition."
+        }
+      }
+    },
+    "FormVersionViewXml": {
+      "title": {
+        "string": "Tazama XML",
+        "developer_comment": "This is the title at the top of a pop-up."
+      }
+    },
+    "Loading": {
+      "text": {
+        "string": "Inapakia..."
+      }
+    },
+    "MarkdownTextarea": {
+      "markdownSupported": {
+        "string": "Markdown inatumika",
+        "developer_comment": "This is a link to an external website with Markdown style guidelines"
+      },
+      "preview": {
+        "string": "Hakiki",
+        "developer_comment": "This is text shown as a label above the preview of Markdown formatting (special formatting of user-submitted text)"
+      }
+    },
+    "Navbar": {
+      "action": {
+        "toggle": {
+          "string": "Geuza urambazaji",
+          "developer_comment": "Used by screen readers to describe the button used to show or hide the navigation bar on small screens (\"hamburger menu\")."
+        }
+      },
+      "analyticsNotice": {
+        "string": "Saidia kuboresha Central"
+      }
+    },
+    "NavbarActions": {
+      "notLoggedIn": {
+        "string": "Hujaingia",
+        "developer_comment": "This text is shown if the user is not logged in. It is shown in the navigation bar at the top of the page."
+      },
+      "action": {
+        "logOut": {
+          "string": "toka kwenye ukurasa",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "alert": {
+        "logOut": {
+          "string": "Umetoka  kwenye ukurasa kwa mafanikio."
+        }
+      }
+    },
+    "NavbarHelpDropdown": {
+      "docs": {
+        "string": "hati",
+        "developer_comment": "This is the text of a link that links to the documentation."
+      },
+      "forum": {
+        "string": "Jukwaa",
+        "developer_comment": "This is the text of a link that links to the ODK forum."
+      },
+      "version": {
+        "string": "Toleo",
+        "developer_comment": "This is the text of a link that shows what version of ODK Central is in use."
+      }
+    },
+    "NavbarLinks": {
+      "current": {
+        "string": "sasa",
+        "developer_comment": "Used by screen readers to identify the currently-selected navigation tab"
+      }
+    },
+    "NavbarLocaleDropdown": {
+      "helpTranslate": {
+        "string": "Saidia kutafsiri Central",
+        "developer_comment": "This is shown below the list of languages and links to the ODK Central translation guide."
+      }
+    },
+    "NotFound": {
+      "body": {
+        "string": "Ukurasa ulioomba haukupatikana."
+      }
+    },
+    "ProjectArchive": {
+      "title": {
+        "string": "Mradi wa Kuhifadhi kumbukumbu",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Unakaribia kuweka Mradi \"{name}\" kwenye kumbukumbu. Bado itafanya kazi kama inavyofanya sasa, lakini itapangwa hadi chini ya Orodha ya Mradi kwenye ukurasa wa nyumbani wa  Central"
+        },
+        "1": {
+          "full": {
+            "string": "{noUndo}, lakini uwezo wa kutoa Mradi kwenye kumbukumbu umepangwa kutolewa siku zijazo.",
+            "developer_comment": "{noUndo} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nThis action cannot be undone"
+          },
+          "noUndo": {
+            "string": "Kitendo hiki hakiwezi kutenduliwa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {noUndo} is in the following text:\n\n{noUndo}, but the ability to unarchive a Project is planned for a future release."
+          }
+        }
+      }
+    },
+    "ProjectEdit": {
+      "title": {
+        "string": "Maelezo ya Msingi",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "field": {
+        "name": {
+          "string": "Jina la mradi",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "alert": {
+        "success": {
+          "string": "Mipangilio ya mradi imehifadhiwa!"
+        }
+      }
+    },
+    "ProjectEnableEncryption": {
+      "title": {
+        "string": "Washa Usimbaji",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "steps": {
+        "0": {
+          "introduction": {
+            "0": {
+              "0": {
+                "string": "Ukiwezesha usimbaji fiche, mambo yafuatayo yatafanyika:"
+              },
+              "1": {
+                "string": "Data iliyokamilishwa ya Uwasilishaji itasimbwa kwa njia fiche kwenye vifaa vya mkononi."
+              },
+              "2": {
+                "string": "Data ya uwasilishaji imesalia itasimbwa kwa njia fiche kwenye seva ya Central"
+              },
+              "3": {
+                "0": {
+                  "string": "Fomu zilizosanidiwa kwa funguo za mwongozo za {submission} zitaendelea kutumia funguo hizo, na lazima zisimbuwe wewe mwenyewe",
+                  "developer_comment": "{submission} will have the text \"<submission>\", which is XML and will not be translated."
+                },
+                "1": {
+                  "string": "li kutumia mchakato wa usimbaji fiche wa Kati kiotomatiki kwenye Fomu hizi, ondoa usanidi wa {base64RsaPublicKey}.",
+                  "developer_comment": "{base64RsaPublicKey} will have the text \"base64RsaPublicKey\", which is code and will not be translated."
+                }
+              },
+              "4": {
+                "string": "Hutaweza tena kuhakiki data ya Wasilisho mtandaoni."
+              },
+              "5": {
+                "string": "Hutaweza tena kuunganisha kwa data kupitia OData."
+              },
+              "6": {
+                "string": "Hutaweza tena kuhariri Mawasilisho katika kivinjari chako cha wavuti."
+              }
+            },
+            "1": {
+              "0": {
+                "string": "kwa kuongeza, yafuatayo ni kweli katika toleo hili la ODK Central:"
+              },
+              "1": {
+                "0": {
+                  "string": "Mawasilisho yaliyopo yatasalia kuwa hayajasimbwa."
+                },
+                "1": {
+                  "string": "katika toleo la baadaye, utakuwa na chaguo la kusimba data iliyopo"
+                }
+              },
+              "2": {
+                "0": {
+                  "string": "Usimbaji fiche hauwezi kuzimwa baada ya kuwezeshwa"
+                },
+                "1": {
+                  "string": "Katika toleo la baadaye, utaweza kuzima usimbaji fiche, ambao utaondoa usimbaji fiche wa data yako. Hii itakuwa kweli hata ukiwezesha usimbaji fiche sasa."
+                }
+              }
+            },
+            "2": {
+              "full": {
+                "string": "Unaweza kupata maelezo zaidi kuhusu usimbaji fiche {here}. Ikiwa hii inaonekana kama kitu unachotaka, bonyeza Ifuatayo ili kuendelea.",
+                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
+              },
+              "here": {
+                "string": "hapa",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nYou can learn more about encryption {here}. If this sounds like something you want, press Next to proceed."
+              }
+            }
+          }
+        },
+        "1": {
+          "introduction": {
+            "0": {
+              "string": "Kwanza, utahitaji kuchagua neno la siri. Kaulisiri hii itahitajika ili kusimbua Mawasilisho yako. Kwa faragha yako, seva haitakumbuka kaulisiri hii: watu walio na kaulisiri pekee wataweza kusimbua na kusoma data yako ya Wasilisho."
+            },
+            "1": {
+              "full": {
+                "string": "Hakuna urefu au vizuizi vya maudhui kwenye kaulisiri, lakini ukiipoteza, hakuna njia {no} ya kuirejesha au data yako!",
+                "developer_comment": "{no} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nno"
+              },
+              "no": {
+                "string": "Hapana",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {no} is in the following text:\n\nThere are no length or content restrictions on the passphrase, but if you lose it, there is {no} way to recover it or your data!"
+              }
+            }
+          }
+        },
+        "2": {
+          "introduction": {
+            "0": {
+              "string": "Usimbaji fiche umesanidiwa kwa Mradi huu. Kifaa chochote cha rununu kitalazimika kuleta au kuleta tena Fomu za hivi punde zaidi ili usimbaji fiche ufanyike."
+            }
+          }
+        }
+      },
+      "field": {
+        "hint": {
+          "string": "Kidokezo cha kaulisiri (si lazima)",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "alert": {
+        "passphraseTooShort": {
+          "string": "Tafadhali weka kaulisiri yenye urefu wa angalau vibambo 10."
+        }
+      }
+    },
+    "ProjectFormAccess": {
+      "heading": {
+        "0": {
+          "string": "Watumiaji wa Programu wanaweza tu kuona na kujaza Fomu ambazo wamepewa ufikiaji wa uwazi katika jedwali lililo hapa chini. Wasimamizi wa Miradi na Wakusanyaji Data wanaweza kutumia kivinjari cha wavuti kujaza Fomu yoyote katika Mradi ambayo iko katika hali ya Wazi."
+        }
+      },
+      "emptyTable": {
+        "string": "Hakuna Fomu za kuonyesha."
+      },
+      "alert": {
+        "success": {
+          "string": "Mabadiliko yako yamehifadhiwa!"
+        }
+      }
+    },
+    "ProjectFormAccessRow": {
+      "draftTitle": {
+        "string": "Fomu hii bado haina toleo lililochapishwa. Haitaonekana kwenye vifaa hadi Rasimu itakapochapishwa. Ukishachapisha Fomu, mipangilio iliyoonyeshwa hapa itatumika"
+      },
+      "field": {
+        "state": {
+          "string": "Hali",
+          "developer_comment": "This is the text of a form field. \"State\" refers to the Form State. Form States control the lifecycle state of each Form."
+        },
+        "appUserAccess": {
+          "string": "Ufikiaji wa Mtumiaji wa Programu",
+          "developer_comment": "This is the text of a form field."
+        }
+      }
+    },
+    "ProjectFormAccessStates": {
+      "title": {
+        "string": "Hali ya fomu",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Hali ya Fomu hudhibiti hali ya mzunguko wa maisha ya kila Fomu. Kwa kawaida, lakini si mara zote, Fomu itaanza Fungua na kuendelea na Kufunga hadi Kufungwa wakati haihitajiki tena."
+        },
+        "1": {
+          "full": {
+            "string": "{open} Fomu zinapatikana kwa kupakuliwa na zitakubali Mawasilisho mapya.",
+            "developer_comment": "{open} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nOpen"
+          },
+          "open": {
+            "string": "Fungua",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {open} is in the following text:\n\n{open} Forms are available to download and will accept new Submissions."
+          }
+        },
+        "2": {
+          "full": {
+            "string": "{closing} Fomu zitakubali Mawasilisho mapya, lakini si {not} kupakuliwa.",
+            "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closing} has the text: Closing\n- {not} has the text: not"
+          },
+          "closing": {
+            "string": "Kufunga",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closing} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
+          },
+          "not": {
+            "string": "sivyo",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not} is in the following text:\n\n{closing} Forms will accept new Submissions, but are {not} available to download."
+          }
+        },
+        "3": {
+          "full": {
+            "string": "{closed} Fomu {not1} kupakuliwa na {not2} hazitakubali Mawasilisho mapya",
+            "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {closed} has the text: Closed\n- {not1} has the text: not\n- {not2} has the text: not"
+          },
+          "closed": {
+            "string": "Imefungwa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {closed} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
+          },
+          "not1": {
+            "string": "Sivyo",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not1} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
+          },
+          "not2": {
+            "string": "Sivyo",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {not2} is in the following text:\n\n{closed} Forms are {not1} available to download and will {not2} accept new Submissions."
+          }
+        }
+      }
+    },
+    "ProjectFormAccessTable": {
+      "header": {
+        "form": {
+          "string": "fomu",
+          "developer_comment": "This is the text of a table column header."
+        },
+        "state": {
+          "string": "hali",
+          "developer_comment": "This is the text of a table column header."
+        }
+      }
+    },
+    "ProjectIntroduction": {
+      "title": {
+        "string": "Miradi ni nini?",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Miradi hukuruhusu kupanga Fomu na Watumiaji zinazohusiana. Watumiaji wa Wavuti wanaweza kupewa Majukumu ambayo huwaruhusu kutekeleza vitendo fulani ndani ya Mradi, ikijumuisha kutumia kivinjari cha wavuti kujaza Fomu. Watumiaji wa Programu za Mradi wanaweza tu kuona Fomu katika Mradi ambao wanaweza kufikia."
+        }
+      }
+    },
+    "ProjectList": {
+      "heading": {
+        "0": {
+          "string": "Karibu Central."
+        },
+        "1": {
+          "string": "Hebu tufanye baadhi ya mambo.",
+          "developer_comment": "This is a tagline displayed next to \"Welcome to Central\". The text adds visual balance to the page and does not need to be translated literally to your language. The text should be action-oriented, collaborative, and a little bit fun."
+        }
+      },
+      "gettingStarted": {
+        "title": {
+          "string": "Kuanza",
+          "developer_comment": "This is a title shown above a section of the page."
+        },
+        "body": {
+          "0": {
+            "full": {
+              "string": "Iwapo huna uhakika pa kuanzia, kuna mwongozo wa kuanza na hati za mtumiaji zinazopatikana kwenye {docsWebsite}.",
+              "developer_comment": "{docsWebsite} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nODK Docs website"
+            },
+            "docsWebsite": {
+              "string": "Tovuti ya Hati za ODK",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {docsWebsite} is in the following text:\n\nIf you’re not sure where to begin, there is a getting started guide and user documentation available on the {docsWebsite}."
+            }
+          },
+          "1": {
+            "full": {
+              "string": "Kwa kuongeza, unaweza kupata usaidizi kutoka kwa wengine kwenye {forum} wakati wowote, ambapo unaweza kutafuta maswali ya awali au kuuliza moja yako mwenyewe.",
+              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nODK community forum"
+            },
+            "forum": {
+              "string": "ODK jamii forum",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nIn addition, you can always get help from others on the {forum}, where you can search previous questions or ask one of your own."
+            }
+          }
+        }
+      },
+      "news": {
+        "string": "Habari",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "rightNow": {
+        "users": {
+          "full": {
+            "string": "{count, plural, one {{webUsers} ambaye anaweza kusimamia Miradi kupitia tovuti hii.} other {{webUsers} ambao wanaweza kusimamia Miradi kupitia tovuti hii.}}",
+            "developer_comment": "The count of Web Users is shown separately above this text.\n\n{webUsers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nWeb Users"
+          },
+          "webUsers": {
+            "string": "{count, plural, one {Mtumiaji wa Mtandao} other {Watumiaji wa Mtandao}}",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {webUsers} is in the following text. (The plural form of the text is shown.)\n\n{webUsers} who can administer Projects through this website."
+          }
+        },
+        "projects": {
+          "full": {
+            "string": "{count, plural, one {{projects} ambayo inaweza kupanga Fomu na Watumiaji wa Programu kwa ajili ya kusambaza kifaa.} other {{projects} ambayo inaweza kupanga Fomu na Watumiaji wa Programu kwa ajili ya kusambaza kifaa.}}",
+            "developer_comment": "The count of Projects is shown separately above this text.\n\n{projects} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nProjects"
+          },
+          "projects": {
+            "string": "{count, plural, one {Mradi} other {Miradi}}",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {projects} is in the following text. (The plural form of the text is shown.)\n\n{projects} which can organize Forms and App Users for device deployment."
+          }
+        }
+      },
+      "projectsTitle": {
+        "string": "Miradi",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "action": {
+        "create": {
+          "string": "Mpya",
+          "developer_comment": "This is the text of a button that is used to create a new Project."
+        }
+      },
+      "header": {
+        "forms": {
+          "string": "Fomu",
+          "developer_comment": "This is the text of a table column header."
+        }
+      },
+      "emptyTable": {
+        "string": "Hakuna Miradi kwako kuona."
+      },
+      "alert": {
+        "create": {
+          "string": "Mradi wako mpya umeundwa."
+        }
+      }
+    },
+    "ProjectNew": {
+      "title": {
+        "string": "Unda Mradi",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Miradi huweka pamoja Fomu na Watumiaji wa Programu ili kurahisisha kupanga na kudhibiti, kwenye tovuti hii na kwenye kifaa chako cha kukusanya data."
+        }
+      }
+    },
+    "ProjectOverviewAbout": {
+      "title": {
+        "string": "Kuhusu Miradi",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "body": {
+        "0": {
+          "full": {
+            "string": "Miradi hukuruhusu kupanga Fomu na Watumiaji zinazohusiana. Watumiaji wa Wavuti wanaweza kupewa Majukumu ambayo huwaruhusu kutekeleza vitendo fulani ndani ya Mradi huu, ikijumuisha kutumia kivinjari cha wavuti kujaza Fomu. Watumiaji wa Programu za Mradi huu wanaweza tu kuona Fomu katika Mradi huu ambao wana {accessTo}",
+            "developer_comment": "{accessTo} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\naccess to"
+          },
+          "accessTo": {
+            "string": "upatikanaji wa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {accessTo} is in the following text:\n\nProjects let you group related Forms and Users. Web Users can be given Roles that let them perform certain actions within this Project, including using a web browser to fill out Forms. App Users for this Project can only see Forms in this Project which they have {accessTo}."
+          }
+        },
+        "1": {
+          "full": {
+            "string": "ikiwa una maoni yoyote, tafadhali tembelea {forumThread}.",
+            "developer_comment": "{forumThread} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthis forum thread"
+          },
+          "forumThread": {
+            "string": "hii thread ya jukwaa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forumThread} is in the following text:\n\nIf you have any feedback, please visit {forumThread}."
+          }
+        }
+      }
+    },
+    "ProjectOverviewRightNow": {
+      "appUsers": {
+        "full": {
+          "string": "{count, plural, one {{appUsers} ambao wanaweza kutumia mteja wa kukusanya data kupakua na kuwasilisha data ya Fomu kwa Mradi huu} other {{appUsers} ambao wanaweza kutumia mteja wa kukusanya data kupakua na kuwasilisha data ya Fomu kwa Mradi huu}}",
+          "developer_comment": "The count of App Users is shown separately above this text.\n\n{appUsers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nApp Users"
+        },
+        "appUsers": {
+          "string": "{count, plural, one {Mtumiaji wa Programu} other {Watumiaji wa Programu}}",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {appUsers} is in the following text. (The plural form of the text is shown.)\n\n{appUsers} who can use a data collection client to download and submit Form data to this Project."
+        }
+      },
+      "forms": {
+        "full": {
+          "string": "{count, plural, one {{forms} ambazo zinaweza kupakuliwa na kutolewa kama tafiti.\n } other {{forms} ambazo zinaweza kupakuliwa na kutolewa kama tafiti.}}",
+          "developer_comment": "The count of Forms is shown separately above this text.\n\n{forms} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\nForms"
+        },
+        "forms": {
+          "string": "{count, plural, one {Fomu} other {Fomu}}",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forms} is in the following text. (The plural form of the text is shown.)\n\n{forms} which can be downloaded and given as surveys."
+        }
+      }
+    },
+    "ProjectRow": {
+      "help": {
+        "string": "Miradi ni nini?"
+      },
+      "noSubmission": {
+        "string": "(Hakuna)",
+        "developer_comment": "This text is shown under the \"Latest Submission\" column of the Projects table. It is shown for a Project with no Submissions."
+      },
+      "encryptionTip": {
+        "string": "Mradi huu unatumia usimbaji fiche unaodhibitiwa"
+      }
+    },
+    "ProjectSettings": {
+      "encryption": {
+        "title": {
+          "string": "Usimbaji fiche",
+          "developer_comment": "This is a title shown above a section of the page."
+        },
+        "body": {
+          "unencrypted": {
+            "0": {
+              "string": "Usimbaji fiche wa data ya uwasilishaji haujawezeshwa kwa Mradi huu."
+            }
+          },
+          "encrypted": {
+            "0": {
+              "full": {
+                "string": "Usimbaji fiche wa data ya uwasilishaji {enabled} kwa Mradi huu.",
+                "developer_comment": "{enabled} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nenabled"
+              },
+              "enabled": {
+                "string": "imewezeshwa",
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {enabled} is in the following text:\n\nSubmission data encryption is {enabled} for this Project."
+              }
+            },
+            "1": {
+              "string": "Katika toleo hili la ODK Central, huwezi kuzima usimbaji fiche mara tu inapowashwa."
+            }
+          }
+        },
+        "action": {
+          "enableEncryption": {
+            "string": "Washa usimbaji fiche",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        }
+      },
+      "dangerZone": {
+        "action": {
+          "archive": {
+            "string": "Hifadhi Mradi huu kwenye kumbukumbu",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        },
+        "archived": {
+          "0": {
+            "string": "Mradi huu umewekwa kwenye kumbukumbu."
+          },
+          "1": {
+            "string": "Katika toleo hili la ODK Central, unaweza usiondoe Mradi kwenye kumbukumbu. Hata hivyo, uwezo wa kufuta Mradi umepangwa kwa ajili ya kutolewa siku zijazo."
+          }
+        }
+      },
+      "alert": {
+        "archive": {
+          "string": "Mradi \"{name}\" uliwekwa kwenye kumbukumbu."
+        }
+      }
+    },
+    "ProjectSubmissionOptions": {
+      "title": {
+        "string": "Chaguzi za Uwasilishaji",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Kuna chaguo kadhaa za kuwasilisha data kwa ODK Central:",
+          "developer_comment": "This text is shown above a list of options for submitting data."
+        },
+        "1": {
+          "full": {
+            "string": "Unda {appUsers} na utumie programu ya Android ya {collect}. Hii inafaa zaidi wakati wakusanyaji wa data wanahitaji ufikiaji wa Fomu nyingi, wako nje ya mtandao, au una Fomu ngumu",
+            "developer_comment": "This text is shown in a list of options for submitting data. {collect} is a link whose text is \"ODK Collect\".\n\n{appUsers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nApp Users"
+          },
+          "appUsers": {
+            "string": "Watumiaji wa Programu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {appUsers} is in the following text:\n\nCreate {appUsers} and use the {collect} Android application. This is most appropriate when data collectors need access to multiple Forms, are offline, or you have a complex Form."
+          }
+        },
+        "2": {
+          "full": {
+            "string": "Unda {publicLinks} moja au zaidi ili kushiriki na waliojibu ambao watajiripoti.",
+            "developer_comment": "This text is shown in a list of options for submitting data.\n\n{publicLinks} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nPublic Access Links"
+          },
+          "publicLinks": {
+            "string": "Viungo vya Ufikiaji wa Umma",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {publicLinks} is in the following text:\n\nCreate one or more {publicLinks} to share with respondents who will self-report."
+          }
+        },
+        "3": {
+          "full": {
+            "string": "Unda {webUser} na Jukumu la {dataCollector} kwa kila mtu ambaye atakuwa akikusanya data. Watumiaji hawa wataingia katika Kituo Kikuu ili kujaza Fomu hii katika kivinjari cha wavuti. Wasimamizi wa Miradi wanaweza pia kuunda Mawasilisho kutoka kwa kivinjari cha wavuti.",
+            "developer_comment": "This text is shown in a list of options for submitting data.\n\nThe following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {webUser} has the text: Web User\n- {dataCollector} has the text: Data Collector"
+          },
+          "webUser": {
+            "string": "Mtumiaji wa Mtandao",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {webUser} is in the following text:\n\nCreate a {webUser} with the Role of {dataCollector} for each individual who will be collecting data. These Users will log into Central to fill out this Form in a web browser. Project Managers can also create Submissions from a web browser."
+          },
+          "dataCollector": {
+            "string": "Mkusanya Data",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {dataCollector} is in the following text:\n\nCreate a {webUser} with the Role of {dataCollector} for each individual who will be collecting data. These Users will log into Central to fill out this Form in a web browser. Project Managers can also create Submissions from a web browser."
+          }
+        }
+      }
+    },
+    "ProjectUserList": {
+      "heading": {
+        "0": {
+          "string": "Wasimamizi wa Tovuti nzima wanazingatiwa kiotomatiki Wasimamizi wa kila Mradi. Watumiaji Wengine wanaweza kuwa na Majukumu mahususi kwa Mradi huu",
+          "developer_comment": "This text is shown above a list of Roles."
+        },
+        "1": {
+          "full": {
+            "string": "{projectManagers} inaweza kutekeleza kazi yoyote ya usimamizi inayohusiana na Mradi huu na inaweza kujaza Fomu katika kivinjari cha wavuti.",
+            "developer_comment": "This text is shown in a list of Roles.\n\n{projectManagers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nProject Managers"
+          },
+          "projectManagers": {
+            "string": "Wasimamizi wa Mradi",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {projectManagers} is in the following text:\n\n{projectManagers} can perform any administrative task related to this Project and can fill Forms out in a web browser"
+          }
+        },
+        "2": {
+          "full": {
+            "string": "{projectViewers} inaweza kufikia na kupakua data yote ya Fomu katika Mradi huu, lakini haiwezi kufanya mabadiliko yoyote kwenye mipangilio au data",
+            "developer_comment": "This text is shown in a list of Roles.\n\n{projectViewers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nProject Viewers"
+          },
+          "projectViewers": {
+            "string": "Watazamaji wa Mradi",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {projectViewers} is in the following text:\n\n{projectViewers} can access and download all Form data in this Project, but cannot make any changes to settings or data"
+          }
+        },
+        "3": {
+          "full": {
+            "string": "{dataCollectors} inaweza kujaza Fomu katika kivinjari, lakini haiwezi kuona au kubadilisha data au mipangilio",
+            "developer_comment": "This text is shown in a list of Roles.\n\n{dataCollectors} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nData Collectors"
+          },
+          "dataCollectors": {
+            "string": "Wakusanyaji Data",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {dataCollectors} is in the following text:\n\n{dataCollectors} can fill Forms out in a web browser, but cannot view or change data or settings"
+          }
+        }
+      },
+      "action": {
+        "clearSearch": {
+          "string": "Futa utafutaji",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "field": {
+        "q": {
+          "canList": {
+            "string": "Tafuta mtumiaji...",
+            "developer_comment": "This is the text of a form field."
+          },
+          "cannotList": {
+            "string": "Weka barua pepe kamili ya mtumiaji...",
+            "developer_comment": "This is the text of a form field."
+          }
+        }
+      },
+      "header": {
+        "user": {
+          "string": "Mtumiaji",
+          "developer_comment": "This is the text of a table column header."
+        },
+        "projectRole": {
+          "string": "Jukumu la Mradi",
+          "developer_comment": "This is the text of a table column header."
+        }
+      },
+      "emptyTable": {
+        "string": "Bado hakuna watumiaji waliokabidhiwa kwa Mradi huu. Ili kuongeza moja, tafuta mtumiaji hapo juu."
+      },
+      "alert": {
+        "unassignWithoutReassign": {
+          "string": "Hitilafu fulani imetokea. \"{displayName}\" imeondolewa kwenye Mradi."
+        },
+        "assignRole": {
+          "string": "Mafanikio! \"{displayName}\" imepewa Jukumu la \"{roleName}\" kwenye Mradi huu."
+        },
+        "unassignRole": {
+          "string": "Mafanikio! \"{displayName}\" imeondolewa kwenye Mradi huu."
+        }
+      }
+    },
+    "ProjectUserRow": {
+      "cannotAssignRole": {
+        "string": "Huenda usihariri Jukumu lako la Mradi."
+      },
+      "field": {
+        "projectRole": {
+          "string": "Jukumu la Mradi",
+          "developer_comment": "This is the text of a form field."
+        }
+      }
+    },
+    "PublicLinkCreate": {
+      "title": {
+        "string": "Unda Kiungo cha Ufikiaji wa Umma",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Mtu yeyote aliye na Kiungo hiki ataweza kujaza Fomu hii katika kivinjari. Tumia jina la onyesho ili kujikumbusha mahali ulipoichapisha, ulishiriki na nani, wakati inakusudiwa kutumika, na kadhalika"
+        }
+      },
+      "field": {
+        "once": {
+          "string": "Uwasilishaji Mmoja",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "onceHelp": {
+        "string": "Ruhusu Uwasilishaji mmoja tu kutoka kwa kila kivinjari.",
+        "developer_comment": "This is help text for the \"Single Submission\" checkbox."
+      }
+    },
+    "PublicLinkList": {
+      "action": {
+        "create": {
+          "string": "Unda Kiungo cha Ufikiaji wa Umma",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "heading": {
+        "0": {
+          "full": {
+            "string": "Mtu yeyote aliye na Kiungo cha Ufikiaji wa Umma anaweza kujaza Fomu hii katika kivinjari. Unaweza kuunda Viungo vingi ili kufuatilia usambazaji tofauti wa Fomu, kuweka kikomo muda ambao kikundi mahususi cha watu kinaweza kufikia Fomu, na zaidi. Viungo hivi vitafanya kazi ikiwa tu Fomu iko katika {state} la Wazi.",
+            "developer_comment": "{state} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstate"
+          },
+          "state": {
+            "string": "Hali",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {state} is in the following text:\n\nAnyone with a Public Access Link can fill out this Form in a web browser. You can create multiple Links to track different distributions of the Form, to limit how long a specific group of people has access to the Form, and more. These links will only work if the Form is in the Open {state}."
+          }
+        },
+        "1": {
+          "full": {
+            "string": "Viungo vya Umma vimekusudiwa kujiripoti. Ikiwa unafanya kazi na wakusanyaji data ambao wanahitaji kuwasilisha Fomu sawa mara nyingi, {clickHere} kwa chaguo zingine.",
+            "developer_comment": "{clickHere} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nclick here"
+          },
+          "clickHere": {
+            "string": "Bonyeza hapa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {clickHere} is in the following text:\n\nPublic Links are intended for self-reporting. If you are working with data collectors who need to submit the same Form multiple times, {clickHere} for other options."
+          }
+        }
+      },
+      "emptyTable": {
+        "string": "Hakuna Viungo vya Ufikiaji wa Umma vya Fomu hii."
+      },
+      "alert": {
+        "create": {
+          "string": "Mafanikio! Kiungo chako cha Kufikia Umma kimeundwa na sasa kinapatikana. Nakili hapa chini ili kuisambaza."
+        },
+        "revoke": {
+          "string": "Kiungo cha Ufikiaji wa Umma \"{displayName}\" kimebatilishwa. Hakuna Mawasilisho Zaidi yatakubaliwa kwa kutumia Kiungo hiki."
+        }
+      }
+    },
+    "PublicLinkRevoke": {
+      "title": {
+        "string": "Batilisha Kiungo cha Ufikiaji wa Umma",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Unakaribia kubatilisha Kiungo hiki cha Ufikiaji wa Umma. Hii ina maana kwamba majaribio yote ya kuwasilisha data kwa kutumia kiungo yatakataliwa, ikiwa ni pamoja na rekodi ambazo tayari zimeanzishwa"
+        }
+      }
+    },
+    "PublicLinkRow": {
+      "action": {
+        "revoke": {
+          "string": "Batilisha",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "revoked": {
+        "string": "Imebatilishwa",
+        "developer_comment": "This text is shown for a Public Access Link that has been revoked. The text appears on its own and is not part of a longer sentence."
+      },
+      "unavailable": {
+        "text": {
+          "string": "Haipatikani bado",
+          "developer_comment": "This text is shown for a Public Access Link that is not available yet."
+        },
+        "title": {
+          "string": "Kiungo cha Ufikiaji wa Umma bado hakipatikani. Haijamaliza kuchakatwa. Tafadhali onyesha upya baadaye na ujaribu tena."
+        }
+      }
+    },
+    "PublicLinkTable": {
+      "header": {
+        "once": {
+          "string": "Uwasilishaji Mmoja",
+          "developer_comment": "This is the text of a table column header."
+        },
+        "accessLink": {
+          "string": "Kiungo cha Ufikiaji",
+          "developer_comment": "This is the text of a table column header."
+        }
+      }
+    },
+    "SubmissionAnalyze": {
+      "title": {
+        "string": "Kwa kutumia OData",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "OData ni kiwango kipya cha kuhamisha data kati ya zana na huduma. Zana za uchanganuzi zisizolipishwa na zenye nguvu kama vile Excel, {powerBi} na {r} zinaweza kuleta data kupitia OData kwa uchanganuzi.",
+          "developer_comment": "The text of {powerBi} is \"Microsoft Power BI\". The text of {r} is \"R\". {powerBi} and {r} are both links."
+        },
+        "1": {
+          "string": "Kuna faida nyingi kwa OData, lakini muhimu zaidi inaauni uhamishaji wa uaminifu kamili wa aina ngumu kama vile nambari na data ya kijiografia, na huwezesha toleo jipya zaidi la data yako kusawazisha kwa urahisi na zana zozote zinazoitumia."
+        },
+        "2": {
+          "string": "Ili kuanza kutumia OData, chagua zana yako na unakili kiungo ndani yake."
+        }
+      },
+      "tab": {
+        "microsoft": {
+          "string": "Excel/Power BI",
+          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+        },
+        "other": {
+          "string": "Nyingine",
+          "developer_comment": "This is the text of a navigation tab. \"Other\" refers to \"other tool\"."
+        }
+      },
+      "help": {
+        "microsoft": {
+          "full": {
+            "string": "Kwa usaidizi wa kutumia OData na Excel, angalia {pageForExcel}. Kwa usaidizi wa Power BI, angalia {pageForPowerBi}.",
+            "developer_comment": "The following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {pageForExcel} has the text: this page\n- {pageForPowerBi} has the text: this page"
+          },
+          "pageForExcel": {
+            "string": "ukurasa huu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {pageForExcel} is in the following text:\n\nFor help using OData with Excel, see {pageForExcel}. For help with Power BI, see {pageForPowerBi}."
+          },
+          "pageForPowerBi": {
+            "string": "ukurasa huu",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {pageForPowerBi} is in the following text:\n\nFor help using OData with Excel, see {pageForExcel}. For help with Power BI, see {pageForPowerBi}."
+          }
+        },
+        "r": {
+          "0": {
+            "full": {
+              "string": "Ili kufikia data ya Kati kutoka kwa {r}, tunapendekeza utumie {ruODK}. Tazama vignette za ruODK kwa mifano ya kutumia API ya {oData} na {restful}.",
+              "developer_comment": "The text of {r} is \"R\". The text of {ruODK} is \"ruODK\". The text of {oData} is \"OData\". All three are links.\n\n{restful} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nRESTful"
+            },
+            "restful": {
+              "string": "Tulivu",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {restful} is in the following text:\n\nTo access Central data from {r}, we recommend you use {ruODK}. See ruODK’s vignettes for examples of using both the {oData} and the {restful} API."
+            }
+          },
+          "1": {
+            "full": {
+              "string": "kama vile ODK yenyewe, ruODK inatengenezwa na kuungwa mkono na wanajamii. Ikiwa ungependa kusaidia kuiboresha, unaweza kupata maelezo {here}.",
+              "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
+            },
+            "here": {
+              "string": "Hapa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nJust like ODK itself, ruODK is developed and supported by community members. If you wish to help improve it, you can find information {here}."
+            }
+          }
+        },
+        "other": {
+          "full": {
+            "string": "Kwa maelezo kamili ya usaidizi wetu wa OData, tafadhali angalia {article}.",
+            "developer_comment": "{article} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthis article"
+          },
+          "article": {
+            "string": "Makala hii",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {article} is in the following text:\n\nFor a full description of our OData support, please see {article}."
+          }
+        }
+      }
+    },
+    "SubmissionBasicDetails": {
+      "reviewState": {
+        "string": "Kagua hali"
+      },
+      "formVersion": {
+        "string": "Toleo la fomu"
+      },
+      "deviceId": {
+        "string": "Kitambulisho cha Kifaa"
+      },
+      "userAgent": {
+        "string": "Wakala wa mtumiaji"
+      },
+      "attachments": {
+        "string": "Faili za media"
+      },
+      "present": {
+        "string": "{count, plural, one {faili {count}} other {faili {count}}}"
+      },
+      "expected": {
+        "string": "{count, plural, one {{count} inatarajiwa} other {{count} inatarajiwa}}",
+        "developer_comment": "This shows the number of files that were expected to be submitted."
+      },
+      "attachmentSummary": {
+        "string": "{present} / {expected}",
+        "developer_comment": "{present} shows the number of files that were submitted, and {expected} shows the number of files that were expected to be submitted. For example: \"2 files / 3 expected\""
+      }
+    },
+    "SubmissionComment": {
+      "editWithoutComment": {
+        "string": "Umefanya mabadiliko kwenye data hii. Tafadhali eleza mabadiliko uliyofanya."
+      }
+    },
+    "SubmissionDataAccess": {
+      "action": {
+        "apiAccess": {
+          "string": "Ufikiaji wa API",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        },
+        "analyze": {
+          "string": "Changanua kupitia OData",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "analyzeDisabled": {
+        "string": "Ufikiaji wa OData haupatikani kwa sababu ya usimbaji fiche wa Fomu"
+      }
+    },
+    "SubmissionDecrypt": {
+      "title": {
+        "string": "Pakua Mawasilisho",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "exportOptions": {
+        "string": "Chaguzi za export",
+        "developer_comment": "This text is shown above options for downloading Submissions."
+      },
+      "field": {
+        "splitSelectMultiples": {
+          "string": "Gawanya chaguo za \"chagua nyingi\" kwenye safu wima",
+          "developer_comment": "This is the text of a form field."
+        },
+        "removeGroupNames": {
+          "string": "Ondoa majina ya kikundi",
+          "developer_comment": "This is the text of a form field."
+        },
+        "deletedFields": {
+          "string": "Jumuisha sehemu za Fomu zilizofutwa hapo awali",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "noSelectMultiple": {
+        "string": "Fomu hii haina sehemu nyingi zilizochaguliwa"
+      },
+      "encryptedForm": {
+        "string": "Fomu Zilizosimbwa kwa njia fiche haziwezi kuchakatwa kwa njia hii"
+      },
+      "introduction": {
+        "0": {
+          "string": "Ili kupakua data hii, utahitaji kutoa neno lako la siri. Kauli yako ya siri itatumika tu kusimbua data yako kwa ajili ya kupakua, na kisha seva itaisahau tena."
+        }
+      },
+      "hint": {
+        "string": "Kidokezo: {hint}",
+        "developer_comment": "This text is shown if there is a passphrase hint. {hint} is the passphrase hint."
+      },
+      "noRepeat": {
+        "string": "Fomu hii haina marudio",
+        "developer_comment": "\"Repeats\" refers to repeat groups."
+      },
+      "action": {
+        "download": {
+          "mainTable": {
+            "string": "Jedwali kuu la data (hakuna marudio)",
+            "developer_comment": "This is the text of a button. \"Repeats\" refers to repeat groups."
+          },
+          "allTables": {
+            "string": "Jedwali zote za data",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          },
+          "withMedia": {
+            "string": "Data zote na faili za midia",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        }
+      },
+      "alert": {
+        "unavailable": {
+          "string": "Upakuaji wa data bado haupatikani. Tafadhali jaribu tena baada ya muda mfupi"
+        },
+        "submit": {
+          "string": "Upakuaji wa data yako unapaswa kuanza hivi karibuni. Mara tu inapoanza, unaweza kufunga kisanduku hiki. Ikiwa umekuwa ukingoja na haijaanza, tafadhali jaribu tena."
+        }
+      }
+    },
+    "SubmissionDiffItem": {
+      "editCaption": {
+        "added": {
+          "string": "(imeongezwa)",
+          "developer_comment": "The description of how a specific field in a form submission changed"
+        },
+        "deleted": {
+          "string": "(imefutwa)",
+          "developer_comment": "The description of how a specific field in a form submission changed"
+        }
+      },
+      "empty": {
+        "string": "tupu",
+        "developer_comment": "Text showing that a value in a submission edit is empty"
+      }
+    },
+    "SubmissionDownloadDropdown": {
+      "action": {
+        "download": {
+          "unfiltered": {
+            "string": "{count, plural, one {Pakua rekodi {count}} other {Pakua rekodi {count}}}",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          },
+          "filtered": {
+            "withoutCount": {
+              "string": "Pakua rekodi zinazolingana",
+              "developer_comment": "This is the text of a button. This text is shown when the number of matching records is unknown."
+            },
+            "withCount": {
+              "string": "{count, plural, one {Pakua rekodi {count} zinazolingana} other {Pakua rekodi {count} zinazolingana}}",
+              "developer_comment": "This is the text for an action, for example, the text of a button."
+            }
+          }
+        }
+      }
+    },
+    "SubmissionFeedEntry": {
+      "title": {
+        "create": {
+          "string": "Imewasilishwa na {name}",
+          "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Submitted\", so it is essential for \"Submitted\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nSubmitted by {name}\n\nyou could split it into:\n\nSubmitted • {name}"
+        },
+        "updateReviewState": {
+          "null": {
+            "full": {
+              "string": "{reviewState} kwa {name}",
+              "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\n{reviewState} per {name}\n\nyou could split it into:\n\n{reviewState} • {name}\n\n{reviewState} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nReceived"
+            },
+            "reviewState": {
+              "string": "Imepokelewa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {reviewState} is in the following text:\n\n{reviewState} per {name}"
+            }
+          },
+          "hasIssues": {
+            "full": {
+              "string": "{reviewState} kwa {name}",
+              "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\n{reviewState} per {name}\n\nyou could split it into:\n\n{reviewState} • {name}\n\n{reviewState} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nHas Issues"
+            },
+            "reviewState": {
+              "string": "Ina Masuala",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {reviewState} is in the following text:\n\n{reviewState} per {name}"
+            }
+          },
+          "edited": {
+            "full": {
+              "string": "{reviewState} kwa {name}",
+              "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\n{reviewState} by {name}\n\nyou could split it into:\n\n{reviewState} • {name}\n\n{reviewState} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nEdited"
+            },
+            "reviewState": {
+              "string": "Imehaririwa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {reviewState} is in the following text:\n\n{reviewState} by {name}"
+            }
+          },
+          "approved": {
+            "full": {
+              "string": "{reviewState} kwa {name}",
+              "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\n{reviewState} by {name}\n\nyou could split it into:\n\n{reviewState} • {name}\n\n{reviewState} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nApproved"
+            },
+            "reviewState": {
+              "string": "Imeidhinishwa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {reviewState} is in the following text:\n\n{reviewState} by {name}"
+            }
+          },
+          "rejected": {
+            "full": {
+              "string": "{reviewState} kwa {name}",
+              "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\n{reviewState} by {name}\n\nyou could split it into:\n\n{reviewState} • {name}\n\n{reviewState} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nRejected"
+            },
+            "reviewState": {
+              "string": "Imekataliwa",
+              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {reviewState} is in the following text:\n\n{reviewState} by {name}"
+            }
+          }
+        },
+        "comment": {
+          "string": "Maoni kutoka kwa {name}",
+          "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Comment\", so it is essential for \"Comment\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nComment by {name}\n\nyou could split it into:\n\nComment • {name}"
+        }
+      }
+    },
+    "SubmissionFieldDropdown": {
+      "placeholder": {
+        "string": "{selected} kati ya {total}",
+        "developer_comment": "This is the text of a dropdown that allows the user to select which columns to display in a table. {selected} is the number of columns selected; {total} is the total number of columns."
+      },
+      "field": {
+        "columns": {
+          "string": "Safu wima zimeonyeshwa",
+          "developer_comment": "This is shown beneath text that indicates the number of columns that the user has selected to display in a table. For example, that text may read \"10 of 100\", where 10 is the number of columns selected, and 100 is the total number of columns."
+        },
+        "search": {
+          "string": "Tafuta safu wima...",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "disabled": {
+        "string": "Haiwezi kuchagua zaidi ya safu wima 100."
+      },
+      "action": {
+        "select": {
+          "full": {
+            "string": "Chagua {all} / {none}",
+            "developer_comment": "This text is shown in a dropdown that allows the user to select which columns to display in a table.\n\nThe following are separate strings that will be translated below. They will be formatted within ODK Central, for example, they might be bold or a link.\n\n- {all} has the text: All\n- {none} has the text: None"
+          },
+          "all": {
+            "string": "zote",
+            "developer_comment": "This text is shown in a dropdown that allows the user to select which columns to display in a table.\n\nThis text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {all} is in the following text:\n\nSelect {all} / {none}"
+          },
+          "none": {
+            "string": "hakuna",
+            "developer_comment": "This text is shown in a dropdown that allows the user to select which columns to display in a table.\n\nThis text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {none} is in the following text:\n\nSelect {all} / {none}"
+          }
+        }
+      }
+    },
+    "SubmissionFilters": {
+      "field": {
+        "submissionDate": {
+          "string": "Imewasilishwa kwa",
+          "developer_comment": "This is the text of a form field that allows the user to filter by a date range."
+        }
+      }
+    },
+    "SubmissionFiltersReviewState": {
+      "anyState": {
+        "string": "(hali lolote)",
+        "developer_comment": "This text is shown in a dropdown that allows the user to filter to show only Submissions in a particular Review State."
+      }
+    },
+    "SubmissionFiltersSubmitter": {
+      "field": {
+        "submitter": {
+          "string": "Iliyowasilishwa na",
+          "developer_comment": "This is the text of a form field that shows the names of users who have submitted data."
+        }
+      }
+    },
+    "SubmissionList": {
+      "loading": {
+        "withoutCount": {
+          "string": "Inapakia Mawasilisho...",
+          "developer_comment": "This text is shown when the number of Submissions loading is unknown."
+        },
+        "all": {
+          "string": "{count, plural, one {Inapakia Mawasilisho {count}...} other {Inapakia Mawasilisho {count}...}}"
+        },
+        "first": {
+          "string": "{count, plural, one {Inapakia {top} ya kwanza kati ya Mawasilisho {count}...} other {Inapakia {top} ya kwanza kati ya Mawasilisho {count}...}}",
+          "developer_comment": "{top} is a number that is either 250 or 1000. {count} may be any number that is at least 250. The string will be pluralized based on {count}."
+        },
+        "middle": {
+          "string": "{count, plural, one {Inapakia {top} zaidi ya Mawasilisho {count} yaliyosalia...} other {Inapakia {top} zaidi ya Mawasilisho {count} yaliyosalia...}}",
+          "developer_comment": "{top} is a number that is either 250 or 1000. {count} may be any number that is at least 250. The string will be pluralized based on {count}."
+        },
+        "last": {
+          "multiple": {
+            "string": "{count, plural, one {Inapakia Mawasilisho {count} ya mwisho...} other {Inapakia Mawasilisho {count} ya mwisho...}}"
+          },
+          "one": {
+            "string": "Inapakia Wasilisho la mwisho..."
+          }
+        },
+        "filtered": {
+          "withoutCount": {
+            "string": "Inapakia Mawasilisho yanayolingana...",
+            "developer_comment": "This text is shown when the number of Submissions loading is unknown."
+          },
+          "middle": {
+            "string": "{count, plural, one {Inapakia {top} zaidi ya Mawasilisho {count} yanayolingana...} other {Inapakia {top} zaidi ya Mawasilisho {count} yanayolingana...}}",
+            "developer_comment": "{top} is a number that is either 250 or 1000. {count} may be any number that is at least 250. The string will be pluralized based on {count}."
+          },
+          "last": {
+            "multiple": {
+              "string": "{count, plural, one {Inapakia Mawasilisho {count} ya mwisho yanayolingana...} other {Inapakia Mawasilisho {count} ya mwisho yanayolingana...}}"
+            },
+            "one": {
+              "string": "Inapakia Wasilisho linalolingana la mwisho..."
+            }
+          }
+        }
+      },
+      "emptyTable": {
+        "string": "Bado hakuna Mawasilisho."
+      },
+      "noMatching": {
+        "string": "Hakuna Mawasilisho yanayolingana."
+      }
+    },
+    "SubmissionShow": {
+      "back": {
+        "title": {
+          "string": "Maelezo ya Uwasilishaji",
+          "developer_comment": "This is shown at the top of the page."
+        },
+        "back": {
+          "string": "Rudi kwenye Jedwali la Mawasilisho",
+          "developer_comment": "This is shown at the top of the page."
+        }
+      }
+    },
+    "SubmissionTable": {
+      "header": {
+        "stateAndActions": {
+          "string": "Hali na vitendo",
+          "developer_comment": "This is the text of a table column header."
+        }
+      }
+    },
+    "SubmissionUpdateReviewState": {
+      "title": {
+        "string": "Sasisha Uhakiki wa hali",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "field": {
+        "notes": {
+          "string": "Vidokezo na maoni (si lazima)",
+          "developer_comment": "This is the text of a form field."
+        }
+      }
+    },
+    "TimeAndUser": {
+      "text": {
+        "string": "{dateTime} na {displayName}",
+        "developer_comment": "This shows the date and time at which a particular user completed an action, for example: \"2020/01/01 01:23 by Alice\". {dateTime} may show a formatted date like \"2020/01/01\", or it may use a word like \"today\", \"yesterday\", or \"Sunday\"."
+      }
+    },
+    "UserEditBasicDetails": {
+      "title": {
+        "string": "Maelezo ya Msingi",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "action": {
+        "update": {
+          "string": "Sasisha maelezo",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "alert": {
+        "success": {
+          "string": "Maelezo ya mtumiaji yamehifadhiwa!"
+        }
+      }
+    },
+    "UserEditPassword": {
+      "title": {
+        "string": "Badilisha neno la siri",
+        "developer_comment": "This is a title shown above a section of the page."
+      },
+      "action": {
+        "change": {
+          "string": "Badilisha neno la siri",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "cannotChange": {
+        "string": "Ni mmiliki wa akaunti pekee ndiye anayeweza kuweka nenosiri lake moja kwa moja."
+      },
+      "alert": {
+        "mismatch": {
+          "string": "Ni mmiliki wa akaunti pekee ndiye anayeweza kuweka nenosiri lake moja kwa moja."
+        },
+        "success": {
+          "string": "Mafanikio! Nenosiri lako limesasishwa."
+        }
+      }
+    },
+    "UserHome": {
+      "title": {
+        "string": "Mipangilio ya Mtumiaji",
+        "developer_comment": "This is shown as the title at the top of the page."
+      },
+      "tab": {
+        "users": {
+          "string": "Watumiaji wa Mtandao",
+          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+        },
+        "roles": {
+          "string": "Mipangilio ya Wajibu",
+          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+        }
+      },
+      "comingSoon": {
+        "string": "(inakuja hivi karibuni)",
+        "developer_comment": "This is shown within a disabled navigation tab to indicate that the functionality is not yet implemented, but will be soon."
+      }
+    },
+    "UserList": {
+      "action": {
+        "create": {
+          "string": "Unda Mtumiaji wa Wavuti",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
+      "heading": {
+        "0": {
+          "string": "Watumiaji Wavuti wana akaunti kwenye tovuti hii ili kusimamia na kusimamia Miradi kwenye seva hii. Wasimamizi wanaweza kudhibiti chochote kwenye tovuti. Watumiaji wasio na Jukumu la Tovuti Pote wanaweza kupewa Jukumu kwenye Mradi wowote, kutoka kwa mipangilio ya Mradi huo. Wasimamizi wa Tovuti nzima na baadhi ya Majukumu ya Mradi wanaweza kutumia kivinjari cha wavuti kujaza Fomu. Ili kuwasilisha data kupitia programu kama vile {collect}, unda Watumiaji wa Programu kwa kila Mradi.",
+          "developer_comment": "{collect} is a link whose text is \"ODK Collect\"."
+        }
+      },
+      "header": {
+        "sitewideRole": {
+          "string": "Jukumu la Tovuti nzima",
+          "developer_comment": "This is the text of a table column header."
+        }
+      },
+      "alert": {
+        "create": {
+          "string": "Mtumiaji ameundwa kwa ajili ya \"{displayName}\"."
+        },
+        "assignRole": {
+          "string": "Mafanikio! \"{displayName}\" imepewa Jukumu la Eneo Lote la \"{roleName}\"."
+        },
+        "resetPassword": {
+          "string": "Nenosiri la \"{displayName}\" limebatilishwa. Barua pepe imetumwa kwa {email} ikiwa na maagizo ya jinsi ya kuendelea."
+        },
+        "retire": {
+          "string": "Mtumiaji \"{displayName}\" amestaafu."
+        }
+      }
+    },
+    "UserNew": {
+      "title": {
+        "string": "Unda Mtumiaji wa Wavuti",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "0": {
+          "string": "Ukishafungua akaunti hii, barua pepe utakayotoa itatumiwa maelekezo ya jinsi ya kuweka nenosiri na kuendelea."
+        }
+      }
+    },
+    "UserResetPassword": {
+      "title": {
+        "string": "Weka upya Nenosiri",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "full": {
+          "string": "Ukibofya {resetPassword} hapa chini, nenosiri la mtumiaji “{displayName}” <{email}> litabatilishwa mara moja. Barua pepe itatumwa kwa {email} ikiwa na maagizo ya jinsi ya kuendelea.",
+          "developer_comment": "{resetPassword} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nReset password"
+        },
+        "resetPassword": {
+          "string": "Weka upya nenosiri",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {resetPassword} is in the following text:\n\nOnce you click {resetPassword} below, the password for the user “{displayName}” <{email}> will be immediately invalidated. An email will be sent to {email} with instructions on how to proceed."
+        }
+      }
+    },
+    "UserRetire": {
+      "title": {
+        "string": "Mtumiaji Anayestaafu",
+        "developer_comment": "This is the title at the top of a pop-up. An Administrator can use the pop-up to retire another Web User."
+      },
+      "introduction": {
+        "0": {
+          "string": "Unakaribia kustaafu akaunti ya mtumiaji \"{displayName}\" <{email}>. Mtumiaji huyo atazuiwa mara moja kufanya vitendo vyovyote na kuondoka"
+        },
+        "1": {
+          "full": {
+            "string": "{noUndo}, lakini akaunti mpya inaweza kufunguliwa kwa ajili ya mtu huyo kwa kutumia anwani sawa ya barua pepe.",
+            "developer_comment": "{noUndo} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nThis action cannot be undone"
+          },
+          "noUndo": {
+            "string": "Kitendo hiki hakiwezi kutenduliwa",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {noUndo} is in the following text:\n\n{noUndo}, but a new account can always be created for that person with the same email address."
+          }
+        }
+      }
+    },
+    "UserRow": {
+      "cannotAssignRole": {
+        "string": "Huenda usihariri Jukumu lako la Tovuti nzima."
+      },
+      "field": {
+        "sitewideRole": {
+          "string": "Jukumu la Tovuti nzima",
+          "developer_comment": "This is the text of a form field."
+        }
+      },
+      "cannotRetire": {
+        "string": "Huenda usistaafu mwenyewe.",
+        "developer_comment": "An Administrator may retire other Web Users, but not their own account."
+      },
+      "action": {
+        "retire": {
+          "string": "Staafu mtumiaji",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Swahili to Frontend. This required a couple of changes in addition to the usual tasks.

First, there was an error parsing the Transifex JSON, because the translator used a `\n`. That shouldn't have been a problem, because we convert `\n` in Transifex strings to space. Actually, the Transifex JSON for Japanese also seems to contain strings with `\n` without issue. However, the presence of `\n` specifically within a pluralized string resulted in an error here. Luckily, a small change to a regular expression was all that was needed.

Second, Swahili is the first locale for us for which there isn't a flatpickr localization. I think we should consider submitting a PR to flatpickr for that, since I think it'd be pretty easy. However, for now, I modified `DateRangePicker` so that it works even if there isn't a flatpickr localization (it falls back to English). I didn't want to add more flatpickr-related logic to `src/util/i18n.js` as part of that and instead decided to move the existing flatpickr logic in that file into `DateRangePicker`. The result is more consistent with how we approach internationalization in other components. I had also already made that change as part of moving to Vue 3 (in #526). That PR makes a few changes to `src/util/i18n.js`, in large part because the i18n object will no longer be a global object. More about flatpickr localization: https://flatpickr.js.org/localization/

I may update the last commit as translations are updated, but I don't plan to make changes to the other commits. Because of that, I think we can go ahead and review this PR. An interactive review would probably be easiest, but I think async would also work. Because this PR touches the same file as the Vue 3 PR, it'd be good to merge it soon. (Swahili will hopefully be ready by the time we want to release, but even if we decide to release it in a patch, we'd be able to temporarily hide these translations.)