### PR TITLE
Small style changes for v2023.2

### DIFF
--- a/src/components/password-strength.vue
+++ b/src/components/password-strength.vue
@@ -42,6 +42,7 @@ const score = computed(() => {
 
 <style lang="scss">
 @use 'sass:color';
+@use 'sass:math';
 @import '../assets/scss/mixins';
 
 .password-strength {
@@ -56,7 +57,7 @@ const score = computed(() => {
   // Use the borders of two pseduo-elements to create 4 blank spaces (gaps),
   // resulting in 5 bars.
   $between-bars: 5px;
-  $bar-width: calc(20% - #{4 * $between-bars / 5});
+  $bar-width: calc(20% - #{math.div(4 * $between-bars, 5)});
   &::before, &::after {
     background-color: transparent;
     border-color: #fff;

--- a/src/components/submission/decrypt.vue
+++ b/src/components/submission/decrypt.vue
@@ -63,7 +63,9 @@ except according to the terms contained in the LICENSE file.
             <form-group v-model="passphrase" type="password"
               :placeholder="$t('field.passphrase')" required
               autocomplete="off"/>
-            <p v-if="managedKey.hint != null" class="modal-introduction">
+            <p v-if="managedKey.hint != null"
+              id="submission-download-passphrase-hint"
+              class="modal-introduction">
               {{ $t('hint', managedKey) }}
             </p>
           </template>
@@ -322,6 +324,7 @@ export default {
   max-width: 305px;
 }
 #submission-download-passphrase-help { margin-top: 21px; }
+#submission-download-passphrase-hint { overflow-wrap: break-word; }
 #submission-download-container form :last-child { margin-bottom: 0; }
 #submission-download-divider {
   border-left: 1px solid $color-subpanel-border-strong;


### PR DESCRIPTION
A couple of small style changes before releasing v2023.2.

#### What has been done to verify that this works as intended?

For the first commit, I checked the display of a lengthy word in a passphrase hint. The word wrapped as expected.

For the second commit, I confirmed that the Sass warning is no shown in the build.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think the risk of regression is low.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced