### PR TITLE
Add Entity access to roles

### DIFF
--- a/src/components/project/user/list.vue
+++ b/src/components/project/user/list.vue
@@ -252,7 +252,7 @@ export default {
       },
       {
         // This text is shown in a list of Roles.
-        "full": "{projectViewers} can access and download all Form data in this Project, but cannot make any changes to settings or data",
+        "full": "{projectViewers} can access and download all Form and Entity data in this Project, but cannot make any changes to settings or data",
         "projectViewers": "Project Viewers"
       },
       {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3247,12 +3247,12 @@
         },
         "2": {
           "full": {
-            "string": "{projectViewers} can access and download all Form data in this Project, but cannot make any changes to settings or data",
+            "string": "{projectViewers} can access and download all Form and Entity data in this Project, but cannot make any changes to settings or data",
             "developer_comment": "This text is shown in a list of Roles.\n\n{projectViewers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nProject Viewers"
           },
           "projectViewers": {
             "string": "Project Viewers",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {projectViewers} is in the following text:\n\n{projectViewers} can access and download all Form data in this Project, but cannot make any changes to settings or data"
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {projectViewers} is in the following text:\n\n{projectViewers} can access and download all Form and Entity data in this Project, but cannot make any changes to settings or data"
           }
         },
         "3": {


### PR DESCRIPTION
Progress towards https://github.com/getodk/central/issues/462

#### What has been done to verify that this works as intended?
Visual inspection only

#### Why is this the best possible solution? Were any other approaches considered?
For admins, I think that it's clear that project admin tasks would include anything related to entities. For data collectors, I think it's expected that forms they have access to gives them access to the corresponding entities. So I only added an explicit reference to entities for project viewers.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
String only. I guess a risk would be that this is more confusing because entities aren't mentioned explicitly for the other two roles.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced