### PR TITLE
Showing form IDs next to duplicated form names

### DIFF
--- a/src/components/form/row.vue
+++ b/src/components/form/row.vue
@@ -132,7 +132,7 @@ export default {
       );
     },
     showIdForDuplicateName() {
-      const name = this.form.nameOrId().toLowerCase();
+      const name = this.form.nameOrId().toLocaleLowerCase();
       return this.duplicateFormNames.has(name);
     }
   }

--- a/src/components/form/row.vue
+++ b/src/components/form/row.vue
@@ -15,6 +15,7 @@ except according to the terms contained in the LICENSE file.
       <link-if-can :to="primaryFormPath(form)">
         {{ form.nameOrId() }}
       </link-if-can>
+      <span v-if="showIdForDuplicateName" class="duplicate-form-id">({{ form.xmlFormId }})</span>
     </td>
 
     <td v-for="reviewState of visibleReviewStates" :key="reviewState" class="review-state">
@@ -112,7 +113,7 @@ export default {
   computed: {
     // The component assumes that this data will exist when the component is
     // created.
-    ...requestData(['project']),
+    ...requestData(['project', 'forms', 'deletedForms']),
     visibleReviewStates: () => ['received', 'hasIssues', 'edited'],
     urlFilterEncode() {
       return new Map()
@@ -126,6 +127,11 @@ export default {
         this.form.xmlFormId,
         'draft/testing'
       );
+    },
+    showIdForDuplicateName() {
+      const allForms = [...this.forms || [], ...this.deletedForms || []];
+      const formNames = allForms.flatMap((form) => ((form.xmlFormId !== this.form.xmlFormId) ? form.nameOrId() : []));
+      return formNames.includes(this.form.nameOrId());
     }
   }
 };
@@ -145,6 +151,11 @@ export default {
 
   .name {
     font-size: 18px;
+  }
+
+  .duplicate-form-id {
+    font-family: $font-family-monospace;
+    padding-left: 6px;
   }
 
   .review-state, .total-submissions, .not-published {

--- a/src/components/form/row.vue
+++ b/src/components/form/row.vue
@@ -82,6 +82,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 import DateTime from '../date-time.vue';
 import EnketoFill from '../enketo/fill.vue';
 import EnketoPreview from '../enketo/preview.vue';
@@ -114,6 +116,7 @@ export default {
     // The component assumes that this data will exist when the component is
     // created.
     ...requestData(['project', 'forms', 'deletedForms']),
+    ...mapGetters(['duplicateFormNames']),
     visibleReviewStates: () => ['received', 'hasIssues', 'edited'],
     urlFilterEncode() {
       return new Map()
@@ -129,9 +132,8 @@ export default {
       );
     },
     showIdForDuplicateName() {
-      const allForms = [...this.forms || [], ...this.deletedForms || []];
-      const formNames = allForms.flatMap((form) => ((form.xmlFormId !== this.form.xmlFormId) ? form.nameOrId() : []));
-      return formNames.includes(this.form.nameOrId());
+      const name = this.form.nameOrId().toLowerCase();
+      return this.duplicateFormNames.has(name);
     }
   }
 };

--- a/src/components/form/trash-row.vue
+++ b/src/components/form/trash-row.vue
@@ -13,6 +13,7 @@ except according to the terms contained in the LICENSE file.
   <tr class="form-trash-row">
     <td class="name">
       <span class="form-name">{{ form.nameOrId() }}</span>
+      <span v-if="showIdForDuplicateName" class="duplicate-form-id">({{ form.xmlFormId }})</span>
     </td>
     <td class="deleted">
       <i18n-t tag="div" keypath="deletedDate" class="deleted-date">
@@ -67,7 +68,7 @@ export default {
   computed: {
     // The component assumes that this data will exist when the component is
     // created.
-    ...requestData(['forms']),
+    ...requestData(['forms', 'deletedForms']),
     activeFormIds() {
       // returns ids of existing forms to disable restoring deleted
       // forms with conflicting ids (also prevented on backend)
@@ -82,6 +83,11 @@ export default {
       if (this.disabled)
         return this.$t('disabled.conflict');
       return null;
+    },
+    showIdForDuplicateName() {
+      const allForms = [...this.forms || [], ...this.deletedForms || []];
+      const formNames = allForms.flatMap((form) => ((form.xmlFormId !== this.form.xmlFormId) ? form.nameOrId() : []));
+      return formNames.includes(this.form.nameOrId());
     }
   },
   methods: {
@@ -106,6 +112,11 @@ export default {
 
   .name {
     font-size: 18px;
+  }
+
+  .duplicate-form-id {
+    font-family: $font-family-monospace;
+    padding-left: 6px;
   }
 
   .deleted {

--- a/src/components/form/trash-row.vue
+++ b/src/components/form/trash-row.vue
@@ -88,7 +88,7 @@ export default {
       return null;
     },
     showIdForDuplicateName() {
-      const name = this.form.nameOrId().toLowerCase();
+      const name = this.form.nameOrId().toLocaleLowerCase();
       return this.duplicateFormNames.has(name);
     }
   },

--- a/src/components/form/trash-row.vue
+++ b/src/components/form/trash-row.vue
@@ -51,6 +51,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 import DateTime from '../date-time.vue';
 import Form from '../../presenters/form';
 import { requestData } from '../../store/modules/request';
@@ -69,6 +71,7 @@ export default {
     // The component assumes that this data will exist when the component is
     // created.
     ...requestData(['forms', 'deletedForms']),
+    ...mapGetters(['duplicateFormNames']),
     activeFormIds() {
       // returns ids of existing forms to disable restoring deleted
       // forms with conflicting ids (also prevented on backend)
@@ -85,9 +88,8 @@ export default {
       return null;
     },
     showIdForDuplicateName() {
-      const allForms = [...this.forms || [], ...this.deletedForms || []];
-      const formNames = allForms.flatMap((form) => ((form.xmlFormId !== this.form.xmlFormId) ? form.nameOrId() : []));
-      return formNames.includes(this.form.nameOrId());
+      const name = this.form.nameOrId().toLowerCase();
+      return this.duplicateFormNames.has(name);
     }
   },
   methods: {

--- a/src/components/project/form-row.vue
+++ b/src/components/project/form-row.vue
@@ -92,7 +92,6 @@ import Form from '../../presenters/form';
 import Project from '../../presenters/project';
 import routes from '../../mixins/routes';
 
-import { requestData } from '../../store/modules/request';
 import useReviewState from '../../composables/review-state';
 import { enketoBasePath } from '../../util/util';
 

--- a/src/components/project/form-row.vue
+++ b/src/components/project/form-row.vue
@@ -26,6 +26,7 @@ except according to the terms contained in the LICENSE file.
           {{ form.nameOrId() }}
         </template>
       </template>
+      <span v-if="showIdForDuplicateName" class="duplicate-form-id">({{ form.xmlFormId }})</span>
     </td>
     <template v-if="form.publishedAt != null">
       <td v-for="reviewState of visibleReviewStates" :key="reviewState" class="review-state">
@@ -137,6 +138,10 @@ export default {
     enketoPath() {
       const encodedId = encodeURIComponent(this.form.enketoId);
       return `${enketoBasePath}/${encodedId}`;
+    },
+    showIdForDuplicateName() {
+      const formNames = this.project.formList.map((form) => (form.xmlFormId !== this.form.xmlFormId ? form.nameOrId() : null));
+      return formNames.includes(this.form.nameOrId());
     }
   }
 };
@@ -151,6 +156,11 @@ export default {
     padding: 4px 0px 4px 6px;
     color: #333;
     a { @include text-link; }
+  }
+
+  .duplicate-form-id {
+    font-family: $font-family-monospace;
+    padding-left: 6px;
   }
 
   .review-state, .total-submissions, .not-published {

--- a/src/components/project/form-row.vue
+++ b/src/components/project/form-row.vue
@@ -85,11 +85,14 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 import DateTime from '../date-time.vue';
 import Form from '../../presenters/form';
 import Project from '../../presenters/project';
 import routes from '../../mixins/routes';
 
+import { requestData } from '../../store/modules/request';
 import useReviewState from '../../composables/review-state';
 import { enketoBasePath } from '../../util/util';
 
@@ -112,6 +115,7 @@ export default {
     return { reviewStateIcon };
   },
   computed: {
+    ...mapGetters(['duplicateFormNamesPerProject']),
     canLinkToFormOverview() {
       return this.project.permits('form.update');
     },
@@ -140,8 +144,11 @@ export default {
       return `${enketoBasePath}/${encodedId}`;
     },
     showIdForDuplicateName() {
-      const formNames = this.project.formList.map((form) => (form.xmlFormId !== this.form.xmlFormId ? form.nameOrId() : null));
-      return formNames.includes(this.form.nameOrId());
+      const formNames = this.duplicateFormNamesPerProject[this.project.id];
+      if (formNames) {
+        return formNames.has(this.form.nameOrId().toLocaleLowerCase());
+      }
+      return false;
     }
   }
 };

--- a/src/store/modules/request/keys.js
+++ b/src/store/modules/request/keys.js
@@ -197,6 +197,16 @@ const dataGetters = {
         result.push(audit);
     }
     return result;
+  },
+
+  // Returns a set containing just the form names that appear more than once
+  // in a project. Used on project overview to show form ID next to form name
+  // when form names are duplicated.
+  duplicateFormNames: ({ data: { forms, deletedForms } }) => {
+    const allForms = [...forms || [], ...deletedForms || []];
+    const formNames = allForms.map((form) => (form.nameOrId().toLowerCase()));
+    const findDuplicates = a => a.filter((item, index) => a.indexOf(item) !== index);
+    return new Set(findDuplicates(formNames));
   }
 };
 export const getters = dataGetters;

--- a/src/store/modules/request/keys.js
+++ b/src/store/modules/request/keys.js
@@ -204,9 +204,31 @@ const dataGetters = {
   // when form names are duplicated.
   duplicateFormNames: ({ data: { forms, deletedForms } }) => {
     const allForms = [...forms || [], ...deletedForms || []];
-    const formNames = allForms.map((form) => (form.nameOrId().toLowerCase()));
-    const findDuplicates = a => a.filter((item, index) => a.indexOf(item) !== index);
-    return new Set(findDuplicates(formNames));
+    const seenNames = new Set();
+    const dupeNames = new Set();
+    for (const form of allForms) {
+      const formName = form.nameOrId().toLocaleLowerCase();
+      if (seenNames.has(formName)) dupeNames.add(formName);
+      seenNames.add(formName);
+    }
+    return dupeNames;
+  },
+
+  // Returns an object of Sets containing duplicate project names for use
+  // by the Project list page.
+  duplicateFormNamesPerProject: ({ data: { projects } }) => {
+    if (projects == null) return {};
+    const dupeNamesByProject = {};
+    for (const project of projects) {
+      const seenNames = new Set();
+      dupeNamesByProject[project.id] = new Set();
+      for (const form of project.formList) {
+        const formName = form.nameOrId().toLocaleLowerCase();
+        if (seenNames.has(formName)) dupeNamesByProject[project.id].add(formName);
+        seenNames.add(formName);
+      }
+    }
+    return dupeNamesByProject;
   }
 };
 export const getters = dataGetters;

--- a/test/components/form/trash-row.spec.js
+++ b/test/components/form/trash-row.spec.js
@@ -46,21 +46,21 @@ describe('FormTrashRow', () => {
     beforeEach(mockLogin);
 
     it('shows the submission count', () => {
-      const formData = { submissions: 12345 };
+      const formData = { name: 'a form', submissions: 12345 };
       const cell = mountComponent(formData).get('.total-submissions');
       cell.text().should.equal('12,345');
       cell.find('span').attributes().title.should.equal('Total');
     });
 
     it('shows the submission count when 0', () => {
-      const formData = { submissions: 0 };
+      const formData = { name: 'a form', submissions: 0 };
       const text = mountComponent(formData).get('.total-submissions').text();
       text.should.equal('0');
     });
 
     it('shows the time since last submission', () => {
       const lastSubmission = new Date().toISOString();
-      const formData = { submissions: 1, lastSubmission };
+      const formData = { name: 'a form', submissions: 1, lastSubmission };
       const row = mountComponent(formData);
       const cell = row.get('.last-submission');
       cell.text().should.match(/ago$/);
@@ -71,7 +71,7 @@ describe('FormTrashRow', () => {
     });
 
     it('does not render time if there is no last submission', () => {
-      const formData = { submissions: 0 };
+      const formData = { name: 'a form', submissions: 0 };
       const cell = mountComponent(formData).get('.last-submission');
       cell.text().should.equal('(none)');
       cell.find('span').attributes().title.should.equal('Latest Submission');
@@ -82,7 +82,7 @@ describe('FormTrashRow', () => {
     beforeEach(mockLogin);
 
     it('shows the undelete button', () => {
-      const button = mountComponent({}).get('.form-trash-row-restore-button');
+      const button = mountComponent({ name: 'foo' }).get('.form-trash-row-restore-button');
       button.element.tagName.should.equal('BUTTON');
       button.element.disabled.should.be.false();
     });

--- a/test/components/project/home-block.spec.js
+++ b/test/components/project/home-block.spec.js
@@ -125,4 +125,19 @@ describe('ProjectHomeBlock', () => {
     const rows = block.findAllComponents(FormRow);
     rows.map((row) => row.props().form.name).should.eql(['a', 'c', 'd', 'e']);
   });
+
+  it('shows form ID in parentheses next to duplicated form names', () => {
+    const project = testData.extendedProjects.createPast(1).last();
+    testData.extendedForms.createPast(1, { name: 'Same Name', xmlFormId: 'a' });
+    testData.extendedForms.createPast(1, { name: 'Same Name', xmlFormId: 'b' });
+    testData.extendedForms.createPast(1, { name: 'Different Name', xmlFormId: 'c' });
+    project.formList.push(...testData.extendedForms.sorted().map((form) => new Form(form)));
+    const block = mountComponent();
+    const rows = block.findAllComponents(FormRow);
+    rows.map((row) => row.find('.form-name').text()).should.eql([
+      'Same Name(a)',
+      'Same Name(b)',
+      'Different Name'
+    ]);
+  });
 });

--- a/test/components/project/home-block.spec.js
+++ b/test/components/project/home-block.spec.js
@@ -125,19 +125,4 @@ describe('ProjectHomeBlock', () => {
     const rows = block.findAllComponents(FormRow);
     rows.map((row) => row.props().form.name).should.eql(['a', 'c', 'd', 'e']);
   });
-
-  it('shows form ID in parentheses next to duplicated form names', () => {
-    const project = testData.extendedProjects.createPast(1).last();
-    testData.extendedForms.createPast(1, { name: 'Same Name', xmlFormId: 'a' });
-    testData.extendedForms.createPast(1, { name: 'Same Name', xmlFormId: 'b' });
-    testData.extendedForms.createPast(1, { name: 'Different Name', xmlFormId: 'c' });
-    project.formList.push(...testData.extendedForms.sorted().map((form) => new Form(form)));
-    const block = mountComponent();
-    const rows = block.findAllComponents(FormRow);
-    rows.map((row) => row.find('.form-name').text()).should.eql([
-      'Same Name(a)',
-      'Same Name(b)',
-      'Different Name'
-    ]);
-  });
 });

--- a/test/components/project/list.spec.js
+++ b/test/components/project/list.spec.js
@@ -314,5 +314,31 @@ describe('ProjectList', () => {
       blocks[1].findAllComponents(FormRow).length.should.equal(2);
     });
   });
+
+  describe('duplicate form names', () => {
+    beforeEach(mockLogin);
+
+    it('calculates duplicate form names per project', () => {
+      createProjectsWithForms(
+        [{ name: 'Project 1' }, { name: 'Project 2' }],
+        [
+          [{ name: 'A', xmlFormId: 'a_1' }, { name: 'A', xmlFormId: 'a_2' }, { name: 'B', xmlFormId: 'b_1' }],
+          [{ name: 'C', xmlFormId: 'c_1' }, { name: 'c', xmlFormId: 'c_2' }, { name: 'B', xmlFormId: 'b_1' }]
+        ]
+      );
+      const component = mountComponent();
+      const blocks = component.findAllComponents(ProjectHomeBlock);
+      blocks[0].findAllComponents(FormRow).map((row) => row.find('.form-name').text()).should.eql([
+        'A(a_1)',
+        'A(a_2)',
+        'B'
+      ]);
+      blocks[1].findAllComponents(FormRow).map((row) => row.find('.form-name').text()).should.eql([
+        'B',
+        'c(c_2)',
+        'C(c_1)'
+      ]);
+    });
+  });
 });
 

--- a/test/components/project/overview.spec.js
+++ b/test/components/project/overview.spec.js
@@ -119,6 +119,18 @@ describe('ProjectOverview', () => {
       ]);
     });
 
+    it('considers different capitalizations to be the same and shows form ID', async () => {
+      mockLogin();
+      testData.extendedForms.createPast(1, { name: 'Same Name', xmlFormId: 'foo' });
+      testData.extendedForms.createPast(1, { name: 'same NAME', xmlFormId: 'bar' });
+      const app = await load('/projects/1', {}, {});
+      const rows = app.getComponent(FormList).findAllComponents(FormRow);
+      rows.map((row) => row.find('.name').text()).should.eql([
+        'same NAME(bar)',
+        'Same Name(foo)'
+      ]);
+    });
+
     it('shows form ID even when form is in separate closed table', async () => {
       mockLogin();
       testData.extendedForms.createPast(1, { name: 'Same Name', xmlFormId: 'foo', state: 'closed' });


### PR DESCRIPTION
Added form ID next to form name for duplicate forms on both the Project List and the Form List.

<img width="1115" alt="Screen Shot 2022-06-20 at 2 40 24 PM" src="https://user-images.githubusercontent.com/76205/174680985-675b29c8-d5fa-4fab-85c3-942fe84e62b4.png">

<img width="1116" alt="Screen Shot 2022-06-20 at 2 41 10 PM" src="https://user-images.githubusercontent.com/76205/174681049-474169bd-fd6f-4e71-b271-bc0a2c34124e.png">

