### PR TITLE
Prevent text overflow in PageHead title

### DIFF
--- a/src/components/page/head.vue
+++ b/src/components/page/head.vue
@@ -35,6 +35,8 @@ export default {
   border-bottom: 1px solid $color-subpanel-border-strong;
 }
 
+#page-head-title { overflow-wrap: break-word; }
+
 #page-head-body {
   color: #555;
   font-size: 15px;


### PR DESCRIPTION
The QA team shared a screenshot in which the `PageHead` title overflows the element:

![image](https://github.com/getodk/central-frontend/assets/5970131/72cb2804-3b11-4161-b302-8b549682b0f3)

`PageHead` already wraps the title today. This PR allows it to wrap even if doing so would cause a word to be split.

#### What has been done to verify that this works as intended?

I tried it locally.

#### Why is this the best possible solution? Were any other approaches considered?

We could force the title to be a single line, using the `text-overflow-ellipsis` mixin and `v-tooltip`. That's what `FormHead` does, and I'd be happy to implement that approach. That said, I think the title exceeding a single line is rare in practice, and I think it's fine for it to wrap in that case. Mostly I just want to prevent text overflow in some way.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Regression risk should be low.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced