### PR TITLE
Call submit() rather than requestSubmit() to circumvent Firefox bug

### DIFF
--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -218,12 +218,7 @@ export default {
 
       passphraseInput.value = this.passphrase;
       csrf.value = this.session.csrf;
-      // Using requestSubmit() if it is available in order to facilitate
-      // testing.
-      if (form.requestSubmit != null)
-        form.requestSubmit();
-      else
-        form.submit();
+      form.submit();
       // Ensure that the inputs' values are no longer in the DOM.
       form.reset();
     },


### PR DESCRIPTION
Fixing a bug that the QA team found:

> I’m not able to download submissions from encrypted project on Firefox &hellip; Everything is fine in Chrome and Safari