### PR TITLE
Move required asterisk to before label/placeholder

### DIFF
--- a/src/components/date-range-picker.vue
+++ b/src/components/date-range-picker.vue
@@ -16,7 +16,7 @@ except according to the terms contained in the LICENSE file.
     https://github.com/ankurk91/vue-flatpickr-component/issues/47 -->
     <flatpickr ref="flatpickr" v-model="flatpickrValue" :config="config"
       class="form-control" :class="{ required }"
-      :placeholder="`${placeholder}${star}`" autocomplete="off"
+      :placeholder="`${star}${placeholder}`" autocomplete="off"
       @on-close="close"/>
     <template v-if="!required">
       <button v-show="modelValue.length === 2" type="button" class="close"
@@ -24,7 +24,7 @@ except according to the terms contained in the LICENSE file.
         <span aria-hidden="true">&times;</span>
       </button>
     </template>
-    <span class="form-label">{{ placeholder }}{{ star }}</span>
+    <span class="form-label">{{ star }}{{ placeholder }}</span>
   </label>
 </template>
 
@@ -81,7 +81,7 @@ export default {
       return config;
     },
     star() {
-      return this.required ? '*' : '';
+      return this.required ? '* ' : '';
     }
   },
   watch: {

--- a/src/components/form-group.vue
+++ b/src/components/form-group.vue
@@ -13,12 +13,12 @@ except according to the terms contained in the LICENSE file.
   <label class="form-group" :class="htmlClass">
     <slot name="before"></slot>
     <input ref="input" v-bind="$attrs" class="form-control" :value="modelValue"
-      :placeholder="`${placeholder}${star}`" :required="required"
+      :placeholder="`${star}${placeholder}`" :required="required"
       :autocomplete="autocomplete"
       @input="$emit('update:modelValue', $event.target.value)">
     <password-strength v-if="autocomplete === 'new-password'"
       :password="modelValue"/>
-    <span class="form-label">{{ placeholder }}{{ star }}</span>
+    <span class="form-label">{{ star }}{{ placeholder }}</span>
     <slot name="after"></slot>
   </label>
 </template>
@@ -55,7 +55,7 @@ const htmlClass = computed(() => ({
   'new-password': props.autocomplete === 'new-password',
   'has-error': props.hasError
 }));
-const star = computed(() => (props.required ? ' *' : ''));
+const star = computed(() => (props.required ? '* ' : ''));
 
 const input = ref(null);
 const focus = () => { input.value.focus(); };

--- a/test/components/date-range-picker.spec.js
+++ b/test/components/date-range-picker.spec.js
@@ -258,13 +258,13 @@ describe('DateRangePicker', () => {
       component.get('.form-label').text().should.equal('My date range');
     });
 
-    it('appends * to the placeholder if the required prop is true', () => {
+    it('adds * to the placeholder if the required prop is true', () => {
       const component = mountComponent({
         props: { placeholder: 'My date range', required: true }
       });
       const { placeholder } = component.get('input').attributes();
-      placeholder.should.equal('My date range*');
-      component.get('.form-label').text().should.equal('My date range*');
+      placeholder.should.equal('* My date range');
+      component.get('.form-label').text().should.equal('* My date range');
     });
   });
 

--- a/test/components/form-group.spec.js
+++ b/test/components/form-group.spec.js
@@ -33,7 +33,7 @@ describe('FormGroup', () => {
       });
       const { required, placeholder } = formGroup.get('input').attributes();
       should.exist(required);
-      placeholder.should.equal('My input *');
+      placeholder.should.equal('* My input');
     });
 
     it('renders correctly if the prop is false', () => {

--- a/test/components/project/enable-encryption.spec.js
+++ b/test/components/project/enable-encryption.spec.js
@@ -53,14 +53,14 @@ describe('ProjectEnableEncryption', () => {
       attachTo: document.body
     }));
     await modal.get('.btn-primary').trigger('click');
-    modal.get('input[placeholder="Passphrase *"]').should.be.focused();
+    modal.get('input[placeholder="* Passphrase"]').should.be.focused();
   });
 
   it('shows a danger alert if the passphrase is too short', async () => {
     testData.extendedProjects.createPast(1);
     const modal = mount(ProjectEnableEncryption, mountOptions());
     await modal.get('.btn-primary').trigger('click');
-    await modal.get('input[placeholder="Passphrase *"]').setValue('x');
+    await modal.get('input[placeholder="* Passphrase"]').setValue('x');
     await modal.get('form').trigger('submit');
     modal.should.alert('danger', 'Please input a passphrase at least 10 characters long.');
   });
@@ -69,12 +69,12 @@ describe('ProjectEnableEncryption', () => {
     testData.extendedProjects.createPast(1);
     const modal = mount(ProjectEnableEncryption, mountOptions());
     await modal.get('.btn-primary').trigger('click');
-    await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
+    await modal.get('input[placeholder="* Passphrase"]').setValue('supersecret');
     await modal.setProps({ state: false });
     await modal.setProps({ state: true });
     modal.find('.info-item').exists().should.be.true();
     await modal.get('.btn-primary').trigger('click');
-    modal.get('input[placeholder="Passphrase *"]').element.value.should.equal('');
+    modal.get('input[placeholder="* Passphrase"]').element.value.should.equal('');
   });
 
   describe('request', () => {
@@ -87,7 +87,7 @@ describe('ProjectEnableEncryption', () => {
         .mount(ProjectEnableEncryption, mountOptions())
         .request(async (modal) => {
           await modal.get('.btn-primary').trigger('click');
-          await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
+          await modal.get('input[placeholder="* Passphrase"]').setValue('supersecret');
           return modal.get('form').trigger('submit');
         })
         .beforeEachResponse((_, { method, url, data }) => {
@@ -102,7 +102,7 @@ describe('ProjectEnableEncryption', () => {
         .mount(ProjectEnableEncryption, mountOptions())
         .request(async (modal) => {
           await modal.get('.btn-primary').trigger('click');
-          await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
+          await modal.get('input[placeholder="* Passphrase"]').setValue('supersecret');
           const hint = modal.get('input[placeholder="Passphrase hint (optional)"]');
           await hint.setValue('bar');
           return modal.get('form').trigger('submit');
@@ -122,7 +122,7 @@ describe('ProjectEnableEncryption', () => {
         button: 'button[type="submit"]',
         disabled: ['.btn-link'],
         request: async (modal) => {
-          await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
+          await modal.get('input[placeholder="* Passphrase"]').setValue('supersecret');
           return modal.get('form').trigger('submit');
         },
         modal: true
@@ -139,7 +139,7 @@ describe('ProjectEnableEncryption', () => {
         .mount(ProjectEnableEncryption, mountOptions())
         .request(async (modal) => {
           await modal.get('.btn-primary').trigger('click');
-          await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
+          await modal.get('input[placeholder="* Passphrase"]').setValue('supersecret');
           return modal.get('form').trigger('submit');
         })
         .respondWithSuccess()
@@ -152,7 +152,7 @@ describe('ProjectEnableEncryption', () => {
         .mount(ProjectEnableEncryption, mountOptions())
         .request(async (modal) => {
           await modal.get('.btn-primary').trigger('click');
-          const passphrase = modal.get('input[placeholder="Passphrase *"]');
+          const passphrase = modal.get('input[placeholder="* Passphrase"]');
           await passphrase.setValue('x');
           const form = modal.get('form');
           await form.trigger('submit');
@@ -171,7 +171,7 @@ describe('ProjectEnableEncryption', () => {
           await app.get('#project-settings-enable-encryption-button').trigger('click');
           const modal = app.getComponent(ProjectEnableEncryption);
           await modal.get('.btn-primary').trigger('click');
-          await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
+          await modal.get('input[placeholder="* Passphrase"]').setValue('supersecret');
           return modal.get('form').trigger('submit');
         })
         .respondWithData(() => {


### PR DESCRIPTION
In Collect and Enketo, the asterisk for a required form field appears before the text, but in Central, it's after. This PR makes things more consistent by changing it to before the text in Central as well. Here's an example from the login page:

<img width="685" src="https://github.com/getodk/central-frontend/assets/5970131/a85e7e34-8b60-4034-81ad-090bab6244e2">

#### What has been done to verify that this works as intended?

I searched src/components for `*`, and I'm pretty sure the only places to change are `FormGroup` and `DateRangePicker`. I've viewed the change locally as well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk of regression should be low.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Probably some screenshots will be out-of-date, but I wouldn't think we need to update those just for this.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced