### PR TITLE
Make changes related to disabled elements

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -784,13 +784,11 @@ becomes more complicated.
       }
 
       > a {
-        pointer-events: none;
-
-        &, &:focus {
+        &, &:hover, &:focus {
           color: #999;
         }
 
-        &:focus {
+        &:hover, &:focus {
           border-bottom-color: transparent;
         }
       }

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -120,7 +120,7 @@ class. */
     + .caret { margin-left: 0; }
   }
 
-  &[disabled], &.disabled, fieldset[disabled] & {
+  &[aria-disabled="true"], &.disabled, fieldset[disabled] & {
     cursor: not-allowed;
     opacity: 0.65;
   }
@@ -138,20 +138,20 @@ $btn-focus-box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.18);
 
   &:focus, &:active:focus { outline: none; }
   &:focus { box-shadow: $btn-focus-box-shadow; }
-  &[disabled], &.disabled, fieldset[disabled] & { box-shadow: none; }
+  &[aria-disabled="true"], &.disabled, fieldset[disabled] & { box-shadow: none; }
 }
 
 .btn-primary {
   background-color: $color-action-background;
 
-  &[disabled], &.disabled, fieldset[disabled] & {
+  &[aria-disabled="true"], &.disabled, fieldset[disabled] & {
     background-color: $color-action-background-disabled;
   }
 
   &:hover, &:focus, &:active:focus {
     background-color: $color-action-background-hover;
 
-    &[disabled], &.disabled, fieldset[disabled] & {
+    &[aria-disabled="true"], &.disabled, fieldset[disabled] & {
       background-color: $color-action-background-disabled;
     }
   }
@@ -162,7 +162,7 @@ $btn-focus-box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.18);
 
   &:hover, &:focus, &:active:focus {
     background-color: #ccc;
-    &[disabled], &.disabled, fieldset[disabled] & { background-color: #ddd; }
+    &[aria-disabled="true"], &.disabled, fieldset[disabled] & { background-color: #ddd; }
   }
 
   > [class^="icon-"]:first-child { color: $color-action-background; }
@@ -173,7 +173,10 @@ $btn-focus-box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.18);
 
   &:hover, &:focus, &:active:focus {
     background-color: $color-danger-dark;
-    &[disabled], &.disabled, fieldset[disabled] { background-color: $color-danger; }
+
+    &[aria-disabled="true"], &.disabled, fieldset[disabled] {
+      background-color: $color-danger;
+    }
   }
 }
 
@@ -187,7 +190,7 @@ a, .btn-link {
     text-decoration: underline;
   }
 
-  &.disabled, &[disabled], fieldset[disabled] & {
+  &.disabled, &[aria-disabled="true"], fieldset[disabled] & {
     color: #888;
     text-decoration: none;
   }
@@ -223,7 +226,7 @@ a {
 .btn-link {
   border-radius: 0;
 
-  &, &:active, &[disabled] fieldset[disabled] & {
+  &, &:active, &[aria-disabled="true"], fieldset[disabled] & {
     background-color: transparent;
   }
 
@@ -324,35 +327,29 @@ $form-group-padding-bottom: 15px;
   padding-bottom: $form-group-padding-bottom;
   position: relative;
 
-  &:focus-within {
-    .form-label {
-      color: $color-action-foreground;
-    }
-  }
-
   $form-control-z-index: 1;
   .form-control {
     background: $color-input-background;
     border: none;
     border-bottom: 1px solid $color-input-inactive;
     border-radius: 0;
-    box-shadow: none;
     color: $color-input;
     position: relative;
     z-index: $form-control-z-index;
 
-    &:focus {
+    &, &:focus { box-shadow: none; }
+
+    &:focus:not([aria-disabled="true"]) {
       border-bottom-color: $color-action-foreground;
-      box-shadow: none;
     }
 
     &::placeholder { color: $color-text; }
 
-    &[disabled], &[readonly], fieldset[disabled] & {
+    &[aria-disabled="true"], &[readonly], fieldset[disabled] & {
       &, &::placeholder { color: $color-input-inactive; }
     }
 
-    &[disabled], fieldset[disabled] & { cursor: not-allowed; }
+    &[aria-disabled="true"], fieldset[disabled] & { cursor: not-allowed; }
   }
 
   .form-label {
@@ -364,8 +361,10 @@ $form-group-padding-bottom: 15px;
     transform: translateY(2px);
     transition: 0.15s transform, 0.15s color;
   }
+  &:focus-within .form-label { color: $color-action-foreground; }
   .form-control {
     &:placeholder-shown ~ .form-label { transform: translateY(-15px); }
+    &[aria-disabled="true"] ~ .form-label { color: $color-input-inactive; }
   }
 
   .close {
@@ -479,8 +478,9 @@ select {
     border-color: $color-danger;
 
     &:focus {
-      border-color: $color-danger-dark;
       box-shadow: none;
+
+      &:not([aria-disabled="true"]) { border-color: $color-danger-dark; }
     }
   }
 
@@ -493,7 +493,9 @@ select {
     color: $color-danger;
   }
 
-  .form-control:focus ~ .form-label { color: $color-danger-dark; }
+  .form-control:focus:not([aria-disabled="true"]) ~ .form-label {
+    color: $color-danger-dark;
+  }
 }
 
 // In Safari, the effect of this class is not visible on input and select

--- a/src/components/account/claim.vue
+++ b/src/components/account/claim.vue
@@ -26,7 +26,7 @@ except according to the terms contained in the LICENSE file.
               autocomplete="new-password"/>
             <div class="panel-footer">
               <button type="submit" class="btn btn-primary"
-                :disabled="awaitingResponse">
+                :aria-disabled="awaitingResponse">
                 {{ $t('action.set') }} <spinner :state="awaitingResponse"/>
               </button>
             </div>

--- a/src/components/account/login.vue
+++ b/src/components/account/login.vue
@@ -25,11 +25,11 @@ except according to the terms contained in the LICENSE file.
               autocomplete="current-password"/>
             <div class="panel-footer">
               <button type="submit" class="btn btn-primary"
-                :disabled="disabled">
+                :aria-disabled="disabled">
                 {{ $t('action.logIn') }} <spinner :state="disabled"/>
               </button>
               <router-link v-slot="{ navigate }" to="/reset-password" custom>
-                <button type="button" class="btn btn-link" :disabled="disabled"
+                <button type="button" class="btn btn-link" :aria-disabled="disabled"
                   @click="navigate">
                   {{ $t('action.resetPassword') }}
                 </button>

--- a/src/components/account/reset-password.vue
+++ b/src/components/account/reset-password.vue
@@ -22,7 +22,7 @@ except according to the terms contained in the LICENSE file.
               :placeholder="$t('field.email')" required autocomplete="off"/>
             <div class="panel-footer">
               <button type="submit" class="btn btn-primary"
-                :disabled="awaitingResponse">
+                :aria-disabled="awaitingResponse">
                 {{ $t('action.resetPassword') }} <spinner :state="awaitingResponse"/>
               </button>
               <router-link v-slot="{ navigate }" to="/login" custom>

--- a/src/components/analytics/form.vue
+++ b/src/components/analytics/form.vue
@@ -70,7 +70,7 @@ except according to the terms contained in the LICENSE file.
           :placeholder="$t('field.organization')" autocomplete="organization"/>
       </fieldset>
     </fieldset>
-    <button type="submit" class="btn btn-primary" :disabled="awaitingResponse">
+    <button type="submit" class="btn btn-primary" :aria-disabled="awaitingResponse">
       {{ $t('action.saveSettings') }} <spinner :state="awaitingResponse"/>
     </button>
   </form>

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -31,6 +31,7 @@ import Alert from './alert.vue';
 import Navbar from './navbar.vue';
 
 import useCallWait from '../composables/call-wait';
+import useDisabled from '../composables/disabled';
 import { useRequestData } from '../request-data';
 import { useSessions } from '../util/session';
 
@@ -40,6 +41,7 @@ export default {
   inject: ['alert'],
   setup() {
     useSessions();
+    useDisabled();
 
     const { centralVersion } = useRequestData();
     const { callWait } = useCallWait();

--- a/src/components/enketo/fill.vue
+++ b/src/components/enketo/fill.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     :href="href" target="_blank">
     <slot></slot>
   </a>
-  <button v-else type="button" class="enketo-fill btn btn-primary" disabled
+  <button v-else type="button" class="enketo-fill btn btn-primary" aria-disabled="true"
     :title="disabledTitle">
     <slot></slot>
   </button>

--- a/src/components/enketo/preview.vue
+++ b/src/components/enketo/preview.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     :href="href" target="_blank">
     <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </a>
-  <button v-else type="button" class="enketo-preview btn btn-default" disabled
+  <button v-else type="button" class="enketo-preview btn btn-default" aria-disabled="true"
     :title="disabledTitle">
     <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </button>

--- a/src/components/field-key/new.vue
+++ b/src/components/field-key/new.vue
@@ -21,11 +21,11 @@ except according to the terms contained in the LICENSE file.
             :placeholder="$t('field.displayName')" required autocomplete="off"/>
           <div class="modal-actions">
             <button type="submit" class="btn btn-primary"
-              :disabled="awaitingResponse">
+              :aria-disabled="awaitingResponse">
               {{ $t('action.create') }} <spinner :state="awaitingResponse"/>
             </button>
             <button type="button" class="btn btn-link"
-              :disabled="awaitingResponse" @click="hideOrComplete">
+              :aria-disabled="awaitingResponse" @click="hideOrComplete">
               {{ $t('action.cancel') }}
             </button>
           </div>

--- a/src/components/field-key/revoke.vue
+++ b/src/components/field-key/revoke.vue
@@ -25,10 +25,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="revoke">
+          :aria-disabled="awaitingResponse" @click="revoke">
           {{ $t('action.yesProceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.noCancel') }}
         </button>

--- a/src/components/field-key/row.vue
+++ b/src/components/field-key/row.vue
@@ -38,7 +38,9 @@ except according to the terms contained in the LICENSE file.
         <ul class="dropdown-menu dropdown-menu-right"
           :aria-labelledby="actionsId">
           <li :class="{ disabled: fieldKey.token == null }">
-            <a href="#" @click.prevent="revoke">{{ $t('action.revokeAccess') }}&hellip;</a>
+            <a href="#" @click.prevent="$emit('revoke', fieldKey)">
+              {{ $t('action.revokeAccess') }}&hellip;
+            </a>
           </li>
         </ul>
       </div>
@@ -69,12 +71,6 @@ export default {
   methods: {
     showCode() {
       this.$emit('show-code', this.fieldKey, this.$refs.popoverLink);
-    },
-    revoke() {
-      // Bootstrap does not truly disable dropdown menu items marked as
-      // disabled.
-      if (this.fieldKey.token == null) return;
-      this.$emit('revoke', this.fieldKey);
     }
   }
 };

--- a/src/components/form-attachment/link-dataset.vue
+++ b/src/components/form-attachment/link-dataset.vue
@@ -23,10 +23,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-primary btn-link-dataset"
-          :disabled="awaitingResponse" @click="link">
+          :aria-disabled="awaitingResponse" @click="link">
           {{ $t('action.link') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.cancel') }}
         </button>

--- a/src/components/form-draft/abandon.vue
+++ b/src/components/form-draft/abandon.vue
@@ -26,10 +26,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="abandon">
+          :aria-disabled="awaitingResponse" @click="abandon">
           {{ $t('action.abandon') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.cancel') }}
         </button>

--- a/src/components/form-draft/publish.vue
+++ b/src/components/form-draft/publish.vue
@@ -77,21 +77,21 @@ except according to the terms contained in the LICENSE file.
         will do some basic form validation when it is clicked). -->
         <div class="modal-actions">
           <button type="submit" class="btn btn-primary"
-            :disabled="awaitingResponse">
+            :aria-disabled="awaitingResponse">
             {{ $t('action.proceed') }} <spinner :state="awaitingResponse"/>
           </button>
           <button type="button" class="btn btn-link"
-            :disabled="awaitingResponse" @click="$emit('hide')">
+            :aria-disabled="awaitingResponse" @click="$emit('hide')">
             {{ $t('action.cancel') }}
           </button>
         </div>
       </form>
       <div v-else class="modal-actions">
         <button type="button" class="btn btn-primary"
-          :disabled="awaitingResponse" @click="publish">
+          :aria-disabled="awaitingResponse" @click="publish">
           {{ $t('action.proceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.cancel') }}
         </button>

--- a/src/components/form/delete.vue
+++ b/src/components/form/delete.vue
@@ -27,10 +27,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="del">
+          :aria-disabled="awaitingResponse" @click="del">
           {{ $t('action.yesProceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.noCancel') }}
         </button>

--- a/src/components/form/new.vue
+++ b/src/components/form/new.vue
@@ -59,7 +59,7 @@ definition for an existing form -->
         </p>
         <p>
           <button type="button" class="btn btn-primary"
-            :disabled="awaitingResponse" @click="upload(true)">
+            :aria-disabled="awaitingResponse" @click="upload(true)">
             {{ $t('action.uploadAnyway') }} <spinner :state="awaitingResponse"/>
           </button>
         </p>
@@ -83,7 +83,7 @@ definition for an existing form -->
             <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
             <input v-show="false" ref="input" type="file" accept=".xls,.xlsx,.xml" @change="afterChange">
             <button type="button" class="btn btn-primary"
-              :disabled="awaitingResponse" @click="$refs.input.click()">
+              :aria-disabled="awaitingResponse" @click="$refs.input.click()">
               <span class="icon-folder-open"></span>{{ $t('dropZone.chooseOne') }}
             </button>
           </template>
@@ -94,11 +94,11 @@ definition for an existing form -->
       </div>
       <div class="modal-actions">
         <button id="form-new-upload-button" type="button"
-          class="btn btn-primary" :disabled="awaitingResponse"
+          class="btn btn-primary" :aria-disabled="awaitingResponse"
           @click="upload(false)">
           {{ $t('action.upload') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.cancel') }}
         </button>

--- a/src/components/form/overview.vue
+++ b/src/components/form/overview.vue
@@ -123,7 +123,7 @@ export default {
 
     &:hover, &:focus, &:active:focus {
       background-color: #bbb;
-      &[disabled] { background-color: #ccc; }
+      &[aria-disabled="true"] { background-color: #ccc; }
     }
   }
 }

--- a/src/components/form/restore.vue
+++ b/src/components/form/restore.vue
@@ -25,10 +25,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="doRestore">
+          :aria-disabled="awaitingResponse" @click="doRestore">
           {{ $t('action.yesProceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.noCancel') }}
         </button>

--- a/src/components/form/trash-row.vue
+++ b/src/components/form/trash-row.vue
@@ -42,7 +42,7 @@ except according to the terms contained in the LICENSE file.
     </td>
     <td class="actions">
       <button class="form-trash-row-restore-button btn btn-default" type="button"
-        :disabled="disabled" :title="disabledTitle"
+        :aria-disabled="disabled" :title="disabledTitle"
         :data-form-id="form.id"
         @click="openRestoreModal(form)">
         <span class="icon-recycle"></span>{{ $t('action.restore') }}

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -17,7 +17,7 @@ except according to the terms contained in the LICENSE file.
     <div class="modal-dialog" :class="{ 'modal-lg': large }" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" :disabled="!hideable"
+          <button type="button" class="close" :aria-disabled="!hideable"
             :aria-label="$t('action.close')" @click="hideIfCan">
             <span aria-hidden="true">&times;</span>
           </button>
@@ -197,7 +197,7 @@ export default {
         margin-top: 0;
         opacity: 1;
 
-        &[disabled] {
+        &[aria-disabled="true"] {
           cursor: not-allowed;
         }
       }

--- a/src/components/multiselect.vue
+++ b/src/components/multiselect.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
     not show a menu with the placeholder option. This approach seems to work
     across browsers. -->
     <select :id="toggleId" ref="toggle" class="form-control"
-      :disabled="options == null" data-toggle="dropdown" role="button"
+      :aria-disabled="options == null" data-toggle="dropdown" role="button"
       aria-haspopup="true" aria-expanded="false" :aria-label="label"
       @keydown="toggleAfterEnter" @mousedown.prevent>
       <option value="">{{ selectOption }}</option>

--- a/src/components/project/archive.vue
+++ b/src/components/project/archive.vue
@@ -25,10 +25,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="archive">
+          :aria-disabled="awaitingResponse" @click="archive">
           {{ $t('action.yesProceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.noCancel') }}
         </button>

--- a/src/components/project/edit.vue
+++ b/src/components/project/edit.vue
@@ -25,7 +25,7 @@ except according to the terms contained in the LICENSE file.
           <span class="note">{{ $t('field.note') }}</span>
         </label>
         <button type="submit" class="btn btn-primary"
-          :disabled="awaitingResponse">
+          :aria-disabled="awaitingResponse">
           {{ $t('action.saveSettings') }} <spinner :state="awaitingResponse"/>
         </button>
       </form>

--- a/src/components/project/enable-encryption.vue
+++ b/src/components/project/enable-encryption.vue
@@ -102,11 +102,11 @@ except according to the terms contained in the LICENSE file.
             autocomplete="off"/>
           <div class="modal-actions">
             <button type="submit" class="btn btn-danger"
-              :disabled="awaitingResponse">
+              :aria-disabled="awaitingResponse">
               {{ $t('action.finish') }} <spinner :state="awaitingResponse"/>
             </button>
             <button type="button" class="btn btn-link"
-              :disabled="awaitingResponse" @click="$emit('hide')">
+              :aria-disabled="awaitingResponse" @click="$emit('hide')">
               {{ $t('action.neverMind') }}
             </button>
           </div>

--- a/src/components/project/form-access.vue
+++ b/src/components/project/form-access.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
       <button id="project-form-access-save-button" type="button"
         class="btn btn-primary"
         :class="{ 'uncommitted-change': changeCount !== 0 }"
-        :disabled="saveDisabled" @click="save">
+        :aria-disabled="saveDisabled" @click="save">
         <span class="icon-floppy-o"></span>{{ $t('action.save') }}
         <spinner :state="awaitingResponse"/>
       </button>

--- a/src/components/project/new.vue
+++ b/src/components/project/new.vue
@@ -27,11 +27,11 @@ except according to the terms contained in the LICENSE file.
           :placeholder="$t('field.name')" required autocomplete="off"/>
         <div class="modal-actions">
           <button type="submit" class="btn btn-primary"
-            :disabled="awaitingResponse">
+            :aria-disabled="awaitingResponse">
             {{ $t('action.create') }} <spinner :state="awaitingResponse"/>
           </button>
           <button type="button" class="btn btn-link"
-            :disabled="awaitingResponse" @click="$emit('hide')">
+            :aria-disabled="awaitingResponse" @click="$emit('hide')">
             {{ $t('action.cancel') }}
           </button>
         </div>

--- a/src/components/project/user/list.vue
+++ b/src/components/project/user/list.vue
@@ -44,7 +44,7 @@ are Project Manager, Project Viewer, and Data Collector. -->
       @submit.prevent>
       <label class="form-group">
         <input class="form-control" :value="q" :placeholder="searchLabel"
-          :disabled="searchDisabled" autocomplete="off"
+          :aria-disabled="searchDisabled" autocomplete="off"
           @change="changeQ($event.target.value)">
         <!-- When search is disabled, we hide rather than disable this button,
         because Bootstrap does not have CSS for .close[disabled]. -->

--- a/src/components/project/user/row.vue
+++ b/src/components/project/user/row.vue
@@ -20,7 +20,8 @@ except according to the terms contained in the LICENSE file.
       <form>
         <div class="form-group">
           <select class="form-control" :value="selectedRoleId"
-            :disabled="disabled" :title="selectTitle"
+            :aria-disabled="disabled || awaitingResponse"
+            :title="disabled ? $t('cannotAssignRole') : null"
             :aria-label="$t('field.projectRole')"
             @change="change($event.target.value)">
             <option v-for="role of roles.projectRoles" :key="role.id"
@@ -73,13 +74,7 @@ export default {
   },
   computed: {
     disabled() {
-      return this.assignment.actor.id === this.currentUser.id ||
-        this.awaitingResponse;
-    },
-    selectTitle() {
-      return this.assignment.actor.id === this.currentUser.id
-        ? this.$t('cannotAssignRole')
-        : null;
+      return this.assignment.actor.id === this.currentUser.id;
     }
   },
   methods: {

--- a/src/components/public-link/create.vue
+++ b/src/components/public-link/create.vue
@@ -32,11 +32,11 @@ except according to the terms contained in the LICENSE file.
         </div>
         <div class="modal-actions">
           <button type="submit" class="btn btn-primary"
-            :disabled="awaitingResponse">
+            :aria-disabled="awaitingResponse">
             {{ $t('action.create') }} <spinner :state="awaitingResponse"/>
           </button>
           <button type="button" class="btn btn-link"
-            :disabled="awaitingResponse" @click="$emit('hide')">
+            :aria-disabled="awaitingResponse" @click="$emit('hide')">
             {{ $t('action.cancel') }}
           </button>
         </div>

--- a/src/components/public-link/revoke.vue
+++ b/src/components/public-link/revoke.vue
@@ -20,10 +20,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="revoke">
+          :aria-disabled="awaitingResponse" @click="revoke">
           {{ $t('action.yesProceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.noCancel') }}
         </button>

--- a/src/components/submission/activity.vue
+++ b/src/components/submission/activity.vue
@@ -26,7 +26,7 @@ except according to the terms contained in the LICENSE file.
             <span class="icon-pencil"></span>{{ $t('action.edit') }}
           </a>
           <button v-else id="submission-activity-edit-button" type="button"
-            class="btn btn-default" disabled
+            class="btn btn-default" aria-disabled="true"
             :title="$t('submission.editDisabled')">
             <span class="icon-pencil"></span>{{ $t('action.edit') }}
           </button>

--- a/src/components/submission/comment.vue
+++ b/src/components/submission/comment.vue
@@ -18,7 +18,7 @@ except according to the terms contained in the LICENSE file.
       <markdown-textarea v-model="body" :default-text="$t('field.comment')"
         :show-footer="editWithoutComment || awaitingResponse" required>
         <button type="submit" class="btn btn-primary"
-          :disabled="awaitingResponse">
+          :aria-disabled="awaitingResponse">
           {{ $t('action.comment') }} <spinner :state="awaitingResponse"/>
         </button>
       </markdown-textarea>

--- a/src/components/submission/data-access.vue
+++ b/src/components/submission/data-access.vue
@@ -17,7 +17,7 @@ except according to the terms contained in the LICENSE file.
       <span class="icon-plug"></span>{{ $t('action.apiAccess') }}
     </a>
     <button id="submission-data-access-analyze-button" type="button"
-      class="btn btn-default" :disabled="analyzeDisabled"
+      class="btn btn-default" :aria-disabled="analyzeDisabled"
       :title="analyzeDisabled ? $t('analyzeDisabled') : null"
       @click="$emit('analyze')">
       <span class="icon-bar-chart"></span>{{ $t('action.analyze') }}&hellip;

--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -277,11 +277,9 @@ export default {
     download(event) {
       const a = event.target.closest('a');
       if (a == null) return;
-      const willDownload = !a.classList.contains('disabled') &&
+      const willDownload = this.managedKey == null ||
         this.$refs.form.reportValidity();
-      if (this.managedKey == null) {
-        if (!willDownload) event.preventDefault();
-      } else {
+      if (this.managedKey != null) {
         event.preventDefault();
         if (willDownload) this.decrypt(a.getAttribute('href'));
       }

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -22,7 +22,7 @@ except according to the terms contained in the LICENSE file.
             v-if="selectedFields != null && fields.selectable.length > 11"
             v-model="selectedFields"/>
           <button id="submission-list-refresh-button" type="button"
-            class="btn btn-default" :disabled="refreshing"
+            class="btn btn-default" :aria-disabled="refreshing"
             @click="fetchChunk(0, false)">
             <span class="icon-refresh"></span>{{ $t('action.refresh') }}
             <spinner :state="refreshing"/>

--- a/src/components/submission/metadata-row.vue
+++ b/src/components/submission/metadata-row.vue
@@ -38,7 +38,7 @@ except according to the terms contained in the LICENSE file.
             :href="editPath" target="_blank" :title="editTitle">
             <span class="icon-pencil"></span>
           </a>
-          <button v-else type="button" class="btn btn-default" disabled
+          <button v-else type="button" class="btn btn-default" aria-disabled="true"
             :title="$t('submission.editDisabled')">
             <span class="icon-pencil"></span>
           </button>

--- a/src/components/submission/update-review-state.vue
+++ b/src/components/submission/update-review-state.vue
@@ -36,11 +36,11 @@ except according to the terms contained in the LICENSE file.
         </div>
         <div class="modal-actions">
           <button type="submit" class="btn btn-primary"
-            :disabled="awaitingResponse">
+            :aria-disabled="awaitingResponse">
             {{ $t('action.update') }} <spinner :state="awaitingResponse"/>
           </button>
           <button type="button" class="btn btn-link"
-            :disabled="awaitingResponse" @click="$emit('hide')">
+            :aria-disabled="awaitingResponse" @click="$emit('hide')">
             {{ $t('action.neverMind') }}
           </button>
         </div>

--- a/src/components/user/edit/basic-details.vue
+++ b/src/components/user/edit/basic-details.vue
@@ -20,8 +20,8 @@ except according to the terms contained in the LICENSE file.
           :placeholder="$t('field.email')" required autocomplete="off"/>
         <form-group v-model.trim="displayName" type="text"
           :placeholder="$t('field.displayName')" required autocomplete="off"/>
-        <button :disabled="awaitingResponse" type="submit"
-          class="btn btn-primary">
+        <button type="submit" class="btn btn-primary"
+          :aria-disabled="awaitingResponse">
           {{ $t('action.update') }}<spinner :state="awaitingResponse"/>
         </button>
       </form>

--- a/src/components/user/edit/password.vue
+++ b/src/components/user/edit/password.vue
@@ -27,8 +27,8 @@ except according to the terms contained in the LICENSE file.
         <form-group id="user-edit-password-confirm" v-model="confirm"
           type="password" :placeholder="$t('field.passwordConfirm')" required
           :has-error="mismatch" autocomplete="new-password"/>
-        <button :disabled="awaitingResponse" type="submit"
-          class="btn btn-primary">
+        <button type="submit" class="btn btn-primary"
+          :aria-disabled="awaitingResponse">
           {{ $t('action.change') }} <spinner :state="awaitingResponse"/>
         </button>
       </form>

--- a/src/components/user/new.vue
+++ b/src/components/user/new.vue
@@ -21,12 +21,12 @@ except according to the terms contained in the LICENSE file.
         <form-group v-model.trim="displayName" type="text"
           :placeholder="$t('field.displayName')" autocomplete="off"/>
         <div class="modal-actions">
-          <button :disabled="awaitingResponse" type="submit"
-            class="btn btn-primary">
+          <button type="submit" class="btn btn-primary"
+            :aria-disabled="awaitingResponse">
             {{ $t('action.create') }} <spinner :state="awaitingResponse"/>
           </button>
-          <button :disabled="awaitingResponse" type="button"
-            class="btn btn-link" @click="$emit('hide')">
+          <button type="button" class="btn btn-link"
+            :aria-disabled="awaitingResponse" @click="$emit('hide')">
             {{ $t('action.cancel') }}
           </button>
         </div>

--- a/src/components/user/reset-password.vue
+++ b/src/components/user/reset-password.vue
@@ -24,10 +24,10 @@ except according to the terms contained in the LICENSE file.
       </i18n-t>
       <div class="modal-actions">
         <button type="button" class="btn btn-primary"
-          :disabled="awaitingResponse" @click="resetPassword">
+          :aria-disabled="awaitingResponse" @click="resetPassword">
           {{ $t('action.resetPassword') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.close') }}
         </button>

--- a/src/components/user/retire.vue
+++ b/src/components/user/retire.vue
@@ -25,10 +25,10 @@ except according to the terms contained in the LICENSE file.
       </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-danger"
-          :disabled="awaitingResponse" @click="retire">
+          :aria-disabled="awaitingResponse" @click="retire">
           {{ $t('action.yesProceed') }} <spinner :state="awaitingResponse"/>
         </button>
-        <button type="button" class="btn btn-link" :disabled="awaitingResponse"
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
           @click="$emit('hide')">
           {{ $t('action.noCancel') }}
         </button>

--- a/src/components/user/row.vue
+++ b/src/components/user/row.vue
@@ -52,7 +52,8 @@ except according to the terms contained in the LICENSE file.
             </a>
           </li>
           <li :class="{ disabled }" :title="retireTitle">
-            <a class="retire-user" href="#" @click.prevent="retire">
+            <a class="retire-user" href="#"
+              @click.prevent="$emit('retire', user)">
               {{ $t('action.retire') }}&hellip;
             </a>
           </li>
@@ -123,9 +124,6 @@ export default {
           this.$emit('assigned-role', this.user, this.selectedRole === 'admin');
         })
         .catch(noop);
-    },
-    retire() {
-      if (!this.disabled) this.$emit('retire', this.user);
     }
   }
 };

--- a/src/components/user/row.vue
+++ b/src/components/user/row.vue
@@ -19,7 +19,8 @@ except according to the terms contained in the LICENSE file.
       <form>
         <div class="form-group">
           <select class="form-control" :value="selectedRole"
-            :disabled="disabled" :title="selectTitle"
+            :aria-disabled="disabled || awaitingResponse"
+            :title="disabled ? $t('cannotAssignRole') : null"
             :aria-label="$t('field.sitewideRole')"
             @change="assignRole($event.target.value)">
             <option value="admin">{{ $t('role.admin') }}</option>
@@ -51,7 +52,7 @@ except according to the terms contained in the LICENSE file.
               {{ $t('action.resetPassword') }}&hellip;
             </a>
           </li>
-          <li :class="{ disabled }" :title="retireTitle">
+          <li :class="{ disabled }" :title="disabled ? $t('cannotRetire') : null">
             <a class="retire-user" href="#"
               @click.prevent="$emit('retire', user)">
               {{ $t('action.retire') }}&hellip;
@@ -97,20 +98,10 @@ export default {
   },
   computed: {
     disabled() {
-      return this.user.id === this.currentUser.id || this.awaitingResponse;
-    },
-    selectTitle() {
-      return this.user.id === this.currentUser.id
-        ? this.$t('cannotAssignRole')
-        : null;
+      return this.user.id === this.currentUser.id;
     },
     actionsButtonId() {
       return `user-row-actions-button${this.user.id}`;
-    },
-    retireTitle() {
-      return this.user.id === this.currentUser.id
-        ? this.$t('cannotRetire')
-        : null;
     }
   },
   methods: {

--- a/src/composables/disabled.js
+++ b/src/composables/disabled.js
@@ -9,6 +9,48 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
+
+/*
+We disable elements in a few different ways:
+
+  - For <button> elements, we use the attribute aria-disabled="true". This
+    allows buttons to be the target of mouse and focus events, enabling us to
+    add tooltips to buttons. It also means that disabled buttons will continue
+    to be focusable. Neither of those would be the case if we used the
+    `disabled` attribute. For more context, see this article:
+    https://css-tricks.com/making-disabled-buttons-more-inclusive/
+  - For similar reasons, we use aria-disabled="true" for .form-control elements,
+    including <select> elements and most <input> elements.
+  - For checkboxes specifically, we use the `disabled` attribute rather than
+    aria-disabled. That's because it's not trivial to style checkboxes so that
+    an aria-disabled checkbox looks like a checkbox with a `disabled` attribute.
+    In particular, it doesn't seem easy to style the checkbox border: in Chrome
+    and Firefox, the border is a different color if the checkbox has a
+    `disabled` attribute. The border also changes color on hover if the checkbox
+    doesn't have a `disabled` attribute, even if has an aria-disabled attribute.
+    There seem to be CSS options to style the border that are more complicated,
+    which we could investigate at some point. However, we actually don't add
+    tooltips to <input type="checkbox"> elements, but rather to their parent
+    <label> element. That means that even as we use the `disabled` attribute
+    with checkboxes, we can still add tooltips to them. However, disabled
+    checkboxes won't be focusable.
+  - The other element for which we use the `disabled` attribute rather than
+    aria-disabled is <fieldset>. We don't add tooltips to <fieldset> elements as
+    a whole, and it's not clear that it would be better to allow nested form
+    controls to be focusable and interactive before the <fieldset> is enabled.
+  - For <a> elements, we use the `disabled` class. (It appears that
+    aria-disabled is not recommended for <a> elements with an `href` attribute,
+    and <a> elements also do not support the `disabled` attribute.) An <a>
+    element that is a child of a .disabled element (for example, a disabled tab)
+    will also be disabled.
+
+Among these, the only elements that the browser natively disables are those with
+a `disabled` attribute. This composable can be used to effectively disable
+elements with aria-disabled="true" and links with the `disabled` class. For
+certain events on these elements, the composable will prevent the default
+behavior and stop the propagation of the event.
+*/
+
 import { onMounted, onUnmounted } from 'vue';
 
 const preventAndStop = (event) => {
@@ -18,15 +60,37 @@ const preventAndStop = (event) => {
 
 const preventDisabledClick = (event) => {
   const { target } = event;
-  const disabled = target.closest('a.disabled, .disabled > a');
+  const disabled = target.closest('button[aria-disabled="true"], a.disabled, .disabled > a');
   if (disabled != null) preventAndStop(event);
+};
+
+const preventDisabledInput = (event) => {
+  if (event.target.tagName === 'INPUT' &&
+    event.target.getAttribute('aria-disabled') === 'true')
+    preventAndStop(event);
+};
+
+// Prevents the menu of a <select> element from being shown if the element has
+// aria-disabled="true". event.type will be either 'mousedown' or 'keydown'.
+const preventDisabledSelect = (event) => {
+  if (event.target.tagName === 'SELECT' &&
+    event.target.getAttribute('aria-disabled') === 'true' &&
+    (event.type === 'mousedown' ||
+    event.key === ' ' || event.key === 'ArrowDown' || event.key === 'ArrowUp'))
+    preventAndStop(event);
 };
 
 export default () => {
   onMounted(() => {
     document.body.addEventListener('click', preventDisabledClick, true);
+    document.body.addEventListener('beforeinput', preventDisabledInput, true);
+    document.body.addEventListener('mousedown', preventDisabledSelect, true);
+    document.body.addEventListener('keydown', preventDisabledSelect, true);
   });
   onUnmounted(() => {
     document.body.removeEventListener('click', preventDisabledClick, true);
+    document.body.removeEventListener('beforeinput', preventDisabledInput, true);
+    document.body.removeEventListener('mousedown', preventDisabledSelect, true);
+    document.body.removeEventListener('keydown', preventDisabledSelect, true);
   });
 };

--- a/src/composables/disabled.js
+++ b/src/composables/disabled.js
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+import { onMounted, onUnmounted } from 'vue';
+
+const preventAndStop = (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+};
+
+const preventDisabledClick = (event) => {
+  const { target } = event;
+  const disabled = target.closest('a.disabled, .disabled > a');
+  if (disabled != null) preventAndStop(event);
+};
+
+export default () => {
+  onMounted(() => {
+    document.body.addEventListener('click', preventDisabledClick, true);
+  });
+  onUnmounted(() => {
+    document.body.removeEventListener('click', preventDisabledClick, true);
+  });
+};

--- a/test/components/account/login.spec.js
+++ b/test/components/account/login.spec.js
@@ -228,8 +228,8 @@ describe('AccountLogin', () => {
         .afterResponses(app => {
           app.find('#navbar-links').exists().should.be.false();
           app.get('#navbar-actions a').text().should.equal('Not logged in');
-          app.get('#account-login .btn-primary').element.disabled.should.be.true();
-          app.get('#account-login .btn-link').element.disabled.should.be.true();
+          app.get('#account-login .btn-primary').attributes('aria-disabled').should.equal('true');
+          app.get('#account-login .btn-link').attributes('aria-disabled').should.equal('true');
         });
     });
   });

--- a/test/components/enketo/fill.spec.js
+++ b/test/components/enketo/fill.spec.js
@@ -28,7 +28,7 @@ describe('EnketoFill', () => {
       slots: { default: TestUtilSpan }
     });
     button.element.tagName.should.equal('BUTTON');
-    button.element.disabled.should.be.true();
+    button.attributes('aria-disabled').should.equal('true');
     button.attributes().title.should.equal('Web Form is not available yet. It has not finished being processed. Please refresh later and try again.');
     button.get('span').text().should.equal('Some span text');
   });

--- a/test/components/enketo/preview.spec.js
+++ b/test/components/enketo/preview.spec.js
@@ -23,7 +23,7 @@ describe('EnketoPreview', () => {
       props: { formVersion: form }
     });
     button.element.tagName.should.equal('BUTTON');
-    button.element.disabled.should.be.true();
+    button.attributes('aria-disabled').should.equal('true');
     button.attributes().title.should.equal('Preview has not finished processing for this Form. Please refresh later and try again.');
   });
 

--- a/test/components/field-key/revoke.spec.js
+++ b/test/components/field-key/revoke.spec.js
@@ -23,8 +23,6 @@ describe('FieldKeyRevoke', () => {
       const app = await load('/projects/1/app-users');
       const li = app.get('.field-key-row .dropdown-menu li');
       li.classes('disabled').should.be.true();
-      await li.get('a').trigger('click');
-      app.getComponent(FieldKeyRevoke).props().state.should.be.false();
     });
   });
 

--- a/test/components/form/new.spec.js
+++ b/test/components/form/new.spec.js
@@ -253,7 +253,7 @@ describe('FormNew', () => {
         const dropZone = modal.get('#form-new-drop-zone');
         dropZone.classes('form-new-disabled').should.be.true();
         const button = dropZone.get('.btn-primary');
-        button.element.disabled.should.be.true();
+        button.attributes('aria-disabled').should.equal('true');
       })
       .respondWithProblem();
   });

--- a/test/components/form/restore.spec.js
+++ b/test/components/form/restore.spec.js
@@ -56,9 +56,9 @@ describe('FormRestore', () => {
     return load('/projects/1', {}, {
       deletedForms: () => [{ xmlFormId: 'this_id_exists', id: 111, deletedAt: ago({ days: 15 }).toISO() }]
     })
-      .afterResponses(component => {
-        const button = component.get('[data-form-id="111"]');
-        button.element.disabled.should.be.true();
+      .afterResponses(async (app) => {
+        const button = app.get('[data-form-id="111"]');
+        button.attributes('aria-disabled').should.equal('true');
         button.attributes().title.should.equal('This Form cannot be undeleted because an active Form with the same ID exists.');
       });
   });

--- a/test/components/form/trash-row.spec.js
+++ b/test/components/form/trash-row.spec.js
@@ -95,14 +95,14 @@ describe('FormTrashRow', () => {
     it('shows the undelete button', () => {
       const button = mountComponent({ name: 'foo' }).get('.form-trash-row-restore-button');
       button.element.tagName.should.equal('BUTTON');
-      button.element.disabled.should.be.false();
+      button.attributes('aria-disabled').should.equal('false');
     });
 
     it('disables the undelete button if active form with same id exists', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'foo' });
       const button = mountComponent({ xmlFormId: 'foo' }).get('.form-trash-row-restore-button');
       button.element.tagName.should.equal('BUTTON');
-      button.element.disabled.should.be.true();
+      button.attributes('aria-disabled').should.equal('true');
       button.attributes().title.should.equal('This Form cannot be undeleted because an active Form with the same ID exists.');
     });
   });

--- a/test/components/multiselect.spec.js
+++ b/test/components/multiselect.spec.js
@@ -557,7 +557,7 @@ describe('Multiselect', () => {
       const component = mountComponent({
         props: { options: null, loading: true }
       });
-      component.get('select').element.disabled.should.be.true();
+      component.get('select').attributes('aria-disabled').should.equal('true');
     });
   });
 
@@ -573,7 +573,7 @@ describe('Multiselect', () => {
       const component = mountComponent({
         props: { options: null, loading: false }
       });
-      component.get('select').element.disabled.should.be.true();
+      component.get('select').attributes('aria-disabled').should.equal('true');
     });
   });
 

--- a/test/components/project/form-access.spec.js
+++ b/test/components/project/form-access.spec.js
@@ -60,7 +60,8 @@ describe('ProjectFormAccess', () => {
     it('initially disables the Save button', async () => {
       createData();
       const app = await load('/projects/1/form-access');
-      app.get('#project-form-access-save-button').element.disabled.should.be.true();
+      const button = app.get('#project-form-access-save-button');
+      button.attributes('aria-disabled').should.equal('true');
     });
 
     it('correctly renders the column headers of the table', async () => {
@@ -101,7 +102,7 @@ describe('ProjectFormAccess', () => {
         await app.get('#project-form-access-table select').setValue('open');
         const button = app.get('#project-form-access-save-button');
         button.classes('uncommitted-change').should.be.true();
-        button.element.disabled.should.be.false();
+        button.attributes('aria-disabled').should.equal('false');
       });
 
       it('increments unsavedChanges', async () => {
@@ -123,7 +124,7 @@ describe('ProjectFormAccess', () => {
         // Save button
         const button = app.get('#project-form-access-save-button');
         button.classes('uncommitted-change').should.be.false();
-        button.element.disabled.should.be.true();
+        button.attributes('aria-disabled').should.equal('true');
 
         // unsavedChanges
         app.vm.$container.unsavedChanges.count.should.equal(0);
@@ -146,7 +147,7 @@ describe('ProjectFormAccess', () => {
         await checkbox.setChecked(false);
         const button = app.get('#project-form-access-save-button');
         button.classes('uncommitted-change').should.be.true();
-        button.element.disabled.should.be.false();
+        button.attributes('aria-disabled').should.equal('false');
       });
 
       it('increments unsavedChanges', async () => {
@@ -169,7 +170,7 @@ describe('ProjectFormAccess', () => {
         // Save button
         const button = app.get('#project-form-access-save-button');
         button.classes('uncommitted-change').should.be.false();
-        button.element.disabled.should.be.true();
+        button.attributes('aria-disabled').should.equal('true');
 
         // unsavedChanges
         app.vm.$container.unsavedChanges.count.should.equal(0);
@@ -193,7 +194,7 @@ describe('ProjectFormAccess', () => {
         await checkboxes[1].setChecked();
         const button = app.get('#project-form-access-save-button');
         button.classes('uncommitted-change').should.be.true();
-        button.element.disabled.should.be.false();
+        button.attributes('aria-disabled').should.equal('false');
       });
     });
 
@@ -277,7 +278,8 @@ describe('ProjectFormAccess', () => {
 
       it('disables the Save button', () =>
         saveWithSuccess().afterResponses(app => {
-          app.get('#project-form-access-save-button').element.disabled.should.be.true();
+          const button = app.get('#project-form-access-save-button');
+          button.attributes('aria-disabled').should.equal('true');
         }));
 
       it('updates the table', () =>

--- a/test/components/project/user/list.spec.js
+++ b/test/components/project/user/list.spec.js
@@ -78,7 +78,7 @@ describe('ProjectUserList', () => {
         return load('/projects/1/users', { root: false })
           .beforeEachResponse(component => {
             const input = component.get('#project-user-list-search-form input');
-            input.element.disabled.should.be.true();
+            input.attributes('aria-disabled').should.equal('true');
           });
       });
 
@@ -155,20 +155,19 @@ describe('ProjectUserList', () => {
         });
     });
 
-    it('renders the select correctly for the current user', () => {
+    it('renders the select correctly for the current user', async () => {
       createData(['manager', 'manager']);
-      return load('/projects/1/users', { root: false }).afterResponses(component => {
-        const tr = component.findAll('tbody tr');
-        tr.length.should.equal(2);
-        const selects = tr.map(wrapper => wrapper.get('select'));
+      const component = await load('/projects/1/users', { root: false });
+      const tr = component.findAll('tbody tr');
+      tr.length.should.equal(2);
+      const selects = tr.map(wrapper => wrapper.get('select'));
 
-        tr[0].get('td').text().should.equal('User 1');
-        selects[0].element.disabled.should.be.true();
-        selects[0].attributes().title.should.equal('You may not edit your own Project Role.');
+      tr[0].get('td').text().should.equal('User 1');
+      selects[0].attributes('aria-disabled').should.equal('true');
+      selects[0].attributes().title.should.equal('You may not edit your own Project Role.');
 
-        selects[1].element.disabled.should.be.false();
-        should.not.exist(selects[1].attributes().title);
-      });
+      selects[1].attributes('aria-disabled').should.equal('false');
+      should.not.exist(selects[1].attributes().title);
     });
 
     describe('no assignments', () => {
@@ -248,7 +247,7 @@ describe('ProjectUserList', () => {
           .complete()
           .request(component => changeRole(component, 'viewer'))
           .beforeEachResponse(component => {
-            component.get('select').element.disabled.should.be.true();
+            component.get('select').attributes('aria-disabled').should.equal('true');
           })
           .respondWithSuccess()
           .respondWithSuccess();
@@ -273,7 +272,7 @@ describe('ProjectUserList', () => {
           .request(component => changeRole(component, 'viewer'))
           .beforeEachResponse(component => {
             const input = component.get('#project-user-list-search-form input');
-            input.element.disabled.should.be.true();
+            input.attributes('aria-disabled').should.equal('true');
           })
           .respondWithSuccess()
           .respondWithSuccess();
@@ -379,7 +378,7 @@ describe('ProjectUserList', () => {
     it('does not disable the search input', () =>
       search({ root: false }).beforeAnyResponse(component => {
         const input = component.get('#project-user-list-search-form input');
-        input.element.disabled.should.be.false();
+        input.attributes('aria-disabled').should.equal('false');
       }));
 
     it('shows the .close button', () =>
@@ -498,7 +497,7 @@ describe('ProjectUserList', () => {
     it('disables the search input during the request', () =>
       giveRoleThenClearSearch().beforeAnyResponse(component => {
         const input = component.get('#project-user-list-search-form input');
-        input.element.disabled.should.be.true();
+        input.attributes('aria-disabled').should.equal('true');
       }));
 
     it('hides the .close button during the request', () =>

--- a/test/components/submission/activity.spec.js
+++ b/test/components/submission/activity.spec.js
@@ -166,7 +166,7 @@ describe('SubmissionActivity', () => {
       testData.extendedAudits.createPast(1, { action: 'submission.create' });
       const component = mountComponent();
       const btn = component.get('#submission-activity-edit-button');
-      btn.element.disabled.should.be.true();
+      btn.attributes('aria-disabled').should.equal('true');
       btn.attributes().title.should.equal('You cannot edit encrypted Submissions.');
     });
 

--- a/test/components/submission/data-access.spec.js
+++ b/test/components/submission/data-access.spec.js
@@ -30,7 +30,7 @@ describe('SubmissionDataAccess', () => {
         submissions: 0
       });
       const button = mountComponent().get('button');
-      button.element.disabled.should.be.true();
+      button.attributes('aria-disabled').should.equal('true');
       should.exist(button.attributes().title);
     });
 
@@ -44,7 +44,7 @@ describe('SubmissionDataAccess', () => {
       testData.standardKeys.createPast(1, { managed: false });
       testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
       const button = mountComponent().get('button');
-      button.element.disabled.should.be.true();
+      button.attributes('aria-disabled').should.equal('true');
       should.exist(button.attributes().title);
     });
   });

--- a/test/components/submission/decrypt.spec.js
+++ b/test/components/submission/decrypt.spec.js
@@ -307,16 +307,6 @@ describe('SubmissionDownload', () => {
       modal.get('a').trigger('click');
       modal.should.alert('info');
     });
-
-    it('does nothing if the link is disabled', () => {
-      const modal = mountComponent();
-      const event = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true
-      });
-      modal.findAll('a')[1].element.dispatchEvent(event).should.be.false();
-      modal.should.not.alert();
-    });
   });
 
   describe('clicking a link if there is a managed key', () => {
@@ -415,18 +405,6 @@ describe('SubmissionDownload', () => {
       const modal = await setup();
       modal.get('a').trigger('click');
       modal.should.alert('info');
-    });
-
-    it('does nothing if the link is disabled', async () => {
-      const onSubmit = sinon.fake();
-      const modal = await setup(onSubmit);
-      const event = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true
-      });
-      modal.findAll('a')[1].element.dispatchEvent(event).should.be.false();
-      onSubmit.called.should.be.false();
-      modal.should.not.alert();
     });
 
     it('does nothing if the passphrase is empty', async () => {

--- a/test/components/submission/metadata-row.spec.js
+++ b/test/components/submission/metadata-row.spec.js
@@ -225,7 +225,7 @@ describe('SubmissionMetadataRow', () => {
     it('disables the button if the submission is encrypted', () => {
       testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
       const button = mountComponent().findAll('.btn')[1];
-      button.element.disabled.should.be.true();
+      button.attributes('aria-disabled').should.equal('true');
       const { title } = button.attributes();
       title.should.equal('You cannot edit encrypted Submissions.');
     });

--- a/test/components/user/list.spec.js
+++ b/test/components/user/list.spec.js
@@ -59,8 +59,8 @@ describe('UserList', () => {
     const component = await load('/users', { root: false });
     const selects = component.findAll('.user-row select');
 
-    selects[0].element.disabled.should.be.true();
-    selects[1].element.disabled.should.be.false();
+    selects[0].attributes('aria-disabled').should.equal('true');
+    selects[1].attributes('aria-disabled').should.equal('false');
 
     should.exist(selects[0].attributes().title);
     should.not.exist(selects[1].attributes().title);
@@ -110,12 +110,12 @@ describe('UserList', () => {
           loadUsersAndChangeRole({ rowIndex, selectValue })
             .beforeAnyResponse(component => {
               const select = component.findAll('.user-row select')[rowIndex];
-              select.element.disabled.should.be.true();
+              select.attributes('aria-disabled').should.equal('true');
             })
             .respondWithSuccess()
             .afterResponse(component => {
               const select = component.findAll('.user-row select')[rowIndex];
-              select.element.disabled.should.be.false();
+              select.attributes('aria-disabled').should.equal('false');
             }));
 
         it('shows a spinner during the request', () =>

--- a/test/components/user/retire.spec.js
+++ b/test/components/user/retire.spec.js
@@ -26,8 +26,6 @@ describe('UserRetire', () => {
       const li = a.element.parentNode;
       li.classList.contains('disabled').should.be.true();
       li.getAttribute('title').should.equal('You may not retire yourself.');
-      await a.trigger('click');
-      component.getComponent(UserRetire).props().state.should.be.false();
     });
   });
 

--- a/test/composables/disabled.spec.js
+++ b/test/composables/disabled.spec.js
@@ -1,0 +1,72 @@
+import sinon from 'sinon';
+
+import useDisabled from '../../src/composables/disabled';
+
+import { mount } from '../util/lifecycle';
+
+const mountComponent = (template) => {
+  const handler = sinon.fake();
+  const setup = () => {
+    useDisabled();
+    return { handler };
+  };
+  const component = mount(
+    { template, setup },
+    { attachTo: document.body }
+  );
+  return [component, handler];
+};
+
+describe('useDisabled()', () => {
+  // Set up access to the most recently triggered event so that we can check
+  // whether preventDefault() was called on it.
+  let event;
+  const storeEvent = (e) => { event = e; };
+  const toggleEventListeners = (add) => {
+    const method = add ? 'addEventListener' : 'removeEventListener';
+    document[method]('click', storeEvent, true);
+  };
+  before(() => { toggleEventListeners(true); });
+  after(() => { toggleEventListeners(false); });
+
+  it('disables a link that has the disabled class', () => {
+    const [component, handler] = mountComponent(`<div>
+      <a @click="handler">Enabled</a>
+      <a class="disabled" @click="handler">Disabled</a>
+    </div>`);
+    const a = component.findAll('a');
+
+    a[0].trigger('click');
+    event.defaultPrevented.should.be.false();
+    handler.callCount.should.equal(1);
+
+    a[1].trigger('click');
+    event.defaultPrevented.should.be.true();
+    handler.callCount.should.equal(1);
+  });
+
+  it('disables a .disabled link for a click inside the link', () => {
+    const [component, handler] = mountComponent(`<a class="disabled" @click="handler">
+      <span class="icon-question-circle></span>
+    </a>`);
+    component.get('span').trigger('click');
+    event.defaultPrevented.should.be.true();
+    handler.callCount.should.equal(0);
+  });
+
+  it('disables a link in a disabled tab', () => {
+    const [component, handler] = mountComponent(`<ul class="nav nav-tabs">
+      <li role="presentation"><a @click="handler">Enabled</a></li>
+      <li class="disabled" role="presentation"><a @click="handler">Disabled</a></li>
+    </ul>`);
+    const a = component.findAll('a');
+
+    a[0].trigger('click');
+    event.defaultPrevented.should.be.false();
+    handler.callCount.should.equal(1);
+
+    a[1].trigger('click');
+    event.defaultPrevented.should.be.true();
+    handler.callCount.should.equal(1);
+  });
+});

--- a/test/util/http/common.js
+++ b/test/util/http/common.js
@@ -103,15 +103,17 @@ const assertStandardButton = (
   showsAlert
 ) => {
   const button = component.get(buttonSelector);
-  button.element.disabled.should.equal(awaitingResponse);
+  (button.attributes('aria-disabled') === 'true').should.equal(awaitingResponse);
 
   const spinners = component.findAllComponents(Spinner).filter(spinner =>
     button.element.contains(spinner.element));
   spinners.length.should.equal(1);
   spinners[0].props().state.should.equal(awaitingResponse);
 
-  for (const selector of disabledSelectors)
-    component.get(selector).element.disabled.should.equal(awaitingResponse);
+  for (const selector of disabledSelectors) {
+    const wrapper = component.get(selector);
+    (wrapper.attributes('aria-disabled') === 'true').should.equal(awaitingResponse);
+  }
 
   if (modal != null) {
     const parent = (modal === true ? component : component.getComponent(modal));


### PR DESCRIPTION
The primary purpose of this PR is to set things up so that it is possible to add instant tooltips to disabled elements. I think that the PR is also a useful change on its own, for example, closing #686.

One challenge that I have encountered while working on instant tooltips is elements with a `disabled` attribute. We have a fair number of cases in which a disabled element has a `title` attribute. The browser will gladly show that `title` attribute, but it isn't straightforward to add an instant tooltip to such an element. That's because the element no longer triggers the events to show/hide the tooltip (`mouseenter`/`mouseleave` + `focus`/`blur`).

Researching online, I read about a few different approaches:

- **Use the [`aria-disabled`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute rather than `disabled`.** This is the approach I ended up going with. By using `aria-disabled`, disabled elements will continue to trigger `mouseenter`/`mouseleave` events and to be focusable, allowing us to add tooltips. The fact that they will continue to be focusable is a change from our behavior today: it's not currently possible to tab to an element with a `disabled` attribute. However, I think it's a good change in terms of accessibility. For example, with this change, a user using the keyboard will be able to focus a disabled element and see its tooltip. I found [this article](https://css-tricks.com/making-disabled-buttons-more-inclusive/) helpful when thinking about accessibility. Using `aria-disabled` seemed like a relatively straightforward way to enable us to add tooltips and also seemed like a good approach in terms of accessibility.
- **Position an overlay over each disabled element** or wrap the element in another element, then listen for events on the overlay/wrapper rather than the element itself. Because the overlay/wrapper wouldn't be focusable, this would result in the closest behavior to what we have today. The overlay idea felt complex to me though, and the wrapper idea also didn't seem ideal.
- **Put a help icon next to each disabled button and add the tooltip to that** (or replace the disabled button with the help icon entirely). This wouldn't be hard to do, but it would be the biggest change from our current behavior.

I also wanted to leave some notes about disabled links, to which we sometimes add tooltips:

- `<a>` elements don't use the `disabled` attribute, so there weren't the same issues for tooltips as elements with that attribute. We use the `disabled` class to disable links, which styles them to look disabled and (for tab links only) sets `pointer-events` to `none`.
- We actually don't want to set `pointer-events` to `none` because like the `disabled` attribute, it prevents `mouseenter`/`mouseleave` events. Also, it still allows the link to be navigated into via the keyboard. I set `pointer-events` back to `auto` and used JavaScript to disable these links, including via the keyboard.
- Disabled links have been and will continue to be focusable.
- I would love to set `aria-disabled="true"` on disabled links so that screen readers will announce them as disabled and so that we have fewer different ways to disable things. However, according to [this article](https://www.scottohara.me/blog/2021/05/28/disabled-links.html), it's not recommended to set `aria-disabled="true"` on an `<a>` element with an `href` attribute (which we always set in Frontend).
  - Among `<a>` elements that we disable, we have many with `href="#"`. We sometimes set `role="button"` on those and sometimes don't, though probably we almost always should. As long as we set `role="button"`, I don't think we need to set `href="#"`. And if we don't set `href="#"`, I think that would allow us to set `aria-disabled` on these `<a>` elments. I think that would be an improvement that we could consider for the future.
  - There are other `<a>` elements that we disable that set `href` to something other than `#`. But there aren't many: the ones in `FormHead` are the only ones that come to mind. According to the article above, you can disable an `<a>` element by removing its `href` attribute and setting `role="link"` and `aria-disabled="true"`. The resulting element isn't focusable, so I think we would add a `tabindex` attribute as well. Again, I think that's something we could consider for the future.
  - I found this [other article](https://css-tricks.com/how-to-disable-links/) helpful as well. It seemed consistent with the article above.
- In several places where a link is styled as a button, the link is rendered as an `<a>` element when it is enabled and rendered as a `<button>` when it is disabled (for example, `EnketoPreview`). I think I did it that way because it felt like the easiest way to fully disable the "link" and because the link looked like a button anyway. I'm also not sure that `a.btn.disabled` elements have been styled the same as `button.btn[disabled]` elements. However, I am starting to question whether this pattern works well for screen readers. It seems funny that an element would sometimes be announced as a link and sometimes as a button. If we make the improvements to disabled links in the bullet point above, we could also look into consistently rendering these links as `<a>` elements.

I tried to adjust our styles so that `aria-disabled` elements appear the same way that elements with a `disabled` attribute appeared before. However, there are some combinations that are possible now that weren't possible before, for example, focus + disabled. I fixed related issues that I noticed and also took a look through app.scss for styles to adjust there. However, I'm not certain that I have accounted for all new combinations in all places. I'll keep my eyes open for related issues.