### PR TITLE
Use defineOptions() instead of separate <script> tag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
     }],
     'vue/max-attributes-per-line': 'off',
     'vue/multi-word-component-names': 'off',
+    'vue/no-setup-props-destructure': 'off',
     'vue/no-template-target-blank': 'off',
     'vue/object-curly-newline': 'off',
     'vue/require-default-prop': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,9 +463,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4727,9 +4727,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.16.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.16.1.tgz",
-      "integrity": "sha512-2FtnTqazA6aYONfDuOZTk0QzwhAwi7Z4+uJ7+GHeGxcKapjqWlDsRWDenvyG/utyOfAS5bVRmAG3cEWiYEz2bA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.17.0.tgz",
+      "integrity": "sha512-r7Bp79pxQk9I5XDP0k2dpUC7Ots3OSWgvGZNu3BxmKK6Zg7NgVtcOB6OCna5Kb9oQwJPl5hq183WD0SY5tZtIQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -13114,9 +13114,9 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-          "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
           "dev": true
         }
       }
@@ -16653,9 +16653,9 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "9.16.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.16.1.tgz",
-      "integrity": "sha512-2FtnTqazA6aYONfDuOZTk0QzwhAwi7Z4+uJ7+GHeGxcKapjqWlDsRWDenvyG/utyOfAS5bVRmAG3cEWiYEz2bA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.17.0.tgz",
+      "integrity": "sha512-r7Bp79pxQk9I5XDP0k2dpUC7Ots3OSWgvGZNu3BxmKK6Zg7NgVtcOB6OCna5Kb9oQwJPl5hq183WD0SY5tZtIQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,6 +447,33 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -4700,17 +4727,17 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
-      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.16.1.tgz",
+      "integrity": "sha512-2FtnTqazA6aYONfDuOZTk0QzwhAwi7Z4+uJ7+GHeGxcKapjqWlDsRWDenvyG/utyOfAS5bVRmAG3cEWiYEz2bA==",
       "dev": true,
       "dependencies": {
-        "eslint-utils": "^3.0.0",
+        "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
-        "nth-check": "^2.0.1",
-        "postcss-selector-parser": "^6.0.9",
-        "semver": "^7.3.5",
-        "vue-eslint-parser": "^9.0.1",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^6.0.13",
+        "semver": "^7.5.4",
+        "vue-eslint-parser": "^9.3.1",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -4721,9 +4748,9 @@
       }
     },
     "node_modules/eslint-plugin-vue/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -9479,9 +9506,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11474,9 +11501,9 @@
       "dev": true
     },
     "node_modules/vue-eslint-parser": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.1.0.tgz",
-      "integrity": "sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
+      "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -13076,6 +13103,23 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+          "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+          "dev": true
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -16609,24 +16653,24 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
-      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.16.1.tgz",
+      "integrity": "sha512-2FtnTqazA6aYONfDuOZTk0QzwhAwi7Z4+uJ7+GHeGxcKapjqWlDsRWDenvyG/utyOfAS5bVRmAG3cEWiYEz2bA==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^3.0.0",
+        "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
-        "nth-check": "^2.0.1",
-        "postcss-selector-parser": "^6.0.9",
-        "semver": "^7.3.5",
-        "vue-eslint-parser": "^9.0.1",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^6.0.13",
+        "semver": "^7.5.4",
+        "vue-eslint-parser": "^9.3.1",
         "xml-name-validator": "^4.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -19921,9 +19965,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -21426,9 +21470,9 @@
       "dev": true
     },
     "vue-eslint-parser": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.1.0.tgz",
-      "integrity": "sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.1.tgz",
+      "integrity": "sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",

--- a/src/components/account/edit.vue
+++ b/src/components/account/edit.vue
@@ -13,15 +13,14 @@ except according to the terms contained in the LICENSE file.
   <user-edit :id="currentUser.id.toString()"/>
 </template>
 
-<script>
-export default {
-  name: 'AccountEdit'
-};
-</script>
 <script setup>
 import UserEdit from '../user/edit.vue';
 
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'AccountEdit'
+});
 
 const { currentUser } = useRequestData();
 </script>

--- a/src/components/audit/table.vue
+++ b/src/components/audit/table.vue
@@ -26,15 +26,14 @@ except according to the terms contained in the LICENSE file.
   </table>
 </template>
 
-<script>
-export default {
-  name: 'AuditTable'
-};
-</script>
 <script setup>
 import AuditRow from './row.vue';
 
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'AuditTable'
+});
 
 const { audits } = useRequestData();
 </script>

--- a/src/components/dataset/list.vue
+++ b/src/components/dataset/list.vue
@@ -24,11 +24,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'DatasetList'
-};
-</script>
 <script setup>
 import DatasetIntroduction from './introduction.vue';
 import DatasetTable from './table.vue';
@@ -39,6 +34,9 @@ import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'DatasetList'
+});
 const props = defineProps({
   projectId: {
     type: String,

--- a/src/components/dataset/pending-submissions.vue
+++ b/src/components/dataset/pending-submissions.vue
@@ -58,17 +58,14 @@ except according to the terms contained in the LICENSE file.
   </modal>
 </template>
 
-<script>
-export default {
-  name: 'DatasetPendingSubmissions'
-};
-</script>
-
 <script setup>
 import { ref } from 'vue';
 
 import Modal from '../modal.vue';
 
+defineOptions({
+  name: 'DatasetPendingSubmissions'
+});
 defineProps({
   state: {
     type: Boolean,
@@ -79,7 +76,6 @@ defineProps({
     required: true
   }
 });
-
 defineEmits(['hide', 'success']);
 
 const convert = ref(null);

--- a/src/components/dataset/settings.vue
+++ b/src/components/dataset/settings.vue
@@ -45,12 +45,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'DatasetSettings'
-};
-</script>
-
 <script setup>
 import { ref, watch, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -59,6 +53,10 @@ import DatasetPendingSubmissions from './pending-submissions.vue';
 
 import { apiPaths, isProblem } from '../../util/request';
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'DatasetSettings'
+});
 
 const { t } = useI18n();
 

--- a/src/components/dataset/table.vue
+++ b/src/components/dataset/table.vue
@@ -29,15 +29,14 @@ except according to the terms contained in the LICENSE file.
   </p>
 </template>
 
-<script>
-export default {
-  name: 'DatasetTable'
-};
-</script>
 <script setup>
 import DatasetRow from './row.vue';
 
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'DatasetTable'
+});
 
 // The component does not assume that this data will exist when the component is
 // created.

--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -24,11 +24,6 @@ except according to the terms contained in the LICENSE file.
   </page-section>
 </template>
 
-<script>
-export default {
-  name: 'EntityActivity'
-};
-</script>
 <script setup>
 import { computed } from 'vue';
 
@@ -37,6 +32,10 @@ import Loading from '../loading.vue';
 import PageSection from '../page/section.vue';
 
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'EntityActivity'
+});
 
 // The component does not assume that this data will exist when the component is
 // created.

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -45,11 +45,6 @@ except according to the terms contained in the LICENSE file.
   </page-section>
 </template>
 
-<script>
-export default {
-  name: 'EntityBasicDetails'
-};
-</script>
 <script setup>
 import { inject, ref, watchEffect } from 'vue';
 
@@ -59,6 +54,10 @@ import PageSection from '../page/section.vue';
 
 import useRoutes from '../../composables/routes';
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'EntityBasicDetails'
+});
 
 const projectId = inject('projectId');
 

--- a/src/components/entity/data-row.vue
+++ b/src/components/entity/data-row.vue
@@ -19,12 +19,10 @@ except according to the terms contained in the LICENSE file.
   </tr>
 </template>
 
-<script>
-export default {
-  name: 'EntityDataRow'
-};
-</script>
 <script setup>
+defineOptions({
+  name: 'EntityDataRow'
+});
 defineProps({
   entity: {
     type: Object,

--- a/src/components/entity/data.vue
+++ b/src/components/entity/data.vue
@@ -33,11 +33,6 @@ except according to the terms contained in the LICENSE file.
   </page-section>
 </template>
 
-<script>
-export default {
-  name: 'EntityData'
-};
-</script>
 <script setup>
 import { computed } from 'vue';
 
@@ -46,6 +41,9 @@ import PageSection from '../page/section.vue';
 
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'EntityData'
+});
 defineEmits(['update']);
 
 // The component does not assume that this data will exist when the component is

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -77,11 +77,6 @@ except according to the terms contained in the LICENSE file.
   </feed-entry>
 </template>
 
-<script>
-export default {
-  name: 'EntityFeedEntry'
-};
-</script>
 <script setup>
 import { computed, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -94,6 +89,9 @@ import useReviewState from '../../composables/review-state';
 import useRoutes from '../../composables/routes';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'EntityFeedEntry'
+});
 const props = defineProps({
   entry: {
     type: Object,

--- a/src/components/entity/metadata-row.vue
+++ b/src/components/entity/metadata-row.vue
@@ -45,11 +45,6 @@ except according to the terms contained in the LICENSE file.
   </tr>
 </template>
 
-<script>
-export default {
-  name: 'EntityMetadataRow'
-};
-</script>
 <script setup>
 import { computed, inject } from 'vue';
 
@@ -57,6 +52,9 @@ import DateTime from '../date-time.vue';
 
 import useRoutes from '../../composables/routes';
 
+defineOptions({
+  name: 'EntityMetadataRow'
+});
 const props = defineProps({
   entity: {
     type: Object,

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -36,11 +36,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'EntityShow'
-};
-</script>
 <script setup>
 import { inject, provide, reactive } from 'vue';
 
@@ -59,6 +54,9 @@ import { apiPaths } from '../../util/request';
 import { setDocumentTitle } from '../../util/reactivity';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'EntityShow'
+});
 const props = defineProps({
   projectId: {
     type: String,

--- a/src/components/entity/table.vue
+++ b/src/components/entity/table.vue
@@ -39,11 +39,6 @@ except according to the terms contained in the LICENSE file.
   </table-freeze>
 </template>
 
-<script>
-export default {
-  name: 'EntityTable'
-};
-</script>
 <script setup>
 import { computed, ref } from 'vue';
 
@@ -54,6 +49,9 @@ import TableFreeze from '../table-freeze.vue';
 import { markRowsChanged } from '../../util/dom';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'EntityTable'
+});
 defineProps({
   properties: Array
 });

--- a/src/components/entity/update.vue
+++ b/src/components/entity/update.vue
@@ -55,11 +55,6 @@ except according to the terms contained in the LICENSE file.
   </modal>
 </template>
 
-<script>
-export default {
-  name: 'EntityUpdate'
-};
-</script>
 <script setup>
 import { computed, nextTick, ref, watch } from 'vue';
 
@@ -74,6 +69,9 @@ import { noop } from '../../util/util';
 import { px, styleBox } from '../../util/dom';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'EntityUpdate'
+});
 const props = defineProps({
   state: Boolean,
   entity: Object

--- a/src/components/entity/update/row.vue
+++ b/src/components/entity/update/row.vue
@@ -34,10 +34,6 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 let id = 0;
-
-export default {
-  name: 'EntityUpdateRow'
-};
 </script>
 <script setup>
 import { computed, ref, watch } from 'vue';
@@ -46,6 +42,9 @@ import TextareaAutosize from '../../textarea-autosize.vue';
 
 import { requiredLabel } from '../../../util/dom';
 
+defineOptions({
+  name: 'EntityUpdateRow'
+});
 const props = defineProps({
   modelValue: String,
   oldValue: String,

--- a/src/components/form-group.vue
+++ b/src/components/form-group.vue
@@ -23,11 +23,6 @@ except according to the terms contained in the LICENSE file.
   </label>
 </template>
 
-<script>
-export default {
-  inheritAttrs: false
-};
-</script>
 <script setup>
 import { computed, ref } from 'vue';
 
@@ -35,6 +30,9 @@ import PasswordStrength from './password-strength.vue';
 
 import { requiredLabel } from '../util/dom';
 
+defineOptions({
+  inheritAttrs: false
+});
 const props = defineProps({
   modelValue: {
     type: String,

--- a/src/components/form-version/table.vue
+++ b/src/components/form-version/table.vue
@@ -25,16 +25,14 @@ except according to the terms contained in the LICENSE file.
   </table>
 </template>
 
-<script>
-export default {
-  name: 'FormVersionTable'
-};
-</script>
 <script setup>
 import FormVersionRow from './row.vue';
 
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'FormVersionTable'
+});
 defineEmits(['view-xml']);
 
 // The component does not assume that this data will exist when the component is

--- a/src/components/home/summary.vue
+++ b/src/components/home/summary.vue
@@ -43,17 +43,16 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'HomeSummary'
-};
-</script>
 <script setup>
 import HomeSummaryItem from './summary/item.vue';
 import Loading from '../loading.vue';
 
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'HomeSummary'
+});
 
 const { currentUser, projects, createResource } = useRequestData();
 const users = createResource('users');

--- a/src/components/page/body.vue
+++ b/src/components/page/body.vue
@@ -15,13 +15,12 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'PageBody'
-};
-</script>
 <script setup>
 import { computed, inject } from 'vue';
+
+defineOptions({
+  name: 'PageBody'
+});
 
 const { router } = inject('container');
 const htmlClass = computed(() => ({

--- a/src/components/project/archive.vue
+++ b/src/components/project/archive.vue
@@ -37,11 +37,6 @@ except according to the terms contained in the LICENSE file.
   </modal>
 </template>
 
-<script>
-export default {
-  name: 'ProjectArchive'
-};
-</script>
 <script setup>
 import Modal from '../modal.vue';
 import Spinner from '../spinner.vue';
@@ -50,6 +45,9 @@ import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'ProjectArchive'
+});
 defineProps({
   state: {
     type: Boolean,

--- a/src/components/project/edit.vue
+++ b/src/components/project/edit.vue
@@ -33,11 +33,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'ProjectEdit'
-};
-</script>
 <script setup>
 import { inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -49,6 +44,10 @@ import MarkdownTextarea from '../markdown/textarea.vue';
 import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'ProjectEdit'
+});
 
 // The component assumes that this data will exist when the component is
 // created.

--- a/src/components/project/submission-options.vue
+++ b/src/components/project/submission-options.vue
@@ -68,11 +68,6 @@ except according to the terms contained in the LICENSE file.
   </modal>
 </template>
 
-<script>
-export default {
-  name: 'ProjectSubmissionOptions'
-};
-</script>
 <script setup>
 import DocLink from '../doc-link.vue';
 import LinkIfCan from '../link-if-can.vue';
@@ -80,6 +75,9 @@ import Modal from '../modal.vue';
 
 import useRoutes from '../../composables/routes';
 
+defineOptions({
+  name: 'ProjectSubmissionOptions'
+});
 defineProps({
   state: Boolean
 });

--- a/src/components/public-link/table.vue
+++ b/src/components/public-link/table.vue
@@ -27,16 +27,14 @@ except according to the terms contained in the LICENSE file.
   </table>
 </template>
 
-<script>
-export default {
-  name: 'PublicLinkTable'
-};
-</script>
 <script setup>
 import PublicLinkRow from './row.vue';
 
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'PublicLinkTable'
+});
 defineProps({
   highlighted: Number
 });

--- a/src/components/submission/field-dropdown.vue
+++ b/src/components/submission/field-dropdown.vue
@@ -23,11 +23,6 @@ except according to the terms contained in the LICENSE file.
   </multiselect>
 </template>
 
-<script>
-export default {
-  name: 'SubmissionFieldDropdown'
-};
-</script>
 <script setup>
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -35,6 +30,9 @@ import { useI18n } from 'vue-i18n';
 import Multiselect from '../multiselect.vue';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'SubmissionFieldDropdown'
+});
 defineProps({
   modelValue: {
     type: Array,

--- a/src/components/submission/filters/review-state.vue
+++ b/src/components/submission/filters/review-state.vue
@@ -16,11 +16,6 @@ except according to the terms contained in the LICENSE file.
     :none="$t('action.select.none')" @update:model-value="update"/>
 </template>
 
-<script>
-export default {
-  name: 'SubmissionFiltersReviewState'
-};
-</script>
 <script setup>
 import { inject, nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -30,6 +25,9 @@ import Multiselect from '../../multiselect.vue';
 import useReviewState from '../../../composables/review-state';
 import { odataLiteral } from '../../../util/odata';
 
+defineOptions({
+  name: 'SubmissionFiltersReviewState'
+});
 const props = defineProps({
   modelValue: {
     type: Array,

--- a/src/components/submission/filters/submitter.vue
+++ b/src/components/submission/filters/submitter.vue
@@ -18,11 +18,6 @@ except according to the terms contained in the LICENSE file.
     @update:model-value="update"/>
 </template>
 
-<script>
-export default {
-  name: 'SubmissionFiltersSubmitter'
-};
-</script>
 <script setup>
 import { computed, nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -31,6 +26,9 @@ import Multiselect from '../../multiselect.vue';
 
 import { useRequestData } from '../../../request-data';
 
+defineOptions({
+  name: 'SubmissionFiltersSubmitter'
+});
 const props = defineProps({
   modelValue: {
     type: Array,

--- a/src/components/submission/table.vue
+++ b/src/components/submission/table.vue
@@ -39,11 +39,6 @@ except according to the terms contained in the LICENSE file.
   </table-freeze>
 </template>
 
-<script>
-export default {
-  name: 'SubmissionTable'
-};
-</script>
 <script setup>
 import { computed, ref } from 'vue';
 
@@ -55,6 +50,9 @@ import useChunkyArray from '../../composables/chunky-array';
 import { markRowsChanged } from '../../util/dom';
 import { useRequestData } from '../../request-data';
 
+defineOptions({
+  name: 'SubmissionTable'
+});
 defineProps({
   projectId: {
     type: String,

--- a/src/components/system/home.vue
+++ b/src/components/system/home.vue
@@ -33,11 +33,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'SystemHome'
-};
-</script>
 <script setup>
 import { inject } from 'vue';
 
@@ -45,6 +40,10 @@ import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
 
 import useTabs from '../../composables/tabs';
+
+defineOptions({
+  name: 'SystemHome'
+});
 
 const { tabPath, tabClass } = useTabs('/system');
 const config = inject('config');

--- a/src/components/user/edit.vue
+++ b/src/components/user/edit.vue
@@ -28,11 +28,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'UserEdit'
-};
-</script>
 <script setup>
 import { useRoute } from 'vue-router';
 
@@ -47,6 +42,9 @@ import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { setDocumentTitle } from '../../util/reactivity';
 
+defineOptions({
+  name: 'UserEdit'
+});
 const props = defineProps({
   id: {
     type: String,

--- a/src/components/user/edit/basic-details.vue
+++ b/src/components/user/edit/basic-details.vue
@@ -29,11 +29,6 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'UserEditBasicDetails'
-};
-</script>
 <script setup>
 import { inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -44,6 +39,10 @@ import Spinner from '../../spinner.vue';
 import { apiPaths } from '../../../util/request';
 import { noop } from '../../../util/util';
 import { useRequestData } from '../../../request-data';
+
+defineOptions({
+  name: 'UserEditBasicDetails'
+});
 
 // The component assumes that this data will exist when the component is
 // created.

--- a/src/components/user/home.vue
+++ b/src/components/user/home.vue
@@ -25,16 +25,15 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-export default {
-  name: 'UserHome'
-};
-</script>
 <script setup>
 import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
 
 import useTabs from '../../composables/tabs';
+
+defineOptions({
+  name: 'UserHome'
+});
 
 const { tabPath, tabClass } = useTabs('/users');
 </script>


### PR DESCRIPTION
Now that we're using Vue 3.3, we can use [`defineOptions()`](https://vuejs.org/api/sfc-script-setup.html#defineoptions). `defineOptions()` is a useful way in Composition API components to avoid a separate `<script>` tag just to specify the component name or other component options. With this change, it should be pretty rare that two `<script>` tags are needed.

I think it can be confusing when there are two `<script>` tags, which is part of why I think this change is appealing. I also like that `defineOptions()` allows us to specify component options in the same place as we call `defineProps()` and `defineEmits()`, grouping component configuration together.

ESLint needed to be updated for it to understand `defineOptions()` (specifically `eslint-plugin-vue` did). After I updated ESLint, I turned off a new Vue-related rule that I think has too many false positives.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced