### PR TITLE
Update usage information metrics for v2023.3

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -110,7 +110,7 @@ export default {
       "num_followup_forms": "Number of Forms that use the Dataset",
       "num_entities": "Number of Entities in the Dataset",
       "num_failed_entities": "Number of Entity creation errors",
-      "num_updated_entities": "Number of Entity updates"
+      "num_entity_updates": "Number of Entity updates"
     }
   }
 }

--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -109,7 +109,8 @@ export default {
       "num_creation_forms": "Number of Forms that update the Dataset",
       "num_followup_forms": "Number of Forms that use the Dataset",
       "num_entities": "Number of Entities in the Dataset",
-      "num_failed_entities": "Number of Entity creation errors"
+      "num_failed_entities": "Number of Entity creation errors",
+      "num_updated_entities": "Number of Entity updates"
     }
   }
 }

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -35,7 +35,7 @@ const analyticsPreview = {
           num_followup_forms: 1,
           num_entities: { total: 10, recent: 5 },
           num_failed_entities: { total: 2, recent: 1 },
-          num_updated_entities: { total: 15, recent: 8 }
+          num_entity_updates: { total: 15, recent: 8 }
         }
       ]
     }
@@ -134,7 +134,7 @@ describe('AnalyticsPreview', () => {
       num_followup_forms: 1,
       num_entities: { total: 10, recent: 5 },
       num_failed_entities: { total: 2, recent: 1 },
-      num_updated_entities: { total: 15, recent: 8 }
+      num_entity_updates: { total: 15, recent: 8 }
     };
     table.props().metrics.should.eql(subMetrics);
   });

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -34,7 +34,8 @@ const analyticsPreview = {
           num_creation_forms: 1,
           num_followup_forms: 1,
           num_entities: { total: 10, recent: 5 },
-          num_failed_entities: { total: 2, recent: 1 }
+          num_failed_entities: { total: 2, recent: 1 },
+          num_updated_entities: { total: 15, recent: 8 }
         }
       ]
     }
@@ -132,7 +133,8 @@ describe('AnalyticsPreview', () => {
       num_creation_forms: 1,
       num_followup_forms: 1,
       num_entities: { total: 10, recent: 5 },
-      num_failed_entities: { total: 2, recent: 1 }
+      num_failed_entities: { total: 2, recent: 1 },
+      num_updated_entities: { total: 15, recent: 8 }
     };
     table.props().metrics.should.eql(subMetrics);
   });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1169,7 +1169,7 @@
         "num_failed_entities": {
           "string": "Number of Entity creation errors"
         },
-        "num_updated_entities": {
+        "num_entity_updates": {
           "string": "Number of Entity updates"
         }
       }

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Number of Entity creation errors"
+        },
+        "num_updated_entities": {
+          "string": "Number of Entity updates"
         }
       }
     },


### PR DESCRIPTION
This PR makes progress on getodk/central#410 by updating `AnalyticsPreview` with the metric added in getodk/central-backend#889. For the text, I used the label in the form attached to the Backend PR.

#### What has been done to verify that this works as intended?

`num_updated_entities` is structured very similarly to `num_failed_entities`: both are groups in the nested repeat group /projects/datasets. I based this change on what was done previously for `num_failed_entities`.

I also took a look at the new metric locally. The dataset metrics are in their own table, so the text has the full width of the modal — so there shouldn't be space/overflow concerns. Screenshot:

<img width="920" alt="Screen Shot 2023-05-24 at 12 44 52 AM" src="https://github.com/getodk/central-frontend/assets/5970131/f1fd74c5-0f5a-473f-9c42-d331a6b9dc01">

#### Why is this the best possible solution? Were any other approaches considered?

Following existing patterns.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk of regression should be low.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced