### PR TITLE
Move edit button from EntityActivity to EntityData

### DIFF
--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -13,10 +13,6 @@ except according to the terms contained in the LICENSE file.
   <page-section id="entity-activity">
     <template #heading>
       <span>{{ $t('common.activity') }}</span>
-      <button v-if="rendersUpdateButton" id="entity-activity-update-button"
-        type="button" class="btn btn-default" @click="$emit('update')">
-        <span class="icon-pencil"></span>{{ $t('action.edit') }}
-      </button>
     </template>
     <template #body>
       <loading :state="initiallyLoading"/>
@@ -42,15 +38,10 @@ import PageSection from '../page/section.vue';
 
 import { useRequestData } from '../../request-data';
 
-defineEmits(['update']);
-
 // The component does not assume that this data will exist when the component is
 // created.
-const { project, dataset, audits, diffs, resourceStates } = useRequestData();
+const { audits, diffs, resourceStates } = useRequestData();
 const { initiallyLoading, dataExists } = resourceStates([audits, diffs]);
-
-const rendersUpdateButton = computed(() => project.dataExists &&
-  project.permits('entity.update') && dataset.dataExists);
 
 const feed = computed(() => {
   const result = [];

--- a/src/components/entity/data.vue
+++ b/src/components/entity/data.vue
@@ -10,11 +10,17 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <page-section v-if="dataset.dataExists && dataset.properties.length !== 0"
-    id="entity-data">
-    <template #heading><span>{{ $t('title') }}</span></template>
+  <page-section id="entity-data">
+    <template #heading>
+      <span>{{ $t('title') }}</span>
+      <button v-if="rendersUpdateButton" id="entity-data-update-button"
+        type="button" class="btn btn-default" @click="$emit('update')">
+        <span class="icon-pencil"></span>{{ $t('action.edit') }}
+      </button>
+    </template>
     <template #body>
-      <dl v-if="entity.dataExists">
+      <loading :state="dataset.initiallyLoading"/>
+      <dl v-if="dataExists">
         <div v-for="{ name } of dataset.properties" :key="name">
           <dt><span v-tooltip.text>{{ name }}</span></dt>
           <dd v-if="data[name] == null || data[name] === ''" class="empty">
@@ -35,14 +41,20 @@ export default {
 <script setup>
 import { computed } from 'vue';
 
+import Loading from '../loading.vue';
 import PageSection from '../page/section.vue';
 
 import { useRequestData } from '../../request-data';
 
+defineEmits(['update']);
+
 // The component does not assume that this data will exist when the component is
 // created.
-const { dataset, entity } = useRequestData();
+const { project, dataset, entity, resourceStates } = useRequestData();
+const { dataExists } = resourceStates([dataset, entity]);
 
+const rendersUpdateButton = computed(() => project.dataExists &&
+  project.permits('entity.update') && dataset.dataExists);
 const data = computed(() => entity.currentVersion.data);
 </script>
 

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -23,10 +23,10 @@ except according to the terms contained in the LICENSE file.
       <div v-show="entity.dataExists" class="row">
         <div class="col-xs-4">
           <entity-basic-details/>
-          <entity-data/>
+          <entity-data @update="update.state = true"/>
         </div>
         <div class="col-xs-8">
-          <entity-activity @update="update.state = true"/>
+          <entity-activity/>
         </div>
       </div>
     </page-body>

--- a/test/components/entity/activity.spec.js
+++ b/test/components/entity/activity.spec.js
@@ -1,12 +1,9 @@
 import EntityActivity from '../../../src/components/entity/activity.vue';
 import EntityFeedEntry from '../../../src/components/entity/feed-entry.vue';
-import EntityUpdate from '../../../src/components/entity/update.vue';
 
 import useEntity from '../../../src/request-data/entity';
 
 import testData from '../../data';
-import { load } from '../../util/http';
-import { mockLogin } from '../../util/session';
 import { mockRouter } from '../../util/router';
 import { mount } from '../../util/lifecycle';
 import { testRequestData } from '../../util/request-data';
@@ -17,8 +14,6 @@ const mountComponent = () => mount(EntityActivity, {
   },
   container: {
     requestData: testRequestData([useEntity], {
-      project: testData.extendedProjects.last(),
-      dataset: testData.extendedDatasets.last(),
       entity: testData.extendedEntities.last(),
       audits: testData.extendedAudits.sorted()
         .filter(({ action }) => action.startsWith('entity.')),
@@ -29,34 +24,6 @@ const mountComponent = () => mount(EntityActivity, {
 });
 
 describe('EntityActivity', () => {
-  describe('edit button', () => {
-    it('renders the button for a sitewide administrator', () => {
-      mockLogin();
-      testData.extendedEntities.createPast(1, { uuid: 'e' });
-      const button = mountComponent().find('#entity-activity-update-button');
-      button.exists().should.be.true();
-    });
-
-    it('does not render the button for a project viewer', () => {
-      mockLogin({ role: 'none' });
-      testData.extendedProjects.createPast(1, { role: 'viewer', datasets: 1 });
-      testData.extendedEntities.createPast(1, { uuid: 'e' });
-      const button = mountComponent().find('#entity-activity-update-button');
-      button.exists().should.be.false();
-    });
-
-    it('toggles the modal', () => {
-      mockLogin();
-      testData.extendedEntities.createPast(1, { uuid: 'e' });
-      return load('/projects/1/datasets/trees/entities/e', { root: false })
-        .testModalToggles({
-          modal: EntityUpdate,
-          show: '#entity-activity-update-button',
-          hide: ['.btn-link']
-        });
-    });
-  });
-
   describe('feed', () => {
     it('renders 2 entries if entity was created on submission receipt', () => {
       const sourceDetails = testData.extendedEntities

--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -132,7 +132,7 @@ describe('EntityBasicDetails', () => {
           dd.text().should.equal('s');
         })
         .request(async (component) => {
-          await component.get('#entity-activity-update-button').trigger('click');
+          await component.get('#entity-data-update-button').trigger('click');
           const form = component.get('#entity-update form');
           await form.get('textarea').setValue('Updated Entity');
           return form.trigger('submit');

--- a/test/components/entity/data.spec.js
+++ b/test/components/entity/data.spec.js
@@ -1,15 +1,19 @@
 import EntityData from '../../../src/components/entity/data.vue';
+import EntityUpdate from '../../../src/components/entity/update.vue';
 
 import useEntity from '../../../src/request-data/entity';
 
 import testData from '../../data';
+import { load } from '../../util/http';
 import { mergeMountOptions, mount } from '../../util/lifecycle';
+import { mockLogin } from '../../util/session';
 import { testRequestData } from '../../util/request-data';
 
 const mountComponent = (options = undefined) =>
   mount(EntityData, mergeMountOptions(options, {
     container: {
       requestData: testRequestData([useEntity], {
+        project: testData.extendedProjects.last(),
         dataset: testData.extendedDatasets.last(),
         entity: testData.extendedEntities.last()
       })
@@ -17,10 +21,32 @@ const mountComponent = (options = undefined) =>
   }));
 
 describe('EntityData', () => {
-  it('does not render if there are no properties', () => {
-    testData.extendedDatasets.createPast(1, { properties: [], entities: 1 });
-    testData.extendedEntities.createPast(1);
-    mountComponent().find('*').exists().should.be.false();
+  describe('edit button', () => {
+    it('renders the button for a sitewide administrator', () => {
+      mockLogin();
+      testData.extendedEntities.createPast(1);
+      const button = mountComponent().find('#entity-data-update-button');
+      button.exists().should.be.true();
+    });
+
+    it('does not render the button for a project viewer', () => {
+      mockLogin({ role: 'none' });
+      testData.extendedProjects.createPast(1, { role: 'viewer', datasets: 1 });
+      testData.extendedEntities.createPast(1);
+      const button = mountComponent().find('#entity-data-update-button');
+      button.exists().should.be.false();
+    });
+
+    it('toggles the modal', () => {
+      mockLogin();
+      testData.extendedEntities.createPast(1, { uuid: 'e' });
+      return load('/projects/1/datasets/trees/entities/e', { root: false })
+        .testModalToggles({
+          modal: EntityUpdate,
+          show: '#entity-data-update-button',
+          hide: ['.btn-link']
+        });
+    });
   });
 
   it('renders an item for each property', () => {

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -70,7 +70,7 @@ describe('EntityShow', () => {
       return load('/projects/1/datasets/%C3%A1/entities/e', { root: false })
         .complete()
         .request(async (component) => {
-          await component.get('#entity-activity-update-button').trigger('click');
+          await component.get('#entity-data-update-button').trigger('click');
           const form = component.get('#entity-update form');
           const textareas = form.findAll('textarea');
           textareas.length.should.equal(2);


### PR DESCRIPTION
This PR moves the edit button on the entity detail page to the "Entity Data" section:

<img width="1304" src="https://github.com/getodk/central-frontend/assets/5970131/cc235600-4102-4cbd-9953-c6dee5b011db">

#### What has been done to verify that this works as intended?

I've tried out the button locally. The modal is shown, and I'm able to update the entity.

I've also updated tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk of regression should be low.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced