### PR TITLE
Update usage reporting preview to be able to handle empty projects

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -21,7 +21,10 @@ except according to the terms contained in the LICENSE file.
     <tbody>
       <tr v-for="(value, name) in metrics" :key="name">
         <td>{{ $t(`fields.${name}`) }}</td>
-        <template v-if="value.recent != null">
+        <template v-if="value == null">
+          <td colspan="2" class="metric-value">0</td>
+        </template>
+        <template v-else-if="value.recent != null">
           <td class="metric-value">{{ $n(value.recent) }}</td>
           <td class="metric-value">{{ $n(value.total) }}</td>
         </template>

--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -22,7 +22,7 @@ except according to the terms contained in the LICENSE file.
       <tr v-for="(value, name) in metrics" :key="name">
         <td>{{ $t(`fields.${name}`) }}</td>
         <template v-if="value == null">
-          <td colspan="2" class="metric-value">0</td>
+          <td colspan="2" class="metric-value"></td>
         </template>
         <template v-else-if="value.recent != null">
           <td class="metric-value">{{ $n(value.recent) }}</td>

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -25,7 +25,7 @@ except according to the terms contained in the LICENSE file.
           <span class="header">{{ $t('projects.title') }}</span>
           <span class="explanation">{{ $tcn('projects.subtitle', numProjects) }}</span>
         </div>
-        <div id="analytics-preview-project-tables">
+        <div v-if="firstProject" id="analytics-preview-project-tables">
           <div id="users-forms-column">
             <analytics-metrics-table :title="$t('resource.users')" :metrics="userSummary"/>
             <analytics-metrics-table :title="$t('resource.forms')" :metrics="formSummary"/>
@@ -94,10 +94,10 @@ export default {
       return this.analyticsPreview.system;
     },
     firstProject() {
-      // eslint-disable-next-line arrow-body-style
-      return this.analyticsPreview.projects.reduce((a, b) => {
-        return (a.submissions.num_submissions_received.recent > b.submissions.num_submissions_received.recent) ? a : b;
-      });
+      if (this.analyticsPreview.projects.length === 0)
+        return null;
+      return this.analyticsPreview.projects.reduce((a, b) =>
+        ((a.submissions.num_submissions_received.recent > b.submissions.num_submissions_received.recent) ? a : b));
     },
     firstDataset() {
       const { id, ...ds } = flatten(this.analyticsPreview.projects.map(p => p.datasets)).reduce((a, b) => ((a.num_entities.recent > b.num_entities.recent) ? a : b), { num_entities: {} });

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -21,24 +21,26 @@ except according to the terms contained in the LICENSE file.
       <loading :state="analyticsPreview.initiallyLoading"/>
       <template v-if="analyticsPreview.dataExists">
         <analytics-metrics-table :title="$t('common.system')" :metrics="systemSummary"/>
-        <div id="analytics-preview-project-summary">
-          <span class="header">{{ $t('projects.title') }}</span>
-          <span class="explanation">{{ $tcn('projects.subtitle', numProjects) }}</span>
-        </div>
-        <div v-if="firstProject" id="analytics-preview-project-tables">
-          <div id="users-forms-column">
-            <analytics-metrics-table :title="$t('resource.users')" :metrics="userSummary"/>
-            <analytics-metrics-table :title="$t('resource.forms')" :metrics="formSummary"/>
+        <template v-if="numProjects > 0">
+          <div id="analytics-preview-project-summary">
+            <span class="header">{{ $t('projects.title') }}</span>
+            <span class="explanation">{{ $tcn('projects.subtitle', numProjects) }}</span>
           </div>
-          <div id="submissions-column">
-            <analytics-metrics-table :title="$t('resource.submissions')"
-              :metrics="submissionSummary"/>
-            <analytics-metrics-table :title="$t('submissionStates')"
-              :metrics="submissionStateSummary"/>
-            <analytics-metrics-table :title="$t('other')"
-              :metrics="otherSummary"/>
+          <div id="analytics-preview-project-tables">
+            <div id="users-forms-column">
+              <analytics-metrics-table :title="$t('resource.users')" :metrics="userSummary"/>
+              <analytics-metrics-table :title="$t('resource.forms')" :metrics="formSummary"/>
+            </div>
+            <div id="submissions-column">
+              <analytics-metrics-table :title="$t('resource.submissions')"
+                :metrics="submissionSummary"/>
+              <analytics-metrics-table :title="$t('submissionStates')"
+                :metrics="submissionStateSummary"/>
+              <analytics-metrics-table :title="$t('other')"
+                :metrics="otherSummary"/>
+            </div>
           </div>
-        </div>
+        </template>
         <template v-if="numDatasets > 0">
           <div id="analytics-preview-dataset-summary">
             <span class="header">{{ $t('datasets.title') }}</span>
@@ -94,10 +96,7 @@ export default {
       return this.analyticsPreview.system;
     },
     firstProject() {
-      if (this.analyticsPreview.projects.length === 0)
-        return null;
-      return this.analyticsPreview.projects.reduce((a, b) =>
-        ((a.submissions.num_submissions_received.recent > b.submissions.num_submissions_received.recent) ? a : b));
+      return this.analyticsPreview.projects.reduce((a, b) => ((a.submissions.num_submissions_received.recent > b.submissions.num_submissions_received.recent) ? a : b));
     },
     firstDataset() {
       const { id, ...ds } = flatten(this.analyticsPreview.projects.map(p => p.datasets)).reduce((a, b) => ((a.num_entities.recent > b.num_entities.recent) ? a : b), { num_entities: {} });

--- a/test/components/analytics/metrics-table.spec.js
+++ b/test/components/analytics/metrics-table.spec.js
@@ -47,6 +47,21 @@ describe('AnalyticsMetricsTable', () => {
     td[0].text().should.equal('1,000');
   });
 
+  it('correctly renders a metric with null data', () => {
+    // default/unpopulated data from the server could be 0 or could be null
+    // e.g. calculating the max question count when there are no forms or projects
+    const component = mount(AnalyticsMetricsTable, {
+      props: {
+        title: 'System',
+        metrics: { num_questions_biggest_form: null }
+      }
+    });
+    const td = component.findAll('td.metric-value');
+    td.length.should.equal(1);
+    td[0].attributes().colspan.should.equal('2');
+    td[0].text().should.equal('');
+  });
+
   it('renders a row for each metric', () => {
     const component = mount(AnalyticsMetricsTable, {
       props: {

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -71,6 +71,24 @@ describe('AnalyticsPreview', () => {
     table.props().metrics.should.eql(analyticsPreview.system);
   });
 
+  it('shows preview even when there are zero projects (fresh central install)', async () => {
+    const emptyProjects = {
+      system: { num_admins: { recent: 1, total: 1 } },
+      projects: []
+    };
+    const container = await mockHttp()
+      .mount(AnalyticsPreview)
+      .request(modal => modal.setProps({ state: true }))
+      .respondWithData(() => emptyProjects);
+    // Only the system preview table should be shown
+    const tables = container.findAllComponents(AnalyticsMetricsTable);
+    tables.length.should.equal(1);
+    tables[0].props().metrics.should.eql(emptyProjects.system);
+    // Text should indicate 0 projects
+    const text = container.get('#analytics-preview-project-summary .explanation').text();
+    text.should.equal('(Showing the most active Project of 0 Projects)');
+  });
+
   it('shows the project number and plurailization for a single project', async () => {
     const singleProject = {
       system: { num_admins: { recent: 1, total: 1 } },

--- a/test/components/analytics/preview.spec.js
+++ b/test/components/analytics/preview.spec.js
@@ -84,9 +84,8 @@ describe('AnalyticsPreview', () => {
     const tables = container.findAllComponents(AnalyticsMetricsTable);
     tables.length.should.equal(1);
     tables[0].props().metrics.should.eql(emptyProjects.system);
-    // Text should indicate 0 projects
-    const text = container.get('#analytics-preview-project-summary .explanation').text();
-    text.should.equal('(Showing the most active Project of 0 Projects)');
+    // Project summary should not exist
+    container.find('#analytics-preview-project-summary').exists().should.be.false();
   });
 
   it('shows the project number and plurailization for a single project', async () => {


### PR DESCRIPTION
Closes https://github.com/getodk/central-backend/issues/763 

The main issue with the usage reporting preview not working on a fresh install of Central was that the data wasn't what frontend expected:
1. projects could be empty, so it couldn't pick a first project to show
2. some fields, namely `num_questions_biggest_form` were `null` because with no projects or forms, that value wasn't calculated. I believe the real reporting of the metrics is fine with `null`, but frontend was trying to display that it as a number and running into an error. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Trying it on a local version of central with a fresh database with no projects, just an admin user.

#### Why is this the best possible solution? Were any other approaches considered?

Small changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Allows users to see usage reporting preview even when there are no projects.
<img width="1229" alt="Screen Shot 2023-07-31 at 3 41 07 PM" src="https://github.com/getodk/central-frontend/assets/76205/11b95dce-43d9-4ae8-b8fc-a60566d5d9ab">


#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced