### PR TITLE
Attach component to body in test in order to address error message

### DIFF
--- a/test/components/submission/field-dropdown.spec.js
+++ b/test/components/submission/field-dropdown.spec.js
@@ -58,7 +58,8 @@ describe('SubmissionFieldDropdown', () => {
       props: { modelValue: [] },
       container: {
         requestData: { fields: strings(1, 101) }
-      }
+      },
+      attachTo: document.body
     });
     await component.get('select').trigger('click');
     const after = component.get('.after-list');


### PR DESCRIPTION
Right now, the following error message is logged in a test of `SubmissionFieldDropdown`:

```
ERROR LOG: 'Clicking Multiselect toggle has no effect unless component is attached to body.'
```

To resolve it, we just need to attach the component to the body. The other tests of `SubmissionFieldDropdown` that toggle the `Multiselect` attach the component to the body.

The test was passing before because in some way, it's actually not essential for the test to open the `Multiselect`: the test is verifying the effect of clicking the "select all" button on the `after-list` slot, and both the button and the slot are rendered regardless of whether the `Multiselect` is open. However, I think the test is better if it actually opens the `Multiselect`, since opening the `Multiselect` has side effects on the state of the `Multiselect`. (That's why `Multiselect` logs this error message.)