### PR TITLE
New Block 15 metrics including 'Other' category

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -78,6 +78,7 @@ export default {
       "num_unique_collectors": "Number of unique Data Collectors",
       "backups_configured": "Backups configured",
       "database_size": "System database size",
+      "uses_external_db": "Server uses an external database",
       "num_managers": "Number of Project Managers",
       "num_viewers": "Number of Project Viewers",
       "num_data_collectors": "Number of Data Collectors",
@@ -90,6 +91,9 @@ export default {
       "num_forms_with_encryption": "Number of Forms with encryption",
       "num_forms_with_audits": "Number of Forms with audits",
       "num_reused_form_ids": "Number of reused Form IDs",
+      "num_open_forms": "Number of open Forms",
+      "num_closing_forms": "Number of closing Forms",
+      "num_closed_forms": "Number of closed Forms",
       "num_submissions_received": "Number of Submissions - Received",
       "num_submissions_approved": "Number of Submissions - Approved",
       "num_submissions_has_issues": "Number of Submissions - Has Issues",
@@ -99,7 +103,8 @@ export default {
       "num_submissions_with_comments": "Number of Submissions with comments",
       "num_submissions_from_app_users": "Number of Submissions from App Users",
       "num_submissions_from_public_links": "Number of Submissions from Public Links",
-      "num_submissions_from_web_users": "Number of Submissions from Web Users"
+      "num_submissions_from_web_users": "Number of Submissions from Web Users",
+      "has_description": "Project has a description"
     }
   }
 }

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -35,6 +35,8 @@ except according to the terms contained in the LICENSE file.
               :metrics="submissionSummary"/>
             <analytics-metrics-table :title="$t('submissionStates')"
               :metrics="submissionStateSummary"/>
+            <analytics-metrics-table :title="$t('other')"
+              :metrics="otherSummary"/>
           </div>
         </div>
       </template>
@@ -102,6 +104,9 @@ export default {
     },
     numProjects() {
       return this.analyticsPreview.projects.length;
+    },
+    otherSummary() {
+      return this.firstProject.other;
     }
   },
   watch: {
@@ -170,7 +175,10 @@ export default {
     },
     // This is the title of a single table in the analytics metrics report
     // of metrics about submission state (approved, rejected, etc)
-    "submissionStates": "Submission States"
+    "submissionStates": "Submission States",
+    // This is the title of a single table in the analytics metrics report
+    // of other additional metrics that don't fit into other categories
+    "other": "Other"
   }
 }
 </i18n>

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -13,7 +13,8 @@ const analyticsPreview = {
       submissions: {
         num_submissions_received: { recent: 0, total: 0 },
         num_submissions_from_web_users: { recent: 0, total: 0 }
-      }
+      },
+      other: { has_description: 0 }
     },
     {
       users: { num_managers: { recent: 1, total: 1 } },
@@ -21,7 +22,8 @@ const analyticsPreview = {
       submissions: {
         num_submissions_received: { recent: 1, total: 1 },
         num_submissions_from_web_users: { recent: 1, total: 1 }
-      }
+      },
+      other: { has_description: 1 }
     }
   ]
 };
@@ -46,7 +48,7 @@ describe('AnalyticsPreview', () => {
 
   it('renders the correct number of tables', async () => {
     const modal = await mockHttpForComponent();
-    modal.findAllComponents(AnalyticsMetricsTable).length.should.equal(5);
+    modal.findAllComponents(AnalyticsMetricsTable).length.should.equal(6);
   });
 
   it('shows system metrics', async () => {
@@ -98,5 +100,12 @@ describe('AnalyticsPreview', () => {
     const stateMetrics = { num_submissions_received: { recent: 1, total: 1 } };
     tables[3].props().metrics.should.eql(subMetrics);
     tables[4].props().metrics.should.eql(stateMetrics);
+  });
+
+  it('shows other metrics', async () => {
+    const modal = await mockHttpForComponent();
+    const table = modal.findAllComponents(AnalyticsMetricsTable)[5];
+    const subMetrics = { has_description: 1 };
+    table.props().metrics.should.eql(subMetrics);
   });
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -982,6 +982,9 @@
         "database_size": {
           "string": "System database size"
         },
+        "uses_external_db": {
+          "string": "Server uses an external database"
+        },
         "num_managers": {
           "string": "Number of Project Managers"
         },
@@ -1018,6 +1021,15 @@
         "num_reused_form_ids": {
           "string": "Number of reused Form IDs"
         },
+        "num_open_forms": {
+          "string": "Number of open Forms"
+        },
+        "num_closing_forms": {
+          "string": "Number of closing Forms"
+        },
+        "num_closed_forms": {
+          "string": "Number of closed Forms"
+        },
         "num_submissions_received": {
           "string": "Number of Submissions - Received"
         },
@@ -1047,6 +1059,9 @@
         },
         "num_submissions_from_web_users": {
           "string": "Number of Submissions from Web Users"
+        },
+        "has_description": {
+          "string": "Project has a description"
         }
       }
     },
@@ -1078,6 +1093,10 @@
       "submissionStates": {
         "string": "Submission States",
         "developer_comment": "This is the title of a single table in the analytics metrics report of metrics about submission state (approved, rejected, etc)"
+      },
+      "other": {
+        "string": "Other",
+        "developer_comment": "This is the title of a single table in the analytics metrics report of other additional metrics that don't fit into other categories"
       }
     },
     "App": {


### PR DESCRIPTION
New metrics:

- Project has a description (1/0)
    - This doesn't really fit under project forms/users/submissions so there is now a new "Other" category for project metrics
- Number of Open Forms
- Number of Closing Forms
- Number of Closed Forms
- Server uses an external database (1/0)