### PR TITLE
Address warnings in testing about entities-intro.svg

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,11 +25,13 @@ module.exports = (config) => {
     files: [
       'test/index.js',
       { pattern: 'public/fonts/icomoon.ttf', served: true, included: false },
+      { pattern: 'public/images/*', served: true, included: false },
       { pattern: 'public/blank.html', served: true, included: false },
       { pattern: 'test/files/*', served: true, included: false }
     ],
     proxies: {
       '/fonts/': '/base/public/fonts/',
+      '/img/entities-intro.ff844445.svg': '/base/public/images/entities-intro.svg',
       '/blank.html': '/base/public/blank.html',
       '/test/files/': '/base/test/files/'
     },


### PR DESCRIPTION
Right now in testing, whenever `DatasetIntroduction` is rendered, the following warning is shown:

```
WARN [web-server]: 404: /img/entities-intro.ff844445.svg
```

For example, that warning is shown after navigating to the datasets page.

Karma doesn't automatically serve our assets, which is why there's a 404. In the past, we've solved this by having Karma serve the asset, then proxying from the location where Frontend expects to find the asset to the location where Karma serves it. I've done something similar here.

There is one way in which the strategy here is different from what we've done in the past. I think we're having webpack process entities-intro.svg, resulting in the hash in the filename and the location of the image at /img rather than /images. I don't think we have webpack process our other assets in the same way. When the icon files change, for example, we manage our own cache-busting in icomoon.css using a query parameter. It's because the webpack-processed image has a hash in its filename that I've included that hash in the Karma `proxies` option.

I think that's OK, because the image isn't likely to change, so its hash also isn't likely to change. We're also going to try to move away from webpack at some point (#671), so I think we probably don't need to dig too deeply into this. We could maybe also stop having webpack process the image, though I think it's OK that we do. For now, I mostly just wanted to remove these warnings in testing.