### PR TITLE
Review state tooltips and Markdown view line fix

### DIFF
--- a/src/components/markdown/view.vue
+++ b/src/components/markdown/view.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div v-html="renderedMarkdown"></div>
+  <div class="markdown-view" v-html="renderedMarkdown"></div>
 </template>
 
 <script>
@@ -52,3 +52,9 @@ export default {
   }
 };
 </script>
+
+<style lang="scss">
+.markdown-view {
+  overflow-wrap: break-word;
+}
+</style>

--- a/src/components/project/form-row.vue
+++ b/src/components/project/form-row.vue
@@ -29,43 +29,49 @@ except according to the terms contained in the LICENSE file.
     </td>
     <template v-if="form.publishedAt != null">
       <td v-for="reviewState of visibleReviewStates" :key="reviewState" class="review-state">
-        <template v-if="canLinkToSubmissions">
-          <router-link :to="submissionsPath[reviewState]">
-            <span>{{ $n(form.reviewStates[reviewState], 'default') }}</span>
-            <span :class="reviewStateIcon(reviewState)"></span>
-          </router-link>
-        </template>
-        <template v-else>
-          <span>{{ $n(form.reviewStates[reviewState], 'default') }}</span>
-          <span :class="reviewStateIcon(reviewState)"></span>
-        </template>
-      </td>
-      <td class="last-submission">
-        <template v-if="form.lastSubmission != null">
+        <span :title="$t(`reviewState.${reviewState}`)">
           <template v-if="canLinkToSubmissions">
-            <router-link :to="submissionsPath.all">
-              <date-time :iso="form.lastSubmission" relative="past"/>
-              <span class="icon-clock-o"></span>
+            <router-link :to="submissionsPath[reviewState]">
+              <span>{{ $n(form.reviewStates[reviewState], 'default') }}</span>
+              <span :class="reviewStateIcon(reviewState)"></span>
             </router-link>
           </template>
           <template v-else>
-            <date-time :iso="form.lastSubmission" relative="past"/>
-            <span class="icon-clock-o"></span>
+            <span>{{ $n(form.reviewStates[reviewState], 'default') }}</span>
+            <span :class="reviewStateIcon(reviewState)"></span>
           </template>
-        </template>
-        <template v-else>{{ $t('submission.noSubmission') }}</template>
+        </span>
+      </td>
+      <td class="last-submission">
+        <span :title="$t('header.lastSubmission')">
+          <template v-if="form.lastSubmission != null">
+            <template v-if="canLinkToSubmissions">
+              <router-link :to="submissionsPath.all">
+                <date-time :iso="form.lastSubmission" relative="past"/>
+                <span class="icon-clock-o"></span>
+              </router-link>
+            </template>
+            <template v-else>
+              <date-time :iso="form.lastSubmission" relative="past"/>
+              <span class="icon-clock-o"></span>
+            </template>
+          </template>
+          <template v-else>{{ $t('submission.noSubmission') }}</template>
+        </span>
       </td>
       <td class="total-submissions">
-        <template v-if="canLinkToSubmissions">
-          <router-link :to="submissionsPath.all">
+        <span :title="$t('common.total')">
+          <template v-if="canLinkToSubmissions">
+            <router-link :to="submissionsPath.all">
+              <span>{{ $n(form.submissions, 'default') }}</span>
+              <span class="icon-asterisk"></span>
+            </router-link>
+          </template>
+          <template v-else>
             <span>{{ $n(form.submissions, 'default') }}</span>
             <span class="icon-asterisk"></span>
-          </router-link>
-        </template>
-        <template v-else>
-          <span>{{ $n(form.submissions, 'default') }}</span>
-          <span class="icon-asterisk"></span>
-        </template>
+          </template>
+        </span>
       </td>
     </template>
     <template v-else>

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -186,10 +186,6 @@ export default {
 
   .actor-link { font-weight: normal; }
 
-  .body {
-    overflow-wrap: break-word;
-  }
-
   .body > p:last-child { margin: 0 0 0px; }
 }
 </style>

--- a/test/components/markdown/view.spec.js
+++ b/test/components/markdown/view.spec.js
@@ -12,42 +12,42 @@ describe('MarkdownView', () => {
   it('renders basic text', () => {
     const component = mountComponent('some text');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div><p>some text</p>\n</div>');
+    outerHTML.should.equal('<div class="markdown-view"><p>some text</p>\n</div>');
   });
 
   it('shows rendered markdown', () => {
     const component = mountComponent('Some **bold** comment');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div><p>Some <strong>bold</strong> comment</p>\n</div>');
+    outerHTML.should.equal('<div class="markdown-view"><p>Some <strong>bold</strong> comment</p>\n</div>');
   });
 
   it('shows a multi-line input rendered on multiple lines', () => {
     const component = mountComponent('Line 1\nLine 2');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div><p>Line 1<br>Line 2</p>\n</div>');
+    outerHTML.should.equal('<div class="markdown-view"><p>Line 1<br>Line 2</p>\n</div>');
   });
 
   it('augments links to add target=_blank and open in new tab', () => {
     const component = mountComponent('[link](https://getodk.org)');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div><p><a href="https://getodk.org" target="_blank" rel="noreferrer noopener">link</a></p>\n</div>');
+    outerHTML.should.equal('<div class="markdown-view"><p><a href="https://getodk.org" target="_blank" rel="noreferrer noopener">link</a></p>\n</div>');
   });
 
   it('does allow raw html in markdown', () => {
     const component = mountComponent('<b>bold</b>');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div><p><b>bold</b></p>\n</div>');
+    outerHTML.should.equal('<div class="markdown-view"><p><b>bold</b></p>\n</div>');
   });
 
   it('removes script and svg tags and sanitizes html', () => {
     const component = mountComponent('<script>foo</script><svg>bar</svg>');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div></div>');
+    outerHTML.should.equal('<div class="markdown-view"></div>');
   });
 
   it('removes unwanted attributes', () => {
     const component = mountComponent('<b style="color: red;" class="c" data-foo="bar">foo</b>');
     const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div><p><b>foo</b></p>\n</div>');
+    outerHTML.should.equal('<div class="markdown-view"><p><b>foo</b></p>\n</div>');
   });
 });

--- a/test/components/project/form-row.spec.js
+++ b/test/components/project/form-row.spec.js
@@ -132,6 +132,9 @@ describe('ProjectFormRow', () => {
       columns[0].find('.icon-dot-circle-o').exists().should.be.true();
       columns[1].find('.icon-comments').exists().should.be.true();
       columns[2].find('.icon-pencil').exists().should.be.true();
+      columns[0].find('span').attributes().title.should.equal('Received');
+      columns[1].find('span').attributes().title.should.equal('Has issues');
+      columns[2].find('span').attributes().title.should.equal('Edited');
     });
 
     it('shows blank review state columns when the form is a draft', () => {
@@ -158,6 +161,7 @@ describe('ProjectFormRow', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a b', submissions: 4 });
       const cell = mountComponent().find('.last-submission');
       cell.find('.icon-clock-o').exists().should.be.true();
+      cell.find('span').attributes().title.should.equal('Latest Submission');
     });
 
     it('shows (none) if no submission', () => {
@@ -190,6 +194,7 @@ describe('ProjectFormRow', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a b', submissions: 4 });
       const cell = mountComponent().find('.total-submissions');
       cell.find('.icon-asterisk').exists().should.be.true();
+      cell.find('span').attributes().title.should.equal('Total');
     });
   });
 


### PR DESCRIPTION
1. Add tooltips to review states on Project List page
2. Change Markdown View component to word-break and wrap lines that are too long