### PR TITLE
Remove "Role Settings" tab in UserHome

### DIFF
--- a/src/components/user/home.vue
+++ b/src/components/user/home.vue
@@ -15,13 +15,7 @@ except according to the terms contained in the LICENSE file.
       <template #title>{{ $t('title') }}</template>
       <template #tabs>
         <li :class="tabClass('')" role="presentation">
-          <router-link :to="tabPath('')">{{ $t('tab.users') }}</router-link>
-        </li>
-        <li class="disabled" role="presentation">
-          <a href="#">
-            {{ $t('tab.roles') }}
-            <span class="coming-soon">{{ $t('comingSoon') }}</span>
-          </a>
+          <router-link :to="tabPath('')">{{ $t('resource.webUsers') }}</router-link>
         </li>
       </template>
     </page-head>
@@ -46,11 +40,8 @@ const { tabPath, tabClass } = useTabs('/users');
 </script>
 
 <style lang="scss">
-@import '../../assets/scss/variables';
-
-#user-home .coming-soon {
-  color: $color-text;
-  font-size: 10px;
+#user-home {
+  #page-head-tabs li { display: block; }
 }
 </style>
 
@@ -58,14 +49,7 @@ const { tabPath, tabClass } = useTabs('/users');
 {
   "en": {
     // This is shown as the title at the top of the page.
-    "title": "User Settings",
-    "tab": {
-      "users": "Web Users",
-      "roles": "Role Settings"
-    },
-    // This is shown within a disabled navigation tab to indicate that the
-    // functionality is not yet implemented, but will be soon.
-    "comingSoon": "(coming soon)"
+    "title": "User Settings"
   }
 }
 </i18n>

--- a/test/components/user/home.spec.js
+++ b/test/components/user/home.spec.js
@@ -1,0 +1,13 @@
+import { load } from '../../util/http';
+import { mockLogin } from '../../util/session';
+
+describe('UserHome', () => {
+  beforeEach(mockLogin);
+
+  it('shows the correct tabs', async () => {
+    const app = await load('/users', { attachTo: document.body });
+    const li = app.findAll('#page-head-tabs li');
+    li.map(wrapper => wrapper.text()).should.eql(['Web Users']);
+    li[0].should.be.visible(true);
+  });
+});

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3951,20 +3951,6 @@
       "title": {
         "string": "User Settings",
         "developer_comment": "This is shown as the title at the top of the page."
-      },
-      "tab": {
-        "users": {
-          "string": "Web Users",
-          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
-        },
-        "roles": {
-          "string": "Role Settings",
-          "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
-        }
-      },
-      "comingSoon": {
-        "string": "(coming soon)",
-        "developer_comment": "This is shown within a disabled navigation tab to indicate that the functionality is not yet implemented, but will be soon."
       }
     },
     "UserList": {


### PR DESCRIPTION
Closes getodk/central#450.

#### What has been done to verify that this works as intended?

I viewed the page locally. The "Role Settings" tab is gone, but everything seems to be the same. I also wrote a new test.

#### Why is this the best possible solution? Were any other approaches considered?

It's a pretty small PR, so not a lot of different options to consider. However, I'll leave a comment about a particular line.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk of regression should be low.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No changes needed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced