### PR TITLE
Dataset and Entity audit log events

### DIFF
--- a/src/components/audit/filters/action.vue
+++ b/src/components/audit/filters/action.vue
@@ -76,6 +76,9 @@ export default {
         this.actionOption('public_link.assignment.delete'),
         this.actionOption('public_link.session.end'),
         this.actionOption('public_link.delete'),
+        this.categoryOption('dataset'),
+        this.actionOption('dataset.create'),
+        this.actionOption('dataset.update'),
         this.categoryOption('config'),
         this.actionOption('config.set')
       ];

--- a/src/components/audit/row.vue
+++ b/src/components/audit/row.vue
@@ -53,6 +53,7 @@ const typeByCategory = {
   user: 'resource.user',
   project: 'resource.project',
   form: 'resource.form',
+  dataset: 'resource.dataset',
   public_link: 'resource.publicLink',
   field_key: 'resource.appUser',
   config: 'resource.config',
@@ -72,6 +73,9 @@ const acteeSpeciesByCategory = {
   form: {
     title: (actee) => (actee.name != null ? actee.name : actee.xmlFormId),
     path: (actee, { primaryFormPath }) => primaryFormPath(actee)
+  },
+  dataset: {
+    title: (actee) => actee.name
   },
   public_link: {
     title: getDisplayName

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -31,6 +31,17 @@ except according to the terms contained in the LICENSE file.
             <template #name><actor-link :actor="entry.actor"/></template>
           </i18n-t>
         </template>
+        <template v-else-if="entry.action === 'entity.create'">
+          <span class="icon-check entity-icon submission-feed-entry-icon"></span>
+          <i18n-t keypath="title.entity.create">
+            <template #label><span class="submission-feed-entry-entity-data">{{ entityLabel(entry) }}</span></template>
+            <template #dataset><span class="submission-feed-entry-entity-data">{{ entityDataset(entry) }}</span></template>
+          </i18n-t>
+        </template>
+        <template v-else-if="entry.action === 'entity.create.error'">
+          <span class="icon-warning entity-icon submission-feed-entry-icon"></span>
+          <span class="submission-feed-entry-entity-error" :title="entityProblem(entry)">{{ $t('title.entity.error') }}</span>
+        </template>
         <template v-else>
           <span class="icon-comment submission-feed-entry-icon"></span>
           <i18n-t keypath="title.comment">
@@ -135,6 +146,21 @@ export default {
   methods: {
     updateOrEditIcon(state) {
       return `${this.reviewStateIcon(state)} submission-feed-entry-icon`;
+    },
+    entityLabel(entry) {
+      if ('entity' in entry.details)
+        return entry.details.entity.label;
+      return '';
+    },
+    entityDataset(entry) {
+      if ('entity' in entry.details)
+        return entry.details.entity.dataset;
+      return '';
+    },
+    entityProblem(entry) {
+      if ('problem' in entry.details && 'problemDetails' in entry.details.problem)
+        return entry.details.problem.problemDetails.reason;
+      return '';
     }
   }
 };
@@ -142,6 +168,7 @@ export default {
 
 <style lang="scss">
 @import '../../assets/scss/mixins';
+@import '../../assets/scss/variables';
 
 .submission-feed-entry {
   box-shadow: 0 7px 18px rgba(0, 0, 0, 0.05);
@@ -173,9 +200,19 @@ export default {
       text-align: center;
       width: 18px;
     }
+
+    .submission-feed-entry-entity-data {
+      font-weight: normal;
+      color: $color-action-foreground;
+    }
+
+    .submission-feed-entry-entity-error {
+      cursor: help;
+    }
   }
 
   .icon-cloud-upload, .icon-comment { color: #bbb; }
+  .entity-icon { color: $color-action-foreground; }
   .review-state {
     color: #999;
     &.hasIssues { color: $color-warning; }
@@ -202,6 +239,10 @@ you could split it into:
 
 Submitted • {name} */
       "create": "Submitted by {name}",
+      "entity": {
+        "create": "Created Entity {label} in {dataset} Dataset",
+        "error": "Problem creating Entity",
+      },
       "updateReviewState": {
         "null": {
           /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -203,7 +203,6 @@ export default {
 
     .submission-feed-entry-entity-data {
       font-weight: normal;
-      color: $color-action-foreground;
     }
 
     .submission-feed-entry-entity-error {

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -79,6 +79,7 @@
       "user": "Web User Actions",
       "project": "Project Actions",
       "form": "Form Actions",
+      "dataset": "Dataset Actions",
       "field_key": "App User Actions",
       "public_link": "Public Access Link Actions",
       "config": "Server Configuration Actions",
@@ -101,6 +102,12 @@
       // type of action that can be taken on a Server Configuration.
       "config": {
         "set": "Set"
+      },
+      // This is shown in the log of actions performed on the server. It is a
+      // type of action that can be taken on a Dataset.
+      "dataset": {
+        "create": "@:audit.action.default.create",
+        "update": "Update"
       },
       // This is shown in the log of actions performed on the server. It is a
       // type of action that can be taken on an App User.
@@ -249,6 +256,7 @@
     "appUser": "App User",
     "appUsers": "App Users",
     "config": "Server Configuration",
+    "dataset": "Dataset",
     "datasets": "Datasets",
     "form": "Form",
     "forms": "Forms",

--- a/test/components/audit/table.spec.js
+++ b/test/components/audit/table.spec.js
@@ -273,6 +273,28 @@ describe('AuditTable', () => {
     });
   });
 
+  describe('dataset target', () => {
+    const cases = [
+      ['dataset.create', ['Dataset', 'Create']],
+      ['dataset.update', ['Dataset', 'Update']]
+    ];
+
+    for (const [action, type] of cases) {
+      it(`renders a ${action} audit correctly`, () => {
+        testData.extendedAudits.createPast(1, {
+          actor: testData.extendedUsers.first(),
+          action,
+          actee: testData.extendedDatasets
+            .createPast(1, { name: 'people' })
+            .last()
+        });
+        const row = mountComponent();
+        testType(row, type);
+        testTarget(row, 'people');
+      });
+    }
+  });
+
   describe('app user target', () => {
     const cases = [
       ['field_key.create', ['App User', 'Create']],

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -153,6 +153,38 @@ describe('SubmissionFeedEntry', () => {
       title.find('.icon-comment').exists().should.be.true();
       title.text().should.equal('Comment by Alice');
     });
+
+    describe('entity.create audit', () => {
+      it('renders correctly for newly created entity with ideally formatted details', () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.create',
+          details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
+        });
+        const title = mountComponent().get('.title');
+        title.text().should.equal('Created Entity EntityName in DatasetName Dataset');
+      });
+
+      it('renders okay and does not crash for action where entity details are missing', () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.create',
+          details: { entity: { uuid: 'xyz' } }
+        });
+        const title = mountComponent().get('.title');
+        title.text().should.equal('Created Entity  in  Dataset');
+      });
+    });
+
+    describe('entity.create.error audit', () => {
+      it('renders entity creation error message and help text', () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.create.error',
+          details: { problem: { problemCode: 409.14, problemDetails: { reason: 'ID empty or missing.' } } }
+        });
+        const title = mountComponent().get('.title');
+        title.text().should.equal('Problem creating Entity');
+        title.get('.submission-feed-entry-entity-error').attributes().title.should.equal('ID empty or missing.');
+      });
+    });
   });
 
   describe('body', () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -161,6 +161,10 @@
         "string": "Form Actions",
         "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
       },
+      "dataset": {
+        "string": "Dataset Actions",
+        "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
+      },
       "field_key": {
         "string": "App User Actions",
         "developer_comment": "This is a category of actions performed on the server. It is shown in a dropdown when filtering the log of actions by type."
@@ -209,6 +213,12 @@
         "set": {
           "string": "Set",
           "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Server Configuration."
+        }
+      },
+      "dataset": {
+        "update": {
+          "string": "Update",
+          "developer_comment": "This is shown in the log of actions performed on the server. It is a type of action that can be taken on a Dataset."
         }
       },
       "field_key": {
@@ -546,6 +556,10 @@
     },
     "config": {
       "string": "Server Configuration",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
+    "dataset": {
+      "string": "Dataset",
       "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
     },
     "datasets": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3301,6 +3301,14 @@
           "string": "Submitted by {name}",
           "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Submitted\", so it is essential for \"Submitted\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nSubmitted by {name}\n\nyou could split it into:\n\nSubmitted • {name}"
         },
+        "entity": {
+          "create": {
+            "string": "Created Entity {label} in {dataset} Dataset"
+          },
+          "error": {
+            "string": "Problem creating Entity"
+          }
+        },
         "updateReviewState": {
           "null": {
             "full": {


### PR DESCRIPTION
This PR shows new Dataset and Entity audit log events in two places:

### In the Submission activity feed
When a submission is approved and turns into an entity successfully, the `entity.create` is shown with some brief info about the entity.
<img width="786" alt="Screen Shot 2022-11-09 at 10 58 25 AM" src="https://user-images.githubusercontent.com/76205/200947314-a72f0e71-7ed0-4870-a271-ec85e873d0ab.png">

If the submission should become an entity but has a validation error, the `entity.create.error` is shown with the problem reason visible as a tool tip.
<img width="791" alt="Screen Shot 2022-11-09 at 10 59 12 AM" src="https://user-images.githubusercontent.com/76205/200947745-973c1cca-7d0d-41d9-af0c-b594469bcca2.png">

### In the system Audit Log
Dataset events are shown in the audit log. Like submission events, entity events are filtered out in the API and NOT shown in the system audit log because they might drown out other events.
<img width="1055" alt="Screen Shot 2022-11-09 at 1 43 03 PM" src="https://user-images.githubusercontent.com/76205/200948097-3dcf9be3-e63b-4e4e-ba31-7f48ec038fc5.png">



TODO:
- [ ] Update the icon to the 'wand-magic-sparkles'
- [ ] Finalize what to show when there is an error creating an entity that is due to a validation problem that the form designer should know about and fix