### PR TITLE
Remove reference to Form in generic odata modal

### DIFF
--- a/src/components/submission/analyze.vue
+++ b/src/components/submission/analyze.vue
@@ -176,7 +176,7 @@ export default {
       // The text of {python} is "Python". The text of {excel} is "Excel".
       // {powerBi}, {r}, {excel} and {python} are all links.
       "OData is a standard for transferring data between tools and services. Free and powerful analysis tools like {powerBi}, {excel}, {python}, and {r} can fetch data via OData for analysis.",
-      "To connect to this Form’s OData feed, select your tool and copy the link into it."
+      "To connect to this OData feed, select your tool and copy the link into it."
     ],
     "tab": {
       "microsoft": "Power BI or Excel",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3282,7 +3282,7 @@
           "developer_comment": "The text of {powerBi} is \"Microsoft Power BI\". The text of {r} is \"R\". The text of {python} is \"Python\". The text of {excel} is \"Excel\". {powerBi}, {r}, {excel} and {python} are all links."
         },
         "1": {
-          "string": "To connect to this Form’s OData feed, select your tool and copy the link into it."
+          "string": "To connect to this OData feed, select your tool and copy the link into it."
         }
       },
       "tab": {


### PR DESCRIPTION
Closes design feedback issue from issa.

Used to say "To connect to this Form's OData feed..." even on an entity page. Now it says "To connect to this OData feed..."

<img width="622" alt="Screen Shot 2023-03-07 at 2 19 47 PM" src="https://user-images.githubusercontent.com/76205/223566756-a6765cd3-e56e-4b6c-8d5a-668c9e33bca2.png">