### PR TITLE
Updated code to get entity problem message

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -70,7 +70,7 @@ except according to the terms contained in the LICENSE file.
       <template v-else-if="entry.action === 'entity.error'">
         <span class="icon-warning"></span>
         <span class="submission-feed-entry-entity-error">{{ $t('title.entity.error') }}</span>
-        <span class="entity-error-message" v-tooltip.text>{{ entityProblem(entry) }}</span>
+        <span class="entity-error-message" v-tooltip.text>{{ entry.details.problem?.problemDetails?.reason ?? entry.details.errorMessage ?? '' }}</span>
       </template>
       <template v-else>
         <span class="icon-comment"></span>
@@ -174,18 +174,6 @@ export default {
       const deprecatedIdDiff = this.allDiffs.find((entry) => last(entry.path) === 'deprecatedID');
       if (deprecatedIdDiff == null) return null;
       return deprecatedIdDiff.new;
-    }
-  },
-  methods: {
-    entityProblem(entry) {
-      if ('problem' in entry.details &&
-        'problemDetails' in entry.details.problem &&
-        'reason' in entry.details.problem.problemDetails)
-        return entry.details.problem.problemDetails.reason;
-      if ('problem' in entry.details &&
-        'errorMessage' in entry.details)
-        return entry.details.errorMessage;
-      return '';
     }
   }
 };

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -299,6 +299,32 @@ describe('SubmissionFeedEntry', () => {
         title.get('.entity-error-message').text().should.equal('A resource already exists with uuid value(s) abc.');
         await title.get('.entity-error-message').should.have.textTooltip();
       });
+
+      it('renders error message when there is a problem without a reason and an error message', async () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.error',
+          details: {
+            problem: null,
+            errorMessage: 'Mystery Error'
+          }
+        });
+        const title = mountComponent().get('.feed-entry-title');
+        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem processing Entity');
+        title.get('.entity-error-message').text().should.equal('Mystery Error');
+        await title.get('.entity-error-message').should.have.textTooltip();
+      });
+
+      it('renders problem but no specific error message if audit details are malformed', async () => {
+        testData.extendedAudits.createPast(1, {
+          action: 'entity.error',
+          details: {
+            foo: 'bar'
+          }
+        });
+        const title = mountComponent().get('.feed-entry-title');
+        title.get('.submission-feed-entry-entity-error').text().should.equal('Problem processing Entity');
+        title.get('.entity-error-message').text().should.equal('');
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/536

Changes how the error messages are pulled out of audit log details now with optional changing and nullish coalescing.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

trying it, tests.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced