### PR TITLE
fixes #911: add warning to encryption popup

### DIFF
--- a/src/components/project/enable-encryption.vue
+++ b/src/components/project/enable-encryption.vue
@@ -62,12 +62,14 @@ except according to the terms contained in the LICENSE file.
             <div class="info-item">
               <span class="icon-circle-o"></span>
               <p>{{ $t('steps[0].introduction[1][1][0]') }}</p>
-              <p>{{ $t('steps[0].introduction[1][1][1]') }}</p>
             </div>
             <div class="info-item">
               <span class="icon-close"></span>
               <p>{{ $t('steps[0].introduction[1][2][0]') }}</p>
-              <p>{{ $t('steps[0].introduction[1][2][1]') }}</p>
+            </div>
+            <div class="info-item">
+              <span class="icon-close"></span>
+              <p>{{ $t('steps[0].introduction[1][3]') }} </p>
             </div>
           </div>
           <i18n-t tag="p" keypath="steps[0].introduction[2].full">
@@ -298,7 +300,8 @@ export default {
             [
               "Encryption cannot be turned off once enabled.",
               "In a future version, you will be able to disable encryption, which will decrypt your data. This will be true even if you enable encryption now."
-            ]
+            ],
+            "Draft Submissions from all Forms will be deleted."
           ],
           {
             "full": "You can learn more about encryption {here}. If this sounds like something you want, press Next to proceed.",

--- a/src/components/project/enable-encryption.vue
+++ b/src/components/project/enable-encryption.vue
@@ -41,6 +41,14 @@ except according to the terms contained in the LICENSE file.
               </i18n-t>
             </div>
             <div class="info-item">
+              <span class="icon-circle-o"></span>
+              <p>{{ $t('steps[0].introduction[1][1][0]') }}</p>
+            </div>
+            <div class="info-item">
+              <span class="icon-circle-o"></span>
+              <p>{{ $t('steps[0].introduction[1][3]') }} </p>
+            </div>
+            <div class="info-item">
               <span class="icon-close"></span>
               <p>{{ $t('steps[0].introduction[0][4]') }}</p>
             </div>
@@ -56,20 +64,9 @@ except according to the terms contained in the LICENSE file.
               <span class="icon-close"></span>
               <p>{{ $t('steps[0].introduction[0][7]') }}</p>
             </div>
-          </div>
-          <div class="info-block">
-            <p>{{ $t('steps[0].introduction[1][0]') }}</p>
-            <div class="info-item">
-              <span class="icon-circle-o"></span>
-              <p>{{ $t('steps[0].introduction[1][1][0]') }}</p>
-            </div>
             <div class="info-item">
               <span class="icon-close"></span>
               <p>{{ $t('steps[0].introduction[1][2][0]') }}</p>
-            </div>
-            <div class="info-item">
-              <span class="icon-close"></span>
-              <p>{{ $t('steps[0].introduction[1][3]') }} </p>
             </div>
           </div>
           <i18n-t tag="p" keypath="steps[0].introduction[2].full">
@@ -292,16 +289,15 @@ export default {
             "New Submissions will no longer be processed into Entities."
           ],
           [
+            // don't translate this sentence, it is not used anywhere
             "In addition, the following are true in this version of ODK Central:",
             [
-              "Existing Submissions will remain unencrypted.",
-              "In a future version, you will have the option to encrypt existing data."
+              "Existing Submissions will remain unencrypted."
             ],
             [
-              "Encryption cannot be turned off once enabled.",
-              "In a future version, you will be able to disable encryption, which will decrypt your data. This will be true even if you enable encryption now."
+              "Encryption cannot be turned off once enabled."
             ],
-            "Draft Submissions from all Forms will be deleted."
+            "Test Submissions to existing Draft Forms will be permanently removed."
           ],
           {
             "full": "You can learn more about encryption {here}. If this sounds like something you want, press Next to proceed.",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2914,26 +2914,21 @@
             },
             "1": {
               "0": {
-                "string": "In addition, the following are true in this version of ODK Central:"
+                "string": "In addition, the following are true in this version of ODK Central:",
+                "developer_comment": "don't translate this sentence, it is not used anywhere"
               },
               "1": {
                 "0": {
                   "string": "Existing Submissions will remain unencrypted."
-                },
-                "1": {
-                  "string": "In a future version, you will have the option to encrypt existing data."
                 }
               },
               "2": {
                 "0": {
                   "string": "Encryption cannot be turned off once enabled."
-                },
-                "1": {
-                  "string": "In a future version, you will be able to disable encryption, which will decrypt your data. This will be true even if you enable encryption now."
                 }
               },
               "3": {
-                "string": "Draft Submissions from all Forms will be deleted."
+                "string": "Test Submissions to existing Draft Forms will be permanently removed."
               }
             },
             "2": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2931,6 +2931,9 @@
                 "1": {
                   "string": "In a future version, you will be able to disable encryption, which will decrypt your data. This will be true even if you enable encryption now."
                 }
+              },
+              "3": {
+                "string": "Draft Submissions from all Forms will be deleted."
               }
             },
             "2": {


### PR DESCRIPTION
Related to getodk/central-backend#911

Show warning that "Draft Submissions from all Forms will be deleted."

I took the liberty to remove "In future" texts as well, I can add them back if everyone want that.

![image](https://github.com/getodk/central-frontend/assets/447837/66a36a0d-5573-4545-88e4-ec96ce70e162)


#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced