### PR TITLE
Improve SubmissionDownload styles for non-English locales

### DIFF
--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -292,11 +292,14 @@ export default {
 #submission-download-container form :last-child { margin-bottom: 0; }
 #submission-download-divider {
   border-left: 1px solid $color-subpanel-border-strong;
-  margin-bottom: -5px;
-  margin-top: -1px;
+  margin: -1px 18px -5px 18px;
 }
-#submission-download-actions { margin-right: 12px; }
 $label-icon-max-width: 15px;
+$actions-padding-left: $label-icon-max-width + $margin-right-icon;
+#submission-download-actions {
+  margin-right: 12px;
+  padding-left: $actions-padding-left;
+}
 .submission-download-action-label {
   // Instead of wrapping the element in a <div> and setting the margin on that,
   // we set `display` to inline-block: that way, the cursor will be shown as
@@ -304,11 +307,13 @@ $label-icon-max-width: 15px;
   display: inline-block;
   font-weight: bold;
   margin-bottom: 3px;
+  text-indent: -$actions-padding-left;
 
   [class^="icon-"] {
     display: inline-block;
     margin-right: $margin-right-icon;
     min-width: $label-icon-max-width;
+    text-indent: 0;
   }
 
   .submission-download-action.disabled & {
@@ -316,10 +321,7 @@ $label-icon-max-width: 15px;
     cursor: not-allowed;
   }
 }
-.submission-download-action {
-  a { margin-left: #{$label-icon-max-width + $margin-right-icon}; }
-  + .submission-download-action { margin-top: 12px; }
-}
+.submission-download-action + .submission-download-action { margin-top: 12px; }
 </style>
 
 <i18n lang="json5">


### PR DESCRIPTION
Right now the "Download Submissions" modal looks as expected when the locale is English:

<img width="609" src="https://user-images.githubusercontent.com/5970131/155409929-a88365ba-42aa-46fe-9776-1ce22d246c29.png">

However, there are issues in Spanish and other locales:

<img width="610" src="https://user-images.githubusercontent.com/5970131/155409930-7517a680-1f4f-4fcb-9bd6-79815939a388.png">

There are two issues here, both related to the fact that the text exceeds the line length and wraps:

1. All horizontal space is used, up to the column divider. We need a minimum amount of space around the divider.
2. On the right-hand side, the text wraps below the icon. Instead, it should wrap directly beneath the text above it.

This PR should fix both issues:

<img width="612" src="https://user-images.githubusercontent.com/5970131/155409932-e16d4dba-c052-49eb-8878-ec0569c0ca92.png">