### PR TITLE
package.json: set node & npm versions in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,9 @@
     "should": "~13.2",
     "sinon": "~9",
     "vue-cli-plugin-i18n": "~2"
+  },
+  "engines": {
+    "node": "14",
+    "npm": "6"
   }
 }


### PR DESCRIPTION
Hopefully should help people avoid constant `package-lock.json` changes.