### PR TITLE
Changed review state column spacing

### DIFF
--- a/src/components/project/form-row.vue
+++ b/src/components/project/form-row.vue
@@ -155,12 +155,13 @@ export default {
 
   .review-state, .total-submissions, .not-published {
     text-align: right;
-    width: 100px;
+    padding-right: 10px;
+    width: 80px;
   }
 
   .last-submission{
     text-align: right;
-    width: 150px;
+    width: 170px;
   }
 
   [class*='icon'] {


### PR DESCRIPTION
Spaced out the review state columns on the front page (project list / form row) a bit more.

<img width="1221" alt="Screen Shot 2022-05-27 at 2 04 48 PM" src="https://user-images.githubusercontent.com/76205/170789339-122bef7d-5e1c-497b-a3ff-f2873cc46f7f.png">

Some things that didn't work as well:

Making the whole set of tds a different color
<img width="1162" alt="Screen Shot 2022-05-27 at 1 59 42 PM" src="https://user-images.githubusercontent.com/76205/170789402-39a7c292-096e-4bd6-8e4a-db30fdaf775c.png">

Making the tds a different color but slightly transparent.
<img width="1299" alt="Screen Shot 2022-05-27 at 1 57 00 PM" src="https://user-images.githubusercontent.com/76205/170789452-3fedc05f-8483-450e-8f1b-d6e1141c6ada.png">

