### PR TITLE
Render two potentially large tables in chunks

### DIFF
--- a/src/components/submission/table.vue
+++ b/src/components/submission/table.vue
@@ -26,7 +26,7 @@ except according to the terms contained in the LICENSE file.
         @mousemove="setActionsTrigger('hover')"
         @focusin="setActionsTrigger('focus')" @click="review">
         <template v-if="odata.dataExists">
-          <submission-metadata-row v-for="(submission, index) in odata.value"
+          <submission-metadata-row v-for="(submission, index) in chunkyOData"
             :key="submission.__id" :project-id="projectId"
             :xml-form-id="xmlFormId" :draft="draft" :submission="submission"
             :row-number="odata.originalCount - index" :can-update="canUpdate"
@@ -48,7 +48,7 @@ except according to the terms contained in the LICENSE file.
         <tbody @mousemove="setActionsTrigger('hover')"
           @mouseover="toggleHoverClass" @mouseleave="removeHoverClass">
           <template v-if="odata.dataExists && fields != null">
-            <submission-data-row v-for="(submission, index) in odata.value"
+            <submission-data-row v-for="(submission, index) in chunkyOData"
               :key="submission.__id" :project-id="projectId"
               :xml-form-id="xmlFormId" :draft="draft" :submission="submission"
               :fields="fields" :data-index="index"/>
@@ -60,9 +60,12 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { computed } from 'vue';
+
 import SubmissionDataRow from './data-row.vue';
 import SubmissionMetadataRow from './metadata-row.vue';
 
+import useChunkyArray from '../../composables/chunky-array';
 import { useRequestData } from '../../request-data';
 
 // We may render many rows, so this component makes use of event delegation and
@@ -88,7 +91,8 @@ export default {
     // The component does not assume that this data will exist when the
     // component is created.
     const { project, odata } = useRequestData();
-    return { project, odata };
+    const chunkyOData = useChunkyArray(computed(() => odata.value));
+    return { project, odata, chunkyOData };
   },
   data() {
     return {

--- a/src/composables/chunky-array.js
+++ b/src/composables/chunky-array.js
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+import { computed, onUnmounted, ref, watch } from 'vue';
+
+/*
+useChunkyArray() creates a proxy of an array such that the length of the proxy
+is less than the actual length of the array. The length of the proxy will
+increase in steps over the course of a second or so, until it equals the length
+of the array. The length of the proxy is reactive. useChunkyArray() is helpful
+if an array may be large and is used in a potentially expensive v-for, because
+it reduces the amount of time during which Frontend is busy rendering and is
+nonresponsive. (There will be more renders, but each render will be shorter.)
+
+useChunkyArray() takes a ref whose value is either an array or nullish,
+returning a computed ref. If the value of the ref is an array, then the value of
+the computed ref will be a proxy as described above. If the value of the ref is
+nullish, then the value of the computed ref will be `null`.
+*/
+export default (arrayRef, minChunkSize = 25) => {
+  // The length of the proxy
+  const length = ref(0);
+  let chunkSize;
+  let intervalId;
+  const stopChunks = () => {
+    if (chunkSize == null) return;
+    chunkSize = null;
+    clearInterval(intervalId);
+    intervalId = null;
+  };
+  const addChunk = () => {
+    length.value += chunkSize;
+    if (length.value >= arrayRef.value.length) {
+      length.value = arrayRef.value.length;
+      stopChunks();
+    }
+    return length.value;
+  };
+  const proxyLength = () => {
+    // If length.value has already been increased to arrayRef.value.length (or
+    // if arrayRef.value.length is 0), return arrayRef.value.length.
+    if (length.value === arrayRef.value.length) return arrayRef.value.length;
+
+    // If chunkSize is set, then an addChunk() interval is in progress and is
+    // working on increasing length.value. In the meantime, we return the
+    // current length.value so that proxyLength() is consistent between
+    // addChunk() calls.
+    if (chunkSize != null) return length.value;
+
+    // If length.value almost equals arrayRef.value.length, don't bother setting
+    // up an addChunk() interval.
+    if (arrayRef.value.length - length.value <= minChunkSize) {
+      length.value = arrayRef.value.length;
+      return arrayRef.value.length;
+    }
+
+    // Set chunkSize and start increasing length.value.
+    chunkSize = Math.max(
+      Math.ceil((arrayRef.value.length - length.value) / 10),
+      minChunkSize
+    );
+    length.value += chunkSize;
+    intervalId = setInterval(addChunk, 25);
+    return length.value;
+  };
+  const proxyHandler = {
+    // Note that the proxy allows access to all elements of the array: it only
+    // returns a different value for the length. Restricting access to elements
+    // would have a performance cost, because it would cause the `length` ref to
+    // become a dependency of more reactive effects. It doesn't seem necessary
+    // to restrict access to elements.
+    get: (array, prop) => (prop === 'length' ? proxyLength() : array[prop])
+  };
+  const result = computed(() => (arrayRef.value != null
+    ? new Proxy(arrayRef.value, proxyHandler)
+    : null));
+
+  watch(
+    [arrayRef, () => arrayRef.value?.length],
+    ([newArray, newLength], [oldArray]) => {
+      if (newArray !== oldArray)
+        length.value = 0;
+      else if (newLength < length.value)
+        length.value = newLength;
+
+      // We call stopChunks() even if newLength > length.value so that
+      // proxyLength() can calculate a new chunkSize. Since
+      // arrayRef.value.length has changed, a reactive effect that has
+      // (indirectly) called proxyLength() (for example, v-for) will end up
+      // calling proxyLength() again.
+      stopChunks();
+    }
+  );
+  onUnmounted(() => {
+    stopChunks();
+    // For testing. If proxyLength() is called after the component is unmounted,
+    // as it is in testing, we don't want it to start a new addChunk() interval.
+    if (arrayRef.value != null) length.value = arrayRef.value.length;
+  });
+  /* Another case that would be nice to watch is if the value of an element
+  changes (for example, after the array is sorted). In that case, if
+  length.value !== arrayRef.value.length already, then length.value should
+  perhaps be reset to 0. However, it's not easy to watch for that case in a
+  performant way. A deep watcher would work, but it could be expensive. (After
+  all, the whole point of useChunkyArray() is to aid performance!) It would be
+  unfortunate if the array were sorted while length.value was increasing,
+  because a v-for might not preserve all components already rendered. However,
+  that also seems unlikely given how quickly length.value increases. */
+
+  return result;
+};

--- a/src/composables/chunky-array.js
+++ b/src/composables/chunky-array.js
@@ -42,7 +42,6 @@ export default (arrayRef, minChunkSize = 25) => {
       length.value = arrayRef.value.length;
       stopChunks();
     }
-    return length.value;
   };
   const proxyLength = () => {
     // If length.value has already been increased to arrayRef.value.length (or

--- a/test/components/project/list.spec.js
+++ b/test/components/project/list.spec.js
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+
 import ProjectList from '../../../src/components/project/list.vue';
 import ProjectHomeBlock from '../../../src/components/project/home-block.vue';
 import FormRow from '../../../src/components/project/form-row.vue';
@@ -132,6 +134,18 @@ describe('ProjectList', () => {
       blocks.map((block) => block.props().project.name).should.eql(['C', 'B', 'A']);
       const formRows = blocks[1].findAllComponents(FormRow);
       formRows.map((row) => row.props().form.name).should.eql(['Z', 'Y', 'X']);
+    });
+
+    it('does not render the list in chunks again after sorting', async () => {
+      const clock = sinon.useFakeTimers(Date.now());
+      createProjectsWithForms(new Array(25).fill({}), new Array(25).fill([]));
+      const component = mountComponent();
+      component.findAllComponents(ProjectHomeBlock).length.should.equal(25);
+      clock.tick(25);
+      await component.vm.$nextTick();
+      component.findAllComponents(ProjectHomeBlock).length.should.equal(28);
+      await component.find('#project-sort select').setValue('alphabetical');
+      component.findAllComponents(ProjectHomeBlock).length.should.equal(28);
     });
 
     it('sorts archived projects by latest submission by default', () => {

--- a/test/composables/chunky-array.spec.js
+++ b/test/composables/chunky-array.spec.js
@@ -1,0 +1,238 @@
+import sinon from 'sinon';
+import { isRef, nextTick, ref, watchEffect } from 'vue';
+
+import useChunkyArray from '../../src/composables/chunky-array';
+
+import { mount, withSetup } from '../util/lifecycle';
+
+describe('useChunkyArray()', () => {
+  it('returns a ref', () => {
+    const chunky = withSetup(() => useChunkyArray(ref([])));
+    isRef(chunky).should.be.true();
+  });
+
+  it('returns a ref whose value is null if value of source ref is nullish', () => {
+    const chunky = withSetup(() => useChunkyArray(ref(null)));
+    should(chunky.value).be.null();
+  });
+
+  describe('value of source ref is an array', () => {
+    it('returns a ref whose value is an array', () => {
+      const chunky = withSetup(() => useChunkyArray(ref([])));
+      Array.isArray(chunky.value).should.be.true();
+    });
+
+    it('increases the length of the resulting array on an interval', () => {
+      const clock = sinon.useFakeTimers();
+      const chunky = withSetup(() =>
+        useChunkyArray(ref(new Array(30).fill(0)), 2));
+      chunky.value.length.should.equal(3);
+      clock.tick(24);
+      chunky.value.length.should.equal(3);
+      clock.tick(1);
+      chunky.value.length.should.equal(6);
+      for (let i = 9; i <= 30; i += 3) {
+        clock.tick(25);
+        chunky.value.length.should.equal(i);
+      }
+      clock.tick(25);
+      chunky.value.length.should.equal(30);
+    });
+
+    it('increases the length by at least the minimum', () => {
+      const clock = sinon.useFakeTimers();
+      const chunky = withSetup(() =>
+        useChunkyArray(ref(new Array(30).fill(0)), 5));
+      chunky.value.length.should.equal(5);
+      clock.tick(25);
+      chunky.value.length.should.equal(10);
+    });
+
+    it('does not increase length above length of source array', () => {
+      const clock = sinon.useFakeTimers();
+      const chunky = withSetup(() =>
+        useChunkyArray(ref(new Array(5).fill(0)), 2));
+      chunky.value.length.should.equal(2);
+      clock.tick(25);
+      chunky.value.length.should.equal(4);
+      clock.tick(25);
+      chunky.value.length.should.equal(5);
+      clock.tick(25);
+      chunky.value.length.should.equal(5);
+    });
+
+    it('does not increase the length if the source array is empty', () => {
+      const clock = sinon.useFakeTimers();
+      const chunky = withSetup(() => useChunkyArray(ref([])));
+      chunky.value.length.should.equal(0);
+      clock.tick(25);
+      chunky.value.length.should.equal(0);
+    });
+
+    it('does not increase length if length of source array is less than minimum', () => {
+      const clock = sinon.useFakeTimers();
+      const chunky = withSetup(() => useChunkyArray(ref([0]), 2));
+      chunky.value.length.should.equal(1);
+      clock.tick(25);
+      chunky.value.length.should.equal(1);
+    });
+
+    it('triggers a reactive effect when increasing the length', async () => {
+      const clock = sinon.useFakeTimers();
+      const chunky = withSetup(() =>
+        useChunkyArray(ref(new Array(30).fill(0)), 2));
+      let result = 0;
+      watchEffect(() => { result = chunky.value.length; });
+      result.should.equal(3);
+      clock.tick(25);
+      await nextTick();
+      result.should.equal(6);
+    });
+
+    it('stops increasing the length after the component is unmounted', () => {
+      const clock = sinon.useFakeTimers();
+      let chunky;
+      const component = mount({
+        template: '<div></div>',
+        setup: () => { chunky = useChunkyArray(ref(new Array(30).fill(0)), 2); }
+      });
+      chunky.value.length.should.equal(3);
+      clock.tick(25);
+      chunky.value.length.should.equal(6);
+      component.unmount();
+      chunky.value.length.should.equal(30);
+      clock.tick(25);
+      chunky.value.length.should.equal(30);
+    });
+
+    it('allows access to all elements of the source array', () => {
+      const chunky = withSetup(() => useChunkyArray(ref([4, 5, 6, 7]), 2));
+      chunky.value.length.should.equal(2);
+      chunky.value[0].should.equal(4);
+      chunky.value[1].should.equal(5);
+      chunky.value[2].should.equal(6);
+      chunky.value[3].should.equal(7);
+      chunky.value.length.should.equal(2);
+    });
+
+    it('provides access to other properties of the source array', () => {
+      const chunky = withSetup(() => useChunkyArray(ref([1, 1, 2, 3, 5]), 2));
+      chunky.value.filter(n => n < 3).should.eql([1, 1]);
+    });
+  });
+
+  describe('change to the value of the source ref', () => {
+    it('starts increasing length after value changes to an array', async () => {
+      const clock = sinon.useFakeTimers();
+      const source = ref(null);
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      should(chunky.value).be.null();
+      source.value = new Array(30).fill(0);
+      await nextTick();
+      Array.isArray(chunky.value).should.be.true();
+      chunky.value.length.should.equal(3);
+      clock.tick(25);
+      chunky.value.length.should.equal(6);
+    });
+
+    it('changes value of resulting ref after value of source ref changes to null', async () => {
+      const source = ref(new Array(30).fill(0));
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      source.value = null;
+      await nextTick();
+      should(chunky.value).be.null();
+    });
+
+    it('resets length after value changes from array to null, then back to array', async () => {
+      const clock = sinon.useFakeTimers();
+      const array = new Array(30).fill(0);
+      const source = ref(array);
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      clock.tick(25);
+      chunky.value.length.should.equal(6);
+      source.value = null;
+      await nextTick();
+      source.value = array;
+      await nextTick();
+      chunky.value.length.should.equal(3);
+      clock.tick(25);
+      chunky.value.length.should.equal(6);
+    });
+
+    it('resets length after value changes from one array to another', async () => {
+      const clock = sinon.useFakeTimers();
+      const source = ref(new Array(30).fill(0));
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      clock.tick(25);
+      chunky.value.length.should.equal(6);
+      source.value = new Array(40).fill(0);
+      await nextTick();
+      chunky.value.length.should.equal(4);
+      clock.tick(25);
+      chunky.value.length.should.equal(8);
+    });
+
+    it('stops increasing length if length of source array changes to current length', async () => {
+      const clock = sinon.useFakeTimers();
+      const source = ref(new Array(30).fill(0));
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      source.value.splice(3);
+      await nextTick();
+      chunky.value.length.should.equal(3);
+      clock.tick(25);
+      chunky.value.length.should.equal(3);
+    });
+
+    it('changes length if length of source array changes to below current length', async () => {
+      const clock = sinon.useFakeTimers();
+      const source = ref(new Array(30).fill(0));
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      source.value.splice(2);
+      await nextTick();
+      chunky.value.length.should.equal(2);
+      clock.tick(25);
+      chunky.value.length.should.equal(2);
+    });
+
+    it('adjusts increase if length of source array changes but stays above current length', async () => {
+      const clock = sinon.useFakeTimers();
+      const source = ref(new Array(30).fill(0));
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      for (let i = 6; i <= 24; i += 3) clock.tick(25);
+      chunky.value.length.should.equal(24);
+      // After this, source.value.length === 64. 64 / 10 = 6.4, but the increase
+      // should be 4 because (64 - 24) / 10 = 4.
+      for (let i = 0; i < 34; i += 1) source.value.push(0);
+      await nextTick();
+      chunky.value.length.should.equal(28);
+      clock.tick(25);
+      chunky.value.length.should.equal(32);
+      for (let i = 36; i <= 64; i += 4) {
+        clock.tick(25);
+        chunky.value.length.should.equal(i);
+      }
+      clock.tick(25);
+      chunky.value.length.should.equal(64);
+    });
+
+    it('starts increasing again if length of source array increases even if it was done', async () => {
+      const clock = sinon.useFakeTimers();
+      const source = ref(new Array(30).fill(0));
+      const chunky = withSetup(() => useChunkyArray(source, 2));
+      chunky.value.length.should.equal(3);
+      for (let i = 6; i <= 30; i += 3) clock.tick(25);
+      chunky.value.length.should.equal(30);
+      for (let i = 0; i < 34; i += 1) source.value.push(0);
+      await nextTick();
+      chunky.value.length.should.equal(34);
+      clock.tick(25);
+      chunky.value.length.should.equal(38);
+    });
+  });
+});


### PR DESCRIPTION
While working on #764, I noticed that there can be a short delay in rendering the submissions table during which Frontend is nonresponsive. The delay is long enough that the CSS transition in which the app becomes full width is interrupted. I'm not sure how often the delay would be seen in production: it would require the OData response to be returned more quickly than the transition completes (0.5 seconds). I checked a few projects on the QA server, and most OData responses took longer than that, but some took less. The issue with the CSS transition is quite noticeable locally.

The first version of #764 attempted to resolve the issue by introducing a `widening` flag that indicates whether the CSS transition is in progress (https://github.com/getodk/central-frontend/pull/764/commits/cd4fd63fcef8a7b0aaf06023fce0e6097ece93b9). The submissions table will not be rendered during that time. However, I think that's not an ideal solution:

- It adds more state to the container.
- It delays the initial rendering of the submissions table.
- The flag might be needed not just for navigation to the submissions page, but also navigation from the submissions page, if navigating to a separate page where initial rendering takes longer. That's because there will be another CSS transition as the width becomes more narrow.

Instead of using a flag, this PR renders the submissions table in chunks. Because there are fewer rows to render at first, the initial render of the submissions table is faster. When I try it locally, I don't see the same issue with the CSS transition.

This is an idea I've had for a while, and it can be dropped into other potentially large tables. We've seen on the QA server that the projects page takes a moment to render even after the response is received from Backend, especially on slower machines. That may be a problem specific to the QA server, which has many projects. But it was easy to use the same approach as the submissions table to render the project list in chunks.

At some point, I think it'd be a good idea to introduce pagination to solve issues like this. With pagination, there would be less data to render at once. However, introducing pagination will likely be a heavier lift. We will also need more search functionality before moving to pagination. I think of this PR as a stopgap for until we have pagination. Until then, it will improve the rendering of large tables.

It's pretty easy to drop in this approach, so if anyone has noticed other tables that can take longer to render, I'd be happy to try adding it to those.

#### What has been done to verify that this works as intended?

New tests. I've tried out the submissions table locally. Once the PR is merged, I'll put it on the QA server. I'm interested to see the effect on the projects page there.

#### Why is this the best possible solution? Were any other approaches considered?

I wanted to make this change as small as possible, especially since I don't imagine us using it forever.

I thought about only rendering additional chunks as the user scrolled through the page. But that would add more complexity and wouldn't work with native browser search. I also thought about list virtualization: there are [existing packages](https://vuejs.org/guide/best-practices/performance.html#virtualize-large-lists) for that. But again, I don't think that works with browser search. (Search keeps coming up!)

I tried a few approaches to the chunking. Right now, there are 10 equal chunks, and Frontend will wait 25 milliseconds after rendering each chunk before rendering the next one. If the array is smaller (<250 elements), then each chunk will be 25 elements, and there will be fewer than 10 chunks. The intention is for the chunking to happen fast enough that users won't notice it. Yet it will still improve the user experience by helping to prevent Frontend from becoming nonresponsive.

I used #766 to look at render times. I saw that chunking increases the total render time, but that each render is shorter. I landed on 10 chunks after trying a few different approaches. I chose 25 as the minimum chunk size with the thought that even on a monitor, the user probably won't see much more than 25 rows at first. We wouldn't want the user to see the chunking happening on-screen.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Rendering in chunks is more complicated than rendering all at once. I'm not sure that this approach would work in all cases: in theory, there could be broken assumptions if the size of the table/list differs from the length of the array. However, I don't think that's an issue for the two tables/lists I modified.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced