### PR TITLE
Update Transifex JSON files

### DIFF
--- a/transifex/strings_cs.json
+++ b/transifex/strings_cs.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Počet chyb při vytváření subjektu"
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_de.json
+++ b/transifex/strings_de.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Anzahl der Fehler bei der Entitätserstellung"
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "Zurück zu {datasetName} Tabelle",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_es.json
+++ b/transifex/strings_es.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Número de errores de creación de entidad"
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "Volver a la tabla {datasetName}",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_fr.json
+++ b/transifex/strings_fr.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Nombre d'erreurs de création d'Entité"
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "Retour à la table {datasetName}",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_id.json
+++ b/transifex/strings_id.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": ""
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_it.json
+++ b/transifex/strings_it.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Numero di errori nella creazione dell'entità"
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "Indietro alla Tabella {datasetName} ",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_ja.json
+++ b/transifex/strings_ja.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": ""
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },

--- a/transifex/strings_sw.json
+++ b/transifex/strings_sw.json
@@ -1168,6 +1168,9 @@
         },
         "num_failed_entities": {
           "string": "Idadi ya hitilafu za kuunda Huluki"
+        },
+        "num_entity_updates": {
+          "string": ""
         }
       }
     },
@@ -1525,6 +1528,14 @@
         "back": {
           "string": "Rudi kwenye Jedwali la {datasetName}\n ",
           "developer_comment": "This is shown at the top of the page. The user can click it to go back."
+        }
+      }
+    },
+    "EntityTable": {
+      "header": {
+        "updatedAtAndActions": {
+          "string": "",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
         }
       }
     },


### PR DESCRIPTION
Pulling translations one last time before release, thereby closing #759. Translations were updated previously in #812. Actually, it doesn't look like there have been any new translations since #812: the structure of the Transifex JSON files has changed slightly after the addition of a couple of strings, but there haven't been content changes. I think it's nice to have the latest Transifex JSON files in the codebase though.

#### What has been done to verify that this works as intended?

Nothing user-facing has changed. The Transifex JSON files are used as data to source the autogenerated `<i18n>` blocks, which haven't changed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced