### PR TITLE
Added link to entity and dataset from submission activity feed

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -34,12 +34,12 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-magic-wand entity-icon"></span>
         <i18n-t keypath="title.entity.create">
           <template #label>
-            <router-link :to="entityPath(projectId, entityDataset(entry), entityUuid(entry))" class="submission-feed-entry-entity-data">
+            <router-link :to="entityPath(projectId, entityDataset(entry), entityUuid(entry))">
               {{ entityLabel(entry) }}
             </router-link>
           </template>
           <template #dataset>
-            <router-link :to="datasetPath(projectId, entityDataset(entry))" class="submission-feed-entry-entity-data">
+            <router-link :to="datasetPath(projectId, entityDataset(entry))">
               {{ entityDataset(entry) }}
             </router-link>
           </template>
@@ -188,10 +188,6 @@ export default {
 @import '../../assets/scss/variables';
 
 .submission-feed-entry {
-  .submission-feed-entry-entity-data {
-    font-weight: normal;
-  }
-
   .entity-error-message{
     font-size: 12px;
     margin-left: 10px;
@@ -230,7 +226,7 @@ export default {
       */
       "create": "Submitted by {name}",
       "entity": {
-        "create": "Created Entity {label} in Dataset {dataset}",
+        "create": "Created Entity {label} in {dataset} Dataset",
         "error": "Problem creating Entity",
       },
       "updateReviewState": {

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -33,8 +33,16 @@ except according to the terms contained in the LICENSE file.
       <template v-else-if="entry.action === 'entity.create'">
         <span class="icon-magic-wand entity-icon"></span>
         <i18n-t keypath="title.entity.create">
-          <template #label><span class="submission-feed-entry-entity-data">{{ entityLabel(entry) }}</span></template>
-          <template #dataset><span class="submission-feed-entry-entity-data">{{ entityDataset(entry) }}</span></template>
+          <template #label>
+            <router-link :to="entityPath(projectId, entityDataset(entry), entityUuid(entry))" class="submission-feed-entry-entity-data">
+              {{ entityLabel(entry) }}
+            </router-link>
+          </template>
+          <template #dataset>
+            <router-link :to="datasetPath(projectId, entityDataset(entry))" class="submission-feed-entry-entity-data">
+              {{ entityDataset(entry) }}
+            </router-link>
+          </template>
         </i18n-t>
       </template>
       <template v-else-if="entry.action === 'entity.create.error'">
@@ -69,6 +77,7 @@ import MarkdownView from '../markdown/view.vue';
 import SubmissionDiffItem from './diff-item.vue';
 
 import useReviewState from '../../composables/review-state';
+import useRoutes from '../../composables/routes';
 import { useRequestData } from '../../request-data';
 
 export default {
@@ -95,7 +104,8 @@ export default {
   setup() {
     const { diffs } = useRequestData();
     const { reviewStateIcon } = useReviewState();
-    return { diffs, reviewStateIcon };
+    const { datasetPath, entityPath } = useRoutes();
+    return { diffs, reviewStateIcon, datasetPath, entityPath };
   },
   computed: {
     updateOrEdit() {
@@ -153,6 +163,11 @@ export default {
     entityDataset(entry) {
       if ('entity' in entry.details)
         return entry.details.entity.dataset;
+      return '';
+    },
+    entityUuid(entry) {
+      if ('entity' in entry.details)
+        return entry.details.entity.uuid;
       return '';
     },
     entityProblem(entry) {
@@ -215,7 +230,7 @@ export default {
       */
       "create": "Submitted by {name}",
       "entity": {
-        "create": "Created Entity {label} in {dataset} Dataset",
+        "create": "Created Entity {label} in Dataset {dataset}",
         "error": "Problem creating Entity",
       },
       "updateReviewState": {

--- a/src/composables/routes.js
+++ b/src/composables/routes.js
@@ -110,6 +110,11 @@ export default memoizeForContainer(({ router, requestData }) => {
     return _datasetPath(projectIdOrSuffix, datasetName, suffix);
   };
 
+  const entityPath = (projectId, datasetName, entityUuid) => {
+    const encodedName = encodeURIComponent(datasetName);
+    return `/projects/${projectId}/datasets/${encodedName}/entities/${entityUuid}`;
+  };
+
   const userPath = (id) => `/users/${id}/edit`;
 
   return {
@@ -117,6 +122,7 @@ export default memoizeForContainer(({ router, requestData }) => {
     formPath, publishedFormPath, primaryFormPath,
     submissionPath,
     datasetPath,
+    entityPath,
     userPath,
     canRoute: canRouteToLocation
   };

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -1,3 +1,6 @@
+
+import { RouterLinkStub } from '@vue/test-utils';
+
 import ActorLink from '../../../src/components/actor-link.vue';
 import DateTime from '../../../src/components/date-time.vue';
 import MarkdownView from '../../../src/components/markdown/view.vue';
@@ -161,7 +164,20 @@ describe('SubmissionFeedEntry', () => {
           details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
         });
         const title = mountComponent().get('.feed-entry-title');
-        title.text().should.equal('Created Entity EntityName in DatasetName Dataset');
+        title.text().should.equal('Created Entity EntityName in Dataset DatasetName');
+      });
+
+      it('renders links to entity and dataset', () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.create',
+          details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
+        });
+        const links = mountComponent().findAllComponents(RouterLinkStub);
+        links.length.should.equal(2);
+        links.map(link => link.props().to).should.eql([
+          '/projects/1/datasets/DatasetName/entities/xyz',
+          '/projects/1/datasets/DatasetName'
+        ]);
       });
 
       it('renders okay and does not crash for action where entity details are missing', () => {
@@ -170,7 +186,7 @@ describe('SubmissionFeedEntry', () => {
           details: { entity: { uuid: 'xyz' } }
         });
         const title = mountComponent().get('.feed-entry-title');
-        title.text().should.equal('Created Entity  in  Dataset');
+        title.text().should.equal('Created Entity  in Dataset');
       });
     });
 

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -164,7 +164,7 @@ describe('SubmissionFeedEntry', () => {
           details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
         });
         const title = mountComponent().get('.feed-entry-title');
-        title.text().should.equal('Created Entity EntityName in Dataset DatasetName');
+        title.text().should.equal('Created Entity EntityName in DatasetName Dataset');
       });
 
       it('renders links to entity and dataset', () => {
@@ -186,7 +186,7 @@ describe('SubmissionFeedEntry', () => {
           details: { entity: { uuid: 'xyz' } }
         });
         const title = mountComponent().get('.feed-entry-title');
-        title.text().should.equal('Created Entity  in Dataset');
+        title.text().should.equal('Created Entity  in  Dataset');
       });
     });
 

--- a/test/composables/routes.spec.js
+++ b/test/composables/routes.spec.js
@@ -157,4 +157,13 @@ describe('useRoutes()', () => {
       datasetPath(1, 'á').should.equal('/projects/1/datasets/%C3%A1');
     });
   });
+
+  describe('entityPath()', () => {
+    it('returns a path if given IDs', () => {
+      const container = createTestContainer({ router: mockRouter('/') });
+      const { entityPath } = withSetup(useRoutes, { container });
+      const path = entityPath(1, 'a b', 'abcd1234');
+      path.should.equal('/projects/1/datasets/a%20b/entities/abcd1234');
+    });
+  });
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3512,7 +3512,7 @@
         },
         "entity": {
           "create": {
-            "string": "Created Entity {label} in {dataset} Dataset"
+            "string": "Created Entity {label} in Dataset {dataset}"
           },
           "error": {
             "string": "Problem creating Entity"

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3512,7 +3512,7 @@
         },
         "entity": {
           "create": {
-            "string": "Created Entity {label} in Dataset {dataset}"
+            "string": "Created Entity {label} in {dataset} Dataset"
           },
           "error": {
             "string": "Problem creating Entity"


### PR DESCRIPTION
Closes #773. Adds links from an entity create event in the submission feed directly to the entity and dataset. Also adds a `entityPath` route in `useRoutes`. 

<img width="465" alt="Screen Shot 2023-05-10 at 4 10 24 PM" src="https://github.com/getodk/central-frontend/assets/76205/ab928cd8-4812-4ee3-947a-0a1236a53b58">


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, trying it in action.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced