### PR TITLE
Do not modify entity test data in place

### DIFF
--- a/test/data/data-store.js
+++ b/test/data/data-store.js
@@ -27,6 +27,68 @@ class Collection {
 
   first() { return this.get(0); }
   last() { return this.get(-1); }
+
+  // Returns an iterator that iterates over the objects of the collection in
+  // creation order.
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next: () => {
+        if (i >= this.size) return { done: true };
+        const result = { value: this.get(i), done: false };
+        i += 1;
+        return result;
+      }
+    };
+  }
+
+  entries() {
+    let i = 0;
+    return {
+      next: () => {
+        if (i >= this.size) return { done: true };
+        const result = { value: [i, this.get(i)], done: false };
+        i += 1;
+        return result;
+      },
+      [Symbol.iterator]() { return this; }
+    };
+  }
+
+  filter(f) {
+    const result = [];
+    for (const [i, obj] of this.entries()) {
+      if (f(obj, i)) result.push(obj);
+    }
+    return result;
+  }
+
+  findIndex(f) {
+    for (const [i, obj] of this.entries()) {
+      if (f(obj, i)) return i;
+    }
+    return -1;
+  }
+
+  findLastIndex(f) {
+    for (let i = this.size - 1; i >= 0; i -= 1) {
+      if (f(this.get(i), i)) return i;
+    }
+    return -1;
+  }
+
+  indexOf(obj) { return this.findIndex(o => o === obj); }
+  lastIndexOf(obj) { return this.findLastIndex(o => o === obj); }
+
+  find(f) {
+    const index = this.findIndex(f);
+    return index !== -1 ? this.get(index) : null;
+  }
+
+  findLast(f) {
+    const index = this.findLastIndex(f);
+    return index !== -1 ? this.get(index) : null;
+  }
 }
 
 // Implements the methods of Collection.
@@ -129,7 +191,8 @@ class Store extends Collection {
     }
     const object = this._objects[normalizedIndex];
     const updated = { ...object, ...props };
-    if ('updatedAt' in object) updated.updatedAt = new Date().toISOString();
+    if ('updatedAt' in object && !('updatedAt' in props))
+      updated.updatedAt = new Date().toISOString();
     this._objects[normalizedIndex] = updated;
     return updated;
   }

--- a/test/data/data-store.js
+++ b/test/data/data-store.js
@@ -191,7 +191,7 @@ class Store extends Collection {
     }
     const object = this._objects[normalizedIndex];
     const updated = { ...object, ...props };
-    if ('updatedAt' in object && !('updatedAt' in props))
+    if ('updatedAt' in object && !(props != null && 'updatedAt' in props))
       updated.updatedAt = new Date().toISOString();
     this._objects[normalizedIndex] = updated;
     return updated;

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -284,6 +284,6 @@ extendedEntities.resolve = (index) => {
       entityVersions.update(i, { resolved: true });
   }
 
-  // Following should be replaced with entity.update(index) once entityVersions is linked via UUID
-  entity.updatedAt = new Date().toISOString();
+  // Update updatedAt.
+  entities.update(index);
 };


### PR DESCRIPTION
There are issues involving how entity test data is updated. @sadiqkhoja noticed that things break after `testData.extendedEntities.update()` is called, because the `entity` reference that the `entityVersions` store holds becomes out-of-date. That's because `update()` doesn't update in-place, but rather replaces the object in the `testData` store. Given that, it doesn't work for `entityVersions` to store an `entity` reference, so I'm having it store the entity UUID instead. It can use the UUID to compare entities, which is one way it used the `entity` reference before.

Beyond that, I had the thought that what `update()` does is indeed what we want in general. If a test entity is already in use in Frontend code that we're testing, then we can't let `testData` modify it in-place, as that would affect the data in Frontend. By replacing the object in the `testData` store rather than modifying it in-place, we create more of a separation between `testData` and the Frontend code we're testing. There were a few places where `testData.extendedEntities` and `testData.extendedEntityVersions` would modify in-place rather than replacing, and I've exchanged those for `update()`.

Since `update()` expects an index, making that change required various kinds of iteration over `testData` stores. I decided it was a good time to do something I've wanted to for a while, which is to make `testData` stores iterable. `testData` stores are supposed to be array-like in many ways, but they lack many array methods. I added a few methods related to iterating, finding, and filtering. Note that these are all based on creation order, which is how most of the methods work. For example, `get()`, `last()`, and `splice()` all use creation-order indices. To get an array sorted in the way that Backend will return it, `sorted()` is still the best way. In other words, `filter()` may return objects in a different order than `sorted().filter()`.

These new methods will work for both `testData` stores and `testData` views. I tried to make them performant by iterating over one object at a time rather than creating a new array of objects. I had in mind some tests that create many `testData` objects.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced