### PR TITLE
link dataset to attachment URL

### DIFF
--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -24,7 +24,7 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-link"></span>
         <i18n-t tag="span" keypath="linkedToDataset" class="dataset-label">
           <template #datasetName>
-            <a :href="datasetLink" target="_blank">{{ datasetName }}</a>
+            <a :href="href" target="_blank">{{ datasetName }}</a>
           </template>
         </i18n-t>
         <span v-show="targeted" class="label label-primary">
@@ -138,9 +138,6 @@ export default {
     },
     datasetName() {
       return this.attachment.name.replace(/.csv$/i, '');
-    },
-    datasetLink() {
-      return apiPaths.entities(this.form.projectId, this.datasetName);
     }
   }
 };

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1048,6 +1048,9 @@ describe('FormAttachmentList', () => {
       });
       component.get('td.form-attachment-list-uploaded .dataset-label').text().should.equal('Linked to Dataset shovels');
       component.get('td.form-attachment-list-action').text().should.equal('Upload a file to override.');
+      const a = component.get('td.form-attachment-list-name a');
+      const { href } = a.attributes();
+      href.should.equal('/v1/projects/1/forms/f/draft/attachments/shovels.csv');
     });
 
     describe('Datasets preview hint', () => {


### PR DESCRIPTION
## Changes:
- Dataset hyperlink on attachments page links to attachment URL instead of entities.csv

#### What has been done to verify that this works as intended?

Verified locally, all tests are passing

#### Why is this the best possible solution? Were any other approaches considered?

NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced