### PR TITLE
Add test data for entity versions

### DIFF
--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -142,9 +142,8 @@ describe('EntityBasicDetails', () => {
           dd.text().should.equal('s');
         })
         .respondWithData(() => {
-          const { currentVersion } = testData.extendedEntities.last();
-          testData.extendedEntities.update(-1, {
-            currentVersion: { ...currentVersion, label: 'Updated Entity' }
+          testData.extendedEntityVersions.createNew({
+            label: 'Updated Entity'
           });
           testData.extendedAudits.createPast(1, {
             action: 'entity.update.version'

--- a/test/components/entity/list.spec.js
+++ b/test/components/entity/list.spec.js
@@ -194,13 +194,10 @@ describe('EntityList', () => {
             return form.trigger('submit');
           })
           .respondWithData(() => {
-            const { currentVersion } = testData.extendedEntities.get(1);
-            testData.extendedEntities.update(1, {
-              currentVersion: {
-                ...currentVersion,
-                label: 'Updated Entity',
-                data: { height: '3', 'circumference.cm': '4' }
-              }
+            testData.extendedEntityVersions.createNew({
+              uuid: 'e2',
+              label: 'Updated Entity',
+              data: { height: '3', 'circumference.cm': '4' }
             });
             return testData.standardEntities.get(1);
           });

--- a/test/components/entity/metadata-row.spec.js
+++ b/test/components/entity/metadata-row.spec.js
@@ -53,8 +53,9 @@ describe('EntityMetadataRow', () => {
 
   describe('last updated date', () => {
     it('shows the date', () => {
-      const { updatedAt } = testData.extendedEntities.createPast(1)
-        .update(-1, { updates: 1 });
+      const { updatedAt } = testData.extendedEntities
+        .createPast(1, { version: 2 })
+        .last();
       should.exist(updatedAt);
       const dateTimes = mountComponent().findAllComponents(DateTime);
       dateTimes.length.should.equal(2);
@@ -70,7 +71,7 @@ describe('EntityMetadataRow', () => {
 
   describe('update count', () => {
     it('shows the count if there has been an update', () => {
-      testData.extendedEntities.createPast(1).update(-1, { updates: 1000 });
+      testData.extendedEntities.createPast(1, { version: 1001 });
       mountComponent().get('.updates').text().should.equal('1,000');
     });
 
@@ -81,7 +82,7 @@ describe('EntityMetadataRow', () => {
   });
 
   it('renders the edit button correctly', async () => {
-    testData.extendedEntities.createPast(1).update(-1, { updates: 1000 });
+    testData.extendedEntities.createPast(1, { version: 1001 });
     const button = mountComponent({ canUpdate: true }).get('.update-button');
     button.attributes('aria-label').should.equal('Edit (1,000)');
     await button.should.have.tooltip('Edit (1,000)');

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -79,13 +79,9 @@ describe('EntityShow', () => {
           return form.trigger('submit');
         })
         .respondWithData(() => {
-          const { currentVersion } = testData.extendedEntities.last();
-          testData.extendedEntities.update(-1, {
-            currentVersion: {
-              ...currentVersion,
-              label: 'Updated Entity',
-              data: { height: '2' }
-            }
+          testData.extendedEntityVersions.createNew({
+            label: 'Updated Entity',
+            data: { height: '2' }
           });
           testData.extendedAudits.createPast(1, {
             action: 'entity.update.version'

--- a/test/components/entity/update.spec.js
+++ b/test/components/entity/update.spec.js
@@ -234,13 +234,9 @@ describe('EntityUpdate', () => {
         return modal.get('form').trigger('submit');
       })
       .respondWithData(() => {
-        const { currentVersion } = testData.extendedEntities.last();
-        testData.extendedEntities.update(-1, {
-          currentVersion: {
-            ...currentVersion,
-            label: 'Updated Entity',
-            data: { height: '2' }
-          }
+        testData.extendedEntityVersions.createNew({
+          label: 'Updated Entity',
+          data: { height: '2' }
         });
         return testData.standardEntities.last();
       })

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -1,5 +1,5 @@
 import faker from 'faker';
-import { comparator, omit } from 'ramda';
+import { comparator, last, omit, pick } from 'ramda';
 
 import { dataStore, view } from './data-store';
 import { extendedAudits } from './audits';
@@ -10,54 +10,183 @@ import { extendedUsers } from './users';
 import { fakePastDate, isBefore } from '../util/date-time';
 import { toActor } from './actors';
 
+// This will be the entities store. We define it immediately to prevent an
+// ESLint error.
+let entities;
+
+const diffVersions = (dataReceived, previousVersion) => {
+  if (previousVersion == null) return [];
+  const diff = Object.keys(dataReceived).filter(name =>
+    name !== 'label' && dataReceived[name] !== previousVersion.data[name]);
+  if (dataReceived.label != null && dataReceived.label !== previousVersion.label)
+    diff.push('label');
+  return diff;
+};
+
+const entityVersions = dataStore({
+  factory: ({
+    inPast,
+    lastCreatedAt,
+
+    // If no UUID is specified, defaults to the last entity.
+    uuid = undefined,
+    baseVersion: baseVersionOption = undefined,
+    label = undefined,
+    data = {},
+    conflictingProperties = undefined,
+    creator = extendedUsers.first(),
+
+    // Internal option for the `entities` store
+    _entity = undefined
+  }) => {
+    if (entities.size === 0 && _entity == null)
+      throw new Error('there is no entity for which to create a new version');
+    const entity = _entity ?? (uuid != null
+      ? entities.sorted().find(e => e.uuid === uuid)
+      : entities.last());
+    if (entity == null) throw new Error('entity not found');
+
+    const versions = entityVersions.sorted()
+      .filter(version => version.entity === entity);
+    const lastVersion = last(versions);
+    if (lastVersion != null) lastVersion.current = false;
+
+    const baseVersion = baseVersionOption == null || baseVersionOption === lastVersion?.version
+      ? lastVersion
+      : versions.find(version => version.version === baseVersionOption);
+    if (baseVersionOption != null && baseVersion == null)
+      throw new Error('base version not found');
+
+    const conflict = baseVersion === lastVersion
+      ? null
+      : (conflictingProperties != null && conflictingProperties.length !== 0
+        ? 'hard'
+        : 'soft');
+
+    const createdAt = lastVersion == null
+      ? entity.createdAt
+      : (!inPast
+        ? new Date().toISOString()
+        : fakePastDate([lastCreatedAt, creator.createdAt]));
+    if (lastVersion != null) entity.updatedAt = createdAt;
+
+    const dataReceived = { ...data };
+    if (label != null) dataReceived.label = label;
+    return {
+      entity,
+      version: versions.length + 1,
+      baseVersion: baseVersion == null ? null : baseVersion.version,
+      current: true,
+      label: label ?? lastVersion.label,
+      data: { ...lastVersion?.data, ...data },
+      conflict,
+      conflictingProperties: conflict == null
+        ? null
+        : conflictingProperties ?? [],
+      baseDiff: diffVersions(dataReceived, baseVersion),
+      serverDiff: diffVersions(dataReceived, lastVersion),
+      resolved: conflict == null,
+      creatorId: creator.id,
+      creator: toActor(creator),
+      createdAt
+    };
+  }
+});
+
+export const extendedEntityVersions = view(entityVersions, omit(['entity']));
+
 const randomData = (properties) => {
   const data = {};
   for (const { name } of properties) data[name] = faker.random.word();
   return data;
 };
 
-export const extendedEntities = dataStore({
+entities = dataStore({
   factory: ({
     inPast,
     lastCreatedAt,
 
+    dataset: datasetOption = undefined,
     uuid = faker.random.uuid(),
-    label = faker.random.word(),
-    updates = 0,
-    updatedAt = null,
     version = 1,
-    ...options
+    label = faker.random.word(),
+    data = undefined,
+    creator: creatorOption = undefined
   }) => {
     if (extendedDatasets.size === 0) {
-      const properties = options.data != null
-        ? Object.keys(options.data).map(name => ({ name, forms: [] }))
+      const properties = data != null
+        ? Object.keys(data).map(name => ({ name, forms: [] }))
         : [];
       extendedDatasets.createPast(1, { properties, entities: 1 });
     }
-    const dataset = options.dataset ?? extendedDatasets.first();
-    const data = options.data ?? randomData(dataset.properties);
-    const creator = options.creator ?? extendedUsers.first();
+    const dataset = datasetOption ?? extendedDatasets.first();
+
+    const creator = creatorOption ?? extendedUsers.first();
     const createdAt = !inPast
       ? new Date().toISOString()
       : fakePastDate([
         lastCreatedAt,
         creator.createdAt
       ]);
-    return {
+    const entity = {
       uuid,
-      currentVersion: { label, data, current: true, version },
-      updates,
       creatorId: creator.id,
       creator: toActor(creator),
       createdAt,
-      updatedAt
+      updatedAt: null
     };
+
+    const createVersion = inPast
+      ? (options) => entityVersions.createPast(1, options)
+      : (options) => entityVersions.createNew(options);
+    createVersion({
+      _entity: entity,
+      label,
+      data: data ?? randomData(dataset.properties),
+      creator
+    });
+    for (let i = 2; i <= version; i += 1)
+      createVersion({ _entity: entity, creator });
+
+    return entity;
   },
   sort: comparator((entity1, entity2) =>
     isBefore(entity2.createdAt, entity1.createdAt))
 });
 
-export const standardEntities = view(extendedEntities, omit(['creator']));
+const findCurrentVersion = (entity) => {
+  for (let i = entityVersions.size - 1; i >= 0; i -= 1) {
+    const version = entityVersions.get(i);
+    if (version.entity === entity) return version;
+  }
+  throw new Error('current version not found');
+};
+const combineEntityWithVersions = (entity) => {
+  const currentVersion = findCurrentVersion(entity);
+
+  const conflicts = currentVersion.version === 1
+    ? []
+    : entityVersions.sorted()
+      .filter(version => version.entity === entity && !version.resolved);
+  const conflict = conflicts.length === 0
+    ? null
+    : (conflicts.some(version => version.conflict === 'hard') ? 'hard' : 'soft');
+
+  return {
+    ...entity,
+    // Add just the properties of currentVersion that are needed. That way, we
+    // don't have to think about extended metadata.
+    currentVersion: pick(
+      ['version', 'label', 'data', 'current'],
+      currentVersion
+    ),
+    conflict,
+    updates: currentVersion.version - 1
+  };
+};
+export const extendedEntities = view(entities, combineEntityWithVersions);
+export const standardEntities = view(entities, (entity) =>
+  omit(['creator'], combineEntityWithVersions(entity)));
 
 // Converts entity response objects to OData.
 export const entityOData = (top = 250, skip = 0) => {
@@ -66,6 +195,7 @@ export const entityOData = (top = 250, skip = 0) => {
   // correct one.
   if (extendedDatasets.size > 1) throw new Error('too many datasets');
   const { properties } = extendedDatasets.last();
+
   return {
     '@odata.count': extendedEntities.size,
     '@odata.nextLink': top > 0 && (top + skip < extendedEntities.size) ? `https://test/Entities?$top=${top}&$skipToken=thetoken` : undefined,
@@ -74,12 +204,13 @@ export const entityOData = (top = 250, skip = 0) => {
         label: entity.currentVersion.label,
         __id: entity.uuid,
         __system: {
+          version: entity.currentVersion.version,
           updates: entity.updates,
+          conflict: entity.conflict,
           creatorId: entity.creator.id.toString(),
           creatorName: entity.creator.displayName,
           createdAt: entity.createdAt,
-          updatedAt: entity.updatedAt,
-          version: entity.currentVersion.version
+          updatedAt: entity.updatedAt
         }
       };
 
@@ -134,4 +265,16 @@ extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {})
   const sourceEvent = extendedAudits.last();
 
   return { submission: submissionWithFormId, submissionCreate, sourceEvent };
+};
+
+extendedEntities.resolve = (index) => {
+  const entity = entities.get(index);
+  if (entity == null) throw new Error('entity not found');
+
+  for (const version of entityVersions.sorted()) {
+    if (version.entity === entity) version.resolved = true;
+  }
+
+  // Update updatedAt.
+  entities.update(-1);
 };


### PR DESCRIPTION
For v2023.5, we need to update `testData` so that it is possible to create multiple versions of a single entity. Some versions will be conflicts, and some conflicts will be resolved.

This PR adds `testData.extendedEntityVersions` for creating a new version of an existing entity. One complication is that right now, `testData.extendedEntities` returns an object with a static `currentVersion` property, which could quickly become outdated. I've set it up so that there's a relationship between `testData.extendedEntities` and `testData.extendedEntityVersions`. When you create an entity, that also creates an entity version. And when you create an entity version, `testData.extendedEntities` will return the correct `currentVersion` and other properties.

This approach is similar to the `testData` for forms and form versions. It's a little less complicated though. While entity responses include information about entity versions, entity version responses don't include information about the logical entity. In contrast, form version responses include information about the logical form.

#### What has been done to verify that this works as intended?

I've updated several tests, for example, using `testData.extendedEntityVersions.createNew()` instead of `testData.extendedEntities.update()`. I find the end result to be more readable.

#### Why is this the best possible solution? Were any other approaches considered?

My main concern is that things might be too magical. `testData` stores aren't usually in-sync with one another. But I also want it to be easy to set up `testData` for complicated scenarios involving multiple entity versions. The approach I took is similar to how `testData` is set up for forms and form versions.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced