### PR TITLE
Move $tcn() installation to container

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -18,6 +18,7 @@ import createCentralI18n from './i18n';
 import createCentralRouter from './router';
 import createUnsavedChanges from './unsaved-changes';
 import defaultConfig from './config';
+import { $tcn } from './util/i18n';
 import { createRequestData } from './request-data';
 import { noop } from './util/util';
 
@@ -62,6 +63,9 @@ export default ({
     // Register <i18n-t>, since we specify `false` for the fullInstall option of
     // vue-cli-plugin-i18n.
     app.use(i18n).component(Translation.name, Translation);
+    // eslint-disable-next-line no-param-reassign
+    app.config.globalProperties.$tcn = $tcn;
+
     app.use(container.pinia);
     app.use(container.requestData);
     if (container.router != null) app.use(container.router);

--- a/src/main.js
+++ b/src/main.js
@@ -18,13 +18,11 @@ import './styles';
 import App from './components/app.vue';
 
 import createContainer from './container';
-import { $tcn } from './util/i18n';
 // ./jquery must be imported before any of Bootstrap's JavaScript plugins,
 // because the plugins require jQuery.
 import './jquery';
 import './bootstrap';
 
-const app = createApp(App);
-app.use(createContainer());
-app.config.globalProperties.$tcn = $tcn;
-app.mount('#app');
+createApp(App)
+  .use(createContainer())
+  .mount('#app');

--- a/test/util/lifecycle.js
+++ b/test/util/lifecycle.js
@@ -1,7 +1,6 @@
 import { last, lensPath, view } from 'ramda';
 import { mount as vtuMount } from '@vue/test-utils';
 
-import { $tcn } from '../../src/util/i18n';
 import { noop } from '../../src/util/util';
 
 import createTestContainer from './container';
@@ -26,7 +25,7 @@ export const mount = (component, options = {}) => {
     ? containerOption
     : createTestContainer(containerOption);
   g.plugins = g.plugins != null ? [container, ...g.plugins] : [container];
-  g.mocks = { $tcn, $container: container, ...g.mocks };
+  g.mocks = { $container: container, ...g.mocks };
   return vtuMount(component, { ...mountOptions, global: g });
 };
 


### PR DESCRIPTION
The container installs Vue I18n. When the app instance is created, we also add our own `$tcn()` method, which combines `$tc()` and `$n()` from Vue I18n. I've gone back and forth on whether the container should be the one to add `$tcn()`, since it also installs Vue I18n. So far, I've opted to add `$tcn()` outside the container. However, with the addition of instant tooltips coming up, I'm now eager to move as much installation into the container as possible, as tooltips will be implemented as an app-level directive. I don't think it makes sense to add the tooltip directive to the container, but given that it seems sensible enough to add `$tcn()`, I'm going to go ahead and do that. Doing so has the effect of simplifying src/main.js and test/util/lifecycle.js, which with the tooltip directive, are about to get slightly more complicated.