### PR TITLE
Add function to help debug watchers

### DIFF
--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -12,6 +12,8 @@ except according to the terms contained in the LICENSE file.
 import { nextTick, onBeforeMount, onBeforeUpdate, onMounted, onUpdated } from 'vue';
 import { sum } from 'ramda';
 
+// Wraps a watcher callback, returning a function that will log if the callback
+// throws an error.
 export const logWatchError = (callback) => (newValue, oldValue) => {
   try {
     callback(newValue, oldValue);

--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -12,6 +12,20 @@ except according to the terms contained in the LICENSE file.
 import { nextTick, onBeforeMount, onBeforeUpdate, onMounted, onUpdated } from 'vue';
 import { sum } from 'ramda';
 
+export const logWatchError = (callback) => (newValue, oldValue) => {
+  try {
+    callback(newValue, oldValue);
+  } catch (error) {
+    /* eslint-disable no-console */
+    console.error('a watcher threw an error');
+    console.error(error);
+    console.error('new value', newValue);
+    console.error('old value', oldValue);
+    /* eslint-enable no-console */
+    throw error;
+  }
+};
+
 // eslint-disable-next-line no-console
 const logTick = () => { console.log('tick'); };
 export const ticking = (count, callback = logTick) => {
@@ -23,6 +37,11 @@ export const ticking = (count, callback = logTick) => {
   };
   nextTick(ticker);
 };
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// useRenderTimer()
 
 class RenderTimer {
   constructor() {


### PR DESCRIPTION
When a watcher throws an error, I often (always?) don't see the error being surfaced. Instead, I see a warning about a likely bug with Vue internals. This PR adds a function to wrap a watcher callback, logging an error if one is thrown. If you think a watcher is throwing an error, but you can't tell why, this function may help.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced