### PR TITLE
Fixes #542: right padding grows when two bootstrap modals are open in same tick

### DIFF
--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -244,7 +244,7 @@ export default {
     hideResolve(showEdit) {
       this.hideModal('resolve');
       if (showEdit) {
-        this.showUpdate(this.resolveIndex);
+        this.$nextTick(() => this.showUpdate(this.resolveIndex));
       } else {
         this.resolve.entity = null;
         this.resolveIndex = null;


### PR DESCRIPTION
Closes getodk/central#542

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced