### PR TITLE
nginx.conf: document dev-specific hacks

### DIFF
--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -73,14 +73,27 @@ http {
       proxy_pass http://localhost:8383;
       proxy_redirect off;
 
-      include ./common-headers.nginx.conf;
-      add_header Set-Cookie $session_cookie;
-      proxy_set_header X-Forwarded-Proto https;
-
       # buffer requests, but not responses, so streaming out works.
       proxy_request_buffering on;
       proxy_buffering off;
       proxy_read_timeout 2m;
+
+      # Dev-specific hacks:
+
+      # In conjunction with the map{} definition above, remap
+      # "Set-Cookie: __Host-session=..." to "Set-Cookie: session=..."
+      #
+      #   1. Cookies cannot use the "__Host-" prefix in non-HTTPs requests
+      #      see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes
+      #   2. central-backend cookie parsing is relaxed and will consider the
+      #      first cookie ending in "session" to be the session cookie
+      add_header Set-Cookie $session_cookie;
+      # re-add common headers after add_header call
+      include ./common-headers.nginx.conf;
+
+      # Trick central-backend from thinking connections are coming
+      # over HTTPS so that ExpressJS will set "secure" cookies.
+      proxy_set_header X-Forwarded-Proto https;
     }
 
     location / {


### PR DESCRIPTION
Moves `X-Forwarded-Proto` to top of `location` block, as per https://github.com/getodk/central/blob/master/files/nginx/odk.conf.template#L36.