### PR TITLE
Add ability to link to (scroll to) specific entity versions in feed

### DIFF
--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -81,8 +81,8 @@ watchEffect(() => {
   scrollTarget.value = match != null ? Number.parseInt(match[1], 10) : null;
 });
 watch(() => audits.awaitingResponse, (awaitingResponse) => {
-  // If a change is made that causes the feed to be refreshed, don't scroll to
-  // or highlight any feed entry.
+  // If the user takes an action that causes the feed to be refreshed, then
+  // don't scroll to or highlight any feed entry.
   if (awaitingResponse) scrollTarget.value = null;
 });
 const scrollData = (entryData) => {

--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -17,8 +17,10 @@ except according to the terms contained in the LICENSE file.
     <template #body>
       <loading :state="initiallyLoading"/>
       <template v-if="dataExists">
-        <entity-feed-entry v-for="(data, i) of feed" :key="feed.length - i"
-          v-bind="data"/>
+        <div v-for="(group, i) of feed" :key="feed.length - i"
+          class="feed-entry-group" v-bind="scrollData(group[0])">
+          <entity-feed-entry v-for="(data, j) of group" :key="j" v-bind="data"/>
+        </div>
       </template>
     </template>
   </page-section>
@@ -26,6 +28,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { computed } from 'vue';
+import { useRoute } from 'vue-router';
 
 import EntityFeedEntry from './feed-entry.vue';
 import Loading from '../loading.vue';
@@ -42,32 +45,68 @@ defineOptions({
 const { audits, entityVersions, resourceStates } = useRequestData();
 const { initiallyLoading, dataExists } = resourceStates([audits, entityVersions]);
 
+// feed.value is an array of feed entry groups, each of which is an array of
+// feed entries.
 const feed = computed(() => {
-  const result = [];
+  const groups = [];
   let versionIndex = entityVersions.length - 1;
   for (const audit of audits) {
     if (audit.action === 'entity.update.version') {
       const { submission } = audit.details;
       const entityVersion = entityVersions[versionIndex];
       versionIndex -= 1;
-      result.push({ entry: audit, submission, entityVersion });
+      groups.push([{ entry: audit, submission, entityVersion }]);
     } else if (audit.action === 'entity.create') {
-      result.push({ entry: audit });
+      const group = [{ entry: audit }];
       const { details } = audit;
       if (details.sourceEvent?.action === 'submission.update')
-        result.push({ entry: details.sourceEvent });
+        group.push({ entry: details.sourceEvent });
       if (details.submissionCreate != null)
-        result.push({ entry: details.submissionCreate, submission: details.submission });
+        group.push({ entry: details.submissionCreate, submission: details.submission });
+      groups.push(group);
     } else {
-      result.push({ entry: audit });
+      groups.push([{ entry: audit }]);
     }
   }
-  return result;
+  return groups;
 });
+
+const route = useRoute();
+const scrollData = (entryData) => {
+  const { action } = entryData.entry;
+  if (!(action === 'entity.create' || action === 'entity.update.version'))
+    return {};
+  const version = action === 'entity.create' ? 1 : entryData.entityVersion.version;
+  const scrollId = `v${version}`;
+  return {
+    'data-scroll-id': scrollId,
+    class: route.hash === `#${scrollId}` ? 'scroll-target' : null
+  };
+};
 </script>
 
 <style lang="scss">
+@use 'sass:color';
+@import '../../assets/scss/variables';
+
 #entity-activity {
   margin-bottom: 35px;
+
+  // Add space for the left/right borders of a .scroll-target.
+  $scroll-target-border-width: 16px;
+  padding-left: $scroll-target-border-width;
+  // In more narrow viewports, 16px felt like too much padding on the right. We
+  // can let the right border of the .scroll-target overflow a little into the
+  // right page gutter.
+  padding-right: #{$scroll-target-border-width - 7px};
+
+  .scroll-target {
+    border: $scroll-target-border-width solid #{color.change($color-action-foreground, $alpha: 0.35)};
+    border-radius: 9px;
+    margin-left: -$scroll-target-border-width;
+    margin-right: -$scroll-target-border-width;
+
+    .feed-entry { box-shadow: none; }
+  }
 }
 </style>

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -11,8 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <feed-entry :iso="entry.loggedAt" :wrap-title="wrapTitle"
-    class="entity-feed-entry"
-    :class="{ 'submission-entry': entry.action.startsWith('submission.') }">
+    class="entity-feed-entry">
     <template #title>
       <template v-if="entry.action === 'submission.create'">
         <span class="icon-cloud-upload"></span>
@@ -162,8 +161,6 @@ const { reviewStateIcon } = useReviewState();
 @import '../../assets/scss/variables';
 
 .entity-feed-entry {
-  &.submission-entry { margin-top: -19px; }
-
   .icon-cloud-upload { color: #bbb; }
   .icon-magic-wand { color: $color-action-foreground; }
   .icon-pencil { color: #666; }

--- a/src/components/feed-entry.vue
+++ b/src/components/feed-entry.vue
@@ -36,9 +36,10 @@ defineProps({
 <style lang="scss">
 @import '../assets/scss/mixins';
 
+$margin-bottom: 20px;
 .feed-entry {
   box-shadow: 0 7px 18px rgba(0, 0, 0, 0.05);
-  margin-bottom: 20px;
+  margin-bottom: $margin-bottom;
 }
 
 .feed-entry-heading, .feed-entry-body .markdown-view { padding: 10px 15px; }
@@ -82,5 +83,14 @@ defineProps({
   background-color: #f9f9f9;
 
   .markdown-view > p:last-child { margin: 0 0 0px; }
+}
+
+// Container of multiple FeedEntry components
+.feed-entry-group {
+  // Move the bottom margin to the container, but keep 1px between FeedEntry
+  // components.
+  margin-bottom: $margin-bottom;
+  .feed-entry { margin-bottom: 0; }
+  .feed-entry + .feed-entry { margin-top: 1px; }
 }
 </style>

--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,7 @@ import { START_LOCATION, createRouter, createWebHashHistory } from 'vue-router';
 import { watchEffect } from 'vue';
 
 import createRoutes from './routes';
-import { canRoute, forceReplace, preservedData, unlessFailure } from './util/router';
+import { canRoute, createScrollBehavior, forceReplace, preservedData, unlessFailure } from './util/router';
 import { loadAsync } from './util/load-async';
 import { loadLocale } from './util/i18n';
 import { localStore } from './util/storage';
@@ -21,8 +21,12 @@ import { logIn, restoreSession } from './util/session';
 import { noop } from './util/util';
 import { setDocumentTitle } from './util/reactivity';
 
-export default (container, history = createWebHashHistory()) => {
-  const router = createRouter({ history, routes: createRoutes(container) });
+export default (container, {
+  history = createWebHashHistory(),
+  scrollBehavior = createScrollBehavior()
+} = {}) => {
+  const routes = createRoutes(container);
+  const router = createRouter({ history, routes, scrollBehavior });
   const { requestData, alert, unsavedChanges, config } = container;
 
 

--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,8 @@ import { START_LOCATION, createRouter, createWebHashHistory } from 'vue-router';
 import { watchEffect } from 'vue';
 
 import createRoutes from './routes';
-import { canRoute, createScrollBehavior, forceReplace, preservedData, unlessFailure } from './util/router';
+import { canRoute, forceReplace, preservedData, unlessFailure } from './util/router';
+import { createScrollBehavior } from './scroll-behavior';
 import { loadAsync } from './util/load-async';
 import { loadLocale } from './util/i18n';
 import { localStore } from './util/storage';

--- a/src/scroll-behavior.js
+++ b/src/scroll-behavior.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+import { useRouter } from 'vue-router';
+
+import { noop } from './util/util';
+
+const scrollers = new WeakMap();
+
+// Returns a scrollBehavior function to pass to createRouter().
+export const createScrollBehavior = (animation = 'smooth') => {
+  let resolvePreviousScroll = noop;
+  const scrollBehavior = (to, from, savedPosition) => {
+    resolvePreviousScroll();
+    if (to.hash === '' || to.hash === '#')
+      return to.path === from.path ? savedPosition : null;
+    return new Promise(resolve => {
+      resolvePreviousScroll = (value) => {
+        resolve(value);
+        resolvePreviousScroll = noop;
+      };
+    });
+  };
+  const scrollTo = (elementOrSelector) => {
+    if (typeof elementOrSelector === 'string') {
+      const el = document.querySelector(elementOrSelector);
+      if (el != null)
+        scrollTo(el);
+      else
+        resolvePreviousScroll();
+    }
+
+    resolvePreviousScroll({ el: elementOrSelector, top: 10, behavior: animation });
+  };
+  scrollers.set(scrollBehavior, scrollTo);
+  return scrollBehavior;
+};
+
+// Returns a function to scroll to a specified element.
+export const useScrollBehavior = () =>
+  scrollers.get(useRouter().options.scrollBehavior);

--- a/src/scroll-behavior.js
+++ b/src/scroll-behavior.js
@@ -9,17 +9,41 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
+
+/*
+createScrollBehavior() and useScrollBehavior() work together to scroll based on
+the route hash. createScrollBehavior() creates a scrollBehavior function to pass
+to createRouter(). After each navigation, the scrollBehavior function returns a
+promise to scroll to an element. However, it is up to component code to resolve
+the promise. That's where useScrollBehavior() comes in. A component can call the
+useScrollBehavior() composable if it needs to scroll to an element based on the
+route hash. The composable returns a function that when called, scrolls to some
+specified element. Calling that function is what resolves the promise that the
+scrollBehavior function returns to Vue Router.
+
+This approach uses the Vue Router scrollBehavior functionality and gives
+components control over where they scroll.
+*/
+
 import { useRouter } from 'vue-router';
 
 import { noop } from './util/util';
 
 const scrollers = new WeakMap();
 
-// Returns a scrollBehavior function to pass to createRouter().
 export const createScrollBehavior = (animation = 'smooth') => {
+  // resolvePreviousScroll stores the `resolve` function from the last promise
+  // returned to Vue Router. If there is no promise, or if the promise has
+  // already been resolved, then resolvePreviousScroll is a no-op.
   let resolvePreviousScroll = noop;
   const scrollBehavior = (to, from, savedPosition) => {
+    // If a promise was previously returned after the last navigation, then
+    // resolve it / cancel it / clean it up. There's been a new navigation, so
+    // any scrolling should be based on the new route hash.
     resolvePreviousScroll();
+    // If there is no hash or nothing after the hash, then don't bother
+    // returning a promise: no target has been specified for a component to
+    // scroll to.
     if (to.hash === '' || to.hash === '#')
       return to.path === from.path ? savedPosition : null;
     return new Promise(resolve => {
@@ -35,15 +59,23 @@ export const createScrollBehavior = (animation = 'smooth') => {
       if (el != null)
         scrollTo(el);
       else
+        // Scrolling was unsuccessful: the element does not exist. Let's just
+        // clean up the promise.
         resolvePreviousScroll();
+      return;
     }
 
     resolvePreviousScroll({ el: elementOrSelector, top: 10, behavior: animation });
   };
+  /* We need to store scrollTo() somewhere so that components can access it
+  later. scrollBehavior isn't a plugin, so we can't use provide/inject. Instead,
+  we use a Map. We use scrollBehavior as the Map key because it's accessible
+  here, and components will also have access to it (via the router). Note that
+  in testing, typically each test will create its own router with its own
+  scrollBehavior. */
   scrollers.set(scrollBehavior, scrollTo);
   return scrollBehavior;
 };
 
-// Returns a function to scroll to a specified element.
 export const useScrollBehavior = () =>
   scrollers.get(useRouter().options.scrollBehavior);

--- a/src/util/router.js
+++ b/src/util/router.js
@@ -79,49 +79,6 @@ export const forceReplace = ({ router, unsavedChanges }, location) => {
   return router.replace(location);
 };
 
-// Returns a scrollBehavior function to pass to createRouter().
-export const createScrollBehavior = (animation = 'smooth') => {
-  // Function to cancel a previous attempt to scroll
-  let cancel;
-  const scrollTo = (scrollId) => {
-    const el = document.querySelector(`[data-scroll-id="${scrollId}"]`);
-    return el != null ? { el, top: 10, behavior: animation } : null;
-  };
-  return (to, from, savedPosition) => {
-    if (cancel != null) cancel();
-    if (to.hash === '') return to.path === from.path ? savedPosition : null;
-    const scrollId = to.hash.replace('#', '');
-    // Certain characters would lead to an invalid CSS selector above, so we
-    // limit the set of accepted characters.
-    if (!/^[\w-]+$/.test(scrollId)) return null;
-    // Try to scroll right away. If the element doesn't exist, then we need to
-    // wait for it. In that case, we will attempt to scroll on an interval,
-    // giving up after 3 minutes or so.
-    return scrollTo(scrollId) ?? new Promise(resolve => {
-      let tries = 0;
-      const intervalId = setInterval(
-        () => {
-          const result = scrollTo(scrollId);
-          if (result != null) {
-            clearInterval(intervalId);
-            cancel = null;
-            resolve(result);
-          } else {
-            tries += 1;
-            if (tries === 720) cancel();
-          }
-        },
-        250
-      );
-      cancel = () => {
-        clearInterval(intervalId);
-        cancel = null;
-        resolve(null);
-      };
-    });
-  };
-};
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/components/entity/activity.spec.js
+++ b/test/components/entity/activity.spec.js
@@ -4,27 +4,56 @@ import EntityFeedEntry from '../../../src/components/entity/feed-entry.vue';
 import useEntity from '../../../src/request-data/entity';
 
 import testData from '../../data';
+import { mergeMountOptions, mount } from '../../util/lifecycle';
 import { mockRouter } from '../../util/router';
-import { mount } from '../../util/lifecycle';
 import { testRequestData } from '../../util/request-data';
 
-const mountComponent = () => mount(EntityActivity, {
-  global: {
-    provide: { projectId: '1', datasetName: 'trees' }
-  },
-  container: {
-    requestData: testRequestData([useEntity], {
-      entity: testData.extendedEntities.last(),
-      audits: testData.extendedAudits.sorted()
-        .filter(({ action }) => action.startsWith('entity.')),
-      entityVersions: testData.extendedEntityVersions.sorted()
-    }),
-    router: mockRouter('/projects/1/entity-lists/trees/entities/e')
-  }
-});
+const mountComponent = (options = undefined) =>
+  mount(EntityActivity, mergeMountOptions(options, {
+    global: {
+      provide: { projectId: '1', datasetName: 'trees' }
+    },
+    container: {
+      requestData: testRequestData([useEntity], {
+        entity: testData.extendedEntities.last(),
+        audits: testData.extendedAudits.sorted()
+          .filter(({ action }) => action.startsWith('entity.')),
+        entityVersions: testData.extendedEntityVersions.sorted()
+      }),
+      router: mockRouter('/projects/1/entity-lists/trees/entities/e')
+    }
+  }));
+// Creates an entity with three versions, including a conflict, then resolves
+// the conflict.
+const resolveConflict = () => {
+  testData.extendedEntities.createPast(1, { uuid: 'e' });
+  testData.extendedAudits.createPast(1, {
+    action: 'entity.create',
+    details: {}
+  });
+  testData.extendedEntityVersions.createPast(1);
+  testData.extendedAudits.createPast(1, {
+    action: 'entity.update.version',
+    details: {}
+  });
+  testData.extendedEntityVersions.createPast(1, { baseVersion: 1 });
+  testData.extendedAudits.createPast(1, {
+    action: 'entity.update.version',
+    details: {}
+  });
+  testData.extendedEntities.resolve(-1);
+  testData.extendedAudits.createPast(1, { action: 'entity.update.resolve' });
+};
 
 describe('EntityActivity', () => {
-  describe('feed', () => {
+  describe('structure of the feed', () => {
+    it('renders each entity event in its own group of feed entries', () => {
+      resolveConflict();
+      const component = mountComponent();
+      component.findAll('.feed-entry-group').length.should.equal(4);
+      component.findAll('.feed-entry-group .entity-feed-entry').length.should.equal(4);
+    });
+
     it('renders 2 entries if entity was created on submission receipt', () => {
       const sourceDetails = testData.extendedEntities
         .createSourceSubmission('submission.create', { instanceId: 'some-uuid' });
@@ -33,7 +62,9 @@ describe('EntityActivity', () => {
         action: 'entity.create',
         details: sourceDetails
       });
-      const entries = mountComponent().findAllComponents(EntityFeedEntry);
+      const component = mountComponent();
+      component.findAll('.feed-entry-group').length.should.equal(1);
+      const entries = component.findAllComponents(EntityFeedEntry);
       entries.length.should.equal(2);
       entries[0].props().entry.action.should.equal('entity.create');
       entries[1].props().entry.action.should.equal('submission.create');
@@ -48,7 +79,9 @@ describe('EntityActivity', () => {
         action: 'entity.create',
         details: sourceDetails
       });
-      const entries = mountComponent().findAllComponents(EntityFeedEntry);
+      const component = mountComponent();
+      component.findAll('.feed-entry-group').length.should.equal(1);
+      const entries = component.findAllComponents(EntityFeedEntry);
       entries.length.should.equal(3);
       entries[0].props().entry.action.should.equal('entity.create');
       entries[1].props().entry.action.should.equal('submission.update');
@@ -64,11 +97,41 @@ describe('EntityActivity', () => {
         action: 'entity.create',
         details: sourceDetails
       });
-      const entries = mountComponent().findAllComponents(EntityFeedEntry);
+      const component = mountComponent();
+      component.findAll('.feed-entry-group').length.should.equal(1);
+      const entries = component.findAllComponents(EntityFeedEntry);
       entries.length.should.equal(2);
       entries[0].props().entry.action.should.equal('entity.create');
       entries[1].props().entry.action.should.equal('submission.create');
       entries[1].props().submission.instanceId.should.equal('some-uuid');
+    });
+  });
+
+  it('passes the correct entityVersion prop', () => {
+    resolveConflict();
+    mountComponent().findAllComponents(EntityFeedEntry)
+      .map(entry => entry.props().entityVersion?.version)
+      .should.eql([undefined, 3, 2, undefined]);
+  });
+
+  describe('scroll behavior', () => {
+    beforeEach(resolveConflict);
+
+    it('sets data-scroll-id attributes correctly', () => {
+      mountComponent().findAll('.feed-entry-group')
+        .map(group => group.attributes('data-scroll-id'))
+        .should.eql([undefined, 'v3', 'v2', 'v1']);
+    });
+
+    it('adds scroll-target class if data-scroll-id matches route hash', () => {
+      const component = mountComponent({
+        container: {
+          router: mockRouter('/projects/1/entity-lists/trees/entities/e#v2')
+        }
+      });
+      component.findAll('.feed-entry-group')
+        .map(group => group.classes('scroll-target'))
+        .should.eql([false, false, true, false]);
     });
   });
 });

--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -152,7 +152,7 @@ describe('EntityBasicDetails', () => {
           return testData.standardEntities.last();
         })
         .respondWithData(() => testData.extendedAudits.sorted())
-        .respondWithData(() => [])
+        .respondWithData(() => testData.extendedEntityVersions.sorted())
         .afterResponses(component => {
           const dd = component.get('#entity-basic-details-creating-submission');
           dd.text().should.equal('s');

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -8,7 +8,6 @@ import FeedEntry from '../../../src/components/feed-entry.vue';
 import useEntity from '../../../src/request-data/entity';
 
 import testData from '../../data';
-import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 import { mockRouter } from '../../util/router';
 import { mergeMountOptions, mount } from '../../util/lifecycle';
@@ -351,32 +350,5 @@ describe('EntityFeedEntry', () => {
       .last();
     const component = mountComponent();
     component.getComponent(FeedEntry).props().iso.should.equal(audit.loggedAt);
-  });
-
-  it('lists submission events immediately below entity.create event', async () => {
-    const sourceDetails = testData.extendedEntities
-      .createSourceSubmission('submission.update');
-    testData.extendedEntities.createPast(1, { uuid: 'e' });
-    testData.extendedAudits.createPast(1, {
-      action: 'entity.create',
-      details: sourceDetails
-    });
-    const component = await load('/projects/1/entity-lists/trees/entities/e', {
-      root: false,
-      attachTo: document.body
-    });
-    const margin = component.findAllComponents(EntityFeedEntry)
-      .map(({ element }) => {
-        const { marginTop, marginBottom } = getComputedStyle(element);
-        return {
-          top: marginTop === '' ? 0 : Number.parseFloat(marginTop),
-          bottom: marginBottom === '' ? 0 : Number.parseFloat(marginBottom)
-        };
-      });
-    margin.length.should.equal(3);
-    margin[0].top.should.equal(0);
-    (margin[0].bottom + margin[1].top).should.equal(1);
-    (margin[1].bottom + margin[2].top).should.equal(1);
-    margin[2].bottom.should.equal(20);
   });
 });

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -90,7 +90,7 @@ describe('EntityShow', () => {
           return testData.standardEntities.last();
         })
         .respondWithData(() => testData.extendedAudits.sorted())
-        .respondWithData(() => []);
+        .respondWithData(() => testData.extendedEntityVersions.sorted());
     };
 
     it('sends the correct requests for activity data', () =>

--- a/test/composables/scroll-behavior.spec.js
+++ b/test/composables/scroll-behavior.spec.js
@@ -31,7 +31,7 @@ const pxTo = (wrapper) => Math.floor(wrapper.element.getBoundingClientRect().y);
 describe('useScrollBehavior()', () => {
   beforeEach(mockLogin);
 
-  it('does not scroll initially', async () => {
+  it('does not scroll if scrollTo() is not called', async () => {
     await mountComponent();
     // Scrolling doesn't seem to be synchronous, so we wait in order to give it
     // a chance to complete. (But we don't actually expect there to be any,
@@ -62,24 +62,24 @@ describe('useScrollBehavior()', () => {
     window.scrollY.should.equal(0);
   });
 
-  it('scrolls only once per navigation', async () => {
+  it('scrolls at most once per navigation', async () => {
     const component = await mountComponent();
     component.vm.scrollTo('#div2');
     await wait();
-    const previousY = window.scrollY;
+    const yForDiv2 = window.scrollY;
     component.vm.scrollTo('#div3');
     await wait();
-    window.scrollY.should.equal(previousY);
+    window.scrollY.should.equal(yForDiv2);
     await component.vm.$router.push('/#foo');
     // Not sure why this tick is needed.
     await nextTick();
     component.vm.scrollTo('#div3');
     await wait();
-    window.scrollY.should.be.above(previousY);
+    window.scrollY.should.be.above(yForDiv2);
     pxTo(component.get('#div3')).should.equal(10);
   });
 
-  it('scrolls even if there was no scroll after previous navigation', async () => {
+  it('scrolls if there was no scroll after previous navigation', async () => {
     // Don't scroll after mounting (after the initial navigation). Wait until
     // after the next navigation.
     const component = await mountComponent();

--- a/test/composables/scroll-behavior.spec.js
+++ b/test/composables/scroll-behavior.spec.js
@@ -1,0 +1,106 @@
+import { nextTick } from 'vue';
+
+import { useScrollBehavior } from '../../src/scroll-behavior';
+
+import { load } from '../util/http';
+import { mockLogin } from '../util/session';
+import { mount } from '../util/lifecycle';
+import { wait } from '../util/util';
+
+const Component = {
+  template: `<div>
+  <div v-for="(_, i) of new Array(5).fill(null)" :id="id(i)" style="height: 2000px;">
+    Some text
+  </div>
+</div>`,
+  setup() {
+    const id = (i) => `div${i + 1}`;
+    const scrollTo = useScrollBehavior();
+    return { id, scrollTo };
+  }
+};
+const mountComponent = async (hash = '#some_hash') => {
+  const app = await load(`/${hash}`);
+  return mount(Component, {
+    container: app.vm.$container,
+    attachTo: document.body
+  });
+};
+const pxTo = (wrapper) => Math.floor(wrapper.element.getBoundingClientRect().y);
+
+describe('useScrollBehavior()', () => {
+  beforeEach(mockLogin);
+
+  it('does not scroll initially', async () => {
+    await mountComponent();
+    // Scrolling doesn't seem to be synchronous, so we wait in order to give it
+    // a chance to complete. (But we don't actually expect there to be any,
+    // which we are about to assert.)
+    await wait();
+    window.scrollY.should.equal(0);
+  });
+
+  it('scrolls to an element in the DOM', async () => {
+    const component = await mountComponent();
+    component.vm.scrollTo(document.querySelector('#div2'));
+    await wait();
+    window.scrollY.should.be.above(0);
+    pxTo(component.get('#div2')).should.equal(10);
+  });
+
+  it('scrolls when passed a CSS selector', async () => {
+    const component = await mountComponent();
+    component.vm.scrollTo('#div2');
+    await wait();
+    pxTo(component.get('#div2')).should.equal(10);
+  });
+
+  it('does not scroll for an element that does not exist', async () => {
+    const component = await mountComponent();
+    component.vm.scrollTo('#div1000');
+    await wait();
+    window.scrollY.should.equal(0);
+  });
+
+  it('scrolls only once per navigation', async () => {
+    const component = await mountComponent();
+    component.vm.scrollTo('#div2');
+    await wait();
+    const previousY = window.scrollY;
+    component.vm.scrollTo('#div3');
+    await wait();
+    window.scrollY.should.equal(previousY);
+    await component.vm.$router.push('/#foo');
+    // Not sure why this tick is needed.
+    await nextTick();
+    component.vm.scrollTo('#div3');
+    await wait();
+    window.scrollY.should.be.above(previousY);
+    pxTo(component.get('#div3')).should.equal(10);
+  });
+
+  it('scrolls even if there was no scroll after previous navigation', async () => {
+    // Don't scroll after mounting (after the initial navigation). Wait until
+    // after the next navigation.
+    const component = await mountComponent();
+    await component.vm.$router.push('/#foo');
+    await nextTick();
+    component.vm.scrollTo('#div2');
+    await wait();
+    pxTo(component.get('#div2')).should.equal(10);
+  });
+
+  it('ignores scrollTo() if there is no hash', async () => {
+    const component = await mountComponent('');
+    component.vm.scrollTo('#div2');
+    await wait();
+    window.scrollY.should.equal(0);
+  });
+
+  it('ignores scrollTo() if there is nothing after the hash', async () => {
+    const component = await mountComponent('#');
+    component.vm.scrollTo('#div2');
+    await wait();
+    window.scrollY.should.equal(0);
+  });
+});

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -243,6 +243,20 @@ describe('createCentralRouter()', () => {
       }
     };
 
+    it('preserves data if the path is the same', () => {
+      testData.extendedEntities.createPast(1, { uuid: 'e' });
+      testData.extendedAudits.createPast(1, {
+        action: 'entity.create',
+        details: {}
+      });
+      return load('/projects/1/entity-lists/trees/entities/e', {
+        attachTo: document.body
+      })
+        .complete()
+        .route('/projects/1/entity-lists/trees/entities/e?foo=bar#v1')
+        .then(dataExists(['project', 'dataset']));
+    });
+
     describe('navigating between project routes', () => {
       beforeEach(() => {
         testData.extendedProjects.createPast(1, { datasets: 1 });

--- a/test/unit/router.spec.js
+++ b/test/unit/router.spec.js
@@ -1,13 +1,12 @@
 import sinon from 'sinon';
 
-import { afterNextNavigation, arrayQuery, createScrollBehavior, forceReplace, routeProps } from '../../src/util/router';
+import { afterNextNavigation, arrayQuery, forceReplace, routeProps } from '../../src/util/router';
 
 import createTestContainer from '../util/container';
 import testData from '../data';
 import { load } from '../util/http';
 import { mockLogin } from '../util/session';
 import { testRouter } from '../util/router';
-import { wait } from '../util/util';
 
 describe('util/router', () => {
   describe('arrayQuery()', () => {
@@ -161,156 +160,6 @@ describe('util/router', () => {
         await forceReplace(container, '/');
         unsavedChanges.count.should.equal(0);
       });
-    });
-  });
-
-  // We try to test this function using mostly integration tests. Where that's
-  // more difficult, we use unit tests.
-  describe('createScrollBehavior()', () => {
-    beforeEach(() => {
-      mockLogin();
-      testData.extendedEntities.createPast(1, { uuid: 'e' });
-      testData.extendedAudits.createPast(1, {
-        action: 'entity.create',
-        details: {}
-      });
-      for (let version = 2; version <= 50; version += 1) {
-        testData.extendedEntityVersions.createPast(1);
-        testData.extendedAudits.createPast(1, {
-          action: 'entity.update.version',
-          details: {}
-        });
-      }
-    });
-
-    // Waits enough time for scrolling to occur.
-    const waitForScroll = (clock) => {
-      clock.tick(250);
-      // I'm not sure why wait() is needed in addition to clock.tick(). Maybe
-      // scrolling is run as a task rather than a microtask?
-      return wait();
-    };
-    const pxTo = (wrapper) =>
-      Math.floor(wrapper.element.getBoundingClientRect().y);
-
-    it('does not scroll if there is no route hash', async () => {
-      const clock = sinon.useFakeTimers(Date.now());
-      await load('/projects/1/entity-lists/trees/entities/e', {
-        attachTo: document.body
-      });
-      window.scrollY.should.equal(0);
-      // Even after waiting, the page should not scroll.
-      await waitForScroll(clock);
-      window.scrollY.should.equal(0);
-    });
-
-    it('immediately scrolls to a target that exists in the DOM', async () => {
-      sinon.useFakeTimers(Date.now());
-      const app = await load('/projects/1/entity-lists/trees/entities/e', {
-        attachTo: document.body
-      });
-
-      // Scroll to v40.
-      await app.vm.$router.push('/projects/1/entity-lists/trees/entities/e#v40');
-      // We don't wait 250 milliseconds, but we do seem to need to give tasks
-      // the chance to run.
-      await wait();
-      const yForV40 = window.scrollY;
-      yForV40.should.be.above(0);
-      pxTo(app.get('[data-scroll-id="v40"]')).should.equal(10);
-
-      // Scroll to v20 even farther below.
-      await app.vm.$router.push('/projects/1/entity-lists/trees/entities/e#v20');
-      await wait();
-      window.scrollY.should.be.above(yForV40);
-      pxTo(app.get('[data-scroll-id="v20"]')).should.equal(10);
-    });
-
-    it('waits for the scroll target to appear in the DOM', async () => {
-      const clock = sinon.useFakeTimers(Date.now());
-      await load('/projects/1/entity-lists/trees/entities/e#v40', {
-        attachTo: document.body
-      });
-      // The first attempt to scroll happened around when requests were sent,
-      // before the page was fully rendered. As a result, there was no initial
-      // scrolling: we need to wait for the second attempt to scroll.
-      window.scrollY.should.equal(0);
-      await waitForScroll(clock);
-      window.scrollY.should.be.above(0);
-    });
-
-    it('does not scroll twice', async () => {
-      const clock = sinon.useFakeTimers(Date.now());
-      await load('/projects/1/entity-lists/trees/entities/e#v40', {
-        attachTo: document.body
-      });
-      await waitForScroll(clock);
-      window.scrollY.should.be.above(0);
-      window.scrollTo(0, 0);
-      window.scrollY.should.equal(0);
-      await waitForScroll(clock);
-      window.scrollY.should.equal(0);
-    });
-
-    it('stops waiting after some amount of time', () => {
-      const clock = sinon.useFakeTimers(Date.now());
-      return load('/projects/1/entity-lists/trees/entities/e#v40', {
-        attachTo: document.body
-      })
-        .beforeAnyResponse(() => {
-          clock.tick(240000);
-        })
-        .respondWithData(() => 'v2023.5') // version.txt
-        .afterResponses(async () => {
-          await waitForScroll(clock);
-          window.scrollY.should.equal(0);
-        });
-    });
-
-    describe('new navigation is confirmed before target appears', () => {
-      it('does not scroll to the previous target', () => {
-        const clock = sinon.useFakeTimers(Date.now());
-        return load('/projects/1/entity-lists/trees/entities/e#v40', {
-          attachTo: document.body
-        })
-          .beforeAnyResponse(app =>
-            // Navigate to a route without a hash.
-            app.vm.$router.push('/projects/1/entity-lists/trees/entities/e'))
-          .afterResponses(async () => {
-            await waitForScroll(clock);
-            window.scrollY.should.equal(0);
-          });
-      });
-
-      it('scrolls to the new target', () => {
-        const clock = sinon.useFakeTimers(Date.now());
-        return load('/projects/1/entity-lists/trees/entities/e#v40', {
-          attachTo: document.body
-        })
-          .beforeAnyResponse(app =>
-            app.vm.$router.push('/projects/1/entity-lists/trees/entities/e#v20'))
-          .afterResponses(async (app) => {
-            await waitForScroll(clock);
-            window.scrollY.should.be.above(0);
-            pxTo(app.get('[data-scroll-id="v20"]')).should.equal(10);
-          });
-      });
-    });
-
-    describe('invalid hash', () => {
-      const cases = [
-        '',
-        '#',
-        // This would break the CSS selector in createScrollBehavior().
-        '#"'
-      ];
-      for (const hash of cases) {
-        it(`does not scroll if the hash is [${hash}]`, () => {
-          const to = { path: '/users', hash };
-          const from = { path: '/' };
-          should.not.exist(createScrollBehavior()(to, from, null));
-        });
-      }
     });
   });
 });

--- a/test/util/http.js
+++ b/test/util/http.js
@@ -593,6 +593,7 @@ class MockHttp {
     }
 
     this._requestCount = 0;
+    this._responseCount = 0;
     this._errorFromBeforeAnyResponse = null;
     this._errorFromBeforeEachResponse = null;
     this._errorFromResponse = null;
@@ -683,6 +684,8 @@ class MockHttp {
           ? this._tryBeforeEachResponse(config, index)
           : null))
         .then(() => new Promise((resolve, reject) => {
+          this._responseCount += 1;
+
           let responseWithoutConfig;
           try {
             const callback = this._responses[index];
@@ -778,6 +781,10 @@ class MockHttp {
         throw new Error('request without response: no response specified for request');
       else
         throw new Error('response without request: not all responses were requested');
+    }
+    if (this._responseCount !== this._responses.length) {
+      this._listRequestResponseLog();
+      throw new Error('All responses were requested, but not all were returned in time. By default, all responses are expected to be returned in microtasks, before the next task. You may need to use the pollWork option of afterResponses().');
     }
   }
 

--- a/test/util/router.js
+++ b/test/util/router.js
@@ -5,7 +5,7 @@ import { shallowRef } from 'vue';
 import RouterViewStub from './components/router-view-stub.vue';
 
 import createCentralRouter from '../../src/router';
-import { createScrollBehavior } from '../../src/util/router';
+import { createScrollBehavior } from '../../src/scroll-behavior';
 import { noop } from '../../src/util/util';
 
 // Returns a function to create a real router configured for use in testing.
@@ -55,6 +55,7 @@ export const mockRouter = (location = undefined) => (container) => {
     : START_LOCATION);
   const mock = {
     currentRoute,
+    options: router.options,
     isReady: currentRoute.value !== START_LOCATION
       ? () => Promise.resolve()
       : () => { throw new Error('not ready'); },

--- a/test/util/router.js
+++ b/test/util/router.js
@@ -5,16 +5,21 @@ import { shallowRef } from 'vue';
 import RouterViewStub from './components/router-view-stub.vue';
 
 import createCentralRouter from '../../src/router';
+import { createScrollBehavior } from '../../src/util/router';
 import { noop } from '../../src/util/util';
 
 // Returns a function to create a real router configured for use in testing.
-export const testRouter = () => (container) =>
+export const testRouter = () => (container) => createCentralRouter(container, {
   // Using memory history mode because there were issues using hash mode. In
   // hash mode, when the router is installed on an application instance, the
   // router examines the hash to determine the initial location. But that
   // becomes an issue during testing, because the hash diverges from the current
   // route over time: Headless Chrome seems to rate-limit hash changes.
-  createCentralRouter(container, createMemoryHistory());
+  history: createMemoryHistory(),
+  // In production, scrolling animates smoothly, but in testing, we make it
+  // instant. That way, we don't have to wait for the animation to complete.
+  scrollBehavior: createScrollBehavior('instant')
+});
 
 /*
 Use setInstallLocation() when you want to trigger a navigation, then mount a
@@ -44,7 +49,7 @@ is initialized. If installed on an app instance, the object will register stubs
 for <router-link> and <router-view>. If you need a router that can navigate, use
 testRouter(). */
 export const mockRouter = (location = undefined) => (container) => {
-  const router = createCentralRouter(container, createMemoryHistory());
+  const router = testRouter()(container);
   const currentRoute = shallowRef(location != null
     ? router.resolve(location)
     : START_LOCATION);


### PR DESCRIPTION
This PR makes it possible to link to a specific element of a page using the route hash. You can link to the element from the same page or a different page. This functionality is needed for getodk/central#529.

Here's an example of the new functionality on the entity detail page. As the hash changes, the page scrolls down to a middle entry in the feed, then up to the top entry, then back down to the bottom entry. A blue border is shown around the associated entry. In the case of the bottom entry, the entry does not appear at the top of the screen because the entry is located at the very bottom of the page. However, you can still see the blue border. In other cases, there are 10px between the top of the screen and the associated entry.

https://github.com/getodk/central-frontend/assets/5970131/0eef6f30-2a95-4df3-abbe-db8d05f48810

#### What has been done to verify that this works as intended?

I tried things locally and also wrote new tests. There's one thing that I wasn't able to test, which I'll make a note of.

#### Why is this the best possible solution? Were any other approaches considered?

I was able to use the scroll behavior functionality provided by Vue Router: https://router.vuejs.org/guide/advanced/scroll-behavior.html. I'll leave comments about a few choices I made.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

One change I made was to modify the structure of the feed, grouping related entries in a different way from before. However, I think that if there are issues there, we'll spot them during regression testing. Other than that, there aren't a lot of changes to existing code.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced