### PR TITLE
Improve Transifex scripts

### DIFF
--- a/bin/util/transifex.js
+++ b/bin/util/transifex.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { equals, last } = require('ramda');
+const { equals, last, path: getPath } = require('ramda');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { parse } = require('comment-json');
 
@@ -405,36 +405,29 @@ const _restructure = (
   for (const [k, v] of entries) {
     // If `v` is a linked locale message, validate it, then skip it so that it
     // does not appear in the Structured JSON.
-    if (v instanceof PluralForms) {
-      const path = pathOfLinkedMessage(v);
-      if (path != null) {
-        const messageLinkedTo = path.reduce(
-          (node, key) => {
-            if (node[key] == null) {
-              // We do not currently support a linked locale message in an i18n
-              // custom block that links to another message in the block, but we
-              // may very well at some point.
-              logThenThrow(value, 'link to message that either does not exist or is in i18n custom block');
-            }
-            return node[key];
-          },
-          root
-        );
-        if (pathOfLinkedMessage(messageLinkedTo) != null) {
-          // Supporting this case would add complexity to
-          // copyLinkedLocaleMessage().
-          logThenThrow(value, 'cannot link to a linked locale message');
-        }
-        if (value.full != null || Array.isArray(value)) {
-          // Supporting these cases would add complexity to
-          // deletePartialTranslation(), because then linking to an untranslated
-          // message could result in a partial translation, which would then be
-          // removed.
-          logThenThrow(value, 'linked locale message not allowed in component interpolation or array element');
-        }
-
-        continue; // eslint-disable-line no-continue
+    const linkedPath = v instanceof PluralForms ? pathOfLinkedMessage(v) : null;
+    if (linkedPath != null) {
+      const dest = getPath(linkedPath, root);
+      if (dest == null) {
+        // We do not currently support a linked locale message in an i18n custom
+        // block that links to another message in the block, but we may very
+        // well at some point.
+        logThenThrow(value, 'link to message that either does not exist or is in i18n custom block');
       }
+      if (pathOfLinkedMessage(dest) != null) {
+        // Supporting this case would add complexity to
+        // copyLinkedLocaleMessage().
+        logThenThrow(value, 'cannot link to a linked locale message');
+      }
+      if (value.full != null || Array.isArray(value)) {
+        // Supporting these cases would add complexity to
+        // deletePartialTranslation(), because then linking to an untranslated
+        // message could result in a partial translation, which would then be
+        // removed.
+        logThenThrow(value, 'linked locale message not allowed in component interpolation or array element');
+      }
+
+      continue; // eslint-disable-line no-continue
     }
 
     const comments = value[Symbol.for(`before:${k}`)];

--- a/bin/util/transifex.js
+++ b/bin/util/transifex.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { equals } = require('ramda');
+const { equals, last } = require('ramda');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { parse } = require('comment-json');
 
@@ -205,7 +205,34 @@ const pathOfLinkedMessage = (pluralForms) => {
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// JSON CONVERSION
+// TRANSIFEX COMMENTS
+
+// Combines the JSON5 comments before a message into a single comment for
+// Transifex.
+const joinComments = (comments) => {
+  const { type } = comments[0];
+  if (comments.some(comment => comment.type !== type))
+    logThenThrow(comments, 'cannot mix line comments and block comments');
+  if (type === 'BlockComment' && comments.length !== 1)
+    logThenThrow(comments, 'too many block comments');
+
+  // Split a block comment into lines.
+  const lines = type === 'BlockComment'
+    ? comments[0].value.split('\n')
+    : comments.map(({ value }) => value);
+
+  // Trim lines.
+  for (const [i, line] of lines.entries()) lines[i] = line.trim();
+  if (lines.every(line => line === ''))
+    logThenThrow(comments, 'comments are all empty');
+  while (lines[0] === '') lines.shift();
+  while (last(lines) === '') lines.pop();
+
+  return lines.reduce((acc, line) => {
+    const separator = line === '' || acc.endsWith('\n') ? '\n' : ' ';
+    return `${acc}${separator}${line}`;
+  });
+};
 
 /*
 Our convention for component interpolation is to group all the messages used in
@@ -332,6 +359,11 @@ const generateCommentsForFull = (messages) => {
   return comments;
 };
 
+
+
+////////////////////////////////////////////////////////////////////////////////
+// JSON CONVERSION
+
 // Converts Vue I18n JSON to Structured JSON, returning an object.
 const _restructure = (
   value,
@@ -409,10 +441,8 @@ const _restructure = (
     structured[k] = _restructure(
       v,
       root,
-      comments != null
-        ? comments.map(comment => comment.value.trim()).join(' ')
-        : commentForPath,
-      commentsByKey[k] != null ? commentsByKey[k] : commentForKey,
+      comments != null ? joinComments(comments) : commentForPath,
+      commentsByKey[k] ?? commentForKey,
       commentsForFull != null ? commentsForFull[k] : null,
       commentsByKey
     );

--- a/bin/util/transifex.js
+++ b/bin/util/transifex.js
@@ -412,7 +412,7 @@ const _restructure = (
         // We do not currently support a linked locale message in an i18n custom
         // block that links to another message in the block, but we may very
         // well at some point.
-        logThenThrow(value, 'link to message that either does not exist or is in i18n custom block');
+        logThenThrow(value, 'link to message that either does not exist or is in an i18n custom block');
       }
       if (pathOfLinkedMessage(dest) != null) {
         // Supporting this case would add complexity to
@@ -424,7 +424,7 @@ const _restructure = (
         // deletePartialTranslation(), because then linking to an untranslated
         // message could result in a partial translation, which would then be
         // removed.
-        logThenThrow(value, 'linked locale message not allowed in component interpolation or array element');
+        logThenThrow(value, 'linked locale message not allowed in a component interpolation or array element');
       }
 
       continue; // eslint-disable-line no-continue

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -200,13 +200,19 @@ export default {
 {
   "en": {
     "title": {
-      /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word "Submitted", so it is essential for "Submitted" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+      /*
+      This text is shown in the list of actions performed on a Submission. There
+      is an icon before the text that corresponds to the word "Submitted", so it
+      is essential for "Submitted" to also come first in the translation. If
+      that is unnatural in your language, you can also split the text into two
+      parts. For example, instead of:
 
-Submitted by {name}
+      Submitted by {name}
 
-you could split it into:
+      you could split it into:
 
-Submitted • {name} */
+      Submitted • {name}
+      */
       "create": "Submitted by {name}",
       "entity": {
         "create": "Created Entity {label} in {dataset} Dataset",
@@ -214,68 +220,104 @@ Submitted • {name} */
       },
       "updateReviewState": {
         "null": {
-          /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+          /*
+          This text is shown in the list of actions performed on a Submission.
+          There is an icon before the text that corresponds to the Review State,
+          so it is essential for the Review State to also come first in the
+          translation. If that is unnatural in your language, you can also split
+          the text into two parts. For example, instead of:
 
-{reviewState} per {name}
+          {reviewState} per {name}
 
-you could split it into:
+          you could split it into:
 
-{reviewState} • {name} */
+          {reviewState} • {name}
+          */
           "full": "{reviewState} per {name}",
           "reviewState": "Received"
         },
         "hasIssues": {
-          /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+          /*
+          This text is shown in the list of actions performed on a Submission.
+          There is an icon before the text that corresponds to the Review State,
+          so it is essential for the Review State to also come first in the
+          translation. If that is unnatural in your language, you can also split
+          the text into two parts. For example, instead of:
 
-{reviewState} per {name}
+          {reviewState} per {name}
 
-you could split it into:
+          you could split it into:
 
-{reviewState} • {name} */
+          {reviewState} • {name}
+          */
           "full": "{reviewState} per {name}",
           "reviewState": "Has Issues"
         },
         "edited": {
-          /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+          /*
+          This text is shown in the list of actions performed on a Submission.
+          There is an icon before the text that corresponds to the Review State,
+          so it is essential for the Review State to also come first in the
+          translation. If that is unnatural in your language, you can also split
+          the text into two parts. For example, instead of:
 
-{reviewState} by {name}
+          {reviewState} by {name}
 
-you could split it into:
+          you could split it into:
 
-{reviewState} • {name} */
+          {reviewState} • {name}
+          */
           "full": "{reviewState} by {name}",
           "reviewState": "Edited"
         },
         "approved": {
-          /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+          /*
+          This text is shown in the list of actions performed on a Submission.
+          There is an icon before the text that corresponds to the Review State,
+          so it is essential for the Review State to also come first in the
+          translation. If that is unnatural in your language, you can also split
+          the text into two parts. For example, instead of:
 
-{reviewState} by {name}
+          {reviewState} by {name}
 
-you could split it into:
+          you could split it into:
 
-{reviewState} • {name} */
+          {reviewState} • {name}
+          */
           "full": "{reviewState} by {name}",
           "reviewState": "Approved"
         },
         "rejected": {
-          /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the Review State, so it is essential for the Review State to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+          /*
+          This text is shown in the list of actions performed on a Submission.
+          There is an icon before the text that corresponds to the Review State,
+          so it is essential for the Review State to also come first in the
+          translation. If that is unnatural in your language, you can also split
+          the text into two parts. For example, instead of:
 
-{reviewState} by {name}
+          {reviewState} by {name}
 
-you could split it into:
+          you could split it into:
 
-{reviewState} • {name} */
+          {reviewState} • {name}
+          */
           "full": "{reviewState} by {name}",
           "reviewState": "Rejected"
         }
       },
-      /* This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word "Comment", so it is essential for "Comment" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:
+      /*
+      This text is shown in the list of actions performed on a Submission.
+      There is an icon before the text that corresponds to the word "Comment",
+      so it is essential for "Comment" to also come first in the translation. If
+      that is unnatural in your language, you can also split the text into two
+      parts. For example, instead of:
 
-Comment by {name}
+      Comment by {name}
 
-you could split it into:
+      you could split it into:
 
-Comment • {name} */
+      Comment • {name}
+      */
       "comment": "Comment by {name}"
     }
   }

--- a/src/components/submission/field-dropdown.vue
+++ b/src/components/submission/field-dropdown.vue
@@ -92,13 +92,21 @@ const placeholder = (counts) => t('placeholder', counts);
     },
     "action": {
       "select": {
-        /* This text is shown in a dropdown that allows the user to select which columns to display in a table. It will be inserted where {all} is in the following text:
+        /*
+        This text is shown in a dropdown that allows the user to select which
+        columns to display in a table. It will be inserted where {all} is in the
+        following text:
 
-Select {all} / {none} */
+        Select {all} / {none}
+        */
         "all": "All",
-        /* This text is shown in a dropdown that allows the user to select which columns to display in a table. It will be inserted where {none} is in the following text:
+        /*
+        This text is shown in a dropdown that allows the user to select which
+        columns to display in a table. It will be inserted where {none} is in
+        the following text:
 
-Select {all} / {none} */
+        Select {all} / {none}
+        */
         "none": "None"
       }
     },

--- a/src/components/submission/filters/review-state.vue
+++ b/src/components/submission/filters/review-state.vue
@@ -79,13 +79,21 @@ const placeholder = (counts) => t('placeholder', counts);
     "placeholder": "{selected} of {total}",
     "action": {
       "select": {
-        /* This text is shown in a dropdown that allows the user to select one or more Review States. It will be inserted where {all} is in the following text:
+        /*
+        This text is shown in a dropdown that allows the user to select one or
+        more Review States. It will be inserted where {all} is in the following
+        text:
 
-Select {all} / {none} */
+        Select {all} / {none}
+        */
         "all": "All",
-        /* This text is shown in a dropdown that allows the user to select one or more Review States. It will be inserted where {none} is in the following text:
+        /*
+        This text is shown in a dropdown that allows the user to select one or
+        more Review States. It will be inserted where {none} is in the following
+        text:
 
-Select {all} / {none} */
+        Select {all} / {none}
+        */
         "none": "None"
       }
     }

--- a/src/components/submission/filters/submitter.vue
+++ b/src/components/submission/filters/submitter.vue
@@ -110,13 +110,21 @@ const placeholder = (counts) => t('placeholder', counts);
     "placeholder": "{selected} of {total}",
     "action": {
       "select": {
-        /* This is the text of a dropdown that allows the user to select one or more submitters. It will be inserted where {all} is in the following text:
+        /*
+        This is the text of a dropdown that allows the user to select one or
+        more submitters. It will be inserted where {all} is in the following
+        text:
 
-Select {all} / {none} */
+        Select {all} / {none}
+        */
         "all": "All",
-        /* This is the text of a dropdown that allows the user to select one or more submitters. It will be inserted where {none} is in the following text:
+        /*
+        This is the text of a dropdown that allows the user to select one or
+        more submitters. It will be inserted where {none} is in the following
+        text:
 
-Select {all} / {none} */
+        Select {all} / {none}
+        */
         "none": "None"
       }
     },


### PR DESCRIPTION
I've gotten started on #722 with the aim that #760 won't result in retranslations. In preparation, I've done a little refactoring of our Transifex scripts.

The most substantial change I made was to how white space works in comments. Right now, restructure.js is pretty particular about white space in block comments. Block comments are also the only way to write newline characters. This PR changes both of those things: block comments are now more flexible, and an empty line comment can be used to specify a newline character. As a result, I think JSON5 comments are now more predictable and also more readable.

#### What has been done to verify that this works as intended?

The output of restructure.js is the same as before even though I changed block comments in a few components.

#### Why is this the best possible solution? Were any other approaches considered?

There aren't big changes in this PR. I've separated out this PR from my other work on #722 so that the PR for that can be more focused.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is not user-facing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced