### PR TITLE
Add convenience methods to request() functions for HTTP verbs

### DIFF
--- a/src/composables/request.js
+++ b/src/composables/request.js
@@ -77,7 +77,7 @@ running watchers and updating the DOM.
 
 import { inject, readonly, ref, watch } from 'vue';
 
-import { isProblem, logAxiosError, requestAlertMessage, withAuth } from '../util/request';
+import { isProblem, logAxiosError, requestAlertMessage, withAuth, withHttpMethods } from '../util/request';
 
 const _request = (container, awaitingResponse) => (config) => {
   const { router, i18n, requestData, alert, http, logger } = container;
@@ -128,7 +128,7 @@ const _request = (container, awaitingResponse) => (config) => {
 export default () => {
   const container = inject('container');
   const awaitingResponse = ref(false);
-  const request = _request(container, awaitingResponse);
+  const request = withHttpMethods(_request(container, awaitingResponse));
 
   const { router } = container;
   // `router` may be `null` in testing.

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -11,6 +11,15 @@ except according to the terms contained in the LICENSE file.
 */
 import { odataLiteral } from './odata';
 
+// Returns `true` if `data` looks like a Backend Problem and `false` if not.
+export const isProblem = (data) => data != null && typeof data === 'object' &&
+  typeof data.code === 'number' && typeof data.message === 'string';
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// API PATHS
+
 export const queryString = (query) => {
   if (query == null) return '';
   const entries = Object.entries(query);
@@ -152,6 +161,11 @@ export const apiPaths = {
   audits: (query) => `/v1/audits${queryString(query)}`
 };
 
+
+
+////////////////////////////////////////////////////////////////////////////////
+// SENDING REQUESTS
+
 export const withAuth = (config, token) => {
   const { headers } = config;
   if ((headers == null || headers.Authorization == null) &&
@@ -163,10 +177,6 @@ export const withAuth = (config, token) => {
   }
   return config;
 };
-
-// Returns `true` if `data` looks like a Backend Problem and `false` if not.
-export const isProblem = (data) => data != null && typeof data === 'object' &&
-  typeof data.code === 'number' && typeof data.message === 'string';
 
 export const logAxiosError = (logger, error) => {
   if (error.response == null)

--- a/test/composables/request.spec.js
+++ b/test/composables/request.spec.js
@@ -15,6 +15,21 @@ const TestUtilRequest = {
 };
 
 describe('useRequest()', () => {
+  it('sends the correct request', () =>
+    mockHttp()
+      .mount(TestUtilRequest)
+      .request(component =>
+        component.vm.request({ method: 'DELETE', url: '/v1/projects/1' }))
+      .respondWithSuccess()
+      .testRequests([{ method: 'DELETE', url: '/v1/projects/1' }]));
+
+  it('provides convenience methods for HTTP verbs', () =>
+    mockHttp()
+      .mount(TestUtilRequest)
+      .request(component => component.vm.request.delete('/v1/projects/1'))
+      .respondWithSuccess()
+      .testRequests([{ method: 'DELETE', url: '/v1/projects/1' }]));
+
   describe('awaitingResponse', () => {
     it('sets awaitingResponse to true during the request', () =>
       mockHttp()

--- a/test/request-data/resource.spec.js
+++ b/test/request-data/resource.spec.js
@@ -95,6 +95,34 @@ describe('createResource()', () => {
           });
       });
     });
+
+    describe('convenience methods for HTTP verbs', () => {
+      it('sends the correct request', () => {
+        const container = createTestContainer();
+        const { project } = container.requestData;
+        return mockHttp(container)
+          .request(() => project.request.get('/v1/projects/1', {
+            // This option should be passed to request() even though it is a
+            // request() option, not an axios option.
+            extended: true
+          }))
+          .respondWithData(() => testData.extendedProjects.createNew())
+          .testRequests([
+            { method: 'GET', url: '/v1/projects/1', extended: true }
+          ]);
+      });
+
+      it('stores the response', () => {
+        const container = createTestContainer();
+        const { project } = container.requestData;
+        return mockHttp(container)
+          .request(() => project.request.get('/v1/projects/1'))
+          .respondWithData(() => testData.standardProjects.createNew())
+          .afterResponse(() => {
+            project.dataExists.should.be.true();
+          });
+      });
+    });
   });
 
   describe('cancelRequest()', () => {

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -359,8 +359,12 @@ describe('util/request', () => {
     });
   });
 
+  // Right now, withHttpMethods() modifies the request() function that is passed
+  // to it. However, an earlier version returned a proxy of the function. These
+  // tests were written for that earlier version, so they do not assume that
+  // withHttpMethods() returns the same function that was passed to it.
   describe('withHttpMethods()', () => {
-    it('returns a proxy that calls the request() function', () => {
+    it('returns a result that calls the request() function', () => {
       const request = sinon.fake(() => 'foo');
       const result = withHttpMethods(request);
       result({ method: 'GET', url: '/v1/projects/1' }).should.equal('foo');

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -1,5 +1,7 @@
+import sinon from 'sinon';
+
 import createCentralI18n from '../../src/i18n';
-import { apiPaths, isProblem, logAxiosError, queryString, requestAlertMessage, withAuth } from '../../src/util/request';
+import { apiPaths, isProblem, logAxiosError, queryString, requestAlertMessage, withAuth, withHttpMethods } from '../../src/util/request';
 
 import { mockAxiosError } from '../util/axios';
 import { mockLogger } from '../util/util';
@@ -354,6 +356,109 @@ describe('util/request', () => {
     it('audits?limit', () => {
       const path = apiPaths.audits({ action: 'nonverbose', limit: 10 });
       path.should.equal('/v1/audits?action=nonverbose&limit=10');
+    });
+  });
+
+  describe('withHttpMethods()', () => {
+    it('returns a proxy that calls the request() function', () => {
+      const request = sinon.fake(() => 'foo');
+      const result = withHttpMethods(request);
+      result({ method: 'GET', url: '/v1/projects/1' }).should.equal('foo');
+      request.args[0][0].should.eql({
+        method: 'GET',
+        url: '/v1/projects/1'
+      });
+    });
+
+    it('adds a convenience method for GET', () => {
+      const request = sinon.fake(() => 'foo');
+      const result = withHttpMethods(request);
+      result.get('/v1/projects/1').should.equal('foo');
+      request.args[0][0].should.eql({
+        method: 'GET',
+        url: '/v1/projects/1'
+      });
+    });
+
+    it('accepts a config argument for GET', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).get('/v1/projects/1', {
+        headers: { 'X-Foo': 'bar' }
+      });
+      request.args[0][0].should.eql({
+        method: 'GET',
+        url: '/v1/projects/1',
+        headers: { 'X-Foo': 'bar' }
+      });
+    });
+
+    it('adds a convenience method for DELETE', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).delete('/v1/projects/1');
+      request.args[0][0].should.eql({
+        method: 'DELETE',
+        url: '/v1/projects/1'
+      });
+    });
+
+    it('adds a convenience method for POST', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).post('/v1/projects');
+      request.args[0][0].should.eql({
+        method: 'POST',
+        url: '/v1/projects'
+      });
+    });
+
+    it('accepts a data argument for POST', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).post('/v1/projects', { foo: 'bar' });
+      request.args[0][0].should.eql({
+        method: 'POST',
+        url: '/v1/projects',
+        data: { foo: 'bar' }
+      });
+    });
+
+    it('accepts a config argument for POST', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).post('/v1/projects', { foo: 'bar' }, {
+        headers: { 'X-Foo': 'baz' }
+      });
+      request.args[0][0].should.eql({
+        method: 'POST',
+        url: '/v1/projects',
+        data: { foo: 'bar' },
+        headers: { 'X-Foo': 'baz' }
+      });
+    });
+
+    it('adds a convenience method for PUT', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).put('/v1/projects/1');
+      request.args[0][0].should.eql({
+        method: 'PUT',
+        url: '/v1/projects/1'
+      });
+    });
+
+    it('adds a convenience method for PATCH', () => {
+      const request = sinon.fake();
+      withHttpMethods(request).patch('/v1/projects/1');
+      request.args[0][0].should.eql({
+        method: 'PATCH',
+        url: '/v1/projects/1'
+      });
+    });
+
+    it('returns other properties on the request() function', () => {
+      const request = (x) => x;
+      request.length.should.equal(1);
+      withHttpMethods(request).length.should.equal(1);
+    });
+
+    it('returns undefined for a property that is not on the function', () => {
+      should(withHttpMethods(() => {}).foo).be.undefined();
     });
   });
 


### PR DESCRIPTION
This PR adds convenience methods for HTTP verbs to the `request()` function returned by `useRequest()`, as discussed [here](https://github.com/getodk/central-frontend/pull/763#discussion_r1153846715). For example, the following two calls will send the same request:

```js
const { request } = useRequest();
request({
  method: 'POST',
  url: '/v1/projects',
  data: { name: 'My Project' }
});
request.post('/v1/projects', { name: 'My Project' });
```

The parameters of the convenience methods are the same as they were in the `request` mixin.

I want to make the `request()` function returned by `useRequest()` and the `request()` method of `requestData` resources as similar as possible (see #675). With that in mind, I've also added the convenience methods to the `request()` method. The `request()` method usually sends GET requests, but there are several cases where it sends a non-GET request.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

In this PR, `useRequest()` and `requestData` call a shared function named `withHttpMethods()`, which adds convenience methods to any `request()` function/method. The main question I had was how to implement `withHttpMethods()`. I wanted to avoid eagerly creating five additional functions for every component that calls `useRequest()`, because most components will use at most one convenience method (and many components won't use a convenience method at all). I tried two different working approaches, which are both in the commit history.

One approach I considered was to subclass `Function`. The convenience methods would go on the subclass's prototype. However, after briefly investigating this option, it sounded like extending `Function` involved complications.

The next approach I considered was to wrap the `request()` function in a proxy. The proxy would behave the same as the `request()` function except when getting one of the convenience methods. In that case, the proxy would create the convenience method on the fly. I got this approach to work, and you can see it in the commit history.

I then realized that if the convenience methods are properties of the `request()` function, they can access the `request()` function via `this`. That means that we don't need to create different convenience methods for each `request()` function: all `request()` functions can use the same convenience methods. So the approach I ended up taking was to define the convenience methods once, then have `withHttpMethods()` assign them on the `request()` function.

`this` ended up coming up in another issue I encountered, which is that calling a convenience method results in a different `this` compared to calling `request()` directly. That isn't an issue for `useRequest()`, but it comes up for `requestData`, because the `request()` method references `this`. For example, if you call `someResource.request()`, then `this` is `someResource`. But if you call `someResource.request.post()`, then `this` is `someResource.request`. I was able to resolve this by binding `someResource.request` to `someResource`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is not user-facing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced