### PR TITLE
Show updating submission link in entity feed

### DIFF
--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -47,7 +47,9 @@ const feed = computed(() => {
   let diffIndex = diffs.length - 1;
   for (const audit of audits) {
     if (audit.action === 'entity.update.version') {
-      result.push({ entry: audit, diff: diffs[diffIndex] });
+      // create event with all details of submission responsible for updating entity
+      const submission = audit.details.submissionCreate ? audit.details.submission : null;
+      result.push({ entry: audit, diff: diffs[diffIndex], submission });
       diffIndex -= 1;
     } else if (audit.action === 'entity.create') {
       result.push({ entry: audit });

--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -47,9 +47,7 @@ const feed = computed(() => {
   let diffIndex = diffs.length - 1;
   for (const audit of audits) {
     if (audit.action === 'entity.update.version') {
-      // create event with all details of submission responsible for updating entity
-      const submission = audit.details.submissionCreate ? audit.details.submission : null;
-      result.push({ entry: audit, diff: diffs[diffIndex], submission });
+      result.push({ entry: audit, diff: diffs[diffIndex], submission: audit.details.submission });
       diffIndex -= 1;
     } else if (audit.action === 'entity.create') {
       result.push({ entry: audit });

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -150,7 +150,7 @@ const deletedSubmission = computed(() => {
 // entities, where the instance ID is found deep inside the submissionCreate event.
 const deletedSubmissionEntityEvent = computed(() => {
   const id = props.entry.details.submissionCreate.details.instanceId;
-  return t('title.submission.create.deleted.deletedSubmission', { id });
+  return t('title.entity.update_version.submission.deleted.deletedSubmission', { id });
 });
 const { reviewStateIcon } = useReviewState();
 </script>

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <feed-entry :iso="entry.loggedAt ?? entry.createdAt"
-    :wrap-title="entry.action === 'entity.create'"
+    :wrap-title="entry.action === 'entity.create' || entry.action === 'entity.update.version'"
     class="submission-feed-entry">
     <template #title>
       <template v-if="entry.action === 'submission.create'">

--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -147,7 +147,8 @@ describe('EntityBasicDetails', () => {
             currentVersion: { ...currentVersion, label: 'Updated Entity' }
           });
           testData.extendedAudits.createPast(1, {
-            action: 'entity.update.version'
+            action: 'entity.update.version',
+            details: {}
           });
           return testData.standardEntities.last();
         })

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -322,17 +322,6 @@ describe('EntityFeedEntry', () => {
       const links = component.findAllComponents(RouterLinkStub);
       links.length.should.equal(0);
     });
-
-    it('renders a DiffItem for each change', () => {
-      const diff = [
-        { new: '1', old: '10', propertyName: 'height' },
-        { new: '2', old: '20', propertyName: 'circumference' }
-      ];
-      const component = mountComponent({
-        props: { ...updateEntityFromSubmission(), diff }
-      });
-      component.findAllComponents(DiffItem).length.should.equal(2);
-    });
   });
 
   it('shows when an audit log event was logged', () => {

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -88,7 +88,8 @@ describe('EntityShow', () => {
             }
           });
           testData.extendedAudits.createPast(1, {
-            action: 'entity.update.version'
+            action: 'entity.update.version',
+            details: {}
           });
           return testData.standardEntities.last();
         })

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1531,6 +1531,21 @@
             }
           },
           "update_version": {
+            "submission": {
+              "notDeleted": {
+                "string": "Data updated by Submission {instanceName}"
+              },
+              "deleted": {
+                "full": {
+                  "string": "Data updated by {deletedSubmission}",
+                  "developer_comment": "{deletedSubmission} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\n(deleted Submission {id})"
+                },
+                "deletedSubmission": {
+                  "string": "(deleted Submission {id})",
+                  "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {deletedSubmission} is in the following text:\n\nData updated by {deletedSubmission}"
+                }
+              }
+            },
             "api": {
               "string": "Data updated by {name}",
               "developer_comment": "This text is shown in a list of events. {name} is the name of a Web User."


### PR DESCRIPTION
Closes #
<img width="1412" alt="Screen Shot 2023-10-24 at 10 47 45 AM" src="https://github.com/getodk/central-frontend/assets/76205/7e382766-1da6-414f-abb7-f4fcacf1996b">

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Trying it out and adding tests.

#### Why is this the best possible solution? Were any other approaches considered?

I don't think this is the best -- this component is complicated and confusing.

It can handle entity events.
It can also handle artificial events for submission creation/approval when that is relevant to an entity... 
It can handle events about entities that contain submission info in the details.
The submissions in the two cases above can be available or deleted, and can show the instance name or instance id depending. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Getting some warnings running the full test suite:
```
WARN LOG: '[Vue warn]: Unhandled error during execution of render function', '
', ' at <PageSection', 'id="entity-activity"', '>', '
', ' at <EntityActivity>', '
', ' at <PageBody>', '
', ' at <EntityShow', 'projectId="1"', 'datasetName="trees"', 'uuid="e"', ' ...', '>', '
', ' at <VTUROOT>'
```

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced