### PR TITLE
Make changes for v2023.3 after design review

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -521,17 +521,18 @@ select {
   }
 }
 
-// In Safari, the effect of this class is not visible on input and select
-// elements.
-.uncommitted-change {
-  // Adding `.form-group &` for specificity reasons, in order to override the
-  // styles on .form-group .form-control.
-  &, .form-group & {
-    &, &:focus {
-      box-shadow: 0 0 0 3px #ffef67;
-    }
-  }
+// In Safari, the effect of .uncommitted-change is not visible on input and
+// select elements.
+input.uncommitted-change,
+select.uncommitted-change,
+// Including .form-control.uncommitted-change in addition to
+// input.uncommitted-change for specificity reasons, in order to override the
+// styles on .form-group .form-control.
+.form-control.uncommitted-change,
+.btn.uncommitted-change {
+  &, &:focus { box-shadow: 0 0 0 3px #ffef67; }
 }
+tr.uncommitted-change { background-color: #ffef67; }
 
 
 

--- a/src/components/entity/update/row.vue
+++ b/src/components/entity/update/row.vue
@@ -10,7 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <tr class="entity-update-row">
+  <tr class="entity-update-row"
+    :class="{ 'uncommitted-change': modelValue != null }">
     <td class="label-cell">
       <label :for="textareaId" v-tooltip.text>
         {{ requiredLabel(label, required) }}
@@ -24,7 +25,6 @@ except according to the terms contained in the LICENSE file.
     <td class="new-value">
       <div class="form-group">
         <textarea-autosize :id="textareaId" ref="textarea"
-          :class="{ 'uncommitted-change': modelValue != null }"
           :model-value="modelValue ?? oldValue ?? ''" :min-height="minHeight"
           :required="required" @update:model-value="update"/>
       </div>

--- a/src/components/entity/update/row.vue
+++ b/src/components/entity/update/row.vue
@@ -85,10 +85,7 @@ const resize = () => {
   textarea.value.resize();
   if (minHeightOutdated) setMinHeight();
 };
-const focus = () => textarea.value.focus();
-defineExpose({
-  textarea: { resize, focus }
-});
+defineExpose({ textarea: computed(() => ({ ...textarea.value, resize })) });
 </script>
 
 <style lang="scss">

--- a/src/components/project/show.vue
+++ b/src/components/project/show.vue
@@ -21,6 +21,12 @@ except according to the terms contained in the LICENSE file.
         <li :class="tabClass('')" role="presentation">
           <router-link :to="tabPath('')">{{ $t('common.tab.overview') }}</router-link>
         </li>
+        <li v-if="canRoute(tabPath('datasets'))" :class="tabClass('datasets')"
+          role="presentation">
+          <router-link :to="tabPath('datasets')">
+            {{ $t('resource.datasets') }}
+          </router-link>
+        </li>
         <li v-if="canRoute(tabPath('users'))" :class="tabClass('users')"
           role="presentation">
           <router-link :to="tabPath('users')">
@@ -37,12 +43,6 @@ except according to the terms contained in the LICENSE file.
           :class="tabClass('form-access')" role="presentation">
           <router-link :to="tabPath('form-access')">
             {{ $t('projectShow.tab.formAccess') }}
-          </router-link>
-        </li>
-        <li v-if="canRoute(tabPath('datasets'))" :class="tabClass('datasets')"
-          role="presentation">
-          <router-link :to="tabPath('datasets')">
-            {{ $t('resource.datasets') }}
           </router-link>
         </li>
         <li v-if="canRoute(tabPath('settings'))" :class="tabClass('settings')"

--- a/src/components/textarea-autosize.vue
+++ b/src/components/textarea-autosize.vue
@@ -135,7 +135,7 @@ const resize = () => {
   }
 };
 const focus = () => el.value.focus();
-defineExpose({ resize, focus });
+defineExpose({ el, resize, focus });
 </script>
 
 <style lang="scss">

--- a/test/components/entity/update.spec.js
+++ b/test/components/entity/update.spec.js
@@ -72,6 +72,16 @@ describe('EntityUpdate', () => {
     modal.get('textarea').should.be.focused();
   });
 
+  it('makes width of current and updated values nearly equal', async () => {
+    testData.extendedEntities.createPast(1);
+    const modal = mountComponent({ attachTo: document.body });
+    await modal.vm.$nextTick();
+    const widths = modal.findAll('th.old-value, th.new-value')
+      .map(th => th.element.getBoundingClientRect().width);
+    // The left + right padding of the textarea is 24px.
+    (widths[1] - widths[0]).should.be.within(23.9, 24.1);
+  });
+
   it('resizes the textarea elements', async () => {
     testData.extendedEntities.createPast(1, {
       data: { height: '1' }

--- a/test/components/entity/update/row.spec.js
+++ b/test/components/entity/update/row.spec.js
@@ -104,7 +104,7 @@ describe('EntityUpdateRow', () => {
       const row = mountComponent({
         props: { oldValue: 'foo', modelValue: 'bar' }
       });
-      row.get('textarea').classes('uncommitted-change').should.be.true();
+      row.classes('uncommitted-change').should.be.true();
     });
   });
 

--- a/test/components/project/show.spec.js
+++ b/test/components/project/show.spec.js
@@ -141,10 +141,10 @@ describe('ProjectShow', () => {
       const li = app.findAll('#page-head-tabs li');
       li.map(wrapper => wrapper.get('a').text()).should.eql([
         'Overview',
+        'Datasets',
         'Project Roles',
         'App Users',
         'Form Access',
-        'Datasets',
         'Settings'
       ]);
       li[0].should.be.visible(true);


### PR DESCRIPTION
See the commits for the specific changes. Here are a few screenshots:

**Change is indicated on the entire row:**

<img width="907" src="https://github.com/getodk/central-frontend/assets/5970131/128f9e08-d535-45a7-8fb2-66a8646ed582">
<img width="908" src="https://github.com/getodk/central-frontend/assets/5970131/6336da42-6fb9-46af-8824-38fe59d2bc2c">
<br>
<br>

**"Current value" and "Updated value" have the same width:**

<img width="910" src="https://github.com/getodk/central-frontend/assets/5970131/358026fe-3ad2-4089-b6e0-f038fc4add5d">

#### What has been done to verify that this works as intended?

Tests and/or viewing things locally.

#### Why is this the best possible solution? Were any other approaches considered?

I'm going to leave some comments on individual lines.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We should maybe ask the QA team to take another quick pass on the entity update modal.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced