### PR TITLE
Check for warnings when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,3 @@ npm-debug.log*
 
 /.nginx/*
 !/.nginx/.gitkeep
-
-/test/output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ npm-debug.log*
 
 /.nginx/*
 !/.nginx/.gitkeep
+
+/test/output.txt

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nf start",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint --no-fix --max-warnings 0 src/ bin/ test/ *.js",
-    "test": "NODE_ENV=test karma start"
+    "test": "./test/run.sh"
   },
   "volta": {
     "node": "16.19.1"

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+set -o pipefail
+
+NODE_ENV=test karma start | tee test/output.txt
+if grep -F -e 'WARN LOG:' -e 'WARN [web-server]:' -C5 test/output.txt; then
+	echo
+	echo 'All tests passed, but there were warnings: see above.'
+	exit 1
+fi
+rm test/output.txt

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -eu
 set -o pipefail
 
-NODE_ENV=test karma start | tee test/output.txt
-if grep -F -e 'WARN LOG:' -e 'WARN [web-server]:' -C5 test/output.txt; then
+output=$(mktemp)
+trap 'rm -- "$output"' EXIT
+NODE_ENV=test karma start | tee "$output"
+if grep -F -e 'WARN LOG:' -e 'WARN [web-server]:' -C5 "$output"; then
 	echo
 	echo 'All tests passed, but there were warnings: see above.'
 	exit 1
 fi
-rm test/output.txt


### PR DESCRIPTION
Closes #712. This PR adds a script that runs tests, and if they're successful, will search the test output for two types of warnings:

- Warnings that contain `WARN LOG:`. Vue warnings fall in this category.
- Warnings that contain `WARN [web-server]:`. We've seen these from Karma.

If a warning is found, then the script will display the warning, display a message, then exit with a non-zero status. That will cause CircleCI to fail.

#### What has been done to verify that this works as intended?

I caused both types of warnings locally and verified that the script caught them both. If there are no warnings, then the script is successful.

#### Why is this the best possible solution? Were any other approaches considered?

My initial plan was to only make this change for CircleCI, but I think it's nice for this to happen locally as well.

I took a quick look for Karma options to do this, but I didn't see anything relevant.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is not user-facing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced