### PR TITLE
Change rendering of entity.create audit event in submission feed

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -35,9 +35,12 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-magic-wand entity-icon"></span>
         <i18n-t keypath="title.entity.create">
           <template #label>
-            <router-link :to="entityPath(projectId, entityDataset(entry), entityUuid(entry))">
+            <router-link v-if="entityLabel(entry) != null" :to="entityPath(projectId, entityDataset(entry), entityUuid(entry))">
               {{ entityLabel(entry) }}
             </router-link>
+            <template v-else>
+              <span class="entity-label">{{ entityUuid(entry) }}</span>
+            </template>
           </template>
           <template #dataset>
             <router-link :to="datasetPath(projectId, entityDataset(entry))">
@@ -157,11 +160,9 @@ export default {
   },
   methods: {
     entityLabel(entry) {
-      // This is probably always true in production, but it wasn't always the
-      // case during the development of v2022.3.
-      if ('entity' in entry.details)
-        return entry.details.entity.label;
-      return '';
+      if ('entity' in entry.details && 'currentVersion' in entry.details.entity)
+        return entry.details.entity.currentVersion.label;
+      return null;
     },
     entityDataset(entry) {
       if ('entity' in entry.details)
@@ -207,6 +208,7 @@ export default {
     &.approved { color: $color-success; }
     &.rejected { color: $color-danger; }
   }
+  .entity-label { font-weight: normal; }
 }
 </style>
 

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -35,16 +35,16 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-magic-wand entity-icon"></span>
         <i18n-t keypath="title.entity.create">
           <template #label>
-            <router-link v-if="entityLabel(entry) != null" :to="entityPath(projectId, entityDataset(entry), entityUuid(entry))">
-              {{ entityLabel(entry) }}
+            <router-link v-if="entry.details?.entity?.currentVersion?.label != null" :to="entityPath(projectId, entry.details?.entity?.dataset, entry.details?.entity?.uuid)">
+              {{ entry.details?.entity?.currentVersion?.label }}
             </router-link>
             <template v-else>
-              <span class="entity-label">{{ entityUuid(entry) }}</span>
+              <span class="entity-label">{{ entry.details?.entity?.uuid }}</span>
             </template>
           </template>
           <template #dataset>
-            <router-link :to="datasetPath(projectId, entityDataset(entry))">
-              {{ entityDataset(entry) }}
+            <router-link :to="datasetPath(projectId, entry.details?.entity?.dataset)">
+              {{ entry.details?.entity?.dataset }}
             </router-link>
           </template>
         </i18n-t>
@@ -159,21 +159,6 @@ export default {
     }
   },
   methods: {
-    entityLabel(entry) {
-      if ('entity' in entry.details && 'currentVersion' in entry.details.entity)
-        return entry.details.entity.currentVersion.label;
-      return null;
-    },
-    entityDataset(entry) {
-      if ('entity' in entry.details)
-        return entry.details.entity.dataset;
-      return '';
-    },
-    entityUuid(entry) {
-      if ('entity' in entry.details)
-        return entry.details.entity.uuid;
-      return '';
-    },
     entityProblem(entry) {
       if ('problem' in entry.details &&
         'problemDetails' in entry.details.problem &&

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -161,7 +161,13 @@ describe('SubmissionFeedEntry', () => {
       it('renders correctly for newly created entity with ideally formatted details', () => {
         testData.extendedAudits.createPast(1, {
           action: 'entity.create',
-          details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
+          details: {
+            entity: {
+              uuid: 'xyz',
+              dataset: 'DatasetName',
+              currentVersion: { label: 'EntityName' }
+            }
+          }
         });
         const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Created Entity EntityName in DatasetName Entity List');
@@ -170,7 +176,13 @@ describe('SubmissionFeedEntry', () => {
       it('renders links to entity and dataset', () => {
         testData.extendedAudits.createPast(1, {
           action: 'entity.create',
-          details: { entity: { uuid: 'xyz', label: 'EntityName', dataset: 'DatasetName' } }
+          details: {
+            entity: {
+              uuid: 'xyz',
+              dataset: 'DatasetName',
+              currentVersion: { label: 'EntityName' }
+            }
+          }
         });
         const links = mountComponent().findAllComponents(RouterLinkStub);
         links.length.should.equal(2);
@@ -180,10 +192,24 @@ describe('SubmissionFeedEntry', () => {
         ]);
       });
 
+      it('does not render link if entity deleted (no currentVersion.label)', () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.create',
+          details: { entity: { uuid: 'xyz', dataset: 'DatasetName' } }
+        });
+        const component = mountComponent();
+        component.get('.feed-entry-title').text().should.equal('Created Entity xyz in DatasetName Entity List');
+        const links = component.findAllComponents(RouterLinkStub);
+        links.length.should.equal(1);
+        links.map(link => link.props().to).should.eql([
+          '/projects/1/entity-lists/DatasetName'
+        ]);
+      });
+
       it('renders okay and does not crash for action where entity details are missing', () => {
         testData.extendedAudits.createPast(1, {
           action: 'entity.create',
-          details: { entity: { uuid: 'xyz' } }
+          details: { entity: { } }
         });
         const title = mountComponent().get('.feed-entry-title');
         title.text().should.equal('Created Entity  in  Entity List');


### PR DESCRIPTION
Frontend part of https://github.com/getodk/central-backend/pull/959 for issue https://github.com/getodk/central-backend/issues/822

`label` was removed from the audit details for `entity.create` events but the backend PR populates the label from the entity's current version's label under `event.details.entity.currentVersion.label`. 

If the entity has been deleted or purged, only `uuid` and `dataset` are available for that entity (the basic information stored in the audit log details) so the `uuid` is used instead and no link is rendered.

<img width="1096" alt="Screen Shot 2023-09-01 at 1 59 14 PM" src="https://github.com/getodk/central-frontend/assets/76205/4a8b0bd6-c10d-4a92-a0cd-a293a6ff1b48">


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests, checking it directly.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Won't show links to deleted entities, will make it easier to create entity deletion tools in the future.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced