### PR TITLE
Update translations for v1.5.3

### DIFF
--- a/src/components/backup/list.vue
+++ b/src/components/backup/list.vue
@@ -122,60 +122,28 @@ export default {
 <i18n>
 {
   "cs": {
-    "auditsTitle": "Nejnovější zálohy",
-    "alert": {
-      "create": "Skvěle! Nyní jsou nakonfigurovány automatické zálohy.",
-      "terminate": "Vaše automatické zálohování bylo ukončeno. Doporučujeme, abyste si nové zálohování nastavili co nejdříve."
-    }
+    "auditsTitle": "Nejnovější zálohy"
   },
   "de": {
-    "auditsTitle": "Letzte Sicherheitskopien",
-    "alert": {
-      "create": "Automatische Sicherungskopien sind jetzt eingerichtet.",
-      "terminate": "Ihre automatischen Backups wurden abgestellt. Wir empfehlen diese schnellstmöglich wieder zu konfigurieren."
-    }
+    "auditsTitle": "Letzte Sicherheitskopien"
   },
   "es": {
-    "auditsTitle": "Últimas copias de seguridad",
-    "alert": {
-      "create": "¡Exitoso! Las copias de seguridad automáticas están ahora configuradas.",
-      "terminate": "Sus copias de seguridad automáticas terminaron. Se recomienda que configure uno nuevo tan pronto como sea posible."
-    }
+    "auditsTitle": "Últimas copias de seguridad"
   },
   "fr": {
-    "auditsTitle": "Dernières Sauvegardes",
-    "alert": {
-      "create": "Succès ! Les sauvegardes automatiques sont maintenant configurées",
-      "terminate": "Vos sauvegardes automatiques ont été interrompus. Il est recommandé d'en mettre une nouvelle en place dès que possible."
-    }
+    "auditsTitle": "Dernières Sauvegardes"
   },
   "id": {
-    "auditsTitle": "Data Cadangan Terakhir",
-    "alert": {
-      "create": "Berhasil! Data cadangan otomatis telah dikonfigurasi.",
-      "terminate": "Data cadangan otomatis Anda telah berakhir. Anda direkomendasikan untuk menyetel cadangan otomatis baru secepatnya."
-    }
+    "auditsTitle": "Data Cadangan Terakhir"
   },
   "it": {
-    "auditsTitle": "Ultimo backup",
-    "alert": {
-      "create": "Successo! I backup automatici sono ora configurati.",
-      "terminate": "I tuoi backup automatici sono stati terminati. Si consiglia di impostarne uno nuovo il prima possibile."
-    }
+    "auditsTitle": "Ultimo backup"
   },
   "ja": {
-    "auditsTitle": "最新のバックアップ",
-    "alert": {
-      "create": "成功です！自動バックアップは設定されました。",
-      "terminate": "自動バックアップを停止しました。 なるべく早急に新たなバックアップ設定を行うことを推奨します。"
-    }
+    "auditsTitle": "最新のバックアップ"
   },
   "sw": {
-    "auditsTitle": "Hifadhi Nakala za Hivi Punde",
-    "alert": {
-      "create": "Mafanikio! Hifadhi rudufu za kiotomatiki sasa zimesanidiwa.",
-      "terminate": "Nakala zako za kiotomatiki zimekatishwa. Inapendekezwa kuwa usanidi mpya haraka iwezekanavyo"
-    }
+    "auditsTitle": "Hifadhi Nakala za Hivi Punde"
   }
 }
 </i18n>

--- a/src/components/backup/status.vue
+++ b/src/components/backup/status.vue
@@ -221,31 +221,17 @@ export default {
       "forum": "komunitní fórum"
     },
     "notConfigured": [
-      "Zálohy nejsou nakonfigurovány.",
-      "Datový server nebyl nastaven tak, aby automaticky zálohoval jeho data kdekoli.",
-      {
-        "full": "Pokud jste nenastavili nějakou jinou formu zálohování dat, o které server neví, je {recommended}, že to uděláte nyní. Pokud si nejste jisti, je nejlepší to udělat jen proto, abyste byli v bezpečí.",
-        "recommended": "silně doporučeno"
-      },
-      "Automatické zálohování dat probíhá prostřednictvím tohoto systému jednou denně. Všechna vaše data jsou zašifrována pomocí hesla, které zadáte, abyste je mohli odemknout pouze vy."
+      "Zálohy nejsou nakonfigurovány."
     ],
     "neverRun": [
       "Nakonfigurované zálohování dosud nebylo spuštěno.",
-      "Pokud jste nakonfigurovali zálohování v posledních několika dnech, je to normální. Jinak se něco pokazilo.",
-      {
-        "full": "V takovém případě je nejpravděpodobnější opravou {terminate} připojení a opětovné nastavení nebo restartování služby.",
-        "terminate": "ukončení"
-      }
+      "Pokud jste nakonfigurovali zálohování v posledních několika dnech, je to normální. Jinak se něco pokazilo."
     ],
     "somethingWentWrong": [
       "Něco je špatně!",
       {
         "full": "Poslední úspěšná záloha byla {moreThanThreeDaysAgo}.",
         "moreThanThreeDaysAgo": "před více než třemi dny"
-      },
-      {
-        "full": "Nejpravděpodobnější opravou je {terminate} připojení a znovu nastavení, nebo restartování služby.",
-        "terminate": "ukončit"
       }
     ],
     "success": [
@@ -253,7 +239,6 @@ export default {
       "Poslední záloha byla úspěšně dokončena {dateTime}."
     ],
     "action": {
-      "setUp": "Nastavit nyní",
       "download": "Stáhnout zálohu hned",
       "terminate": "Ukončit"
     },
@@ -267,31 +252,17 @@ export default {
       "forum": "Community-Forum"
     },
     "notConfigured": [
-      "Sicherungskopien sind nicht konfiguriert.",
-      "Der Datenserver ist nicht für eine automatische Sicherung konfiguriert.",
-      {
-        "full": "Wenn Sie nicht irgendeine andere Methode der Datensicherung implementiert haben, von der der Server nichts weiß, wird {recommended}, dass Sie jetzt eine Konfiguration vornehmen. Wenn Sie sich nicht sicher sind, ob eine Datensicherung besteht, konfigurieren Sie einfach eine weitere - doppelt gesichert schläft sich's bessert.",
-        "recommended": "dringend empfohlen"
-      },
-      "Automatische Sicherungen des gesamten Systems werden einmal am Tag durchgeführt. Alle Ihre Daten werden mit einem von Ihnen vergebenen Passwort verschlüsselt, und nur Sie können sie entschlüsseln."
+      "Sicherungskopien sind nicht konfiguriert."
     ],
     "neverRun": [
       "Die konfigurierte Sicherung ist wurde noch nicht ausgeführt.",
-      "Wenn Sie die Sicherungen in den letzten Tagen konfiguriert haben, ist dies normal. Wenn nicht, ist irgendetwas schief gegangen.",
-      {
-        "full": "In diesem Falle ist es am besten, wenn Sie die Verbindung {terminate} und danach neu starten. Alternativ können Sie den Dienst neu starten.",
-        "terminate": "beenden"
-      }
+      "Wenn Sie die Sicherungen in den letzten Tagen konfiguriert haben, ist dies normal. Wenn nicht, ist irgendetwas schief gegangen."
     ],
     "somethingWentWrong": [
       "Irgendetwas hat da nicht geklappt.",
       {
         "full": "Die letzte vollständige Sicherung wurde {moreThanThreeDaysAgo} ausgeführt.",
         "moreThanThreeDaysAgo": "vor mehr als drei Tagen."
-      },
-      {
-        "full": "Am besten {terminate} Sie die Verbindung und starten sie neu; alternativ können Sie auch den Dienst neu starten.",
-        "terminate": "beenden"
       }
     ],
     "success": [
@@ -299,7 +270,6 @@ export default {
       "Die letzte Sicherungskopie wurde erstellt: {dateTime}"
     ],
     "action": {
-      "setUp": "Jetzt konfigurieren",
       "download": "Backup jetzt herunterladen",
       "terminate": "Beenden"
     },
@@ -313,31 +283,17 @@ export default {
       "forum": "foro de la comunidad"
     },
     "notConfigured": [
-      "Las copias de seguridad no están configuradas.",
-      "El servidor de datos no se ha configurado para hacer una copia de seguridad automática de sus datos en ninguna parte.",
-      {
-        "full": "A menos que haya configurado algún otro formulario de copia de seguridad de datos que el servidor desconozca, es {recommended} que lo haga ahora. Si no está seguro, lo mejor es hacerlo solo para estar seguro.",
-        "recommended": "muy recomendado"
-      },
-      "Las copias de seguridad automáticas de datos se realizan a través de este sistema una vez al día. Todos sus datos están encriptados con una contraseña que proporcione para que solo usted pueda desbloquearla."
+      "Las copias de seguridad no están configuradas."
     ],
     "neverRun": [
       "La copia de seguridad configurada aún no se ha ejecutado.",
-      "Si ha configurado copias de seguridad en los últimos días, esto es normal. De lo contrario, algo ha salido mal.",
-      {
-        "full": "En ese caso, las soluciones más probables son {terminate} la conexión y configurarla nuevamente, o reiniciar el servicio.",
-        "terminate": "terminar"
-      }
+      "Si ha configurado copias de seguridad en los últimos días, esto es normal. De lo contrario, algo ha salido mal."
     ],
     "somethingWentWrong": [
       "¡Algo está mal!",
       {
         "full": "La última copia de seguridad que se completó correctamente fue {moreThanThreeDaysAgo}.",
         "moreThanThreeDaysAgo": "hace más de tres días"
-      },
-      {
-        "full": "Las soluciones más probables son {terminate} la conexión y configurarla nuevamente, o reiniciar el servicio.",
-        "terminate": "terminar"
       }
     ],
     "success": [
@@ -345,7 +301,6 @@ export default {
       "Última copia de seguridad completada con éxito {dateTime}"
     ],
     "action": {
-      "setUp": "Configurar ahora",
       "download": "Descargar copia de seguridad ahora",
       "terminate": "Terminar"
     },
@@ -359,31 +314,17 @@ export default {
       "forum": "forum de la communauté"
     },
     "notConfigured": [
-      "Sauvegarde non configuré",
-      "Le serveur de données n'a pas été configuré pour sauvegarder automatiquement ses données.",
-      {
-        "full": "À moins que vous n'ayez mis en place une autre forme de sauvegarde des données dont le serveur n'a pas connaissance, il est {recommended} de le faire maintenant. Si vous n'êtes pas sûr, il est préférable de le faire juste pour être sûr.",
-        "recommended": "fortement recommandé"
-      },
-      "Les sauvegardes automatiques de données de ce serveur sont quotidiennes. Toutes vos données sont cryptées avec une mot de passe que vous avez fourni de manière à ce que vous seul puissiez les déverrouiller."
+      "Sauvegarde non configuré"
     ],
     "neverRun": [
       "La sauvegarde configurée n'a pas encore été lancée.",
-      "Si vous avez configuré des sauvegardes au cours des deux derniers jours, c'est normal. Sinon, quelque-chose s'est mal passé.",
-      {
-        "full": "Dans ce cas, les solutions les plus probables consistent à {terminate} la connexion et à la rétablir, ou à redémarrer le service.",
-        "terminate": "terminer"
-      }
+      "Si vous avez configuré des sauvegardes au cours des deux derniers jours, c'est normal. Sinon, quelque-chose s'est mal passé."
     ],
     "somethingWentWrong": [
       "Quelque-chose ne va pas.",
       {
         "full": "La dernière sauvegarde correctement terminée était {moreThanThreeDaysAgo}.",
         "moreThanThreeDaysAgo": "plus de trois jours auparavant."
-      },
-      {
-        "full": "Les solutions les plus probables consistent à {terminate} la connexion et à la rétablir, ou à redémarrer le service.",
-        "terminate": "terminer"
       }
     ],
     "success": [
@@ -391,7 +332,6 @@ export default {
       "La dernière sauvegarde correctement exécutée {dateTime}."
     ],
     "action": {
-      "setUp": "Paramétrer maintenant",
       "download": "Télécharger la sauvegarde maintenant",
       "terminate": "Terminer"
     },
@@ -405,31 +345,17 @@ export default {
       "forum": "Forum komunitas"
     },
     "notConfigured": [
-      "Data cadangan tidak terkonfigurasi.",
-      "Server belum diatur untuk melakukan data cadangan otomatis dimanapun.",
-      {
-        "full": "Apabila Anda belum memiliki pengaturan data cadangan sama sekali, {recommended} Anda mengatur cadangan sekarang demi keamanan data Anda.",
-        "recommended": "sangat direkomendasikan"
-      },
-      "Data cadangan otomatis diproses sistem ini satu kali sehari. Semua data Anda dienkripsi dengan kata sandi yang telah Anda tentukan sehingga hanya Anda yang dapat membukanya."
+      "Data cadangan tidak terkonfigurasi."
     ],
     "neverRun": [
       "Data candangan yang dikonfigurasi belum berjalan.",
-      "Hal ini adalah normal ppabila Anda memiliki data cadangan yang telah dikonfigurasi dalam beberapa hari terakhir. Jika tidak, terjadi sebuah kesalahan.",
-      {
-        "full": "Dalam hal ini, saran perbaikan utama adalah dengan {terminate} koneksi dan mengaturnya ulang, atau dengan mengatur ulang servis.",
-        "terminate": "memutus"
-      }
+      "Hal ini adalah normal ppabila Anda memiliki data cadangan yang telah dikonfigurasi dalam beberapa hari terakhir. Jika tidak, terjadi sebuah kesalahan."
     ],
     "somethingWentWrong": [
       "Terjadi kesalahan!",
       {
         "full": "Data cadangan terakhir yang sukses dibuat adalah {moreThanThreeDaysAgo}.",
         "moreThanThreeDaysAgo": "lebih dari tiga hari yang lalu"
-      },
-      {
-        "full": "Saran perbaikan utama adalah dengan {terminate} koneksi dan mengaturnya ulang, atau mengatur ulang servis.",
-        "terminate": "memutus"
       }
     ],
     "success": [
@@ -437,7 +363,6 @@ export default {
       "Data cadangan terakhir telah sukses dibuat {dateTime}."
     ],
     "action": {
-      "setUp": "Atur sekarang",
       "download": "Unduh cadangan sekarang",
       "terminate": "Putuskan"
     },
@@ -451,31 +376,17 @@ export default {
       "forum": "forum comunitario"
     },
     "notConfigured": [
-      "I backup non sono configurati.",
-      "Il server di dati non è stato configurato per eseguire automaticamente il backup dei dati da nessuna parte.",
-      {
-        "full": "A meno che tu non abbia impostato un'altra forma di backup dei dati di cui il server non è a conoscenza, è {recommended} farlo ora. Se non sei sicuro, è meglio farlo solo per essere al sicuro.",
-        "recommended": "fortemente raccomandato"
-      },
-      "I backup automatici dei dati vengono eseguiti tramite questo sistema una volta al giorno. Tutti i tuoi dati sono crittografati con una password che fornisci in modo che solo tu possa accedervi."
+      "I backup non sono configurati."
     ],
     "neverRun": [
       "Il backup configurato non è ancora stato eseguito.",
-      "Se hai configurato i backup negli ultimi due giorni, è normale. Altrimenti qualcosa è andato storto.",
-      {
-        "full": "In tal caso, le soluzioni più probabili sono {terminate} la connessione e configurarla di nuovo o riavviare il servizio.",
-        "terminate": "terminare"
-      }
+      "Se hai configurato i backup negli ultimi due giorni, è normale. Altrimenti qualcosa è andato storto."
     ],
     "somethingWentWrong": [
       "Qualcosa non funziona!",
       {
         "full": "L'ultimo backup completato con successo è stato {moreThanThreeDaysAgo}.",
         "moreThanThreeDaysAgo": "più di tre giorni fa"
-      },
-      {
-        "full": "Le soluzioni più probabili sono {terminate} la connessione e configurarla di nuovo o riavviare il servizio.",
-        "terminate": "terminare"
       }
     ],
     "success": [
@@ -483,7 +394,6 @@ export default {
       "L'ultimo backup è stato completato con successo {dateTime}."
     ],
     "action": {
-      "setUp": "Configura adesso",
       "download": "Scarica il backup ora",
       "terminate": "Terminare"
     },
@@ -497,31 +407,17 @@ export default {
       "forum": "コミュニティーフォーラム"
     },
     "notConfigured": [
-      "バックアップは設定されていません。",
-      "データサーバは自動バックアップの設定をされていません。",
-      {
-        "full": "他の方法でデータをバックアップしている場合を除き、今すぐバックアップすることを{recommended}。確信が持てない場合は、安全のために設定することが望ましいです。",
-        "recommended": "強く推奨します"
-      },
-      "自動バックアップは本システム経由で毎日行われます。全てのデータは、あなたが設定したパスワードで暗号化されバックアップされ、あなたによって復号が可能です。"
+      "バックアップは設定されていません。"
     ],
     "neverRun": [
       "設定されたバックアップは未実行です。",
-      "ここ数日の間にバックアップの設定をしたのならば、これは正常です。そうでない場合は、何か問題が起きています。",
-      {
-        "full": "その場合、最も可能性の高い対処法は、Googleとの連携を{terminate}し、再設定することです。もしくは、サービスを再起動することです。",
-        "terminate": "切断"
-      }
+      "ここ数日の間にバックアップの設定をしたのならば、これは正常です。そうでない場合は、何か問題が起きています。"
     ],
     "somethingWentWrong": [
       "何か問題があります！",
       {
         "full": "最終のバックアップは、{moreThanThreeDaysAgo}に正常に完了しています。",
         "moreThanThreeDaysAgo": "3日以上前"
-      },
-      {
-        "full": "最も可能性の高い対処法は、Googleとの連携を{terminate}して再度設定することです。または、サービスを再起動することです。",
-        "terminate": "切断"
       }
     ],
     "success": [
@@ -529,7 +425,6 @@ export default {
       "{dateTime}に最新のバックアップは成功しています。"
     ],
     "action": {
-      "setUp": "今すぐ設定",
       "download": "今すぐバックアップをダウンロード",
       "terminate": "停止"
     },
@@ -543,31 +438,17 @@ export default {
       "forum": "jamii forum"
     },
     "notConfigured": [
-      "Hifadhi rudufu hazijasanidiwa.",
-      "Seva ya data haijawekwa ili kuhifadhi nakala kiotomatiki data yake popote pale.",
-      {
-        "full": "Isipokuwa umeweka aina nyingine ya kuhifadhi nakala ya data ambayo seva haijui, {recommended} ufanye hivi sasa. Ikiwa huna uhakika, ni bora kufanya hivyo ili tu kuwa salama.",
-        "recommended": "inapendekezwa sana"
-      },
-      "Hifadhi rudufu za data otomatiki hufanyika kupitia mfumo huu mara moja kwa siku. Data yako yote imesimbwa kwa njia fiche kwa nenosiri ulilotoa ili wewe tu uweze kulifungua."
+      "Hifadhi rudufu hazijasanidiwa."
     ],
     "neverRun": [
       "Hifadhi rudufu iliyosanidiwa bado haijatekelezwa",
-      "Ikiwa umesanidi nakala rudufu ndani ya siku chache zilizopita, hii ni kawaida. Vinginevyo, kitu kimeenda vibaya.",
-      {
-        "full": "Katika hali hiyo, marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma.",
-        "terminate": "sitisha"
-      }
+      "Ikiwa umesanidi nakala rudufu ndani ya siku chache zilizopita, hii ni kawaida. Vinginevyo, kitu kimeenda vibaya."
     ],
     "somethingWentWrong": [
       "Kuna kitu hakiko sawa",
       {
         "full": "Hifadhi rudufu ya hivi punde iliyokamilika kwa ufanisi ilikuwa {moreThanThreeDaysAgo}.",
         "moreThanThreeDaysAgo": "zaidi ya siku tatu zilizopita"
-      },
-      {
-        "full": "Marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma",
-        "terminate": "sitisha"
       }
     ],
     "success": [
@@ -575,7 +456,6 @@ export default {
       "Hifadhi rudufu ya mwisho ilikamilika {dateTime}."
     ],
     "action": {
-      "setUp": "Sanidi sasa",
       "download": "Pakua nakala rudufu sasa",
       "terminate": "Sitisha"
     },

--- a/src/components/backup/terminate.vue
+++ b/src/components/backup/terminate.vue
@@ -95,57 +95,49 @@ export default {
   "cs": {
     "title": "Ukončit automatické zálohování",
     "introduction": [
-      "Opravdu chcete ukončit automatické zálohování?",
-      "Budete je muset znovu nakonfigurovat od nuly, abyste je mohli znovu spustit, a tuto akci nelze vrátit zpět."
+      "Opravdu chcete ukončit automatické zálohování?"
     ]
   },
   "de": {
     "title": "Automatische Sicherungskopien beenden",
     "introduction": [
-      "Sind Sie sicher, dass Sie die automatischen Sicherungskopien beenden möchten?",
-      "Sie müssen Sie danach wieder neue konfigurieren, um sie wieder zu starten. Diese Aktion kann nicht rückgängig gemacht werden."
+      "Sind Sie sicher, dass Sie die automatischen Sicherungskopien beenden möchten?"
     ]
   },
   "es": {
     "title": "Terminar copias de seguridad automáticas",
     "introduction": [
-      "¿Está seguro que quiere terminar sus copias de seguridad automáticas?",
-      "Tendrá que volver a configurarlos desde cero para iniciarlos nuevamente, y esta acción no se puede deshacer."
+      "¿Está seguro que quiere terminar sus copias de seguridad automáticas?"
     ]
   },
   "fr": {
     "title": "Terminer les Sauvegardes Automatiques",
     "introduction": [
-      "Êtes-vous sûr de vouloir mettre fin à vos sauvegardes automatiques ?",
-      "Vous devrez les reconfigurer à partir de zéro pour les faire redémarrer, et cette action ne peut être annulée."
+      "Êtes-vous sûr de vouloir mettre fin à vos sauvegardes automatiques ?"
     ]
   },
   "id": {
     "title": "Putuskan Data Cadangan Otomatis",
     "introduction": [
-      "Apakah Anda yakin ingin memutus data cadangan otomatis?",
-      "Anda harus mengonfigurasi ulang dari awal untuk mengaktifkannya kembali, dan tindakan ini tidak bisa dibatalkan/dikembalikan."
+      "Apakah Anda yakin ingin memutus data cadangan otomatis?"
     ]
   },
   "it": {
     "title": "Termina i backup automatici",
     "introduction": [
-      "Sei sicuro di voler terminare i tuoi backup automatici?",
-      "Per riavviarli dovrai riconfigurarli di nuovo da zero e questa azione non può essere annullata."
+      "Sei sicuro di voler terminare i tuoi backup automatici?"
     ]
   },
   "ja": {
     "title": "自動バックアップの停止",
     "introduction": [
-      "自動バックアップを本当に停止しますか？",
-      "バックアップを再開するには、また初めから設定し直す必要があります。なお、この操作は取り消しできません。"
+      "自動バックアップを本当に停止しますか？"
     ]
   },
   "sw": {
     "title": "Sitisha Hifadhi Nakala za Kiotomatiki",
     "introduction": [
-      "Je, una uhakika kuwa ungependa kusitisha hifadhi rudufu zako otomatiki?",
-      "Utalazimika kuzisanidi tena kutoka mwanzo ili kuzianzisha tena, na kitendo hiki hakiwezi kutenduliwa"
+      "Je, una uhakika kuwa ungependa kusitisha hifadhi rudufu zako otomatiki?"
     ]
   }
 }

--- a/src/components/form-draft/checklist.vue
+++ b/src/components/form-draft/checklist.vue
@@ -364,7 +364,7 @@ export default {
           {
             "status": "Si vous avez apporté des changements au formulaire lui-même, y compris au texte des questions ou au règles logiques, il est temps de téléverser le nouveau XML ou XLSForm en utilisant le bouton de droite.",
             "link": {
-              "full": "Si vous avez apporté des changements au formulaire lui-même, y compris au texte des questions ou au règles logiques, il est temps de {upload} the new XML or XLSForm.",
+              "full": "Si vous avez apporté des changements au formulaire lui-même, y compris au texte des questions ou au règles logiques, il est temps de {upload} le nouveau XML ou XLSForm.",
               "upload": "téléverser"
             }
           }

--- a/src/components/form/delete.vue
+++ b/src/components/form/delete.vue
@@ -122,7 +122,10 @@ export default {
     ]
   },
   "id": {
-    "title": "Hapus Formulir"
+    "title": "Hapus Formulir",
+    "introduction": [
+      "Apakah Anda yakin ingin menghapus Formulir {name} dan semua kiriman data di dalamnya?"
+    ]
   },
   "it": {
     "title": "Cancellare il formulario",

--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -389,8 +389,10 @@ $actions-padding-left: $label-icon-max-width + $margin-right-icon;
     "exportOptions": "Možnosti exportu",
     "field": {
       "splitSelectMultiples": "Rozdělení možností \"vybrat více\" do sloupců",
-      "removeGroupNames": "Odstranění názvů skupin"
+      "removeGroupNames": "Odstranění názvů skupin",
+      "deletedFields": "Zahrnout pole, která nejsou ve zveřejněném formuláři"
     },
+    "deletedFieldsHelp": "Tuto možnost použijte, pokud potřebujete zobrazit pole odkazovaná v předchozích verzích formuláře.",
     "noSelectMultiple": "Tento formulář nemá žádná pole pro výběr více položek.",
     "encryptedForm": "Šifrované formuláře nelze tímto způsobem zpracovávat.",
     "deletedFieldsDisabledForDraft": "Návrhy formulářů nelze tímto způsobem zpracovávat.",
@@ -417,8 +419,10 @@ $actions-padding-left: $label-icon-max-width + $margin-right-icon;
     "exportOptions": "Exportoptionen",
     "field": {
       "splitSelectMultiples": "Unterteilen Sie „mehrere auswählen“-Optionen in Spalten",
-      "removeGroupNames": "Gruppennamen entfernen"
+      "removeGroupNames": "Gruppennamen entfernen",
+      "deletedFields": "Felder einschließen, die nicht in der veröffentlichten Version des Formulars enthalten sind"
     },
+    "deletedFieldsHelp": "Verwenden Sie diese Option, um Felder aus früheren Versionen des Formulars anzuzeigen.",
     "noSelectMultiple": "Dieses Formular enthält keine Mehrfachauswahlfelder.",
     "encryptedForm": "Verschlüsselte Formulare können auf diese Weise nicht verarbeitet werden.",
     "deletedFieldsDisabledForDraft": "Formularentwürfe können auf diese Weise nicht bearbeitet werden.",
@@ -473,8 +477,10 @@ $actions-padding-left: $label-icon-max-width + $margin-right-icon;
     "exportOptions": "Options d'exportation",
     "field": {
       "splitSelectMultiples": "Séparer le contenu des questions à choix multiples en plusieurs colonnes.",
-      "removeGroupNames": "Supprimer les noms de groupe"
+      "removeGroupNames": "Supprimer les noms de groupe",
+      "deletedFields": "Inclut les champs qui ne sont pas dans le formulaire publié"
     },
+    "deletedFieldsHelp": "Utilisez cette option si vous avez besoin des champs référencés dans le versions précédentes du formulaire",
     "noSelectMultiple": "Ce formulaire ne contient aucun champ à choix multiples (de type \"select_multiple\").",
     "encryptedForm": "Les formulaires chiffrés ne peuvent être traités de cette manière.",
     "deletedFieldsDisabledForDraft": "Les ébauches de formulaires ne peuvent être utilisées comme cela.",

--- a/transifex/strings_cs.json
+++ b/transifex/strings_cs.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Nejnovější zálohy",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "Skvěle! Nyní jsou nakonfigurovány automatické zálohy."
-        },
         "terminate": {
-          "string": "Vaše automatické zálohování bylo ukončeno. Doporučujeme, abyste si nové zálohování nastavili co nejdříve."
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Nastavení záloh",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "Tato záloha aktuálně neobsahuje odkazy na webové formuláře. Pokud sdílíte veřejné přístupové odkazy nebo externě odkazujete přímo na webové formuláře za účelem vytváření nových příspěvků, důrazně doporučujeme provést také úplnou zálohu systému, dokud nebude tento problém vyřešen. Pokud musíte obnovit ze zálohy a skončit s nefunkčními odkazy na náhled, pošlete příspěvek na {forum} a požádejte o pomoc.",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "fórum",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Pokud chcete, můžete nastavit šifrovací přístupové heslo, které musí být použito k odemknutí zálohy."
-            },
-            "1": {
-              "string": "Pokud heslo ztratíte, není možné jej obnovit."
-            },
-            "2": {
-              "string": "Nezapomeňte si vybrat něco, na co si vzpomenete, nebo si je zapište na bezpečné místo."
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Pro účely úschovy server odešle vaše data na Google Drive. Můžete si zaregistrovat bezplatný účet {here}.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "zde",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Po dalším stisknutí Google potvrdí, že chcete serveru povolit přístup k vašemu účtu. Jediné, čeho se bude server moci dotknout, jsou záložní soubory, které vytvoří."
-            },
-            "2": {
-              "string": "Jakmile to potvrdíte, budete požádáni o zkopírování a vložení textu sem."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Vítej zpět! Dostali jste nějaký text ke kopírování a vložení? Pokud ne, zkuste to znovu kliknutím  {here}.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "zde",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "Jinak jej vložte níže a máte hotovo!"
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Heslo (volitelné)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Potvrzovací text",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Zkuste to prosím znovu a přejděte na komunitní fórum, pokud problém přetrvává."
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "Zálohy nejsou nakonfigurovány."
         },
         "1": {
-          "string": "Datový server nebyl nastaven tak, aby automaticky zálohoval jeho data kdekoli."
-        },
-        "2": {
-          "full": {
-            "string": "Pokud jste nenastavili nějakou jinou formu zálohování dat, o které server neví, je {recommended}, že to uděláte nyní. Pokud si nejste jisti, je nejlepší to udělat jen proto, abyste byli v bezpečí.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "silně doporučeno",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "Automatické zálohování dat probíhá prostřednictvím tohoto systému jednou denně. Všechna vaše data jsou zašifrována pomocí hesla, které zadáte, abyste je mohli odemknout pouze vy."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Pokud jste nakonfigurovali zálohování v posledních několika dnech, je to normální. Jinak se něco pokazilo."
         },
         "2": {
-          "full": {
-            "string": "V takovém případě je nejpravděpodobnější opravou {terminate} připojení a opětovné nastavení nebo restartování služby.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "ukončení",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Nejpravděpodobnější opravou je {terminate} připojení a znovu nastavení, nebo restartování služby.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "ukončit",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Nastavit nyní",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Stáhnout zálohu hned",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "Opravdu chcete ukončit automatické zálohování?"
         },
         "1": {
-          "string": "Budete je muset znovu nakonfigurovat od nuly, abyste je mohli znovu spustit, a tuto akci nelze vrátit zpět."
+          "string": ""
         }
       }
     },
@@ -3285,12 +3173,12 @@
           "developer_comment": "This is the text of a form field."
         },
         "deletedFields": {
-          "string": "",
+          "string": "Zahrnout pole, která nejsou ve zveřejněném formuláři",
           "developer_comment": "This is the text of a form field."
         }
       },
       "deletedFieldsHelp": {
-        "string": ""
+        "string": "Tuto možnost použijte, pokud potřebujete zobrazit pole odkazovaná v předchozích verzích formuláře."
       },
       "noSelectMultiple": {
         "string": "Tento formulář nemá žádná pole pro výběr více položek."
@@ -3367,7 +3255,7 @@
           },
           "filtered": {
             "withoutCount": {
-              "string": "",
+              "string": "Stáhnout odpovídající příspěvky",
               "developer_comment": "This is the text of a button. This text is shown when the number of matching Submissions is unknown."
             },
             "withCount": {

--- a/transifex/strings_de.json
+++ b/transifex/strings_de.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Letzte Sicherheitskopien",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "Automatische Sicherungskopien sind jetzt eingerichtet."
-        },
         "terminate": {
-          "string": "Ihre automatischen Backups wurden abgestellt. Wir empfehlen diese schnellstmöglich wieder zu konfigurieren."
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Sicherheitskopien einrichten",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "Dieses Backup enthält aktuell keine Web-Formular-Links. Wenn Sie öffentliche Zugangslinks teilen oder extern auf Web-Formular-Links verlinken, um neue Übermittlungen zu machen, empfehlen wir, dass Sie auch ein vollständiges System-Backup durchführen, bis dies gelöst ist. Wenn Sie aus einem Backup wiederherstellen müssen und defekte Vorschau-Links erhalten, erstellen Sie einen Eintrag im {forum}, um Hilfe zu erhalten.",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "das Forum",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Sie können das Backup optional mit einer Passphrase sichern. Das Backup kann dann nur mit dieser Passphrase entschlüsselt werden."
-            },
-            "1": {
-              "string": "Eine verlorene Passphrase kann nicht wiederhergestellt werden!"
-            },
-            "2": {
-              "string": "Wählen Sie etwas gut Merkbares, oder bewahren Sie es an einem sicheren Ort schriftlich auf."
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Wir sichern Ihre Daten in Google Drive. Sie können {here} ein kostenloses Benutzerkonto erstellen.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "hier",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Wenn Sie \"weiter\" wählen, wird Google sich bestätigen lassen, dass der Server auf ihr System zugreifen darf. Der Server darf ausschließlich auf die erzeugten Backup-Dateien zugreifen."
-            },
-            "2": {
-              "string": "Wenn Sie das bestätigen, werden Sie gebeten, etwas Text mit Copy-and-Paste hier einzufügen."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Willkommen zurück! Haben Sie einen Text zum Einfügen bekommen? Wenn nicht, klicken Sie bitte {here}.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "hier",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "Oder einfach unten einfügen und fertig."
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Passphrase (optional)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Bestätigungstext",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Bitte versuchen Sie es nochmal, und besuchen Sie das Community Forum, wenn es weiterhin nicht funktioniert."
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "Sicherungskopien sind nicht konfiguriert."
         },
         "1": {
-          "string": "Der Datenserver ist nicht für eine automatische Sicherung konfiguriert."
-        },
-        "2": {
-          "full": {
-            "string": "Wenn Sie nicht irgendeine andere Methode der Datensicherung implementiert haben, von der der Server nichts weiß, wird {recommended}, dass  Sie jetzt eine Konfiguration vornehmen. Wenn Sie sich nicht sicher sind, ob eine Datensicherung besteht, konfigurieren Sie einfach eine weitere - doppelt gesichert schläft sich's bessert.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "dringend empfohlen",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "Automatische Sicherungen des gesamten Systems werden einmal am Tag durchgeführt. Alle Ihre Daten werden mit einem von Ihnen vergebenen Passwort verschlüsselt, und nur Sie können sie entschlüsseln."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Wenn Sie die Sicherungen in den letzten Tagen konfiguriert haben, ist dies normal. Wenn nicht, ist irgendetwas schief gegangen."
         },
         "2": {
-          "full": {
-            "string": "In diesem Falle ist es am besten, wenn Sie die Verbindung {terminate} und danach neu starten. Alternativ können Sie den Dienst neu starten.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "beenden",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Am besten {terminate} Sie die Verbindung und starten sie neu; alternativ können Sie auch den Dienst neu starten.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "beenden",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Jetzt konfigurieren",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Backup jetzt herunterladen",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "Sind Sie sicher, dass Sie die automatischen Sicherungskopien beenden möchten?"
         },
         "1": {
-          "string": "Sie müssen Sie danach wieder neue konfigurieren, um sie wieder zu starten. Diese Aktion kann nicht rückgängig gemacht werden."
+          "string": ""
         }
       }
     },
@@ -3285,12 +3173,12 @@
           "developer_comment": "This is the text of a form field."
         },
         "deletedFields": {
-          "string": "",
+          "string": "Felder einschließen, die nicht in der veröffentlichten Version des Formulars enthalten sind",
           "developer_comment": "This is the text of a form field."
         }
       },
       "deletedFieldsHelp": {
-        "string": ""
+        "string": "Verwenden Sie diese Option, um Felder aus früheren Versionen des Formulars anzuzeigen."
       },
       "noSelectMultiple": {
         "string": "Dieses Formular enthält keine Mehrfachauswahlfelder."
@@ -3362,16 +3250,16 @@
       "action": {
         "download": {
           "unfiltered": {
-            "string": "{count, plural, one {} other {}}",
+            "string": "{count, plural, one {{count} Übermittlung herunterladen} other {{count} Übermittlungen herunterladen}}",
             "developer_comment": "This is the text for an action, for example, the text of a button."
           },
           "filtered": {
             "withoutCount": {
-              "string": "",
+              "string": "Passende Übermittlungen herunterladen",
               "developer_comment": "This is the text of a button. This text is shown when the number of matching Submissions is unknown."
             },
             "withCount": {
-              "string": "{count, plural, one {} other {}}",
+              "string": "{count, plural, one {{count} passende Übermittlung herunterladen} other {{count} passende Übermittlungen herunterladen}}",
               "developer_comment": "This is the text for an action, for example, the text of a button."
             }
           }

--- a/transifex/strings_es.json
+++ b/transifex/strings_es.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Últimas copias de seguridad",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "¡Exitoso! Las copias de seguridad automáticas están ahora configuradas."
-        },
         "terminate": {
-          "string": "Sus copias de seguridad automáticas terminaron. Se recomienda que configure uno nuevo tan pronto como sea posible."
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Configurar copias de seguridad.",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "Actualmente, esta copia de seguridad no incluye enlaces a Formulario web. Si comparte enlaces de acceso público o un enlace externo directamente a formularios web para realizar nuevos envíos, le recomendamos encarecidamente que también haga una copia de seguridad completa del sistema hasta que se solucione este problema. Si tiene que restaurar desde la copia de seguridad y termina con enlaces de vista previa rotos, publique en el {forum} para obtener ayuda.",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "el foro",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Si usted quiere, puede configurar una frase de contraseña de cifrado que debe usarse para desbloquear la copia de seguridad."
-            },
-            "1": {
-              "string": "¡No hay forma de recuperar la frase de contraseña si la pierde!"
-            },
-            "2": {
-              "string": "Asegúrese de elegir algo que recordará o anótelo en un lugar seguro."
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Para su custodia, el servidor envía sus datos a Google Drive. Puedes registrarte para obtener una cuenta gratuita {here}.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "aquí",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Cuando presione siguiente, Google confirmará que desea permitir que el servidor acceda a su cuenta. Lo único que el servidor podrá tocar son los archivos de respaldo que crea."
-            },
-            "2": {
-              "string": "Una vez que confirme esto, se le pedirá que copie y pegue algún texto aquí."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "¡Bienvenido de vuelta! ¿Recibió algún texto para copiar y pegar? Si no, hacer clic {here} para volver a intentarlo.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "Aquí",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "De lo contrario, péguelo a continuación y listo!"
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Frase de contraseña (opcional)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Texto de confirmación",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Vuelva a intentarlo, y vaya al foro de la comunidad si el problema continúa."
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "Las copias de seguridad no están configuradas."
         },
         "1": {
-          "string": "El servidor de datos no se ha configurado para hacer una copia de seguridad automática de sus datos en ninguna parte."
-        },
-        "2": {
-          "full": {
-            "string": "A menos que haya configurado algún otro formulario de copia de seguridad de datos que el servidor desconozca, es {recommended} que lo haga ahora. Si no está seguro, lo mejor es hacerlo solo para estar seguro.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "muy recomendado",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "Las copias de seguridad automáticas de datos se realizan a través de este sistema una vez al día. Todos sus datos están encriptados con una contraseña que proporcione para que solo usted pueda desbloquearla."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Si ha configurado copias de seguridad en los últimos días, esto es normal. De lo contrario, algo ha salido mal."
         },
         "2": {
-          "full": {
-            "string": "En ese caso, las soluciones más probables son {terminate} la conexión y configurarla nuevamente, o reiniciar el servicio.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "terminar",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Las soluciones más probables son {terminate} la conexión y configurarla nuevamente, o reiniciar el servicio.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "terminar",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Configurar ahora",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Descargar copia de seguridad ahora",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "¿Está seguro que quiere terminar sus copias de seguridad automáticas?"
         },
         "1": {
-          "string": "Tendrá que volver a configurarlos desde cero para iniciarlos nuevamente, y esta acción no se puede deshacer."
+          "string": ""
         }
       }
     },

--- a/transifex/strings_fr.json
+++ b/transifex/strings_fr.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Dernières Sauvegardes",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "Succès ! Les sauvegardes automatiques sont maintenant configurées"
-        },
         "terminate": {
-          "string": "Vos sauvegardes automatiques ont été interrompus. Il est recommandé d'en mettre une nouvelle en place dès que possible."
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Configurer des sauvegardes",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "Cette sauvegarde n'inclue pas les liens de formulaires Web. Si vous partagez des liens d'accès public ou partagez des liens directs à vos formulaires Web, nous recommandons fortement que vous fassiez également une sauvegarde complete du système jusqu'à ce que ceci soit adressé. Si vous devez restaurer vos données d'une sauvegarde et vous retrouvez avec des liens d'aperçu qui ne fonctionnent pas, veuillez écrire un message sur {forum} pour recevoir de l'aide.",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "le forum",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Si vous le désirez, vous pouvez définir une phrase de passe de cryptage pour déverrouiller la sauvegarde."
-            },
-            "1": {
-              "string": "Il n'y a aucun moyen de retrouver la phrase de passe si vous la perdez !"
-            },
-            "2": {
-              "string": "Soyez sûr de choisir quelque-chose dont vous vous souviendrez, ou écrivez le dans un endroit sûr."
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Pour la sauvegarde, le serveur envoie vos données à Google Drive. Vous pouvez créer un compte gratuit {here}.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "ici",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Lorsque vous appuyez sur le bouton suivant, Google confirmera que vous souhaitez autoriser le serveur à accéder à votre compte. La seule chose que le serveur sera autorisé à toucher sont les fichiers de sauvegarde qu'il crée."
-            },
-            "2": {
-              "string": "Une fois que vous aurez confirmé cela, il vous sera demandé de copier et de coller du texte ici."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Bienvenue à nouveau ! Vous avez reçu du texte à copier-coller ? Si ce n'est pas le cas, cliquez {here} pour réessayer.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "ici",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "Sinon, collez ci-bas et c'est fini !"
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Phrase de passe (optionnel)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Texte de confirmation",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Merci d'essayer à nouveau, et de consulter le forum de la communauté si le problème persiste."
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "Sauvegarde non configuré"
         },
         "1": {
-          "string": "Le serveur de données n'a pas été configuré pour sauvegarder automatiquement ses données."
-        },
-        "2": {
-          "full": {
-            "string": "À moins que vous n'ayez mis en place une autre forme de sauvegarde des données dont le serveur n'a pas connaissance, il est {recommended} de le faire maintenant. Si vous n'êtes pas sûr, il est préférable de le faire juste pour être sûr.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "fortement recommandé",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "Les sauvegardes automatiques de données de ce serveur sont quotidiennes. Toutes vos données sont cryptées avec une mot de passe que vous avez fourni de manière à ce que vous seul puissiez les déverrouiller."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Si vous avez configuré des sauvegardes au cours des deux derniers jours, c'est normal. Sinon, quelque-chose s'est mal passé."
         },
         "2": {
-          "full": {
-            "string": "Dans ce cas, les solutions les plus probables consistent à {terminate} la connexion et à la rétablir, ou à redémarrer le service.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "terminer",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Les solutions les plus probables consistent à {terminate} la connexion et à la rétablir, ou à redémarrer le service.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "terminer",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Paramétrer maintenant",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Télécharger la sauvegarde maintenant",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "Êtes-vous sûr de vouloir mettre fin à vos sauvegardes automatiques ?"
         },
         "1": {
-          "string": "Vous devrez les reconfigurer à partir de zéro pour les faire redémarrer, et cette action ne peut être annulée."
+          "string": ""
         }
       }
     },
@@ -1854,7 +1742,7 @@
               },
               "link": {
                 "full": {
-                  "string": "Si vous avez apporté des changements au formulaire lui-même, y compris au texte des questions ou au règles logiques, il est temps de {upload} the new XML or XLSForm.",
+                  "string": "Si vous avez apporté des changements au formulaire lui-même, y compris au texte des questions ou au règles logiques, il est temps de {upload} le nouveau XML ou XLSForm.",
                   "developer_comment": "This refers to changes to the Form definition as opposed to just the media associated with the Form. The word \"XLSForm\" should not be translated.\n\n{upload} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nupload"
                 },
                 "upload": {
@@ -3285,12 +3173,12 @@
           "developer_comment": "This is the text of a form field."
         },
         "deletedFields": {
-          "string": "",
+          "string": "Inclut les champs qui ne sont pas dans le formulaire publié",
           "developer_comment": "This is the text of a form field."
         }
       },
       "deletedFieldsHelp": {
-        "string": ""
+        "string": "Utilisez cette option si vous avez besoin des champs référencés dans le versions précédentes du formulaire"
       },
       "noSelectMultiple": {
         "string": "Ce formulaire ne contient aucun champ à choix multiples (de type \"select_multiple\")."
@@ -3362,16 +3250,16 @@
       "action": {
         "download": {
           "unfiltered": {
-            "string": "{count, plural, one {} many {} other {}}",
+            "string": "{count, plural, one {Télécharger {count} soumission} many {Télécharger {count} soumissions} other {Télécharger {count} soumission(s)}}",
             "developer_comment": "This is the text for an action, for example, the text of a button."
           },
           "filtered": {
             "withoutCount": {
-              "string": "",
+              "string": "Télécharger les soumissions correspondantes",
               "developer_comment": "This is the text of a button. This text is shown when the number of matching Submissions is unknown."
             },
             "withCount": {
-              "string": "{count, plural, one {} many {} other {}}",
+              "string": "{count, plural, one {Télécharger {count} soumission correspondant} many {Télécharger {count} soumissions correspondantes} other {Télécharger {count} souission(s) correspondant(s)}}",
               "developer_comment": "This is the text for an action, for example, the text of a button."
             }
           }

--- a/transifex/strings_id.json
+++ b/transifex/strings_id.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Data Cadangan Terakhir",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "Berhasil! Data cadangan otomatis telah dikonfigurasi."
-        },
         "terminate": {
-          "string": "Data cadangan otomatis Anda telah berakhir. Anda direkomendasikan untuk menyetel cadangan otomatis baru secepatnya."
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Mengatur Data Cadangan",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "Forum",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Bila ingin, Anda dapat mengatur enkripsi frasa sandi yang harus digunakan untuk membuka data cadangan."
-            },
-            "1": {
-              "string": "Frasa sandi yang hilang/lupa tidak dapat dikembalikan/diatur ulang!"
-            },
-            "2": {
-              "string": "Pastikan Anda memilih sesuatu yang mudah Anda ingat, atau catat frasa sandi Anda di tempat aman."
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Demi keamanan, server mengirimkan data Anda ke Google Drive. Anda dapat membuat akun gratis {here}.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "di sini",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Ketika mekenan tombol lanjut, Google akan mengonfirmasi bahwa Anda mengizinkan server mengakses akun Anda. Server hanya akan memiliki akses terhadap data cadangan yang dibuat."
-            },
-            "2": {
-              "string": "Setelah mengonfirmasi, Anda akan diminta untuk menyalin dan menempel teks di sini."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Selamat datang kembali! Apakah Anda sudah menerima teks untuk disalin dan ditempel? Jika belum, klik {here} untuk mencoba lagi.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "di sini",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "Cara lainnya, tempel teks di bawah ini dan Anda telah selesai!"
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Frasa sandi (opsional)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Teks konfirmasi",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Mohon coba lagi, dan kunjungi forum komunitas jika terjadi masalah berkelanjutan."
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "Data cadangan tidak terkonfigurasi."
         },
         "1": {
-          "string": "Server belum diatur untuk melakukan data cadangan otomatis dimanapun."
-        },
-        "2": {
-          "full": {
-            "string": "Apabila Anda belum memiliki pengaturan data cadangan sama sekali, {recommended} Anda mengatur cadangan sekarang demi keamanan data Anda.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "sangat direkomendasikan",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "Data cadangan otomatis diproses sistem ini satu kali sehari. Semua data Anda dienkripsi dengan kata sandi yang telah Anda tentukan sehingga hanya Anda yang dapat membukanya."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Hal ini adalah normal ppabila Anda memiliki data cadangan yang telah dikonfigurasi dalam beberapa hari terakhir. Jika tidak, terjadi sebuah kesalahan."
         },
         "2": {
-          "full": {
-            "string": "Dalam hal ini, saran perbaikan utama adalah dengan {terminate} koneksi dan mengaturnya ulang, atau dengan mengatur ulang servis.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "memutus",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Saran perbaikan utama adalah dengan {terminate} koneksi dan mengaturnya ulang, atau mengatur ulang servis.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "memutus",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Atur sekarang",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Unduh cadangan sekarang",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "Apakah Anda yakin ingin memutus data cadangan otomatis?"
         },
         "1": {
-          "string": "Anda harus mengonfigurasi ulang dari awal untuk mengaktifkannya kembali, dan tindakan ini tidak bisa dibatalkan/dikembalikan."
+          "string": ""
         }
       }
     },

--- a/transifex/strings_it.json
+++ b/transifex/strings_it.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Ultimo backup",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "Successo! I backup automatici sono ora configurati."
-        },
         "terminate": {
-          "string": "I tuoi backup automatici sono stati terminati. Si consiglia di impostarne uno nuovo il prima possibile."
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Configura i Backup",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "Questo backup attualmente non include collegamenti a formulari Web. Se condividi link di accesso pubblico o ti colleghi esternamente direttamente a Web Forms per creare nuovi Invii, ti consigliamo vivamente di eseguire anche un backup completo del sistema fino a quando questo non viene risolto. Se devi eseguire il ripristino dal backup e ti ritrovi con collegamenti di anteprima non funzionanti, pubblica su {forum} per ottenere assistenza.",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "il Forum",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Se lo desideri, puoi impostare una passphrase di crittografia che deve essere utilizzata per sbloccare il backup."
-            },
-            "1": {
-              "string": "Non c'è modo di recuperare la passphrase se la perdi!"
-            },
-            "2": {
-              "string": "Assicurati di scegliere qualcosa che ricorderai o scrivilo in un posto sicuro."
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Per motivi di sicurezza, il server invia i tuoi dati a Google Drive. Puoi registrarti {here} per un account gratuito. ",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "qui",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Quando premi Avanti, Google confermerà che desideri consentire al server di accedere al tuo account. L'unica cosa che il server potrà manipolare sono i file di backup che crea."
-            },
-            "2": {
-              "string": "Una volta confermato, ti verrà chiesto di copiare e incollare del testo qui."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Ben tornato! Hai ricevuto del testo da copiare e incollare? In caso contrario, fai clic {here} per riprovare. ",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "qui",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "Altrimenti, incollalo qui sotto e avrai finito! "
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Passphrase (opzionale)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Testo di conferma",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Riprova e vai al forum della community se il problema persiste. "
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "I backup non sono configurati."
         },
         "1": {
-          "string": "Il server di dati non è stato configurato per eseguire automaticamente il backup dei dati da nessuna parte."
-        },
-        "2": {
-          "full": {
-            "string": "A meno che tu non abbia impostato un'altra forma di backup dei dati di cui il server non è a conoscenza, è {recommended} farlo ora. Se non sei sicuro, è meglio farlo solo per essere al sicuro.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "fortemente raccomandato",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "I backup automatici dei dati vengono eseguiti tramite questo sistema una volta al giorno. Tutti i tuoi dati sono crittografati con una password che fornisci in modo che solo tu possa accedervi."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Se hai configurato i backup negli ultimi due giorni, è normale. Altrimenti qualcosa è andato storto."
         },
         "2": {
-          "full": {
-            "string": "In tal caso, le soluzioni più probabili sono {terminate} la connessione e configurarla di nuovo o riavviare il servizio.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "terminare",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Le soluzioni più probabili sono {terminate} la connessione e configurarla di nuovo o riavviare il servizio.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "terminare",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Configura adesso",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Scarica il backup ora",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "Sei sicuro di voler terminare i tuoi backup automatici? "
         },
         "1": {
-          "string": "Per riavviarli dovrai riconfigurarli di nuovo da zero e questa azione non può essere annullata. "
+          "string": ""
         }
       }
     },

--- a/transifex/strings_ja.json
+++ b/transifex/strings_ja.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "最新のバックアップ",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "成功です！自動バックアップは設定されました。"
-        },
         "terminate": {
-          "string": "自動バックアップを停止しました。\nなるべく早急に新たなバックアップ設定を行うことを推奨します。"
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "バックアップの設定",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "このバックアップには、現在、Webフォームのリンクは含まれていません。一般公開リンクを共有している場合や、新規のフォーム提出のためにWebフォームに外部から直接リンクしている場合、この問題が解決するまでシステムのフルバックアップを行うことを強く推奨します。もしバックアップから復元する場合にプレビューリンクが壊れたままの場合、{forum}に状況を投稿し、サポートを受けて下さい。",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "フォーラム",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "暗号化パスフレーズを設定できますが、暗号化パスフレーズはバックアップの復号時に必ず必要です。"
-            },
-            "1": {
-              "string": "パスフレーズを忘れた場合、復元する方法はありません！"
-            },
-            "2": {
-              "string": "覚えやすいものを選ぶか、安全な場所に書き留めて下さい。"
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "保管のために、サーバーはデータをGoogle Driveに送信します。{here}で無料のアカウントを登録できます 。",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "こちら",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "「次へ」を押すと、Googleによって、このサーバーがあなたのGoogleアカウントにアクセス許可を与えるか、が確認されます。サーバーに許されるのは、サーバーが作成したバックアップファイルへのアクセスのみです。"
-            },
-            "2": {
-              "string": "承認後、確認用の文字列をここにコピー＆ペーストすることを要求されます。"
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "おかえりなさい！コピー＆ペースト用のテキストは出てきましたか？見つからない場合は、{here}をクリックしてもう一度試して下さい。",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "こちら",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "問題なければ、これをペーストして終わりです！"
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "パスフレーズ（任意）",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "確認用の文字列",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "再度試し、問題が解決しない場合はコミュニティフォーラムを確認して下さい。"
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "バックアップは設定されていません。"
         },
         "1": {
-          "string": "データサーバは自動バックアップの設定をされていません。"
-        },
-        "2": {
-          "full": {
-            "string": "他の方法でデータをバックアップしている場合を除き、今すぐバックアップすることを{recommended}。確信が持てない場合は、安全のために設定することが望ましいです。",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "強く推奨します",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "自動バックアップは本システム経由で毎日行われます。全てのデータは、あなたが設定したパスワードで暗号化されバックアップされ、あなたによって復号が可能です。"
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "ここ数日の間にバックアップの設定をしたのならば、これは正常です。そうでない場合は、何か問題が起きています。"
         },
         "2": {
-          "full": {
-            "string": "その場合、最も可能性の高い対処法は、Googleとの連携を{terminate}し、再設定することです。もしくは、サービスを再起動することです。",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "切断",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "最も可能性の高い対処法は、Googleとの連携を{terminate}して再度設定することです。または、サービスを再起動することです。",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "切断",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "今すぐ設定",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "今すぐバックアップをダウンロード",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "自動バックアップを本当に停止しますか？"
         },
         "1": {
-          "string": "バックアップを再開するには、また初めから設定し直す必要があります。なお、この操作は取り消しできません。"
+          "string": ""
         }
       }
     },

--- a/transifex/strings_sw.json
+++ b/transifex/strings_sw.json
@@ -1145,100 +1145,19 @@
         }
       }
     },
+    "BackupDeprecation": {
+      "text": {
+        "string": ""
+      }
+    },
     "BackupList": {
       "auditsTitle": {
         "string": "Hifadhi Nakala za Hivi Punde",
         "developer_comment": "This is a title shown above a section of the page."
       },
       "alert": {
-        "create": {
-          "string": "Mafanikio! Hifadhi rudufu za kiotomatiki sasa zimesanidiwa."
-        },
         "terminate": {
-          "string": "Nakala zako za kiotomatiki zimekatishwa. Inapendekezwa kuwa usanidi mpya haraka iwezekanavyo"
-        }
-      }
-    },
-    "BackupNew": {
-      "title": {
-        "string": "Sanidi Hifadhi Nakala",
-        "developer_comment": "This is the title at the top of a pop-up."
-      },
-      "steps": {
-        "0": {
-          "warning": {
-            "full": {
-              "string": "Hifadhi rudufu hii kwa sasa haijumuishi viungo vya Fomu ya Wavuti. Ukishiriki Viungo vya Ufikiaji wa Umma au kuunganisha kwa nje moja kwa moja kwa Fomu za Wavuti kwa ajili ya kufanya Mawasilisho mapya, tunapendekeza kwa dhati kwamba ufanye hifadhi kamili ya mfumo hadi hili lishughulikiwe. Iwapo itabidi urejeshe kutoka kwa nakala na uishie na viungo vilivyovunjika vya Onyesho la Kuchungulia, tafadhali ichapishe kwenye {forum} ili upate usaidizi.",
-              "developer_comment": "{forum} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nthe forum"
-            },
-            "forum": {
-              "string": "jukwaa",
-              "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {forum} is in the following text:\n\nThis backup does not currently include Web Form links. If you share Public Access Links or externally link directly to Web Forms for making new Submissions, we strongly recommend that you also make a full system backup until this is addressed. If you have to restore from backup and end up with broken Preview links, please post to {forum} to get help."
-            }
-          },
-          "introduction": {
-            "0": {
-              "string": "Ukipenda, unaweza kusanidi kaulisiri ya usimbaji ambayo lazima itumike kufungua nakala rudufu."
-            },
-            "1": {
-              "string": "Hakuna njia ya kurejesha kaulisiri ikiwa utaipoteza!"
-            },
-            "2": {
-              "string": "Hakikisha umechagua kitu ambacho utakumbuka, au uandike mahali salama"
-            }
-          }
-        },
-        "1": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Kwa usalama, seva hutuma data yako kwenye Hifadhi ya Google. Unaweza kujiandikisha kwa akaunti isiyolipishwa {here}",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "hapa",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nFor safekeeping, the server sends your data to Google Drive. You can sign up for a free account {here}."
-              }
-            },
-            "1": {
-              "string": "Unapobofya inayofuata, Google itathibitisha kwamba ungependa kuruhusu seva kufikia akaunti yako. Kitu pekee ambacho seva itaruhusiwa kugusa ni faili za chelezo inazounda"
-            },
-            "2": {
-              "string": "Ukishathibitisha hili, utaombwa kunakili na kubandika maandishi hapa nyuma."
-            }
-          }
-        },
-        "2": {
-          "introduction": {
-            "0": {
-              "full": {
-                "string": "Karibu tena! Je, umepata maandishi ya kunakili na kubandika? Ikiwa sivyo, bofya {here} ili kujaribu tena.",
-                "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
-              },
-              "here": {
-                "string": "hapa",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nWelcome back! Did you get some text to copy and paste? If not, click {here} to try again."
-              }
-            },
-            "1": {
-              "string": "Vinginevyo, bandika hapa chini na umemaliza!"
-            }
-          }
-        }
-      },
-      "field": {
-        "passphrase": {
-          "string": "Nenosiri (hiari)",
-          "developer_comment": "This is the text of a form field."
-        },
-        "confirmationText": {
-          "string": "Maandishi ya uthibitisho",
-          "developer_comment": "This is the text of a form field."
-        }
-      },
-      "problem": {
-        "verify": {
-          "string": "Tafadhali jaribu tena, na uende kwenye jamii forum tatizo likiendelea."
+          "string": ""
         }
       }
     },
@@ -1258,20 +1177,7 @@
           "string": "Hifadhi rudufu hazijasanidiwa."
         },
         "1": {
-          "string": "Seva ya data haijawekwa ili kuhifadhi nakala kiotomatiki data yake popote pale."
-        },
-        "2": {
-          "full": {
-            "string": "Isipokuwa umeweka aina nyingine ya kuhifadhi nakala ya data ambayo seva haijui, {recommended} ufanye hivi sasa. Ikiwa huna uhakika, ni bora kufanya hivyo ili tu kuwa salama.",
-            "developer_comment": "{recommended} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nstrongly recommended"
-          },
-          "recommended": {
-            "string": "inapendekezwa sana",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {recommended} is in the following text:\n\nUnless you have set up some other form of data backup that the server doesn’t know about, it is {recommended} that you do this now. If you are not sure, it is best to do it just to be safe."
-          }
-        },
-        "3": {
-          "string": "Hifadhi rudufu za data otomatiki hufanyika kupitia mfumo huu mara moja kwa siku. Data yako yote imesimbwa kwa njia fiche kwa nenosiri ulilotoa ili wewe tu uweze kulifungua."
+          "string": ""
         }
       },
       "neverRun": {
@@ -1282,14 +1188,7 @@
           "string": "Ikiwa umesanidi nakala rudufu ndani ya siku chache zilizopita, hii ni kawaida. Vinginevyo, kitu kimeenda vibaya."
         },
         "2": {
-          "full": {
-            "string": "Katika hali hiyo, marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma.",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "sitisha",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nIn that case, the most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "somethingWentWrong": {
@@ -1307,14 +1206,7 @@
           }
         },
         "2": {
-          "full": {
-            "string": "Marekebisho yanayowezekana zaidi ni {terminate} muunganisho na kuusanidi tena, au kuanzisha upya huduma",
-            "developer_comment": "{terminate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nterminate"
-          },
-          "terminate": {
-            "string": "sitisha",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {terminate} is in the following text:\n\nThe most likely fixes are to {terminate} the connection and set it up again, or to restart the service."
-          }
+          "string": ""
         }
       },
       "success": {
@@ -1328,10 +1220,6 @@
         }
       },
       "action": {
-        "setUp": {
-          "string": "Sanidi sasa",
-          "developer_comment": "This is the text for an action, for example, the text of a button."
-        },
         "download": {
           "string": "Pakua nakala rudufu sasa",
           "developer_comment": "This is the text for an action, for example, the text of a button."
@@ -1357,7 +1245,7 @@
           "string": "Je, una uhakika kuwa ungependa kusitisha hifadhi rudufu zako otomatiki?"
         },
         "1": {
-          "string": "Utalazimika kuzisanidi tena kutoka mwanzo ili kuzianzisha tena, na kitendo hiki hakiwezi kutenduliwa"
+          "string": ""
         }
       }
     },


### PR DESCRIPTION
As part of this PR, I've changed one part of how we import translations from Transifex. Previously, if any element of an array was an untranslated message, we would discard the entire array. Now, we only discard the elements after the untranslated message. (See the code for an explanation of why we have to do this at all.) In general, this isn't a case that comes up a lot: usually an array is either fully translated or fully untranslated. However, right now it comes up a lot in the `BackupStatus` component because we just modified some of the source arrays there. Without making this change, a lot of that page would no longer be translated.

I've also discarded the changes to `SubmissionDownloadDropdown` as was done in #618.