### PR TITLE
Add useRenderTimer() composable to help measure performance

### DIFF
--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -85,11 +85,12 @@ export const useRenderTimer = () => {
   for (const [name, f] of hooks) {
     f(() => { // eslint-disable-line no-loop-func
       const duration = Date.now() - timeBefore;
-      timer._push(duration);
 
       const onOrOff = timer.state ? 'on' : 'off';
       // eslint-disable-next-line no-console
       console.log(`[useRenderTimer] ${name} (timer ${onOrOff})`, duration);
+
+      timer._push(duration);
     });
   }
 

--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -71,8 +71,20 @@ class RenderTimer {
   }
 }
 
-// useRenderTimer() is a composable. It returns a timer object that can help
-// measure performance around rendering.
+/*
+useRenderTimer() is a composable. It returns a timer object that can help
+measure performance around rendering. After the component is mounted and after
+each component update, the composable logs the duration of the render. If you
+turn the timer on by calling its on() method, it will also store the duration of
+each render. Turn the timer off to stop storing durations. Call the summarize()
+method to calculate summary statistics about the durations stored on the timer.
+
+Usually Vue devtools are a more convenient way to learn about the performance of
+a component. However, useRenderTimer() can be helpful when combined with other
+logging or as a way to calculate summary statistics about render times. You may
+find it convenient to temporarily assign the timer to `window` to make it easy
+to access from the console.
+*/
 export const useRenderTimer = () => {
   const timer = new RenderTimer();
 


### PR DESCRIPTION
This PR adds a simple composable to help measure how long rendering takes. Usually I use Vue devtools for that. However, this composable can be helpful in a couple of cases:

- After each render, the composable `console.log()`s how long the render took. That can be useful if there's other `console.log()`-ing happening: you can see the render times around the the other logging that you're doing.
- The composable returns summary statistics about the render times.

#### What has been done to verify that this works as intended?

I wrote this composable while debugging performance issues in another PR (not yet pushed), so I think it works. The composable is a tool for debugging and performance evaluation and isn't used in production. Given that, I think that tests aren't needed.

#### Why is this the best possible solution? Were any other approaches considered?

There may be external packages out there with similar functionality, but I just wanted something simple. In most cases, Vue devtools will be the most useful thing.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is not user-facing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced