### PR TITLE
Add text about datasets/entities

### DIFF
--- a/src/components/dataset/introduction.vue
+++ b/src/components/dataset/introduction.vue
@@ -1,0 +1,79 @@
+<!--
+Copyright 2022 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div id="dataset-introduction" class="panel-dialog">
+    <div class="panel-heading">
+      <span class="panel-title">{{ $t('title') }}</span>
+    </div>
+    <div class="panel-body">
+      <p>{{ $t('body[0]') }}</p>
+      <i18n-t tag="p" keypath="body[1]">
+        <template #icon1><span class="step-number">(1)</span></template>
+      </i18n-t>
+      <i18n-t tag="p" keypath="body[2]">
+        <template #icon2><span class="step-number">(2)</span></template>
+        <template #icon3><span class="step-number">(3)</span></template>
+      </i18n-t>
+      <i18n-t tag="p" keypath="body[3]">
+        <template #icon4><span class="step-number">(4)</span></template>
+      </i18n-t>
+      <p>
+        <span>{{ $t('body[4]') }}</span>
+        <sentence-separator/>
+        <i18n-t keypath="getStarted.full">
+          <template #clickHere>
+            <!-- TODO. Specify the `to` prop. -->
+            <doc-link>{{ $t('getStarted.clickHere') }}</doc-link>
+          </template>
+        </i18n-t>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+import DocLink from '../doc-link.vue';
+import SentenceSeparator from '../sentence-separator.vue';
+
+export default {
+  name: 'DatasetIntroduction',
+  components: { DocLink, SentenceSeparator }
+};
+</script>
+
+<style lang="scss">
+#dataset-introduction {
+  .step-number { font-style: italic; }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    "title": "Welcome to the Datasets preview!",
+    "body": [
+      "Datasets are a new way to create and manage data attachments in ODK. They allow you to use data gathered in Submissions to be downloaded and used as part of another Form.",
+      // {icon1} is an icon that displays the number 1. It refers to the first step in an image that depicts this workflow.
+      "Datasets can be attached {icon1} to Forms and their data queried just like any other attached CSV data file.",
+      // {icon2} and {icon3} are icons that display the numbers 2 and 3. They refer to the second and third steps in an image that depicts this workflow.
+      "When a Submission related to a Dataset is approved {icon2}, the selected data is added {icon3} to the Dataset, so that the next time a client downloads the Form, the new data will be included in the data download.",
+      // {icon4} is an icon that displays the number 4. It refers to the fourth step in an image that depicts this workflow.
+      "In a future version, you will be able to upload {icon4} a CSV to a Dataset directly.",
+      "Datasets are configured during Form design."
+    ],
+    "getStarted": {
+      "full": "For more information on how to get started, {clickHere}.",
+      "clickHere": "click here"
+    }
+  }
+}
+</i18n>

--- a/src/components/dataset/list.vue
+++ b/src/components/dataset/list.vue
@@ -11,6 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div>
+    <dataset-introduction/>
     <dataset-table/>
     <loading :state="datasets.initiallyLoading"/>
   </div>
@@ -22,6 +23,7 @@ export default {
 };
 </script>
 <script setup>
+import DatasetIntroduction from './introduction.vue';
 import DatasetTable from './table.vue';
 import Loading from '../loading.vue';
 

--- a/src/components/form/delete.vue
+++ b/src/components/form/delete.vue
@@ -21,6 +21,9 @@ except according to the terms contained in the LICENSE file.
           </template>
         </i18n-t>
         <p>{{ $t('introduction[1]') }}</p>
+        <p v-if="form.dataExists && form.entityRelated">
+          {{ $t('noDeleteEntities') }}
+        </p>
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
@@ -57,6 +60,8 @@ export default {
   },
   emits: ['hide', 'success'],
   setup() {
+    // The component does not assume that this data will exist when the
+    // component is created.
     const { form } = useRequestData();
     return { form };
   },
@@ -88,7 +93,8 @@ export default {
     "introduction": [
       "Are you sure you want to delete the Form {name} and all of its Submissions?",
       "This action will move the Form to the Trash. After 30 days in the Trash, it will be permanently purged, but it can be undeleted before then."
-    ]
+    ],
+    "noDeleteEntities": "Any Entities created by this Form’s Submissions will not be deleted. In a future version of Central, it will be possible to delete Entities."
   }
 }
 </i18n>

--- a/src/components/project/enable-encryption.vue
+++ b/src/components/project/enable-encryption.vue
@@ -52,6 +52,10 @@ except according to the terms contained in the LICENSE file.
               <span class="icon-close"></span>
               <p>{{ $t('steps[0].introduction[0][6]') }}</p>
             </div>
+            <div class="info-item">
+              <span class="icon-close"></span>
+              <p>{{ $t('steps[0].introduction[0][7]') }}</p>
+            </div>
           </div>
           <div class="info-block">
             <p>{{ $t('steps[0].introduction[1][0]') }}</p>
@@ -279,7 +283,8 @@ export default {
             ],
             "You will no longer be able to preview Submission data online.",
             "You will no longer be able to connect to data over OData.",
-            "You will no longer be able to edit Submissions in your web browser."
+            "You will no longer be able to edit Submissions in your web browser.",
+            "New Submissions will no longer be processed into Entities."
           ],
           [
             "In addition, the following are true in this version of ODK Central:",

--- a/test/components/form/delete.spec.js
+++ b/test/components/form/delete.spec.js
@@ -3,6 +3,14 @@ import FormDelete from '../../../src/components/form/delete.vue';
 import testData from '../../data';
 import { load, mockHttp } from '../../util/http';
 import { mockLogin } from '../../util/session';
+import { mount } from '../../util/lifecycle';
+
+const mountOptions = () => ({
+  props: { state: true },
+  container: {
+    requestData: { form: testData.extendedForms.last() }
+  }
+});
 
 describe('FormDelete', () => {
   beforeEach(mockLogin);
@@ -17,19 +25,32 @@ describe('FormDelete', () => {
       });
   });
 
-  it('implements some standard button things', () =>
-    mockHttp()
-      .mount(FormDelete, {
-        props: { state: true },
-        container: {
-          requestData: { form: testData.extendedForms.createPast(1).last() }
-        }
-      })
+  describe('introductory text', () => {
+    it('shows the correct text if the form creates entities', () => {
+      testData.extendedForms.createPast(1, { entityRelated: true });
+      const modal = mount(FormDelete, mountOptions());
+      const p = modal.findAll('.modal-introduction p');
+      p.length.should.equal(3);
+      p[2].text().should.containEql('Entities');
+    });
+
+    it('shows the correct text if the form does not create entities', () => {
+      testData.extendedForms.createPast(1, { entityRelated: false });
+      const modal = mount(FormDelete, mountOptions());
+      modal.findAll('.modal-introduction p').length.should.equal(2);
+    });
+  });
+
+  it('implements some standard button things', () => {
+    testData.extendedForms.createPast(1);
+    return mockHttp()
+      .mount(FormDelete, mountOptions())
       .testStandardButton({
         button: '.btn-danger',
         disabled: ['.btn-link'],
         modal: true
-      }));
+      });
+  });
 
   describe('after a successful response', () => {
     const del = () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1267,6 +1267,41 @@
         }
       }
     },
+    "DatasetIntroduction": {
+      "title": {
+        "string": "Welcome to the Datasets preview!"
+      },
+      "body": {
+        "0": {
+          "string": "Datasets are a new way to create and manage data attachments in ODK. They allow you to use data gathered in Submissions to be downloaded and used as part of another Form."
+        },
+        "1": {
+          "string": "Datasets can be attached {icon1} to Forms and their data queried just like any other attached CSV data file.",
+          "developer_comment": "{icon1} is an icon that displays the number 1. It refers to the first step in an image that depicts this workflow."
+        },
+        "2": {
+          "string": "When a Submission related to a Dataset is approved {icon2}, the selected data is added {icon3} to the Dataset, so that the next time a client downloads the Form, the new data will be included in the data download.",
+          "developer_comment": "{icon2} and {icon3} are icons that display the numbers 2 and 3. They refer to the second and third steps in an image that depicts this workflow."
+        },
+        "3": {
+          "string": "In a future version, you will be able to upload {icon4} a CSV to a Dataset directly.",
+          "developer_comment": "{icon4} is an icon that displays the number 4. It refers to the fourth step in an image that depicts this workflow."
+        },
+        "4": {
+          "string": "Datasets are configured during Form design."
+        }
+      },
+      "getStarted": {
+        "full": {
+          "string": "For more information on how to get started, {clickHere}.",
+          "developer_comment": "{clickHere} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nclick here"
+        },
+        "clickHere": {
+          "string": "click here",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {clickHere} is in the following text:\n\nFor more information on how to get started, {clickHere}."
+        }
+      }
+    },
     "DatasetRow": {
       "action": {
         "download": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1701,6 +1701,9 @@
         "1": {
           "string": "This action will move the Form to the Trash. After 30 days in the Trash, it will be permanently purged, but it can be undeleted before then."
         }
+      },
+      "noDeleteEntities": {
+        "string": "Any Entities created by this Form’s Submissions will not be deleted. In a future version of Central, it will be possible to delete Entities."
       }
     },
     "FormDraftAbandon": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2527,6 +2527,9 @@
               },
               "6": {
                 "string": "You will no longer be able to edit Submissions in your web browser."
+              },
+              "7": {
+                "string": "New Submissions will no longer be processed into Entities."
               }
             },
             "1": {


### PR DESCRIPTION
This PR adds text about datasets/entities to three places:

- The top of the Datasets page
- The "Enable Encryption" modal
- The "Delete Form" modal

The top of the Datasets page still needs some work, but I think that can come after this PR. (I'm eager to get this text to translators.) Most importantly, we need to add the image there. I believe this will be our first image in Central (!). Given that, I think we should wait to add that until after I either upgrade Vue CLI or switch us to Vite, since that will affect how the image is imported.

I've written tests for the change to the "Delete Form" modal, since that text is shown only conditionally. I didn't write tests for the other text, since there's nothing dynamic there. We don't usually test static text.

I think this PR can be reviewed asynchronously.

Screenshots:

<img width="1021" alt="Screen Shot 2022-11-16 at 3 38 04 PM" src="https://user-images.githubusercontent.com/5970131/202290002-1494bc06-27ae-4ab2-a1c0-6f06a9f9ef0f.png">
<img width="609" alt="Screen Shot 2022-11-16 at 3 35 12 PM" src="https://user-images.githubusercontent.com/5970131/202289996-9f89c049-2823-4b04-9dce-bd93ecdafb08.png">
<img width="611" alt="Screen Shot 2022-11-16 at 3 36 12 PM" src="https://user-images.githubusercontent.com/5970131/202290000-de83aed6-bd8f-4353-a81b-03ade3e199a0.png">