### PR TITLE
Add background color to ExpandableRow button when it is focused

### DIFF
--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -114,7 +114,7 @@ export default {
     }
   }
 
-  a {
+  a, .expandable-row button {
     font-size: 16px;
   }
 

--- a/src/components/expandable-row.vue
+++ b/src/components/expandable-row.vue
@@ -14,13 +14,14 @@ except according to the terms contained in the LICENSE file.
     <div class="title-cell">
       <slot name="title"></slot>
     </div>
-    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/interactive-supports-focus -->
-    <div role="button" class="caption-cell" @click.prevent="toggleExpanded">
+    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
+    <div class="caption-cell" @click="toggleExpanded">
       <slot name="caption"></slot>
     </div>
 
-    <div class="button-cell">
-      <button type="button" class="btn btn-link" @click="toggleExpanded">
+    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
+    <div class="button-cell" @click="toggleExpanded">
+      <button type="button" class="btn btn-link">
         <span v-if="!expanded" class="sr-only">{{ $t('action.expand') }}</span>
         <span v-else class="sr-only">{{ $t('action.collapse') }}</span>
         <span v-if="!expanded" class="icon-caret-left"></span>
@@ -66,6 +67,8 @@ export default {
   .title-cell {
     flex-grow: 1;
   }
+
+  .caption-cell, .button-cell { cursor: pointer; }
 
   .caption-cell {
     text-align: right;

--- a/src/components/expandable-row.vue
+++ b/src/components/expandable-row.vue
@@ -20,12 +20,12 @@ except according to the terms contained in the LICENSE file.
     </div>
 
     <div class="button-cell">
-      <a href="javascript:void(0)" role="button" @click.prevent="toggleExpanded">
+      <button type="button" class="btn btn-link" @click="toggleExpanded">
         <span v-if="!expanded" class="sr-only">{{ $t('action.expand') }}</span>
         <span v-else class="sr-only">{{ $t('action.collapse') }}</span>
         <span v-if="!expanded" class="icon-caret-left"></span>
         <span v-else class="icon-caret-down"></span>
-      </a>
+      </button>
     </div>
     <div v-show="expanded" class="expanded-row">
         <slot name="details"></slot>
@@ -73,25 +73,15 @@ export default {
   }
 
   .button-cell {
-    font-size: 20px;
-    text-align: right;
-    line-height: normal;
+    align-self: center;
+    text-align: center;
     padding: 0px;
+    width: 30px;
 
-    a {
-      color: #888;
-      display: block;
-      width: 30px;
-      text-align: center;
-
-      span {
-        line-height: 38px;
-      }
+    button {
+      padding: 0;
 
       @include text-link;
-      &:focus {
-        background-color: transparent;
-      }
     }
   }
 

--- a/test/components/expandable-row.spec.js
+++ b/test/components/expandable-row.spec.js
@@ -39,19 +39,19 @@ describe('ExpandableRow', () => {
   });
 
   it('expands details', async () => {
-    await component.get('.button-cell a').trigger('click');
+    await component.get('.button-cell button').trigger('click');
     component.get('.expanded-row').should.be.visible();
     component.get('.expanded-row').text().should.be.eql('height, type');
   });
 
   it('collapses details', async () => {
     // expand
-    await component.get('.button-cell a').trigger('click');
+    await component.get('.button-cell button').trigger('click');
     component.get('.expanded-row').should.be.visible();
     component.get('.expanded-row').text().should.be.eql('height, type');
 
     // collapse
-    await component.get('.button-cell a').trigger('click');
+    await component.get('.button-cell button').trigger('click');
     component.get('.expanded-row').should.be.hidden();
   });
 });


### PR DESCRIPTION
The QA team noted:

> When a user uses keyboard navigation other parts are visibly highlighted (when chosen) except from “4 of 7 properties” in Connections to Forms and the form overview.

We usually add a background color on focus to buttons and links, so I think we should do so here as well.

In `ExpandableRow`, the properties count and the toggle button are in two different blocks. At least in Chrome, the properties count isn't focusable via the keyboard. So I've added a background color just to the toggle button, which is focusable. I think that's an improvement and all we need to do for now.

I didn't update the form overview, since that uses `DatasetSummaryRow`, which we will probably replace with `ExpandableRow` at some point in the future.

Other than the background color on focus, everything else about the appearance of the toggle button should be the same as before. I checked things locally in Chrome, and it looked the same.

I'll also add some comments about individual lines.