### PR TITLE
Change entity error message in submission feed

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -49,7 +49,25 @@ except according to the terms contained in the LICENSE file.
           </template>
         </i18n-t>
       </template>
-      <template v-else-if="entry.action === 'entity.create.error'">
+      <template v-else-if="entry.action === 'entity.update.version'">
+        <span class="icon-magic-wand entity-icon"></span>
+        <i18n-t keypath="title.entity.update">
+          <template #label>
+            <router-link v-if="entry.details?.entity?.currentVersion?.label != null" :to="entityPath(projectId, entry.details?.entity?.dataset, entry.details?.entity?.uuid)">
+              {{ entry.details?.entity?.currentVersion?.label }}
+            </router-link>
+            <template v-else>
+              <span class="entity-label">{{ entry.details?.entity?.uuid }}</span>
+            </template>
+          </template>
+          <template #dataset>
+            <router-link :to="datasetPath(projectId, entry.details?.entity?.dataset)">
+              {{ entry.details?.entity?.dataset }}
+            </router-link>
+          </template>
+        </i18n-t>
+      </template>
+      <template v-else-if="entry.action === 'entity.error'">
         <span class="icon-warning"></span>
         <span class="submission-feed-entry-entity-error">{{ $t('title.entity.error') }}</span>
         <span class="entity-error-message" v-tooltip.text>{{ entityProblem(entry) }}</span>
@@ -217,7 +235,8 @@ export default {
       "create": "Submitted by {name}",
       "entity": {
         "create": "Created Entity {label} in {dataset} Entity List",
-        "error": "Problem creating Entity",
+        "update": "Updated Entity {label} in {dataset} Entity List",
+        "error": "Problem processing Entity",
       },
       "updateReviewState": {
         "null": {

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -35,16 +35,16 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-magic-wand entity-icon"></span>
         <i18n-t keypath="title.entity.create">
           <template #label>
-            <router-link v-if="entry.details?.entity?.currentVersion?.label != null" :to="entityPath(projectId, entry.details?.entity?.dataset, entry.details?.entity?.uuid)">
-              {{ entry.details?.entity?.currentVersion?.label }}
+            <router-link v-if="entry.details?.entity?.currentVersion?.label != null" :to="entityPath(projectId, entry.details.entity.dataset, entry.details.entity.uuid)">
+              {{ entry.details.entity.currentVersion.label }}
             </router-link>
             <template v-else>
-              <span class="entity-label">{{ entry.details?.entity?.uuid }}</span>
+              <span class="entity-label">{{ entry.details.entity.uuid }}</span>
             </template>
           </template>
           <template #dataset>
-            <router-link :to="datasetPath(projectId, entry.details?.entity?.dataset)">
-              {{ entry.details?.entity?.dataset }}
+            <router-link :to="datasetPath(projectId, entry.details.entity.dataset)">
+              {{ entry.details.entity.dataset }}
             </router-link>
           </template>
         </i18n-t>
@@ -53,16 +53,16 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-magic-wand entity-icon"></span>
         <i18n-t keypath="title.entity.update">
           <template #label>
-            <router-link v-if="entry.details?.entity?.currentVersion?.label != null" :to="entityPath(projectId, entry.details?.entity?.dataset, entry.details?.entity?.uuid)">
-              {{ entry.details?.entity?.currentVersion?.label }}
+            <router-link v-if="entry.details?.entity?.currentVersion?.label != null" :to="entityPath(projectId, entry.details.entity.dataset, entry.details.entity.uuid)">
+              {{ entry.details.entity.currentVersion.label }}
             </router-link>
             <template v-else>
-              <span class="entity-label">{{ entry.details?.entity?.uuid }}</span>
+              <span class="entity-label">{{ entry.details.entity.uuid }}</span>
             </template>
           </template>
           <template #dataset>
-            <router-link :to="datasetPath(projectId, entry.details?.entity?.dataset)">
-              {{ entry.details?.entity?.dataset }}
+            <router-link :to="datasetPath(projectId, entry.details.entity.dataset)">
+              {{ entry.details.entity.dataset }}
             </router-link>
           </template>
         </i18n-t>

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -216,28 +216,28 @@ describe('SubmissionFeedEntry', () => {
       });
     });
 
-    describe('entity.create.error audit', () => {
+    describe('entity.error audit', () => {
       it('renders entity creation error message and help text', async () => {
         testData.extendedAudits.createPast(1, {
-          action: 'entity.create.error',
+          action: 'entity.error',
           details: { problem: { problemCode: 409.14, problemDetails: { reason: 'ID empty or missing.' } } }
         });
         const title = mountComponent().get('.feed-entry-title');
-        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem creating Entity');
+        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem processing Entity');
         title.get('.entity-error-message').text().should.equal('ID empty or missing.');
         await title.get('.entity-error-message').should.have.textTooltip();
       });
 
       it('renders entity creation error message when it is included as an errorMessage', async () => {
         testData.extendedAudits.createPast(1, {
-          action: 'entity.create.error',
+          action: 'entity.error',
           details: {
             problem: { problemCode: 409.3, problemDetails: { foo: 'blah' } },
             errorMessage: 'A resource already exists with uuid value(s) abc.'
           }
         });
         const title = mountComponent().get('.feed-entry-title');
-        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem creating Entity');
+        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem processing Entity');
         title.get('.entity-error-message').text().should.equal('A resource already exists with uuid value(s) abc.');
         await title.get('.entity-error-message').should.have.textTooltip();
       });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3735,8 +3735,11 @@
           "create": {
             "string": "Created Entity {label} in {dataset} Entity List"
           },
+          "update": {
+            "string": "Updated Entity {label} in {dataset} Entity List"
+          },
           "error": {
-            "string": "Problem creating Entity"
+            "string": "Problem processing Entity"
           }
         },
         "updateReviewState": {


### PR DESCRIPTION
Frontend piece of https://github.com/getodk/central/issues/520


"Problem creating Entity" --> "Problem processing Entity" 

In the context of the submission feed, problems processing submissions about entities now look like this, whether they are failing to create or update an entity.

<img width="919" alt="Screen Shot 2023-10-16 at 4 29 59 PM" src="https://github.com/getodk/central-frontend/assets/76205/22d5d59f-5a66-47dc-b846-bd851a932ef0">


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests and trying it on frontend.

#### Why is this the best possible solution? Were any other approaches considered?

Needed generic error message.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Makes update entity errors clearer. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced