### PR TITLE
Check more dataset and entity verbs in routes

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -359,7 +359,7 @@ const routes = [
           validateData: {
             // Including form.update in order to exclude project viewers and
             // Data Collectors.
-            project: () => project.permits(['form.read', 'form.update']),
+            project: () => project.permits(['form.read', 'form.update', 'dataset.list']),
             form: () => form.publishedAt != null
           },
           title: () => [form.nameOrId]
@@ -440,7 +440,8 @@ const routes = [
             project: () => project.permits([
               'form.read',
               'form.update',
-              'form.delete'
+              'form.delete',
+              'dataset.list'
             ]),
             formDraft: () => formDraft.isDefined()
           },
@@ -454,7 +455,12 @@ const routes = [
         props: true,
         meta: {
           validateData: {
-            project: () => project.permits(['form.read', 'form.update']),
+            project: () => project.permits([
+              'form.read',
+              'form.update',
+              'dataset.list',
+              'entity.list'
+            ]),
             attachments: () => attachments.isDefined() &&
               attachments.get().size !== 0
           },
@@ -510,7 +516,7 @@ const routes = [
         meta: {
           title: () => [dataset.name],
           validateData: {
-            project: () => project.permits('dataset.list')
+            project: () => project.permits('dataset.read')
           }
         }
       }),
@@ -522,7 +528,7 @@ const routes = [
         meta: {
           title: () => [i18n.t('common.data'), dataset.name],
           validateData: {
-            project: () => project.permits(['entity.list'])
+            project: () => project.permits(['dataset.read', 'entity.list'])
           }
         }
       })

--- a/test/data/seed.js
+++ b/test/data/seed.js
@@ -18,6 +18,7 @@ export default () => {
         'config.read',
         'config.set',
         'dataset.list',
+        'dataset.read',
         'entity.list',
         'field_key.create',
         'field_key.list',
@@ -60,6 +61,7 @@ export default () => {
         'assignment.list',
         'assignment.delete',
         'dataset.list',
+        'dataset.read',
         'entity.list',
         'field_key.create',
         'field_key.list',
@@ -84,6 +86,7 @@ export default () => {
       system: 'viewer',
       verbs: [
         'dataset.list',
+        'dataset.read',
         'entity.list',
         'form.list',
         'form.read',


### PR DESCRIPTION
Closes #662. Depends on getodk/central-backend#808.

I determined which routes needed to change by searching for components that call a dataset or entity `apiPaths` method.

#### What has been done to verify that this works as intended?

Tests. Even though this PR changes the specific verbs that are checked, tests don't need to change. That's because tests are based on roles, not verbs, and which roles can access which routes hasn't changed. The only thing that needed to change was adding the `dataset.read` verb to `testData`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change shouldn't be visible to users. Mostly it's for code clarity and future-proofing.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced