### PR TITLE
Remove link to entity list on summary if new and unpublished

### DIFF
--- a/src/components/dataset/summary/row.vue
+++ b/src/components/dataset/summary/row.vue
@@ -14,9 +14,12 @@ except according to the terms contained in the LICENSE file.
     <div class="row">
       <div class="col-xs-6 dataset-name-wrap">
         <div class="dataset-name text-overflow-ellipsis" v-tooltip.text>
-          <router-link :to="datasetPath(projectId, dataset.name)" v-tooltip.text>
+          <router-link v-if="!dataset.isNew" :to="datasetPath(projectId, dataset.name)" v-tooltip.text>
             {{ dataset.name }}
           </router-link>
+          <template v-else>
+            {{ dataset.name }}
+          </template>
         </div>
         <div v-if="dataset.isNew" class="dataset-new">
           <span class="icon-plus-circle"></span>

--- a/test/components/dataset-summary/row.spec.js
+++ b/test/components/dataset-summary/row.spec.js
@@ -25,7 +25,10 @@ describe('Dataset summary row', () => {
         }
       });
       component.get('.dataset-name').text().should.be.equal(dataset.name);
-      component.getComponent(RouterLinkStub).props().to.should.be.equal(`/projects/1/entity-lists/${dataset.name}`);
+      if (data.isNew)
+        component.find('.dataset-name a').exists().should.be.false();
+      else
+        component.getComponent(RouterLinkStub).props().to.should.be.equal(`/projects/1/entity-lists/${dataset.name}`);
       component.find('.dataset-new').exists().should.be.equal(data.isNew);
       component.get('.properties-count').text().should.be.equal(`${inFormProperties.length} of ${dataset.properties.length} ${dataset.properties.length === 1 ? 'property' : 'properties'}`);
 
@@ -46,7 +49,7 @@ describe('Dataset summary row', () => {
   });
 
   it('should show help text when there is no properties', async () => {
-    const dataset = testData.formDraftDatasetDiffs.createPast(1, { isNew: true, properties: [] }).last();
+    const dataset = testData.formDraftDatasetDiffs.createPast(1, { isNew: false, properties: [] }).last();
     const component = mount(Row, {
       props: { dataset, projectId: 1 },
       container: {


### PR DESCRIPTION
Frontend part of https://github.com/getodk/central/issues/467 to de-linkify the name of a new entity list.

<img width="521" alt="Screen Shot 2023-09-12 at 2 59 11 PM" src="https://github.com/getodk/central-frontend/assets/76205/3e538393-7d34-4163-91cc-5bb2993a5ad1">

The corresponding backend change https://github.com/getodk/central-backend/pull/974 makes it so if the user gets to the page that used to be in this link, it will say "resource not found" w/o any changes because backend now returns a 404 for getting details about an unpublished dataset.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Trying it, tests.

#### Why is this the best possible solution? Were any other approaches considered?

I looked at the details coming back from the dataset-diff endpoint for a form draft, and `isNew` on the dataset itself seemed like a good one to use to decided to create a link or not.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Less access to broken parts of frontend, more consistent behavior.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

n/a

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced