### PR TITLE
Use property odataName in entities table

### DIFF
--- a/src/components/entity/data-row.vue
+++ b/src/components/entity/data-row.vue
@@ -12,7 +12,7 @@ except according to the terms contained in the LICENSE file.
 <template>
   <tr>
     <td v-for="property of properties" :key="property.id">
-      <span v-tooltip.text>{{ entity[property.name] }}</span>
+      <span v-tooltip.text>{{ entity[property.odataName] }}</span>
     </td>
     <td><span v-tooltip.text>{{ entity.label }}</span></td>
     <td>{{ entity.__id }}</td>

--- a/test/components/entity/data-row.spec.js
+++ b/test/components/entity/data-row.spec.js
@@ -55,7 +55,7 @@ describe('EntityDataRow', () => {
     td[2].text().should.equal('abcd1234');
   });
 
-  it('renders a cell for each field', () => {
+  it('renders a cell for each property', () => {
     testData.extendedDatasets.createPast(1, {
       name: 'trees',
       properties: [
@@ -89,5 +89,16 @@ describe('EntityDataRow', () => {
     const span = td.get('span');
     span.text().should.equal('foobar');
     await span.should.have.textTooltip();
+  });
+
+  it('uses the odataName of the property', () => {
+    testData.extendedDatasets.createPast(1, {
+      properties: [{ name: 'circumference.cm', odataName: 'circumference_cm' }],
+      entities: 1
+    });
+    testData.extendedEntities.createPast(1, {
+      data: { 'circumference.cm': '555' }
+    });
+    mountComponent().get('td').text().should.equal('555');
   });
 });

--- a/test/data/datasets.js
+++ b/test/data/datasets.js
@@ -3,6 +3,12 @@ import { comparator } from 'ramda';
 import { dataStore } from './data-store';
 import { extendedProjects } from './projects';
 
+const normalizeProperty = (property) => ({
+  odataName: property.name,
+  forms: [],
+  ...property
+});
+
 // eslint-disable-next-line import/prefer-default-export
 export const extendedDatasets = dataStore({
   factory: ({
@@ -23,7 +29,7 @@ export const extendedDatasets = dataStore({
     name,
     entities,
     lastEntity,
-    properties,
+    properties: properties.map(normalizeProperty),
     linkedForms,
     approvalRequired
   }),


### PR DESCRIPTION
Closes #793.

#### What has been done to verify that this works as intended?

A new test. Once it's on staging, I can verify it against the entity mentioned in the issue.

#### Why is this the best possible solution? Were any other approaches considered?

Backend returns the `odataName`, so Frontend just needs to use it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk of regression should be low.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced