### PR TITLE
Check for Sass warnings when running tests

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -4,7 +4,9 @@ set -o pipefail
 output=$(mktemp)
 trap 'rm -- "$output"' EXIT
 NODE_ENV=test karma start | tee "$output"
-if grep -F -e 'WARN LOG:' -e 'WARN [web-server]:' -C5 "$output"; then
+# Search for: warnings from console.warn(), including Vue warnings; Sass
+# warnings; and warnings from Karma.
+if grep -F -e 'WARN LOG:' -e 'Module Warning' -e 'WARN [web-server]:' -C5 "$output"; then
 	echo
 	echo 'All tests passed, but there were warnings: see above.'
 	exit 1

--- a/test/run.sh
+++ b/test/run.sh
@@ -7,6 +7,8 @@ NODE_ENV=test karma start | tee "$output"
 # Search for: warnings from console.warn(), including Vue warnings; Sass
 # warnings; and warnings from Karma.
 if grep -F -e 'WARN LOG:' -e 'Module Warning' -e 'WARN [web-server]:' -C5 "$output"; then
+	# Reset the text format in case the search results contained formatted text.
+	tput sgr0
 	echo
 	echo 'All tests passed, but there were warnings: see above.'
 	exit 1


### PR DESCRIPTION
Sass can display warnings, and I think it'd be nice to automatically catch those warnings. Sass warnings seem to be shown whenever Frontend is built, including during testing, so I think we can add this check to our existing test/run.sh (introduced in #769).

I intentionally caused a Sass warning (by replacing `math.div()` with the `/` operator), then saw what the resulting warning looked like. It looks like sass-loader outputs a `Module Warning` with additional details, so that's what I search for.

#### What has been done to verify that this works as intended?

I caused a Sass warning and verified that test/run.sh caught it.

#### Why is this the best possible solution? Were any other approaches considered?

We could check for Sass warnings separately, but I think it's convenient to do so in test/run.sh, where we're already checking for other warnings.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is not a user-facing change.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced