### PR TITLE
Hide alert about passphrase length after successful response

### DIFF
--- a/src/components/project/enable-encryption.vue
+++ b/src/components/project/enable-encryption.vue
@@ -187,6 +187,7 @@ export default {
       if (this.hint !== '') data.hint = this.hint;
       this.post(apiPaths.projectKey(this.project.id), data)
         .then(() => {
+          this.$alert().blank();
           this.step += 1;
           this.success = true;
         })


### PR DESCRIPTION
While working on #547, I noticed the following sequence:

- In the Enable Encryption modal, submit a passphrase that is too short. An alert is shown.
- Now submit a passphrase that is long enough. The modal, which is multistep, renders a new screen. However, the alert is still shown.

Elsewhere, we hide any alert when moving from one step of a multistep modal to the next:

https://github.com/getodk/central-frontend/blob/a273f313e5977593750e400f6b3e042e8d21fb81/src/components/field-key/new.vue#L119-L134

The goal of this PR is to do the same thing for the Enable Encryption modal.

@ktuite, I think this PR can be reviewed async!