### PR TITLE
new: Added Dataset preview hint box on attachment page

### DIFF
--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -23,16 +23,20 @@ except according to the terms contained in the LICENSE file.
       <div class="panel-heading">
         <span class="panel-title">
           <span class="icon-database"></span>
-          {{ $t('datasetsPreview.title') }}
+          {{ $t('common.datasetsPreview') }}
         </span>
       </div>
       <div class="panel-body">
-        <i18n-t tag="p" keypath="datasetsPreview.body.full">
-          <template #documentation>
-            <!-- TODO. Specify the `to` prop. -->
-            <doc-link>{{ $t('datasetsPreview.body.documentation') }}</doc-link>
-          </template>
-        </i18n-t>
+        <p>
+          <span>{{ $t('datasetsPreview.body[0]') }}</span>
+          <sentence-separator/>
+          <i18n-t keypath="moreInfo.clickHere.full">
+            <template #clickHere>
+              <!-- TODO. Specify the `to` prop. -->
+              <doc-link>{{ $t('moreInfo.clickHere.clickHere') }}</doc-link>
+            </template>
+          </i18n-t>
+        </p>
       </div>
     </div>
     <table id="form-attachment-list-table" class="table">
@@ -51,7 +55,7 @@ except according to the terms contained in the LICENSE file.
           :dragover-attachment="dragoverAttachment"
           :planned-uploads="plannedUploads"
           :updated-attachments="updatedAttachments" :data-name="attachment.name"
-          :linkable="!!dsHashset && dsHashset.has(attachment.name)"
+          :linkable="attachment.type === 'file' && !!dsHashset && dsHashset.has(attachment.name.replace(/\.[^.]+$/i,''))"
           @link="showLinkDatasetModal($event)"/>
       </tbody>
     </table>
@@ -90,6 +94,7 @@ import request from '../../mixins/request';
 import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
+import SentenceSeparator from '../sentence-separator.vue';
 
 export default {
   name: 'FormAttachmentList',
@@ -99,7 +104,8 @@ export default {
     FormAttachmentRow,
     FormAttachmentUploadFiles,
     FormAttachmentLinkDataset,
-    DocLink
+    DocLink,
+    SentenceSeparator
   },
   mixins: [dropZone(), modal(), request()],
   inject: ['alert'],
@@ -178,12 +184,12 @@ export default {
       return this.uploadStatus.total !== 0;
     },
     dsHashset() {
-      return this.datasets.dataExists ? new Set(this.datasets.map(d => `${d.name}.csv`)) : null;
+      return this.datasets.dataExists ? new Set(this.datasets.map(d => `${d.name}`)) : null;
     },
     datasetLinkable() {
       return this.attachments.dataExists &&
-        this.datasets.dataExists &&
-        any(d => this.attachments.data.has(`${d.name}.csv`), this.datasets.data);
+        this.dsHashset &&
+        any(a => a.type === 'file' && this.dsHashset.has(a.name.replace(/\.[^.]+$/i, '')), Array.from(this.attachments.values()));
     }
   },
   watch: {
@@ -446,7 +452,8 @@ export default {
   min-height: calc(100vh - 146px);
 
   .panel-dialog {
-    margin-bottom: 20px;
+    margin-top: -5px;
+    margin-bottom: 25px;
   }
 }
 
@@ -512,12 +519,9 @@ export default {
       "link": "Dataset linked successfully."
     },
     "datasetsPreview": {
-      // This is a title shown above a section of the page.
-      "title": "Datasets Preview",
-      "body": {
-        "full": "One or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic. For information, please see {documentation}.",
-        "documentation": "documentation"
-      }
+      "body": [
+        "One or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic."
+      ]
     }
   }
 }

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -27,9 +27,12 @@ except according to the terms contained in the LICENSE file.
         </span>
       </div>
       <div class="panel-body">
-        <p>
-          {{ $t('datasetsPreview.body[0]') }}
-        </p>
+        <i18n-t tag="p" keypath="datasetsPreview.body.full">
+          <template #documentation>
+            <!-- TODO. Specify the `to` prop. -->
+            <doc-link>{{ $t('datasetsPreview.body.documentation') }}</doc-link>
+          </template>
+        </i18n-t>
       </div>
     </div>
     <table id="form-attachment-list-table" class="table">
@@ -80,6 +83,7 @@ import FormAttachmentPopups from './popups.vue';
 import FormAttachmentRow from './row.vue';
 import FormAttachmentUploadFiles from './upload-files.vue';
 import FormAttachmentLinkDataset from './link-dataset.vue';
+import DocLink from '../doc-link.vue';
 import dropZone from '../../mixins/drop-zone';
 import modal from '../../mixins/modal';
 import request from '../../mixins/request';
@@ -94,7 +98,8 @@ export default {
     FormAttachmentPopups,
     FormAttachmentRow,
     FormAttachmentUploadFiles,
-    FormAttachmentLinkDataset
+    FormAttachmentLinkDataset,
+    DocLink
   },
   mixins: [dropZone(), modal(), request()],
   inject: ['alert'],
@@ -509,9 +514,10 @@ export default {
     "datasetsPreview": {
       // This is a title shown above a section of the page.
       "title": "Datasets Preview",
-      "body": [
-        "This Form can use Datasets of the Project. For now, we recommend testing the use of your Datasets by uploading temporary data as .csv files while testing, then link the Datasets once you are ready."
-      ]
+      "body": {
+        "full": "One or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic. For information, please see {documentation}.",
+        "documentation": "documentation"
+      }
     }
   }
 }

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -19,6 +19,19 @@ except according to the terms contained in the LICENSE file.
       <p>{{ $t('heading[0]') }}</p>
       <p>{{ $t('heading[1]') }}</p>
     </div>
+    <div v-if="datasetLinkable" class="panel-dialog">
+      <div class="panel-heading">
+        <span class="panel-title">
+          <span class="icon-database"></span>
+          {{ $t('datasetsPreview.title') }}
+        </span>
+      </div>
+      <div class="panel-body">
+        <p>
+          {{ $t('datasetsPreview.body[0]') }}
+        </p>
+      </div>
+    </div>
     <table id="form-attachment-list-table" class="table">
       <thead>
         <tr>
@@ -59,6 +72,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { any } from 'ramda';
 import pako from 'pako/lib/deflate';
 import { markRaw } from 'vue';
 import FormAttachmentNameMismatch from './name-mismatch.vue';
@@ -160,6 +174,11 @@ export default {
     },
     dsHashset() {
       return this.datasets.dataExists ? new Set(this.datasets.map(d => `${d.name}.csv`)) : null;
+    },
+    datasetLinkable() {
+      return this.attachments.dataExists &&
+        this.datasets.dataExists &&
+        any(d => this.attachments.data.has(`${d.name}.csv`), this.datasets.data);
     }
   },
   watch: {
@@ -420,6 +439,10 @@ export default {
   // Extend to the bottom of the page (or slightly beyond it) so that the drop
   // zone includes the entire page below the PageHead.
   min-height: calc(100vh - 146px);
+
+  .panel-dialog {
+    margin-bottom: 20px;
+  }
 }
 
 #form-attachment-list-table {
@@ -482,6 +505,13 @@ export default {
       "readError": "Something went wrong while reading “{filename}”.",
       "success": "{count} file has been successfully uploaded. | {count} files have been successfully uploaded.",
       "link": "Dataset linked successfully."
+    },
+    "datasetsPreview": {
+      // This is a title shown above a section of the page.
+      "title": "Datasets Preview",
+      "body": [
+        "This Form can use Datasets of the Project. For now, we recommend testing the use of your Datasets by uploading temporary data as .csv files while testing, then link the Datasets once you are ready."
+      ]
     }
   }
 }

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -25,7 +25,7 @@ except according to the terms contained in the LICENSE file.
               <div class="panel-heading">
                 <span class="panel-title">
                   <span class="icon-database"></span>
-                  {{ $t('datasetsPreview.title') }}
+                  {{ $t('common.datasetsPreview') }}
                 </span>
               </div>
               <div class="panel-body">
@@ -168,8 +168,6 @@ export default {
     // is the title of the Draft Form.
     "collectProjectName": "[Draft] {name}",
     "datasetsPreview": {
-      // This is a title shown above a section of the page.
-      "title": "Datasets Preview",
       "body": [
         "This Form can add Entities to a Dataset.",
         "In this preview release of Datasets, you must publish your Form to see the Dataset update. In a future release of Central, you will be able to test Dataset functionality in a Draft state.",

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -356,7 +356,9 @@
     "lastSubmission": "(last {dateTime})",
     "punctuations": {
       "comma": ","
-    }
+    },
+    // This is a title shown above a section of the page.
+    "datasetsPreview": "Datasets Preview"
   },
   "mixin": {
     "request": {

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1115,7 +1115,7 @@ describe('FormAttachmentList', () => {
       });
 
       it('does not show Datasets preview hint if there is no linkable dataset', async () => {
-        testData.standardFormAttachments.createPast(1, { type: 'file', name: 'people.csv', datasetExists: true });
+        testData.standardFormAttachments.createPast(1, { type: 'file', name: 'people.csv', datasetExists: false });
         const component = await loadAttachmentComponent();
         component.find('.panel-dialog').exists().should.be.false();
       });

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1094,6 +1094,33 @@ describe('FormAttachmentList', () => {
       component.get('td.form-attachment-list-action').text().should.equal('Upload a file to override.');
     });
 
+    describe('Datasets preview hint', () => {
+      beforeEach(() => {
+        testData.extendedProjects.createPast(1, {
+          name: 'My Project Name',
+          forms: 1,
+          datasets: 1
+        });
+        testData.extendedDatasets.createPast(1, { name: 'shovels' });
+      });
+
+      const loadAttachmentComponent = () => load('/projects/1/forms/f/draft/attachments', {
+        root: false
+      }).respondWithData(() => testData.extendedDatasets.sorted());
+
+      it('shows Datasets preview hint', async () => {
+        testData.standardFormAttachments.createPast(1, { type: 'file', name: 'shovels.csv', datasetExists: true });
+        const component = await loadAttachmentComponent();
+        component.get('.panel-dialog').exists().should.be.true();
+      });
+
+      it('does not show Datasets preview hint if there is no linkable dataset', async () => {
+        testData.standardFormAttachments.createPast(1, { type: 'file', name: 'people.csv', datasetExists: true });
+        const component = await loadAttachmentComponent();
+        component.find('.panel-dialog').exists().should.be.false();
+      });
+    });
+
     describe('link dataset', () => {
       beforeEach(() => {
         testData.extendedProjects.createPast(1, {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1621,6 +1621,17 @@
         "link": {
           "string": "Dataset linked successfully."
         }
+      },
+      "datasetsPreview": {
+        "title": {
+          "string": "Datasets Preview",
+          "developer_comment": "This is a title shown above a section of the page."
+        },
+        "body": {
+          "0": {
+            "string": "This Form can use Datasets of the Project. For now, we recommend testing the use of your Datasets by uploading temporary data as .csv files while testing, then link the Datasets once you are ready."
+          }
+        }
       }
     },
     "FormAttachmentNameMismatch": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1628,8 +1628,13 @@
           "developer_comment": "This is a title shown above a section of the page."
         },
         "body": {
-          "0": {
-            "string": "This Form can use Datasets of the Project. For now, we recommend testing the use of your Datasets by uploading temporary data as .csv files while testing, then link the Datasets once you are ready."
+          "full": {
+            "string": "One or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic. For information, please see {documentation}.",
+            "developer_comment": "{documentation} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ndocumentation"
+          },
+          "documentation": {
+            "string": "documentation",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {documentation} is in the following text:\n\nOne or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic. For information, please see {documentation}."
           }
         }
       }

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -779,6 +779,10 @@
       "comma": {
         "string": ","
       }
+    },
+    "datasetsPreview": {
+      "string": "Datasets Preview",
+      "developer_comment": "This is a title shown above a section of the page."
     }
   },
   "mixin": {
@@ -1623,18 +1627,9 @@
         }
       },
       "datasetsPreview": {
-        "title": {
-          "string": "Datasets Preview",
-          "developer_comment": "This is a title shown above a section of the page."
-        },
         "body": {
-          "full": {
-            "string": "One or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic. For information, please see {documentation}.",
-            "developer_comment": "{documentation} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\ndocumentation"
-          },
-          "documentation": {
-            "string": "documentation",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {documentation} is in the following text:\n\nOne or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic. For information, please see {documentation}."
+          "0": {
+            "string": "One or more Form Attachments have filenames that match Dataset names. By default, those are linked to Datasets. For testing, you may want to upload temporary data as .csv files, then link to the Datasets once you have verified your form logic."
           }
         }
       }
@@ -2104,10 +2099,6 @@
         "developer_comment": "This text will be shown in ODK Collect when testing a Draft Form. {name} is the title of the Draft Form."
       },
       "datasetsPreview": {
-        "title": {
-          "string": "Datasets Preview",
-          "developer_comment": "This is a title shown above a section of the page."
-        },
         "body": {
           "0": {
             "string": "This Form can add Entities to a Dataset."


### PR DESCRIPTION
## Changes:

- Added a hint box for the "Dataset Preview" on the attachment page. The hint box is displayed only if there is a linkable Dataset in the Project
- Created integration tests to verify that the hint box is displayed only when there is a linkable Dataset.

![image](https://user-images.githubusercontent.com/447837/203355925-22610a7a-0734-46fc-a257-48c36a380d99.png)
