### PR TITLE
Do not render OdataDataAccess if SSO is enabled

### DIFF
--- a/src/components/dataset/entities.vue
+++ b/src/components/dataset/entities.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 
 <template>
-    <div>
+  <div>
     <page-section>
       <template #heading>
         <span>{{ $t('resource.entities') }}</span>

--- a/src/components/odata/analyze.vue
+++ b/src/components/odata/analyze.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <modal id="odata-analyze" :state="state" hideable backdrop
+  <modal v-if="!config.oidcEnabled" id="odata-analyze" :state="state" hideable backdrop
     @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
@@ -93,6 +93,7 @@ import Selectable from '../selectable.vue';
 export default {
   name: 'OdataAnalyze',
   components: { Modal, Selectable },
+  inject: ['config'],
   props: {
     state: Boolean,
     odataUrl: String

--- a/src/components/odata/data-access.vue
+++ b/src/components/odata/data-access.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <span id="odata-data-access">
+  <span v-if="!oidcEnabled" id="odata-data-access">
     <a class="btn btn-default"
       href="https://odkcentral.docs.apiary.io/#reference/odata-endpoints"
       target="_blank" rel="noopener">
@@ -25,15 +25,19 @@ except according to the terms contained in the LICENSE file.
   </span>
 </template>
 
-<script>
-export default {
-  name: 'OdataDataAccess',
-  props: {
-    analyzeDisabled: Boolean,
-    analyzeDisabledMessage: String
-  },
-  emits: ['analyze']
-};
+<script setup>
+import { inject } from 'vue';
+
+defineOptions({
+  name: 'OdataDataAccess'
+});
+defineProps({
+  analyzeDisabled: Boolean,
+  analyzeDisabledMessage: String
+});
+defineEmits(['analyze']);
+
+const { oidcEnabled } = inject('config');
 </script>
 
 <style lang="scss">

--- a/test/components/odata/data-access.spec.js
+++ b/test/components/odata/data-access.spec.js
@@ -10,6 +10,15 @@ const mountComponent = (options = undefined) =>
   }));
 
 describe('OdataDataAccess', () => {
+  it('does not render anything if SSO is enabled', () => {
+    const component = mountComponent({
+      container: {
+        config: { oidcEnabled: true }
+      }
+    });
+    component.find('*').exists().should.be.false();
+  });
+
   describe('"Analyze via OData" button', () => {
     it('emits an analyze event', async () => {
       testData.extendedForms.createPast(1);


### PR DESCRIPTION
With this change, `OdataDataAccess` will not be rendered if SSO is enabled. That component contains the "Analyze via OData" button, as well as a link to the API docs. If SSO is enabled, then OData and the API will no longer be accessible to users. Hopefully that will change in the near future, at which time we can render this component again. Two pages are affected: the Submissions page and the Entities Data page.

#### What has been done to verify that this works as intended?

I wrote a new test. I also checked locally that the pages look OK if `OdataDataAccess` isn't rendered. I didn't verify this change with the full SSO flow, but I also think that the risk is low.

#### Why is this the best possible solution? Were any other approaches considered?

I added a `v-if` to `OdataDataAccess`. I first thought about adding the `v-if` inside `FormSubmissions` and `DatasetEntities`. But since this is behavior shared by the two pages, it feels better to put the `v-if` in `OdataDataAccess`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I forgot where exactly this component was rendered and was a little worried that I would need to adjust styles. But it's rendered in a `PageSection` heading, not in `SubmissionList`, so I don't think any styles need to change.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced