### PR TITLE
Stop using Pinia in development temporarily

### DIFF
--- a/src/request-data/index.js
+++ b/src/request-data/index.js
@@ -18,7 +18,7 @@ import { createResource, resourceView } from './resource';
 const createState = () =>
   shallowReactive({ data: null, awaitingResponse: false });
 const patchMock = (f) => { f(); };
-const defineResourceStore = process.env.NODE_ENV === 'development'
+const defineResourceStore = false // eslint-disable-line no-constant-condition
   ? (name) => defineStore(`requestData.${name}`, { state: createState })
   : () => {
     const store = createState();


### PR DESCRIPTION
We use Pinia in development only, not production or testing. Pinia is helpful in development because it integrates with Vue devtools and provides nice logging. However, I'm running into an issue with Pinia that's affecting my work on #774: see #787. At some point, I'll want to fix that issue for real. However, for now I'm just going to turn off Pinia in development.

#### What has been done to verify that this works as intended?

#787 is only an issue in development. When I make this change, I no longer see it in development (`entity.data` becomes reactive).

#### Why is this the best possible solution? Were any other approaches considered?

I could remove more code related to Pinia from the file or comment it out, instead of using a constant condition in a ternary. However, since I intend to revert this PR at some point, I think it should be as small as possible. As before, webpack should remove Pinia from the production bundle.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is not user-facing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced