### PR TITLE
Smaller form ID on form list when name duplicated

### DIFF
--- a/src/components/form/row.vue
+++ b/src/components/form/row.vue
@@ -164,6 +164,7 @@ export default {
 
   .duplicate-form-id {
     font-family: $font-family-monospace;
+    font-size: 12px;
     padding-left: 6px;
   }
 

--- a/src/components/form/trash-row.vue
+++ b/src/components/form/trash-row.vue
@@ -130,6 +130,7 @@ export default {
 
   .duplicate-form-id {
     font-family: $font-family-monospace;
+    font-size: 12px;
     padding-left: 6px;
   }
 

--- a/src/components/project/form-row.vue
+++ b/src/components/project/form-row.vue
@@ -176,6 +176,7 @@ export default {
 
   .duplicate-form-id {
     font-family: $font-family-monospace;
+    font-size: 12px;
     padding-left: 6px;
   }
 


### PR DESCRIPTION
Closes #677.

Font size is now 12px. On the form list page, it used to be 18px. Too small, or just right?

(on project page)
<img width="584" alt="Screen Shot 2023-01-24 at 4 11 20 PM" src="https://user-images.githubusercontent.com/76205/214450388-c23d167c-fc90-4892-849c-8196d9b80b78.png">

(on project list / home page)
<img width="455" alt="Screen Shot 2023-01-24 at 4 12 21 PM" src="https://user-images.githubusercontent.com/76205/214450443-3023439e-2705-43c2-a68f-cd6ef44f963e.png">

