### PR TITLE
Always specify `Cache-Control: no-cache` in development

### DIFF
--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -97,8 +97,8 @@ http {
     location / {
       root ./dist;
 
-      add_header Cache-Control no-cache;
       include ./common-headers.nginx.conf;
+      add_header Cache-Control no-cache;
     }
   }
 }

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -97,10 +97,8 @@ http {
     location / {
       root ./dist;
 
-      location /index.html {
-        include ./common-headers.nginx.conf;
-        add_header Cache-Control no-cache;
-      }
+      add_header Cache-Control no-cache;
+      include ./common-headers.nginx.conf;
     }
   }
 }

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -98,8 +98,9 @@ http {
       root ./dist;
 
       include ./common-headers.nginx.conf;
-      # We return this header for fewer files in production. However, in
-      # development, .js file names don't contain hashes.
+      # We return this header for more files in development than we do in
+      # production. That's needed because in development, unlike production,
+      # many file names don't contain hashes.
       add_header Cache-Control no-cache;
     }
   }

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -98,6 +98,8 @@ http {
       root ./dist;
 
       include ./common-headers.nginx.conf;
+      # We return this header for fewer files in production. However, in
+      # development, .js file names don't contain hashes.
       add_header Cache-Control no-cache;
     }
   }


### PR DESCRIPTION
Sometimes in local development, refreshing the page doesn't load the latest Frontend code: the same version of the page is shown as before. That can be especially confusing if the code change isn't visible in the UI, because it's harder to see that the page is outdated. Sometimes hard-refreshing the page doesn't even seem to load the latest code. In that case, I've had to restart `npm run dev`.

I've encountered this issue, and I know @ktuite and @alxndrsn have as well. Part of what's confusing is that it's not consistent (at least not for me). I can work for a long time without seeing this behavior.

Anecdotally, I feel like I've seen this issue much more since we've moved to Vue 3. Vue CLI isn't the preferred build tool for Vue 3, so I've been thinking that it's some issue with Vue CLI. In that case, the answer would probably be to move to Vite, which we want to do anyway (#671).

However, @ktuite was seeing this behavior even before Vue 3: see #520. Reading that issue, I do think that we need to change the `Cache-Control` header in development. I'm hoping that will just solve the issue, and that's the change that this PR makes. Even if that change doesn't fix things, we'll know more afterwards. I certainly don't think this change will hurt anything.

Another anecdote: I think I've seen this behavior most often for files in the main bundle. Whenever I modify src/router.js, it's fairly common for the change not to show up right away. However, most of the time, I'm working on components and files that components import, for example, composables and files in src/util/, and I feel like I see this issue much less often then. Most components are loaded asynchronously, which might have something to do with it. @alxndrsn reports having seen this issue while working on a component. However, the component he was working on, `AccountLogin`, is part of the main bundle, which seems consistent with the idea that the main bundle is a primary part of the issue. All that said, I'm pretty sure I've seen this issue outside the main bundle, just much less often (but more often now than with Vue 2).

There are other strategies we could try if this PR doesn't work. However, I think this is a good first step.

It's hard to know how to verify this PR given that I encounter the issue inconsistently. @alxndrsn, how consistently do you encounter the issue? Could you try out this PR and see if it helps? One thing I have verified is that `Cache-Control` is returned as `no-cache` for a range of Frontend files, not just index.html.