### PR TITLE
Add another path for looking up entity error messages in activity feed

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -159,8 +159,13 @@ export default {
       return '';
     },
     entityProblem(entry) {
-      if ('problem' in entry.details && 'problemDetails' in entry.details.problem)
+      if ('problem' in entry.details &&
+        'problemDetails' in entry.details.problem &&
+        'reason' in entry.details.problem.problemDetails)
         return entry.details.problem.problemDetails.reason;
+      if ('problem' in entry.details &&
+        'errorMessage' in entry.details)
+        return entry.details.errorMessage;
       return '';
     }
   }

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -185,6 +185,20 @@ describe('SubmissionFeedEntry', () => {
         title.get('.entity-error-message').text().should.equal('ID empty or missing.');
         await title.get('.entity-error-message').should.have.textTooltip();
       });
+
+      it('renders entity creation error message when it is included as an errorMessage', async () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.create.error',
+          details: {
+            problem: { problemCode: 409.3, problemDetails: { foo: 'blah' } },
+            errorMessage: 'A resource already exists with uuid value(s) abc.'
+          }
+        });
+        const title = mountComponent().get('.title');
+        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem creating Entity');
+        title.get('.entity-error-message').text().should.equal('A resource already exists with uuid value(s) abc.');
+        await title.get('.entity-error-message').should.have.textTooltip();
+      });
     });
   });
 


### PR DESCRIPTION
Addresses the first part of issue #701 

This was a scenario where backend logged an entity creation error but then wasn't able to show the appropriate error message. This change is basically a catch-all for error messages that we didn't anticipate, and didn't explicitly catch, but still want to show. 

Maybe a better answer is making changes to the backend, and in fact I just made a change to backend (https://github.com/getodk/central-backend/pull/742) to not report an error in this specific case, but I think it'll still be good to a) have this fallback and b) reveal these error messages to any entity problems from the previous release. 

<img width="1466" alt="Screen Shot 2023-01-23 at 4 40 31 PM" src="https://user-images.githubusercontent.com/76205/214187533-1682686a-ec20-4d2f-9572-bf2f5dcb6c84.png">
