### PR TITLE
Make small improvements related to FormOverviewRightNow

### DIFF
--- a/src/components/form/overview/right-now.vue
+++ b/src/components/form/overview/right-now.vue
@@ -117,7 +117,7 @@ export default {
   }
 }
 
-#form-overview-right-now-id .summary-item-heading span {
+#form-overview-right-now-id .summary-item-heading {
   font-family: $font-family-monospace;
 }
 </style>

--- a/src/components/form/overview/right-now.vue
+++ b/src/components/form/overview/right-now.vue
@@ -16,18 +16,6 @@ except according to the terms contained in the LICENSE file.
       <span>{{ $t('common.rightNow') }}</span>
     </template>
     <template #body>
-      <summary-item id="form-overview-right-now-id" icon="tag">
-        <template #heading>
-          <span :title="form.xmlFormId">{{ form.xmlFormId }}</span>
-        </template>
-        <template #body>
-          <i18n-t tag="p" keypath="xmlFormId.full">
-            <template #id>
-              <strong>{{ $t('xmlFormId.id') }}</strong>
-            </template>
-          </i18n-t>
-        </template>
-      </summary-item>
       <summary-item icon="file-o">
         <template #heading>
           <form-version-string :version="form.version"/>
@@ -108,27 +96,17 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../../assets/scss/variables';
-
 #form-overview-right-now.open-form {
-  .icon-tag, .icon-file-o, .icon-inbox {
+  .icon-file-o, .icon-inbox {
     margin-left: 4px;
     margin-right: 4px;
   }
-}
-
-#form-overview-right-now-id .summary-item-heading {
-  font-family: $font-family-monospace;
 }
 </style>
 
 <i18n lang="json5">
 {
   "en": {
-    "xmlFormId": {
-      "full": "{id} of this Form.",
-      "id": "ID"
-    },
     "version": {
       "full": "{publishedVersion} of this Form.",
       "publishedVersion": "Published version"

--- a/src/components/form/overview/right-now.vue
+++ b/src/components/form/overview/right-now.vue
@@ -16,6 +16,18 @@ except according to the terms contained in the LICENSE file.
       <span>{{ $t('common.rightNow') }}</span>
     </template>
     <template #body>
+      <summary-item id="form-overview-right-now-id" icon="tag">
+        <template #heading>
+          <span :title="form.xmlFormId">{{ form.xmlFormId }}</span>
+        </template>
+        <template #body>
+          <i18n-t tag="p" keypath="xmlFormId.full">
+            <template #id>
+              <strong>{{ $t('xmlFormId.id') }}</strong>
+            </template>
+          </i18n-t>
+        </template>
+      </summary-item>
       <summary-item icon="file-o">
         <template #heading>
           <form-version-string :version="form.version"/>
@@ -32,15 +44,16 @@ except according to the terms contained in the LICENSE file.
           </div>
         </template>
       </summary-item>
-      <summary-item :icon="stateIcon">
+      <summary-item id="form-overview-right-now-state" :icon="stateIcon">
         <template #heading>
           {{ $t(`formState.${form.state}`) }}
         </template>
         <template #body>
-          {{ $t(`stateCaption.${form.state}`) }}
+          <p>{{ $t(`stateCaption.${form.state}`) }}</p>
         </template>
       </summary-item>
-      <summary-item :to="formPath('submissions')" icon="inbox">
+      <summary-item id="form-overview-right-now-submissions"
+        :to="formPath('submissions')" icon="inbox">
         <template #heading>
           {{ $n(form.submissions, 'default') }}
           <span class="icon-angle-right"></span>
@@ -95,26 +108,27 @@ export default {
 </script>
 
 <style lang="scss">
-#form-overview-right-now {
-  // .icon-lock is a little more narrow than .icon-file-o and .icon-inbox, so we
-  // use this to center it.
-  .icon-lock {
-    margin-left: 6px;
-    margin-right: 6px;
-  }
+@import '../../../assets/scss/variables';
 
-  &.open-form {
-    .icon-file-o, .icon-inbox {
-      margin-left: 4px;
-      margin-right: 4px;
-    }
+#form-overview-right-now.open-form {
+  .icon-tag, .icon-file-o, .icon-inbox {
+    margin-left: 4px;
+    margin-right: 4px;
   }
+}
+
+#form-overview-right-now-id .summary-item-heading span {
+  font-family: $font-family-monospace;
 }
 </style>
 
 <i18n lang="json5">
 {
   "en": {
+    "xmlFormId": {
+      "full": "{id} of this Form.",
+      "id": "ID"
+    },
     "version": {
       "full": "{publishedVersion} of this Form.",
       "publishedVersion": "Published version"

--- a/src/components/home/summary/item.vue
+++ b/src/components/home/summary/item.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <linkable :to="to" class="home-summary-item">
+  <linkable tag="div" :to="to" class="home-summary-item">
     <div class="heading">
       <span :class="`icon-${icon}`"></span>
       <div>

--- a/src/components/linkable.vue
+++ b/src/components/linkable.vue
@@ -21,15 +21,19 @@ except according to the terms contained in the LICENSE file.
     @click.prevent="$emit('click')">
     <slot></slot>
   </a>
-  <div v-else class="linkable">
+  <component :is="tag" v-else class="linkable">
     <slot></slot>
-  </div>
+  </component>
 </template>
 
 <script>
 export default {
   name: 'Linkable',
   props: {
+    tag: {
+      type: String,
+      default: 'span'
+    },
     to: String,
     clickable: Boolean
   },

--- a/test/components/form/overview/right-now.spec.js
+++ b/test/components/form/overview/right-now.spec.js
@@ -30,7 +30,7 @@ describe('FormOverviewRightNow', () => {
   it('shows the form ID', () => {
     testData.extendedForms.createPast(1, { xmlFormId: 'my_form' });
     const item = findItem(mountComponent(), 'id');
-    const span = item.get('.summary-item-heading span');
+    const span = item.get('.summary-item-heading .linkable span');
     span.text().should.equal('my_form');
     span.attributes().title.should.equal('my_form');
   });

--- a/test/components/form/overview/right-now.spec.js
+++ b/test/components/form/overview/right-now.spec.js
@@ -18,9 +18,22 @@ const mountComponent = () => {
     }
   });
 };
+const findItem = (component, idSuffix) => {
+  const id = `form-overview-right-now-${idSuffix}`;
+  const items = component.findAllComponents(SummaryItem);
+  return items.find(item => item.attributes().id === id);
+};
 
 describe('FormOverviewRightNow', () => {
   beforeEach(mockLogin);
+
+  it('shows the form ID', () => {
+    testData.extendedForms.createPast(1, { xmlFormId: 'my_form' });
+    const item = findItem(mountComponent(), 'id');
+    const span = item.get('.summary-item-heading span');
+    span.text().should.equal('my_form');
+    span.attributes().title.should.equal('my_form');
+  });
 
   it('shows the version string of the primary form version', () => {
     testData.extendedForms.createPast(1);
@@ -42,9 +55,7 @@ describe('FormOverviewRightNow', () => {
   describe('form state', () => {
     it('renders correctly if the form is open', () => {
       testData.extendedForms.createPast(1, { state: 'open' });
-      const items = mountComponent().findAllComponents(SummaryItem);
-      items.length.should.equal(3);
-      const item = items[1];
+      const item = findItem(mountComponent(), 'state');
       item.props().icon.should.equal('exchange');
       item.get('.summary-item-heading').text().should.equal('Open');
       item.get('.summary-item-body').text().should.equal('This Form is downloadable and is accepting Submissions.');
@@ -52,7 +63,7 @@ describe('FormOverviewRightNow', () => {
 
     it('renders correctly if the form is closing', () => {
       testData.extendedForms.createPast(1, { state: 'closing' });
-      const item = mountComponent().findAllComponents(SummaryItem)[1];
+      const item = findItem(mountComponent(), 'state');
       item.props().icon.should.equal('clock-o');
       item.get('.summary-item-heading').text().should.equal('Closing');
       item.get('.summary-item-body').text().should.equal('This Form is not downloadable but still accepts Submissions.');
@@ -60,7 +71,7 @@ describe('FormOverviewRightNow', () => {
 
     it('renders correctly if the form is closed', () => {
       testData.extendedForms.createPast(1, { state: 'closed' });
-      const item = mountComponent().findAllComponents(SummaryItem)[1];
+      const item = findItem(mountComponent(), 'state');
       item.props().icon.should.equal('ban');
       item.get('.summary-item-heading').text().should.equal('Closed');
       item.get('.summary-item-body').text().should.equal('This Form is not downloadable and does not accept Submissions.');
@@ -70,14 +81,13 @@ describe('FormOverviewRightNow', () => {
   describe('submissions', () => {
     it('shows the count', () => {
       testData.extendedForms.createPast(1, { submissions: 123 });
-      const items = mountComponent().findAllComponents(SummaryItem);
-      items.length.should.equal(3);
-      items[2].get('.summary-item-heading').text().should.equal('123');
+      const item = findItem(mountComponent(), 'submissions');
+      item.get('.summary-item-heading').text().should.equal('123');
     });
 
     it('links to the submissions page', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a b' });
-      const item = mountComponent().findAllComponents(SummaryItem)[2];
+      const item = findItem(mountComponent(), 'submissions');
       item.props().to.should.equal('/projects/1/forms/a%20b/submissions');
     });
   });

--- a/test/components/form/overview/right-now.spec.js
+++ b/test/components/form/overview/right-now.spec.js
@@ -27,14 +27,6 @@ const findItem = (component, idSuffix) => {
 describe('FormOverviewRightNow', () => {
   beforeEach(mockLogin);
 
-  it('shows the form ID', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'my_form' });
-    const item = findItem(mountComponent(), 'id');
-    const span = item.get('.summary-item-heading .linkable span');
-    span.text().should.equal('my_form');
-    span.attributes().title.should.equal('my_form');
-  });
-
   it('shows the version string of the primary form version', () => {
     testData.extendedForms.createPast(1);
     testData.extendedFormVersions.createPast(1, { version: 'v2', draft: true });

--- a/test/components/form/submissions.spec.js
+++ b/test/components/form/submissions.spec.js
@@ -1,7 +1,5 @@
 import EnketoFill from '../../../src/components/enketo/fill.vue';
-import FormOverviewRightNow from '../../../src/components/form/overview/right-now.vue';
 import SubmissionDownloadButton from '../../../src/components/submission/download-dropdown.vue';
-import SummaryItem from '../../../src/components/summary-item.vue';
 
 import testData from '../../data';
 import { load } from '../../util/http';
@@ -51,9 +49,8 @@ describe('FormSubmissions', () => {
       testData.extendedSubmissions.createPast(11);
       return load('/projects/1/forms/f')
         .afterResponses(app => {
-          const items = app.getComponent(FormOverviewRightNow)
-            .findAllComponents(SummaryItem);
-          items[2].get('.summary-item-heading').text().should.equal('10');
+          const item = app.get('#form-overview-right-now-submissions');
+          item.get('.summary-item-heading').text().should.equal('10');
         })
         .load('/projects/1/forms/f/submissions', {
           project: false, form: false, formDraft: false, attachments: false
@@ -61,9 +58,8 @@ describe('FormSubmissions', () => {
         .complete()
         .route('/projects/1/forms/f')
         .then(app => {
-          const items = app.getComponent(FormOverviewRightNow)
-            .findAllComponents(SummaryItem);
-          items[2].get('.summary-item-heading').text().should.equal('11');
+          const item = app.get('#form-overview-right-now-submissions');
+          item.get('.summary-item-heading').text().should.equal('11');
         });
     });
   });

--- a/test/components/linkable.spec.js
+++ b/test/components/linkable.spec.js
@@ -42,10 +42,19 @@ describe('Linkable', () => {
     a.find('#content').exists().should.be.true();
   });
 
-  it('renders a <div> otherwise', () => {
-    const linkable = mountComponent();
-    linkable.element.tagName.should.equal('DIV');
-    linkable.find('a').exists().should.be.false();
-    linkable.find('#content').exists().should.be.true();
+  describe('to prop does not exist and clickable prop is false', () => {
+    it('renders a <span> by default', () => {
+      const linkable = mountComponent();
+      linkable.element.tagName.should.equal('SPAN');
+      linkable.find('a').exists().should.be.false();
+      linkable.find('#content').exists().should.be.true();
+    });
+
+    it('uses the tag prop', () => {
+      const linkable = mountComponent({
+        props: { tag: 'div' }
+      });
+      linkable.element.tagName.should.equal('DIV');
+    });
   });
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2279,6 +2279,16 @@
       }
     },
     "FormOverviewRightNow": {
+      "xmlFormId": {
+        "full": {
+          "string": "{id} of this Form.",
+          "developer_comment": "{id} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nID"
+        },
+        "id": {
+          "string": "ID",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {id} is in the following text:\n\n{id} of this Form."
+        }
+      },
       "version": {
         "full": {
           "string": "{publishedVersion} of this Form.",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2279,16 +2279,6 @@
       }
     },
     "FormOverviewRightNow": {
-      "xmlFormId": {
-        "full": {
-          "string": "{id} of this Form.",
-          "developer_comment": "{id} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nID"
-        },
-        "id": {
-          "string": "ID",
-          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {id} is in the following text:\n\n{id} of this Form."
-        }
-      },
       "version": {
         "full": {
           "string": "{publishedVersion} of this Form.",


### PR DESCRIPTION
Hard to know where to put the form ID exactly! Nowhere on the page felt quite right. Ultimately I decided to place the form ID above the form version (the reverse seemed wrong), but let me know if there are other ideas.

<img width="1078" src="https://user-images.githubusercontent.com/5970131/168522385-d70f08a1-29ed-4623-871b-0a90d98dcff0.png">