### PR TITLE
Make small changes to how TextareaAutosize sets height and minHeight

### DIFF
--- a/src/components/entity/update/row.vue
+++ b/src/components/entity/update/row.vue
@@ -102,13 +102,21 @@ defineExpose({
   .label-cell {
     padding-left: $padding-left-modal-header;
     padding-right: 15px;
+    padding-top: #{$vpadding + $padding-top-form-control};
+  }
+  .old-value {
+    padding-top: $vpadding;
+
+    // Add $padding-top-form-control to the <div> rather than the <td> so that
+    // it is included in the minHeight prop passed to TextareaAutosize.
+    div {
+      padding-top: $padding-top-form-control;
+      padding-bottom: $padding-top-form-control;
+    }
   }
   .new-value {
     padding-right: $padding-left-modal-header;
     padding-top: $vpadding;
-  }
-  .label-cell, .old-value {
-    padding-top: #{$vpadding + $padding-top-form-control};
   }
 
   .label-cell { @include text-overflow-ellipsis; }

--- a/src/components/textarea-autosize.vue
+++ b/src/components/textarea-autosize.vue
@@ -35,8 +35,6 @@ const props = defineProps({
     type: String,
     required: true
   },
-  // The min-height not including padding or borders (the min-height of the
-  // textarea's content box)
   minHeight: {
     type: Number,
     default: 0
@@ -76,11 +74,12 @@ const listenForUserResize = () => {
     if (el.value == null) return;
     const mouseupHeight = el.value.getBoundingClientRect().height;
     userResized.value = mouseupHeight !== mousedownHeight || props.mockUserResized;
-    if (userResized.value) {
-      // Remove style.height, which is no longer needed. Leave style.minHeight
-      // at 0 to ensure that there is no change to the height.
-      style.height = '';
-    } else {
+    // If userResized.value is `false`, then we restore style.height and
+    // style.minHeight. If userResized.value is `true`, then we leave
+    // style.minHeight at 0 to ensure that there is no change to the height. We
+    // also do not change style.height, as even clearing it after a user resize
+    // seems to change the height of the textarea.
+    if (!userResized.value) {
       style.height = mousedownHeightStyle;
       style.minHeight = minHeightStyle;
     }
@@ -124,11 +123,7 @@ watch(() => props.modelValue, () => {
   if (!userResized.value) nextTick(setHeight);
 });
 
-const setMinHeight = () => {
-  const box = styleBox(getComputedStyle(el.value));
-  el.value.style.minHeight = px(props.minHeight +
-    box.paddingTop + box.paddingBottom + box.borderTop + box.borderBottom);
-};
+const setMinHeight = () => { el.value.style.minHeight = px(props.minHeight); };
 onMounted(setMinHeight);
 watch(() => props.minHeight, () => { if (!userResized.value) setMinHeight(); });
 

--- a/test/components/textarea-autosize.spec.js
+++ b/test/components/textarea-autosize.spec.js
@@ -115,7 +115,7 @@ describe('TextareaAutosize', () => {
       const component = mountComponent({
         props: { minHeight: 123 }
       });
-      component.element.style.minHeight.should.equal('136px');
+      component.element.style.minHeight.should.equal('123px');
     });
 
     it('changes the min-height after the prop changes', async () => {
@@ -123,7 +123,7 @@ describe('TextareaAutosize', () => {
         props: { minHeight: 123 }
       });
       await component.setProps({ minHeight: 456 });
-      component.element.style.minHeight.should.equal('469px');
+      component.element.style.minHeight.should.equal('456px');
     });
   });
 
@@ -141,7 +141,7 @@ describe('TextareaAutosize', () => {
         props: { minHeight: 1000 }
       });
       await component.trigger('mousedown');
-      component.element.style.height.should.equal('1013px');
+      component.element.style.height.should.equal('1000px');
     });
 
     it('restores the min-height property on mouseup', async () => {
@@ -150,7 +150,7 @@ describe('TextareaAutosize', () => {
       });
       await component.trigger('mousedown');
       await component.trigger('mouseup');
-      component.element.style.minHeight.should.equal('136px');
+      component.element.style.minHeight.should.equal('123px');
     });
 
     it('restores the height CSS property on mouseup', async () => {
@@ -175,16 +175,11 @@ describe('TextareaAutosize', () => {
     };
 
     describe('height', () => {
-      it('removes the height CSS property', async () => {
-        const component = await userResize();
-        component.element.style.height.should.equal('');
-      });
-
       it('ignores changes to the modelValue prop', async () => {
         const component = await userResize();
         await component.setProps({ modelValue: 'a'.repeat(5000) });
         await component.vm.$nextTick();
-        component.element.style.height.should.equal('');
+        component.element.style.height.should.equal('123px');
       });
 
       it('resets the height after resize() is called', async () => {
@@ -224,14 +219,14 @@ describe('TextareaAutosize', () => {
       it('resets min-height after resize() is called', async () => {
         const component = await userResize();
         component.vm.resize();
-        component.element.style.minHeight.should.equal('136px');
+        component.element.style.minHeight.should.equal('123px');
       });
 
       it('stops ignoring changes after resize() is called', async () => {
         const component = await userResize();
         component.vm.resize();
         await component.setProps({ minHeight: 456 });
-        component.element.style.minHeight.should.equal('469px');
+        component.element.style.minHeight.should.equal('456px');
       });
     });
 


### PR DESCRIPTION
I noticed an issue when a textarea in the entity update modal is manually resized. The user's choice of height is supposed to be respected, but instead the textarea snaps to a particular height (I think the height of 2 rows, the textarea default). If the textarea is resized a second time, that resize is respected. But the first resize has this issue. Video:

https://github.com/getodk/central-frontend/assets/5970131/9731d369-ba10-472e-b396-5e91ac69af17

The issue stems from a last-minute change I made, clearing the dynamic `height` style of the textarea after a manual user resize. It seems like the `height` style needs to be left where it is: changing it has an effect even after a user resize (which I guess isn't too surprising). After making that change:

https://github.com/getodk/central-frontend/assets/5970131/c3feb7e8-af64-4406-9319-d0254e5d46dd

That fixes the issue. However, if you take a close look at the video, you can see that there's another small issue. For context, the height of the previous value is greater than the height of the textarea value, and the previous value and the textarea start out as the same height because we set the `min-height` of the textarea to the height of the previous value (all expected). However, when the textarea is resized to a smaller height, the height of the previous value also decreases (not expected). It turns out that the height of the textarea is a few pixels greater than the height of the previous value even though the height of the textarea is based on the height of the previous value. It turns out that we were adding padding and border on top of the `minHeight` prop that wasn't necessary. I modified `TextareaAutosize` so that it no longer adds that padding and border.

There's one more change to make, which is that the `minHeight` passed to the `TextareaAutosize` needs to equal the height of the previous value plus the `$padding-top-form-control` above it. To do that, I moved the padding from the `<td>` to the containing `<div>` of the previous value. I also think it looks a little funny that when the height of the previous value exceeds the height of the textarea value, there's almost no padding beneath the previous value. You can see that at the end of the second video above. I decided to add the same padding to the bottom as on top.

Altogether:

https://github.com/getodk/central-frontend/assets/5970131/06085ad5-6851-433d-a314-10ed6d6a72d1

#### What has been done to verify that this works as intended?

I viewed the changes locally, and I patched existing tests. It's hard to write more tests around this change because it's hard to mock a manual user resize.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly small changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk of regression should be low.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced