### PR TITLE
fix: css fix for entity feature

### DIFF
--- a/src/components/dataset/summary/row.vue
+++ b/src/components/dataset/summary/row.vue
@@ -10,10 +10,10 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="dataset-row">
+  <div class="dataset-summary-row">
     <div class="row">
-      <div class="col-xs-6">
-        <span class="dataset-name">{{ dataset.name }}</span>
+      <div class="col-xs-6 text-overflow-ellipsis">
+        <span class="dataset-name" :title="dataset.name">{{ dataset.name }}</span>
         <span v-if="dataset.isNew" class="dataset-new">
           <span class="icon-plus-circle"></span>
           {{ $t('new') }}
@@ -75,12 +75,16 @@ export default {
 @import '../../../assets/scss/_variables.scss';
 @import '../../../assets/scss/mixins';
 
-.dataset-row {
+.dataset-summary-row {
     @include text-block;
 
+    .text-overflow-ellipsis {
+      @include text-overflow-ellipsis;
+    }
+
     .dataset-name {
-        font-weight: bold;
-        font-size: 18px;
+      font-weight: bold;
+      font-size: 18px;
     }
     .dataset-new {
         vertical-align: super;
@@ -97,6 +101,7 @@ export default {
     .properties-count {
         line-height: 28px;
     }
+
     a {
         color: #666;
 
@@ -104,8 +109,13 @@ export default {
             background-color: inherit;
         }
     }
+
     .expand-button {
       margin-left: 5px;
+    }
+
+    .property-list {
+      hyphens: auto;
     }
 }
 

--- a/src/components/form-draft/publish.vue
+++ b/src/components/form-draft/publish.vue
@@ -205,6 +205,10 @@ export default {
   list-style: none;
   padding-left: 5px;
 
+  li {
+    hyphens: auto;
+  }
+
   li::before {
     @extend [class^="icon-"];
     content: '\f055';


### PR DESCRIPTION
## Changes:

- Add `text-overflow-ellipsis` for Dataset summary:
![image](https://user-images.githubusercontent.com/447837/204333418-5671cca1-b4ef-436f-9cdd-a3f345eb5560.png)

- Add auto hyphens for Dataset details on publish modal:
![Screen Shot 2022-11-28 at 11 19 53 AM](https://user-images.githubusercontent.com/447837/204332493-67187a55-5967-46e5-abc5-e3694a002177.png)

- Fix css bleeding from Dataset summary row component
