### PR TITLE
Some ideas around making dev setup easier 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+vue-builder: vue-cli-service build --mode development --watch
+nginx: nginx -c "$PWD/nginx.conf" -p "$PWD"

--- a/README.md
+++ b/README.md
@@ -43,13 +43,7 @@ Follow these instructions to run ODK Central Frontend in development. For deploy
 
 First, run ODK Central Backend.
 
-Next, build ODK Central Frontend files for development by running `npm run dev`. The files will be outputted to `dist/`. As you update the source code, the files will be automatically rebuilt.
-
-Finally, run NGINX by changing the working directory to the root directory of the repository, then typing the following:
-
-```bash
-nginx -c "$PWD/nginx.conf" -p "$PWD"
-```
+Next, start nginx and build ODK Central Frontend files for development by running `npm run dev`. The files will be outputted to `dist/`. As you update the source code, the files will be automatically rebuilt.
 
 NGINX effectively places ODK Central Frontend and ODK Central Backend at the same origin, avoiding cross-origin requests. We specify `-p "$PWD"` so that relative paths in [`nginx.conf`](/nginx.conf) are relative to the repository root.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5347,6 +5347,18 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "foreman": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/foreman/-/foreman-3.0.1.tgz",
+      "integrity": "sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.15.1",
+        "http-proxy": "^1.17.0",
+        "mustache": "^2.2.1",
+        "shell-quote": "^1.6.1"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7968,6 +7980,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
       "dev": true
     },
     "mute-stream": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-import": "~2",
     "eslint-plugin-vue": "~9",
     "faker": "~4.1",
+    "foreman": "^3.0.1",
     "jsqr": "~1.0",
     "karma": "~6",
     "karma-chrome-launcher": "~3",


### PR DESCRIPTION
1. use node-foreman to build vue / watch for changes / start nginx
2. make `nginx.conf` less dependent on os-specific details / require less manual configuration
3. update README setup instructions to reflect 1 & 2

