### PR TITLE
Add generic FeedEntry component to use for submissions and entities

### DIFF
--- a/src/components/feed-entry.vue
+++ b/src/components/feed-entry.vue
@@ -1,0 +1,78 @@
+<!--
+Copyright 2023 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div class="feed-entry">
+    <div class="feed-entry-heading">
+      <date-time :iso="iso"/>
+      <div class="feed-entry-title"><slot name="title"></slot></div>
+    </div>
+    <div class="feed-entry-body"><slot name="body"></slot></div>
+  </div>
+</template>
+
+<script setup>
+import DateTime from './date-time.vue';
+
+defineProps({
+  iso: {
+    type: String,
+    required: true
+  }
+});
+</script>
+
+<style lang="scss">
+@import '../assets/scss/mixins';
+
+.feed-entry {
+  box-shadow: 0 7px 18px rgba(0, 0, 0, 0.05);
+  margin-bottom: 20px;
+}
+
+.feed-entry-heading, .feed-entry-body .markdown-view { padding: 10px 15px; }
+
+.feed-entry-heading {
+  background-color: #fff;
+
+  time {
+    float: right;
+    font-size: 13px;
+    color: #666;
+    line-height: 25px;
+  }
+}
+
+.feed-entry-title {
+  @include text-overflow-ellipsis;
+  font-size: 17px;
+  font-weight: bold;
+  letter-spacing: -0.02em;
+  width: 70%;
+
+  [class^="icon-"] {
+    display: block;
+    float: left;
+    margin-right: 7px;
+    padding-top: 3px;
+    text-align: center;
+    width: 18px;
+  }
+
+  a { font-weight: normal; }
+}
+
+.feed-entry-body {
+  background-color: #f9f9f9;
+
+  .markdown-view > p:last-child { margin: 0 0 0px; }
+}
+</style>

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -10,61 +10,61 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="submission-feed-entry">
-    <div class="heading">
-      <date-time :iso="entry.loggedAt != null ? entry.loggedAt : entry.createdAt"/>
-      <div class="title">
-        <template v-if="entry.action === 'submission.create'">
-          <span class="icon-cloud-upload submission-feed-entry-icon"></span>
-          <i18n-t keypath="title.create">
-            <template #name><actor-link :actor="entry.actor"/></template>
-          </i18n-t>
-        </template>
-        <template v-else-if="updateOrEdit">
-          <i18n-t :keypath="`title.updateReviewState.${reviewState}.full`">
-            <template #reviewState>
-              <span class="review-state" :class="reviewState">
-                <span :class="updateOrEditIcon(reviewState)"></span>
-                <span>{{ $t(`title.updateReviewState.${reviewState}.reviewState`) }}</span>
-              </span>
-            </template>
-            <template #name><actor-link :actor="entry.actor"/></template>
-          </i18n-t>
-        </template>
-        <template v-else-if="entry.action === 'entity.create'">
-          <span class="icon-magic-wand entity-icon submission-feed-entry-icon"></span>
-          <i18n-t keypath="title.entity.create">
-            <template #label><span class="submission-feed-entry-entity-data">{{ entityLabel(entry) }}</span></template>
-            <template #dataset><span class="submission-feed-entry-entity-data">{{ entityDataset(entry) }}</span></template>
-          </i18n-t>
-        </template>
-        <template v-else-if="entry.action === 'entity.create.error'">
-          <span class="icon-warning entity-icon submission-feed-entry-icon"></span>
-          <span class="submission-feed-entry-entity-error">{{ $t('title.entity.error') }}</span>
-          <span class="entity-error-message" v-tooltip.text>{{ entityProblem(entry) }}</span>
-        </template>
-        <template v-else>
-          <span class="icon-comment submission-feed-entry-icon"></span>
-          <i18n-t keypath="title.comment">
-            <template #name><actor-link :actor="entry.actor"/></template>
-          </i18n-t>
-        </template>
-      </div>
-    </div>
-    <markdown-view v-if="comment != null" class="body" :raw-markdown="comment"/>
-    <div v-if="entryDiffs != null">
-      <submission-diff-item v-for="(diff, index) in entryDiffs" :key="index" :entry="diff"
-        :project-id="projectId" :xml-form-id="xmlFormId" :instance-id="instanceId"
-        :old-version-id="oldVersionId" :new-version-id="newVersionId"/>
-    </div>
-  </div>
+  <feed-entry :iso="entry.loggedAt ?? entry.createdAt"
+    class="submission-feed-entry">
+    <template #title>
+      <template v-if="entry.action === 'submission.create'">
+        <span class="icon-cloud-upload"></span>
+        <i18n-t keypath="title.create">
+          <template #name><actor-link :actor="entry.actor"/></template>
+        </i18n-t>
+      </template>
+      <template v-else-if="updateOrEdit">
+        <i18n-t :keypath="`title.updateReviewState.${reviewState}.full`">
+          <template #reviewState>
+            <span class="review-state" :class="reviewState">
+              <span :class="reviewStateIcon(reviewState)"></span>
+              <span>{{ $t(`title.updateReviewState.${reviewState}.reviewState`) }}</span>
+            </span>
+          </template>
+          <template #name><actor-link :actor="entry.actor"/></template>
+        </i18n-t>
+      </template>
+      <template v-else-if="entry.action === 'entity.create'">
+        <span class="icon-magic-wand entity-icon"></span>
+        <i18n-t keypath="title.entity.create">
+          <template #label><span class="submission-feed-entry-entity-data">{{ entityLabel(entry) }}</span></template>
+          <template #dataset><span class="submission-feed-entry-entity-data">{{ entityDataset(entry) }}</span></template>
+        </i18n-t>
+      </template>
+      <template v-else-if="entry.action === 'entity.create.error'">
+        <span class="icon-warning"></span>
+        <span class="submission-feed-entry-entity-error">{{ $t('title.entity.error') }}</span>
+        <span class="entity-error-message" v-tooltip.text>{{ entityProblem(entry) }}</span>
+      </template>
+      <template v-else>
+        <span class="icon-comment"></span>
+        <i18n-t keypath="title.comment">
+          <template #name><actor-link :actor="entry.actor"/></template>
+        </i18n-t>
+      </template>
+    </template>
+    <template #body>
+      <markdown-view v-if="comment != null" :raw-markdown="comment"/>
+      <template v-else-if="entryDiffs != null">
+        <submission-diff-item v-for="(diff, index) in entryDiffs" :key="index" :entry="diff"
+          :project-id="projectId" :xml-form-id="xmlFormId" :instance-id="instanceId"
+          :old-version-id="oldVersionId" :new-version-id="newVersionId"/>
+      </template>
+    </template>
+  </feed-entry>
 </template>
 
 <script>
 import { last } from 'ramda';
 
 import ActorLink from '../actor-link.vue';
-import DateTime from '../date-time.vue';
+import FeedEntry from '../feed-entry.vue';
 import MarkdownView from '../markdown/view.vue';
 import SubmissionDiffItem from './diff-item.vue';
 
@@ -73,7 +73,7 @@ import { useRequestData } from '../../request-data';
 
 export default {
   name: 'SubmissionFeedEntry',
-  components: { ActorLink, DateTime, MarkdownView, SubmissionDiffItem },
+  components: { ActorLink, FeedEntry, MarkdownView, SubmissionDiffItem },
   props: {
     projectId: {
       type: String,
@@ -145,9 +145,6 @@ export default {
     }
   },
   methods: {
-    updateOrEditIcon(state) {
-      return `${this.reviewStateIcon(state)} submission-feed-entry-icon`;
-    },
     entityLabel(entry) {
       if ('entity' in entry.details)
         return entry.details.entity.label;
@@ -173,49 +170,17 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../assets/scss/mixins';
 @import '../../assets/scss/variables';
 
 .submission-feed-entry {
-  box-shadow: 0 7px 18px rgba(0, 0, 0, 0.05);
-  margin-bottom: 20px;
-
-  .heading, .body { padding: 10px 15px; }
-  .heading { background-color: #fff; }
-  .body { background-color: #f9f9f9; }
-
-  time {
-    float: right;
-    font-size: 13px;
-    color: #666;
-    line-height: 25px;
+  .submission-feed-entry-entity-data {
+    font-weight: normal;
   }
 
-  .title {
-    @include text-overflow-ellipsis;
-    font-size: 17px;
-    font-weight: bold;
-    letter-spacing: -0.02em;
-    width: 70%;
-
-    .submission-feed-entry-icon {
-      display: block;
-      float: left;
-      margin-right: 7px;
-      padding-top: 3px;
-      text-align: center;
-      width: 18px;
-    }
-
-    .submission-feed-entry-entity-data {
-      font-weight: normal;
-    }
-
-    .entity-error-message{
-      font-size: 12px;
-      margin-left: 10px;
-      font-weight: normal;
-    }
+  .entity-error-message{
+    font-size: 12px;
+    margin-left: 10px;
+    font-weight: normal;
   }
 
   .icon-cloud-upload, .icon-comment { color: #bbb; }
@@ -228,10 +193,6 @@ export default {
     &.approved { color: $color-success; }
     &.rejected { color: $color-danger; }
   }
-
-  .actor-link { font-weight: normal; }
-
-  .body > p:last-child { margin: 0 0 0px; }
 }
 </style>
 

--- a/test/components/feed-entry.spec.js
+++ b/test/components/feed-entry.spec.js
@@ -1,0 +1,33 @@
+import DateTime from '../../src/components/date-time.vue';
+import FeedEntry from '../../src/components/feed-entry.vue';
+
+import { mergeMountOptions, mount } from '../util/lifecycle';
+
+const mountComponent = (options) =>
+  mount(FeedEntry, mergeMountOptions(options, {
+    props: { iso: new Date().toISOString() }
+  }));
+
+describe('FeedEntry', () => {
+  it('renders a DateTime component with the iso prop', () => {
+    const component = mountComponent({
+      props: { iso: '2023-01-01T01:23:45.678Z' }
+    });
+    const dateTime = component.getComponent(DateTime);
+    dateTime.props().iso.should.equal('2023-01-01T01:23:45.678Z');
+  });
+
+  it('uses the title slot', () => {
+    const component = mountComponent({
+      slots: { title: '<span id="foo"></span>' }
+    });
+    component.find('.feed-entry-title #foo').exists().should.be.true();
+  });
+
+  it('uses the body slot', () => {
+    const component = mountComponent({
+      slots: { body: '<span id="foo"></span>' }
+    });
+    component.find('.feed-entry-body #foo').exists().should.be.true();
+  });
+});

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -63,7 +63,7 @@ describe('SubmissionFeedEntry', () => {
   describe('title', () => {
     it('renders correctly for a submission.create audit', () => {
       testData.extendedAudits.createPast(1, { action: 'submission.create' });
-      const title = mountComponent().get('.title');
+      const title = mountComponent().get('.feed-entry-title');
       title.find('.icon-cloud-upload').exists().should.be.true();
       title.text().should.equal('Submitted by Alice');
     });
@@ -74,7 +74,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'submission.update',
           details: { reviewState: null }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Received per Alice');
         const reviewState = title.get('.review-state');
         reviewState.attributes().class.should.equal('review-state');
@@ -87,7 +87,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'submission.update',
           details: { reviewState: 'hasIssues' }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Has Issues per Alice');
         const reviewState = title.get('.review-state');
         reviewState.classes('hasIssues').should.be.true();
@@ -100,7 +100,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'submission.update',
           details: { reviewState: 'edited' }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Edited by Alice');
         const reviewState = title.get('.review-state');
         reviewState.classes('edited').should.be.true();
@@ -113,7 +113,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'submission.update',
           details: { reviewState: 'approved' }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Approved by Alice');
         const reviewState = title.get('.review-state');
         reviewState.classes('approved').should.be.true();
@@ -126,7 +126,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'submission.update',
           details: { reviewState: 'rejected' }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Rejected by Alice');
         const reviewState = title.get('.review-state');
         reviewState.classes('rejected').should.be.true();
@@ -139,7 +139,7 @@ describe('SubmissionFeedEntry', () => {
       testData.extendedAudits.createPast(1, {
         action: 'submission.update.version'
       });
-      const title = mountComponent().get('.title');
+      const title = mountComponent().get('.feed-entry-title');
       title.text().should.equal('Edited by Alice');
       const reviewState = title.get('.review-state');
       reviewState.classes('edited').should.be.true();
@@ -149,7 +149,7 @@ describe('SubmissionFeedEntry', () => {
 
     it('renders correctly for a comment', () => {
       testData.extendedComments.createPast(1);
-      const title = mountComponent().get('.title');
+      const title = mountComponent().get('.feed-entry-title');
       title.find('.icon-comment').exists().should.be.true();
       title.text().should.equal('Comment by Alice');
     });
@@ -160,7 +160,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'entity.create',
           details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Created Entity EntityName in DatasetName Dataset');
       });
 
@@ -169,7 +169,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'entity.create',
           details: { entity: { uuid: 'xyz' } }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Created Entity  in  Dataset');
       });
     });
@@ -180,7 +180,7 @@ describe('SubmissionFeedEntry', () => {
           action: 'entity.create.error',
           details: { problem: { problemCode: 409.14, problemDetails: { reason: 'ID empty or missing.' } } }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.get('.submission-feed-entry-entity-error').text().should.equal('Problem creating Entity');
         title.get('.entity-error-message').text().should.equal('ID empty or missing.');
         await title.get('.entity-error-message').should.have.textTooltip();
@@ -194,7 +194,7 @@ describe('SubmissionFeedEntry', () => {
             errorMessage: 'A resource already exists with uuid value(s) abc.'
           }
         });
-        const title = mountComponent().get('.title');
+        const title = mountComponent().get('.feed-entry-title');
         title.get('.submission-feed-entry-entity-error').text().should.equal('Problem creating Entity');
         title.get('.entity-error-message').text().should.equal('A resource already exists with uuid value(s) abc.');
         await title.get('.entity-error-message').should.have.textTooltip();
@@ -209,12 +209,12 @@ describe('SubmissionFeedEntry', () => {
         details: { reviewState: 'approved' },
         notes: 'Some notes'
       });
-      mountComponent().get('.body').text().should.equal('Some notes');
+      mountComponent().get('.feed-entry-body').text().should.equal('Some notes');
     });
 
     it("shows a comment's body", () => {
       testData.extendedComments.createPast(1, { body: 'Some comment' });
-      mountComponent().get('.body').text().should.equal('Some comment');
+      mountComponent().get('.feed-entry-body').text().should.equal('Some comment');
     });
 
     it("shows a comment's body rendered as markdown", () => {


### PR DESCRIPTION
This PR is a first step toward #760. It genericizes the `SubmissionFeedEntry` component, which we will need to use in the entity detail page. The new generic component is `FeedEntry`. I may end up adding more to `FeedEntry` later, but for now, I've just moved things from `SubmissionFeedEntry` to `FeedEntry` that felt like they clearly belonged in `FeedEntry`.

#### What has been done to verify that this works as intended?

I patched tests of `SubmissionFeedEntry` that failed and wrote new tests of `FeedEntry`. I also took a look at a few types of feed entries locally. I think the thing that's most likely to have gone wrong is the Sass, since many styles were moved from `SubmissionFeedEntry` to `FeedEntry`, and some styles became less specific. However, I reviewed my style-related code changes closely.

#### Why is this the best possible solution? Were any other approaches considered?

As mentioned above, I'm not quite sure where `FeedEntry` should end and `SubmissionFeedEntry` should begin. For now, I've moved the most generic things to `FeedEntry`. Almost all the specifics of what goes in the title and the body of the `FeedEntry` are still in `SubmissionFeedEntry`. That may change in the future though.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is a refactor that isn't supposed to have user-facing effects.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced