### PR TITLE
Add max width to PageBody

### DIFF
--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -28,9 +28,10 @@
 }
 
 @mixin clearfix {
-  &::after {
-    clear: both;
+  &::before, &::after {
     content: " ";
     display: table;
   }
+
+  &::after { clear: both; }
 }

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -94,6 +94,7 @@ $padding-modal-body: 15px;
 
 // PageBody
 $margin-top-page-body: 20px;
+$max-width-page-body: 1280px;
 
 // Popover
 $box-shadow-popover: 0 5px 10px rgba(0, 0, 0, 0.2);

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -15,6 +15,12 @@ $color-accent-primary: #bd006b;
 $color-accent-secondary: #8d0050;
 $color-page-background: #f7f7f7;
 
+// Media query breakpoints - copied from bootstrap
+$screen-xs-min: 480px;
+$screen-sm-min: 768px;
+$screen-md-min: 992px;
+$screen-lg-min: 1200px;
+
 // Text
 $color-text: #333;
 $font-family-monospace: Monaco, Menlo, Consolas, "Courier New", monospace;
@@ -91,9 +97,3 @@ $margin-top-page-body: 20px;
 
 // Popover
 $box-shadow-popover: 0 5px 10px rgba(0, 0, 0, 0.2);
-
-// Media query breakpoints - copied from bootstrap
-$screen-xs-min: 480px;
-$screen-sm-min: 768px;
-$screen-md-min: 992px;
-$screen-lg-min: 1200px;

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -9,7 +9,7 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-
+@use 'sass:math';
 @import './mixins';
 
 html {
@@ -680,7 +680,12 @@ becomes more complicated.
 
 .panel-main {
   box-shadow: $box-shadow-panel-main;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: 70px;
+  // A .panel-main element is a child of a .col-sm-6 element. .col-sm-6 has
+  // left + right padding of 30px.
+  max-width: #{math.div($max-width-page-body, 2) - 30px};
 
   .panel-body {
     padding-bottom: 25px;

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -161,6 +161,7 @@ export default {
 </script>
 
 <style lang="scss">
+@use 'sass:math';
 @import '../../assets/scss/variables';
 
 $z-index-backdrop: 1;
@@ -176,7 +177,7 @@ $popup-width: 300px;
 #form-attachment-popups-main {
   bottom: $edge-offset;
   position: fixed;
-  right: $edge-offset;
+  right: calc($edge-offset + max(50% - #{math.div($max-width-page-body, 2)}, 0));
   width: $popup-width;
   z-index: $z-index-main;
 

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -177,7 +177,7 @@ $popup-width: 300px;
 #form-attachment-popups-main {
   bottom: $edge-offset;
   position: fixed;
-  right: calc($edge-offset + max(50% - #{math.div($max-width-page-body, 2)}, 0));
+  right: calc($edge-offset + max(50% - #{math.div($max-width-page-body, 2)}, 0px));
   width: $popup-width;
   z-index: $z-index-main;
 

--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -13,12 +13,14 @@ except according to the terms contained in the LICENSE file.
   <div>
     <div id="home-heading">{{ $t('heading[0]') }}</div>
     <home-summary/>
-    <div id="home-news-container">
-      <home-news/>
-      <home-config-section v-if="config.home.title != null"
-        :title="config.home.title" :body="config.home.body"/>
-    </div>
-    <project-list/>
+    <page-body>
+      <div id="home-news-container">
+        <home-news/>
+        <home-config-section v-if="config.home.title != null"
+          :title="config.home.title" :body="config.home.body"/>
+      </div>
+      <project-list/>
+    </page-body>
   </div>
 </template>
 
@@ -32,6 +34,7 @@ import { defineAsyncComponent, inject } from 'vue';
 
 import HomeNews from './home/news.vue';
 import HomeSummary from './home/summary.vue';
+import PageBody from './page/body.vue';
 import ProjectList from './project/list.vue';
 
 import useProjects from '../request-data/projects';

--- a/src/components/page/body.vue
+++ b/src/components/page/body.vue
@@ -26,8 +26,7 @@ import { computed, inject } from 'vue';
 const { router } = inject('container');
 const htmlClass = computed(() => ({
   // `router` may be `null` in testing.
-  bound: router == null || !router.currentRoute.value.meta.fullWidth,
-  centered: window.centralOptions?.left !== true
+  'full-width': router != null && router.currentRoute.value.meta.fullWidth
 }));
 </script>
 
@@ -36,13 +35,11 @@ const htmlClass = computed(() => ({
 
 #page-body {
   @include clearfix;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: $margin-top-page-body;
+  max-width: $max-width-page-body;
 
-  &.bound { max-width: $max-width-page-body; }
-
-  &.centered {
-    margin-left: auto;
-    margin-right: auto;
-  }
+  &.full-width { max-width: none; }
 }
 </style>

--- a/src/components/page/body.vue
+++ b/src/components/page/body.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div id="page-body" class="row">
+  <div id="page-body" :class="htmlClass">
     <div class="col-xs-12">
       <slot></slot>
     </div>
@@ -22,11 +22,24 @@ export default {
   name: 'PageBody'
 };
 </script>
+<script setup>
+import { computed, inject } from 'vue';
+
+const { router } = inject('container');
+const htmlClass = computed(() => ({
+  row: true,
+  // `router` may be `null` in testing.
+  'full-width': router != null && router.currentRoute.value.meta.fullWidth
+}));
+</script>
 
 <style lang="scss">
 @import '../../assets/scss/variables';
 
 #page-body {
   margin-top: $margin-top-page-body;
+
+  max-width: $max-width-page-body;
+  &.full-width { max-width: none; }
 }
 </style>

--- a/src/components/page/body.vue
+++ b/src/components/page/body.vue
@@ -11,9 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div id="page-body" :class="htmlClass">
-    <div class="col-xs-12">
-      <slot></slot>
-    </div>
+    <slot></slot>
   </div>
 </template>
 
@@ -27,19 +25,24 @@ import { computed, inject } from 'vue';
 
 const { router } = inject('container');
 const htmlClass = computed(() => ({
-  row: true,
   // `router` may be `null` in testing.
-  'full-width': router != null && router.currentRoute.value.meta.fullWidth
+  bound: router == null || !router.currentRoute.value.meta.fullWidth,
+  centered: window.centralOptions?.left !== true
 }));
 </script>
 
 <style lang="scss">
-@import '../../assets/scss/variables';
+@import '../../assets/scss/mixins';
 
 #page-body {
+  @include clearfix;
   margin-top: $margin-top-page-body;
 
-  max-width: $max-width-page-body;
-  &.full-width { max-width: none; }
+  &.bound { max-width: $max-width-page-body; }
+
+  &.centered {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-import { createApp } from 'vue';
+import { createApp, reactive } from 'vue';
 
 // The global styles must be imported before any component so that they precede
 // components' styles.
@@ -28,3 +28,5 @@ createApp(App)
   .use(createContainer())
   .directive('tooltip', vTooltip)
   .mount('#app');
+
+window.centralOptions = reactive({});

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-import { createApp, reactive } from 'vue';
+import { createApp } from 'vue';
 
 // The global styles must be imported before any component so that they precede
 // components' styles.
@@ -28,5 +28,3 @@ createApp(App)
   .use(createContainer())
   .directive('tooltip', vTooltip)
   .mount('#app');
-
-window.centralOptions = reactive({});

--- a/src/routes.js
+++ b/src/routes.js
@@ -310,7 +310,8 @@ const routes = [
               'assignment.delete'
             ])
           },
-          title: () => [i18n.t('projectShow.tab.formAccess'), project.name]
+          title: () => [i18n.t('projectShow.tab.formAccess'), project.name],
+          fullWidth: true
         }
       }),
       asyncRoute({
@@ -362,7 +363,8 @@ const routes = [
             project: () => project.permits(['form.read', 'form.update', 'dataset.list']),
             form: () => form.publishedAt != null
           },
-          title: () => [form.nameOrId]
+          title: () => [form.nameOrId],
+          fullWidth: true
         }
       }),
       asyncRoute({
@@ -393,7 +395,8 @@ const routes = [
             ]),
             form: () => form.publishedAt != null
           },
-          title: () => [i18n.t('resource.submissions'), form.nameOrId]
+          title: () => [i18n.t('resource.submissions'), form.nameOrId],
+          fullWidth: true
         }
       }),
       asyncRoute({
@@ -484,7 +487,8 @@ const routes = [
           title: () => [
             i18n.t('formHead.draftNav.tab.testing'),
             form.nameOrId
-          ]
+          ],
+          fullWidth: true
         }
       })
     ]
@@ -529,7 +533,8 @@ const routes = [
           title: () => [i18n.t('common.data'), dataset.name],
           validateData: {
             project: () => project.permits(['dataset.read', 'entity.list'])
-          }
+          },
+          fullWidth: true
         }
       })
     ]
@@ -595,7 +600,8 @@ const routes = [
           validateData: {
             currentUser: () => currentUser.can('audit.read')
           },
-          title: () => [i18n.t('systemHome.tab.audits'), i18n.t('systemHome.title')]
+          title: () => [i18n.t('systemHome.tab.audits'), i18n.t('systemHome.title')],
+          fullWidth: true
         }
       }),
       asyncRoute({
@@ -613,7 +619,8 @@ const routes = [
           title: () => [
             i18n.t('systemHome.tab.analytics'),
             i18n.t('systemHome.title')
-          ]
+          ],
+          fullWidth: true
         },
         beforeEnter: () => (config.showsAnalytics ? true : '/')
       })
@@ -655,6 +662,7 @@ const routesByName = new Map();
     requireLogin: true,
     requireAnonymity: false,
     preserveData: [],
+    fullWidth: false,
     ...meta,
     validateData: meta == null || meta.validateData == null
       ? []

--- a/src/routes.js
+++ b/src/routes.js
@@ -152,6 +152,13 @@ The following meta fields are supported for bottom-level routes:
       i18n.t('title.project.appUsers'),
       project.name // project.name may be `null`
     ]
+
+  Other
+  -----
+
+  - fullWidth (default: false). If fullWidth is `true`, and the route renders a
+    PageBody component, then the PageBody will use the full width of the page.
+    By default, PageBody has a max width.
 */
 
 /*

--- a/test/components/page/body.spec.js
+++ b/test/components/page/body.spec.js
@@ -1,0 +1,24 @@
+import PageBody from '../../../src/components/page/body.vue';
+
+import testData from '../../data';
+import { load } from '../../util/http';
+import { mockLogin } from '../../util/session';
+
+describe('PageBody', () => {
+  beforeEach(mockLogin);
+
+  describe('fullWidth route meta field', () => {
+    it('does not add full-width class if meta field is false', async () => {
+      const app = await load('/');
+      app.vm.$route.meta.fullWidth.should.be.false();
+      app.getComponent(PageBody).classes('full-width').should.be.false();
+    });
+
+    it('adds the full-width class if the meta field is true', async () => {
+      testData.extendedForms.createPast(1);
+      const app = await load('/projects/1/forms/f/submissions');
+      app.vm.$route.meta.fullWidth.should.be.true();
+      app.getComponent(PageBody).classes('full-width').should.be.true();
+    });
+  });
+});


### PR DESCRIPTION
Closes #447.

This PR is an alternative to #764. Rather than adding a max width to the entire app, this PR adds a max width to only the `PageBody` component. As a result, the navbar is still full-width, as are navigation tabs and the page title above them. By default, the main content of the page (the `PageBody`) has a max width of 1280px. A few pages are exceptions and are still full-width:

- The submissions and draft testing pages, since we want the submissions table to be full-width.
- The entities page, since we want the entities table to be full-width.
- The form access page. Similar to the submissions and entities tables, the table on this page can have an arbitrary number of columns, so I think it's nice for it to be full-width.
- The form overview page. This is needed so that the section about "Your Current Draft" is aligned with the navigation tabs for the draft.
- The audit log and the usage information page. I think it's nice for there to be more room for the details column of the audit log table. I could maybe also just reduce the width of the other columns. Definitely no strong feelings on this one.

Most but not all pages have a `PageBody`. I added a `PageBody` to `Home` so that the content below the summary at the top of the homepage will have a max width. That just left pages with a `.panel-main` element: the login page, the reset password page, the set password page, and the not found page. Those pages take a different approach from `PageBody`, wrapping the `.panel-main` in a `.col-sm-6`, and I didn't want to change them much. Instead of adding a `PageBody` to those pages, I added a max width to `.panel-main` that matches its width when the page width is 1280px.

~In #764, the app is centered on the page. I tried centering `PageBody`, but it looked odd to me. I think it's nice for `PageBody` to continue to be left-aligned.~

#764 only set the max width on the app when the page width was above 1500px — when the page width was quite a bit wider than the max width of 1280px on the app. That's because we wanted to avoid narrow gutters on the sides of the app: the margin to the left and right of the app had a different background from the app. In contrast, this PR always sets a max width of 1280px on `PageBody` (except for the pages that are full-width). I think that works fine because the margin has the same background as `PageBody`.

#### What has been done to verify that this works as intended?

I've tried it out locally, and we had it on the QA server for a while. I've also written a couple of tests of `PageBody`.

#### Why is this the best possible solution? Were any other approaches considered?

The first approach to #447 that I tried was #764, and I compare the two approaches above.

In terms of the implementation of this PR, my main question was how to indicate to `PageBody` whether it should be full-width. At first, I added a `fullWidth` prop that was set by parent components (`ProjectShow`, `FormShow`, `DatasetShow`, `UserHome`, `SystemHome`). I had those parent components compute the prop based on the route path, but it didn't feel right to have route-related logic duplicated across a number of parent components. Ultimately, I concluded that whether the `PageBody` is full-width is a concern of the route, so it makes sense to set it on the route as a meta field, as was done in #764. It's guaranteed that there is only one `PageBody` on the page. Once that information is set on the route, `PageBody` can get it from there and doesn't need to be passed anything from its parent component.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We should quickly check each page with a max width (most pages) and make sure that the max width looks fine. If there are other pages that we want to make full-width, that's easy to do.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced