### PR TITLE
New Project description field

### DIFF
--- a/src/components/project/form-access.vue
+++ b/src/components/project/form-access.vue
@@ -132,6 +132,7 @@ export default {
     projectToSave() {
       return {
         name: this.project.name,
+        description: this.project.description,
         archived: this.project.archived,
         // If there is a form on Backend that is not in this.forms, then at
         // least right now, Backend will return a Problem response. In the

--- a/src/presenters/project.js
+++ b/src/presenters/project.js
@@ -15,6 +15,7 @@ import { presenterClass } from './base';
 const props = [
   'id',
   'name',
+  'description',
   'archived',
   'keyId',
   'createdAt',

--- a/test/components/project/form-access.spec.js
+++ b/test/components/project/form-access.spec.js
@@ -239,6 +239,7 @@ describe('ProjectFormAccess', () => {
             url: '/v1/projects/1',
             data: {
               name: 'My Project',
+              description: '',
               archived: false,
               forms: [
                 {

--- a/test/data/projects.js
+++ b/test/data/projects.js
@@ -26,6 +26,7 @@ export const extendedProjects = dataStore({
     lastCreatedAt,
 
     name = faker.name.findName(),
+    description = '',
     archived = false,
     // The default value of this property does not necessarily match
     // testData.extendedForms.
@@ -45,6 +46,7 @@ export const extendedProjects = dataStore({
   }) => ({
     id,
     name,
+    description,
     archived,
     keyId: key != null ? key.id : null,
     createdAt: inPast


### PR DESCRIPTION
Keeps Frontend consistent with new `project.description` field in [Backend](https://github.com/getodk/central-backend/pull/464). Specifically, it makes sure the description is included in the `PUT` API call to update project form access so it doesn't get erased.

The description isn't yet shown or made editable... that will come later!