### PR TITLE
Added Conflict Summary box on the Entity Feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "nf start",
     "dev:oidc": "VUE_APP_OIDC_ENABLED=true npm run dev",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint --fix --max-warnings 0 src/ bin/ test/ *.js",
+    "lint": "vue-cli-service lint --no-fix --max-warnings 0 src/ bin/ test/ *.js",
+    "lint:fix": "vue-cli-service lint --fix --max-warnings 0 src/ bin/ test/ *.js",
     "test": "./test/run.sh"
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nf start",
     "dev:oidc": "VUE_APP_OIDC_ENABLED=true npm run dev",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint --no-fix --max-warnings 0 src/ bin/ test/ *.js",
+    "lint": "vue-cli-service lint --fix --max-warnings 0 src/ bin/ test/ *.js",
     "test": "./test/run.sh"
   },
   "volta": {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -720,6 +720,26 @@ becomes more complicated.
   }
 }
 
+.panel-hazard {
+  border-color: $color-danger;
+
+  &> .panel-heading {
+    color: white;
+    background-color: $color-danger;
+    border-color: $color-danger;
+  }
+  &> .panel-body {
+    border: 1px solid $color-danger;
+
+    &> .panel-footer {
+      margin: 0 -15px -15px -15px;
+      background-color: #585858;
+      color: white;
+    }
+  }
+  
+}
+
 .panel-dialog {
   border: 2px solid $color-accent-primary;
   border-radius: 5px;

--- a/src/components/confirmation.vue
+++ b/src/components/confirmation.vue
@@ -1,0 +1,74 @@
+<!--
+Copyright 2023 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+
+<template>
+  <modal :state="state" :hideable="!awaitingResponse"
+    backdrop @hide="$emit('hide')">
+    <template #title>{{ title }}</template>
+    <template #body>
+      <div class="modal-introduction">
+        <slot name="body"></slot>
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn btn-danger"
+          :aria-disabled="awaitingResponse" @click="$emit('success')">
+          {{ yesTextC }} <spinner :state="awaitingResponse"/>
+        </button>
+        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
+          @click="$emit('hide')">
+          {{ noTextC }}
+        </button>
+      </div>
+    </template>
+  </modal>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import Modal from './modal.vue';
+import Spinner from './spinner.vue';
+
+const { t } = useI18n();
+
+defineOptions({
+  name: 'Confirmation'
+});
+
+const prop = defineProps({
+  state: {
+    type: Boolean,
+    default: false
+  },
+  title: {
+    type: String,
+    required: true
+  },
+  yesText: {
+    type: String
+  },
+  noText: {
+    type: String
+  },
+  awaitingResponse: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const yesTextC = computed(() => prop.yesText || t('common.yes'));
+const noTextC = computed(() => prop.noText || t('common.no'));
+
+defineEmits(['hide', 'success']);
+
+</script>

--- a/src/components/entity/conflict-summary.vue
+++ b/src/components/entity/conflict-summary.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 
 <template>
-  <div id="conflict-summary" class="panel panel-hazard">
+  <div id="entity-conflict-summary" class="panel panel-hazard">
     <div class="panel-heading">
       <span class="icon-exclamation-circle"></span>
       <div>
@@ -33,8 +33,8 @@ except according to the terms contained in the LICENSE file.
           <br>
           {{ $t('footer[1]') }}
         </p>
-        <button type="button" class="btn btn-default" @click="showConfirmation" @success="markAsResolved">
-          <span class="icon-random"></span> {{ $t('markAsResolved') }}
+        <button type="button" class="btn btn-default" @click="showConfirmation">
+          <span class="icon-random"></span>{{ $t('markAsResolved') }}
         </button>
       </div>
     </div>
@@ -68,7 +68,7 @@ const { dataset } = useRequestData();
 const { alert } = inject('container');
 
 defineOptions({
-  name: 'ConflictSummary'
+  name: 'EntityConflictSummary'
 });
 
 const props = defineProps({
@@ -187,6 +187,7 @@ const markAsResolved = () => {
         "If any values need to be adjusted, you can edit the Entity data directly.",
         "If everything looks okay, click “Mark as resolved” to dismiss this warning."
       ],
+      // @transifexKey component.EntityResolve.action.markAsResolved
       "markAsResolved": "Mark as resolved",
       "confirmation":{
         "title": "Is this Entity okay?",

--- a/src/components/entity/conflict-summary.vue
+++ b/src/components/entity/conflict-summary.vue
@@ -1,0 +1,203 @@
+<!--
+Copyright 2023 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+
+<template>
+  <div id="conflict-summary" class="panel panel-hazard">
+    <div class="panel-heading">
+      <span class="icon-exclamation-circle"></span>
+      <div>
+        <h1 class="panel-title">{{ $t('title') }}</h1>
+        <p>
+          {{ $t('subtitle[0]') }}
+          <br>
+          {{ $t('subtitle[1]') }}
+        </p>
+      </div>
+    </div>
+    <div class="panel-body">
+      <!-- Placeholder for table  -->
+
+      <div class="panel-footer">
+        <span class="icon-arrow-circle-right"></span>
+        <p>
+          {{ $t('footer[0]') }}
+          <br>
+          {{ $t('footer[1]') }}
+        </p>
+        <button type="button" class="btn btn-default" @click="showConfirmation" @success="markAsResolved">
+          <span class="icon-random"></span> {{ $t('markAsResolved') }}
+        </button>
+      </div>
+    </div>
+  </div>
+  <confirmation v-bind="confirm" @hide="hideConfirm" @success="markAsResolved">
+    <template #body>
+      <p>
+        {{ $t('confirmation.body') }}
+      </p>
+    </template>
+  </confirmation>
+</template>
+
+<script setup>
+
+import { ref, inject, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import Confirmation from '../confirmation.vue';
+
+import { apiPaths } from '../../util/request';
+import { noop } from '../../util/util';
+import { useRequestData } from '../../request-data';
+
+import useRequest from '../../composables/request';
+
+const { request, awaitingResponse } = useRequest();
+
+const { t } = useI18n();
+const { dataset } = useRequestData();
+const { alert } = inject('container');
+
+defineOptions({
+  name: 'ConflictSummary'
+});
+
+const props = defineProps({
+  entity: {
+    type: Object,
+    required: true
+  }
+});
+
+const emit = defineEmits(['resolve']);
+
+const confirmModalState = ref(false);
+
+const confirm = computed(() => ({
+  state: confirmModalState.value,
+  title: t('confirmation.title'),
+  yesText: t('confirmation.confirm'),
+  noText: t('action.noCancel'),
+  awaitingResponse: awaitingResponse.value
+}));
+
+const showConfirmation = () => {
+  confirmModalState.value = true;
+};
+
+const hideConfirm = () => {
+  confirmModalState.value = false;
+};
+
+const markAsResolved = () => {
+  const { entity } = props;
+  const url = apiPaths.entity(dataset.projectId, dataset.name, entity.uuid, { resolve: true });
+
+  request.patch(
+    url,
+    null,
+    {
+      headers: { 'If-Match': `"${entity.currentVersion.version}"` },
+      problemToAlert: ({ code }) => {
+        if (code === 409.15) return t('problem.409_15');
+        return null;
+      }
+    }
+  )
+    .then(response => {
+      hideConfirm();
+      alert.success(t('conflictResolved'));
+      emit('resolve', response.data);
+    })
+    .catch(noop);
+};
+
+</script>
+
+<style lang="scss" scoped>
+  .panel-heading {
+    display: flex;
+    padding: 15px;
+
+    span {
+      width: 30px;
+      font-size: 20px;
+    }
+
+    div {
+      flex: auto;
+      h1 {
+        margin-bottom: 2px;
+        font-size: 19px;
+      }
+      p {
+        margin-bottom: 0;
+        line-height: 16px;
+      }
+    }
+
+  }
+
+  .panel-footer {
+    display: flex;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+
+    > span {
+      width: 30px;
+      font-size: 20px;
+      align-self: center;
+      color: #9F9F9F
+    }
+
+    p {
+      flex: auto;
+      margin: 0;
+      max-width: unset;
+      line-height: 16px;
+    }
+
+    button {
+      height: 34px;
+      align-self: center;
+      overflow: visible;
+    }
+  }
+
+</style>
+
+<i18n lang="json5">
+  {
+    "en": {
+      "title": "Data updates in parallel",
+      "subtitle": [
+        "One or more updates have been made based on data that may have been out of date.",
+        "Please review this summary of the parallel updates."
+      ],
+      "footer": [
+        "If any values need to be adjusted, you can edit the Entity data directly.",
+        "If everything looks okay, click “Mark as resolved” to dismiss this warning."
+      ],
+      "markAsResolved": "Mark as resolved",
+      "confirmation":{
+        "title": "Is this Entity okay?",
+        "body": "After you have reviewed the possibly conflicting updates and made any updates you need to, you can click on Confirm below to clear the parallel update warning.",
+        "confirm": "Confirm"
+      },
+      "problem": {
+        // @transifexKey component.EntityUpdate.problem.409_15
+        "409_15": "Data has been modified by another user. Please refresh to see the updated data."
+      },
+      "conflictResolved": "Conflict warning resolved."
+    }
+  }
+</i18n>

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -26,7 +26,7 @@ except according to the terms contained in the LICENSE file.
           <entity-data @update="update.state = true"/>
         </div>
         <div class="col-xs-8">
-          <conflict-summary v-if="entity.data?.conflict" :entity="entity" @resolve="afterResolve"/>
+          <entity-conflict-summary v-if="entity.data?.conflict" :entity="entity" @resolve="afterResolve"/>
           <entity-activity/>
         </div>
       </div>
@@ -48,7 +48,7 @@ import Loading from '../loading.vue';
 import PageBack from '../page/back.vue';
 import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
-import conflictSummary from './conflict-summary.vue';
+import EntityConflictSummary from './conflict-summary.vue';
 
 import useEntity from '../../request-data/entity';
 import useRoutes from '../../composables/routes';
@@ -125,7 +125,7 @@ const afterResolve = (updated) => {
   fetchActivityData();
   entity.patch(() => {
     entity.updatedAt = updated.updatedAt;
-    entity.conflict = update.conflict;
+    entity.conflict = updated.conflict;
   });
 };
 const { datasetPath } = useRoutes();

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -26,6 +26,7 @@ except according to the terms contained in the LICENSE file.
           <entity-data @update="update.state = true"/>
         </div>
         <div class="col-xs-8">
+          <conflict-summary v-if="entity.data?.conflict" :entity="entity" @resolve="afterResolve"/>
           <entity-activity/>
         </div>
       </div>
@@ -47,6 +48,7 @@ import Loading from '../loading.vue';
 import PageBack from '../page/back.vue';
 import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
+import conflictSummary from './conflict-summary.vue';
 
 import useEntity from '../../request-data/entity';
 import useRoutes from '../../composables/routes';
@@ -119,6 +121,13 @@ const afterUpdate = (updated) => {
   });
 };
 
+const afterResolve = (updated) => {
+  fetchActivityData();
+  entity.patch(() => {
+    entity.updatedAt = updated.updatedAt;
+    entity.conflict = update.conflict;
+  });
+};
 const { datasetPath } = useRoutes();
 </script>
 

--- a/test/components/confirmation.spec.js
+++ b/test/components/confirmation.spec.js
@@ -1,0 +1,61 @@
+import Confirmation from '../../src/components/confirmation.vue';
+
+import { mergeMountOptions, mount } from '../util/lifecycle';
+import { assertStandardButton } from '../util/http/common';
+
+const mountComponent = (options = undefined) =>
+  mount(Confirmation, mergeMountOptions(options, {
+    props: { state: true, title: 'Some Title' },
+    slots: {
+      body: { template: '<p>Some text</p>' }
+    }
+  }));
+
+describe('Confirmation', () => {
+  it('shows the title', () => {
+    const text = mountComponent().get('.modal-title').text();
+    text.should.equal('Some Title');
+  });
+
+  it('shows the body', () => {
+    const text = mountComponent().get('.modal-introduction').text();
+    text.should.equal('Some text');
+  });
+
+  it('shows default text for yes button', () => {
+    const text = mountComponent().get('.btn-danger').text();
+    text.should.equal('Yes');
+  });
+
+  it('shows default text for no button', () => {
+    const text = mountComponent().get('.btn-link').text();
+    text.should.equal('No');
+  });
+
+  it('shows passed text for yes button', () => {
+    const text = mountComponent({ props: { yesText: 'Custom Yes Text' } }).get('.btn-danger').text();
+    text.should.equal('Custom Yes Text');
+  });
+
+  it('shows default text for no button', () => {
+    const text = mountComponent({ props: { noText: 'Custom No Text' } }).get('.btn-link').text();
+    text.should.equal('Custom No Text');
+  });
+
+  it('should not hide on ESC when awaitingResponse', async () => {
+    const component = mountComponent({ props: { awaitingResponse: true } });
+    await component.trigger('keydown.esc');
+    component.emitted().should.not.have.property('hide');
+  });
+
+  it('should disable all action buttons when awaitingResponse', async () => {
+    const component = mountComponent({ props: { awaitingResponse: true } });
+    assertStandardButton(component, '.btn-danger', ['.btn-link', '.close'], null, true);
+  });
+
+  it('should emit success on yes button', async () => {
+    const component = mountComponent();
+    await component.get('.btn-danger').trigger('click');
+    component.emitted().should.have.property('success');
+  });
+});

--- a/test/components/confirmation.spec.js
+++ b/test/components/confirmation.spec.js
@@ -37,7 +37,7 @@ describe('Confirmation', () => {
     text.should.equal('Custom Yes Text');
   });
 
-  it('shows default text for no button', () => {
+  it('shows passed text for no button', () => {
     const text = mountComponent({ props: { noText: 'Custom No Text' } }).get('.btn-link').text();
     text.should.equal('Custom No Text');
   });

--- a/test/components/entity/conflict-summary.spec.js
+++ b/test/components/entity/conflict-summary.spec.js
@@ -1,0 +1,83 @@
+import ConflictSummary from '../../../src/components/entity/conflict-summary.vue';
+import Confirmation from '../../../src/components/confirmation.vue';
+
+import testData from '../../data';
+import { mergeMountOptions, mount } from '../../util/lifecycle';
+import { mockHttp } from '../../util/http';
+
+const mountOptions = (options = undefined) => mergeMountOptions(options, {
+  props: { entity: testData.extendedEntities.last() },
+  container: {
+    requestData: { dataset: testData.extendedDatasets.last() }
+  }
+});
+const mountComponent = (options = undefined) =>
+  mount(ConflictSummary, mountOptions(options));
+
+describe('EntityUpdate', () => {
+  it('show the confirmation modal', async () => {
+    testData.extendedEntities.createPast(1);
+    const component = await mountComponent();
+
+    component.getComponent(Confirmation).props().state.should.be.false();
+    await component.get('.btn-default').trigger('click');
+    component.getComponent(Confirmation).props().state.should.be.true();
+  });
+
+  it('sends the correct request', async () => {
+    testData.extendedEntities.createPast(1, { uuid: 'e' });
+    return mockHttp()
+      .mount(ConflictSummary, mountOptions())
+      .request(async (component) => {
+        await component.get('.btn-default').trigger('click');
+        const modal = component.getComponent(Confirmation);
+        await modal.get('.btn-danger').trigger('click');
+      })
+      .respondWithProblem()
+      .testRequests([{
+        method: 'PATCH',
+        url: '/v1/projects/1/datasets/trees/entities/e?resolve=true',
+        headers: {
+          'If-Match': '"1"'
+        }
+      }]);
+  });
+
+  describe('Resolve Conflict', () => {
+    const resolve = () =>
+      mockHttp()
+        .mount(ConflictSummary, mountOptions())
+        .request(async (component) => {
+          await component.get('.btn-default').trigger('click');
+          const modal = component.getComponent(Confirmation);
+          await modal.get('.btn-danger').trigger('click');
+        })
+        .respondWithData(() => {
+          testData.extendedEntities.resolve(-1);
+          return testData.standardEntities.last();
+        });
+
+    it('should emit resolve', async () => {
+      testData.extendedEntities.createPast(1);
+
+      const component = await resolve();
+
+      component.emitted().should.have.property('resolve');
+    });
+
+    it('should show alert', async () => {
+      testData.extendedEntities.createPast(1);
+
+      const component = await resolve();
+      component.should.alert('success');
+    });
+
+    it('should hide confirmation modal', async () => {
+      testData.extendedEntities.createPast(1);
+
+      const component = await resolve();
+
+      component.getComponent(Confirmation).props().state.should.be.false();
+    });
+  });
+});

--- a/test/components/entity/conflict-summary.spec.js
+++ b/test/components/entity/conflict-summary.spec.js
@@ -14,7 +14,7 @@ const mountOptions = (options = undefined) => mergeMountOptions(options, {
 const mountComponent = (options = undefined) =>
   mount(ConflictSummary, mountOptions(options));
 
-describe('EntityUpdate', () => {
+describe('EntityConflictSummary', () => {
   it('show the confirmation modal', async () => {
     testData.extendedEntities.createPast(1);
     const component = await mountComponent();
@@ -78,6 +78,23 @@ describe('EntityUpdate', () => {
       const component = await resolve();
 
       component.getComponent(Confirmation).props().state.should.be.false();
+    });
+
+    it('shows conflict error', () => {
+      testData.extendedEntities.createPast(1);
+      return mockHttp()
+        .mount(ConflictSummary, mountOptions())
+        .request(async (component) => {
+          await component.get('.btn-default').trigger('click');
+          const modal = component.getComponent(Confirmation);
+          await modal.get('.btn-danger').trigger('click');
+        })
+        .respondWithProblem(409.15)
+        .afterResponse(component => {
+          component.should.alert('danger', (message) => {
+            message.should.eql('Data has been modified by another user. Please refresh to see the updated data.');
+          });
+        });
     });
   });
 });

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -1,6 +1,7 @@
 import EntityUpdate from '../../../src/components/entity/update.vue';
 import NotFound from '../../../src/components/not-found.vue';
 import PageBack from '../../../src/components/page/back.vue';
+import Confirmation from '../../../src/components/confirmation.vue';
 
 import testData from '../../data';
 import { load } from '../../util/http';
@@ -131,7 +132,7 @@ describe('EntityShow', () => {
       const component = await load('/projects/1/entity-lists/trees/entities/e', {
         root: false
       });
-      component.find('#conflict-summary').exists().should.be.true();
+      component.find('#entity-conflict-summary').exists().should.be.true();
     });
 
     it('hides conflict summary after resolve', async () => {
@@ -143,15 +144,15 @@ describe('EntityShow', () => {
       })
         .complete()
         .request(async (c) => {
-          await c.get('#conflict-summary .btn-default').trigger('click');
-          await c.get('.modal-actions .btn-danger').trigger('click');
+          await c.get('#entity-conflict-summary .btn-default').trigger('click');
+          await c.getComponent(Confirmation).get('.btn-danger').trigger('click');
         })
         .respondWithData(() => {
           testData.extendedEntities.resolve(-1);
           return testData.standardEntities.last();
         })
         .respondWithData(() => testData.extendedAudits.sorted())
-        .respondWithData(() => []);
+        .respondWithData(() => testData.extendedEntityVersions.sorted());
 
       component.find('#conflict-summary').exists().should.be.false();
     });

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -122,4 +122,38 @@ describe('EntityShow', () => {
 
     it('updates the number of entries in the feed');
   });
+
+  describe('Conflict summary', () => {
+    it('shows conflict summary', async () => {
+      testData.extendedEntities.createPast(1, { uuid: 'e' });
+      testData.extendedEntityVersions.createPast(2, { uuid: 'e', baseVersion: 1 });
+
+      const component = await load('/projects/1/entity-lists/trees/entities/e', {
+        root: false
+      });
+      component.find('#conflict-summary').exists().should.be.true();
+    });
+
+    it('hides conflict summary after resolve', async () => {
+      testData.extendedEntities.createPast(1, { uuid: 'e' });
+      testData.extendedEntityVersions.createPast(2, { uuid: 'e', baseVersion: 1 });
+
+      const component = await load('/projects/1/entity-lists/trees/entities/e', {
+        root: false
+      })
+        .complete()
+        .request(async (c) => {
+          await c.get('#conflict-summary .btn-default').trigger('click');
+          await c.get('.modal-actions .btn-danger').trigger('click');
+        })
+        .respondWithData(() => {
+          testData.extendedEntities.resolve(-1);
+          return testData.standardEntities.last();
+        })
+        .respondWithData(() => testData.extendedAudits.sorted())
+        .respondWithData(() => []);
+
+      component.find('#conflict-summary').exists().should.be.false();
+    });
+  });
 });

--- a/test/util/http/common.js
+++ b/test/util/http/common.js
@@ -94,7 +94,7 @@ export function testModalToggles({
 ////////////////////////////////////////////////////////////////////////////////
 // STANDARD BUTTON THINGS
 
-const assertStandardButton = (
+export const assertStandardButton = (
   component,
   buttonSelector,
   disabledSelectors,

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1503,6 +1503,44 @@
         "string": "This Submission has been deleted."
       }
     },
+    "EntityConflictSummary": {
+      "title": {
+        "string": "Data updates in parallel"
+      },
+      "subtitle": {
+        "0": {
+          "string": "One or more updates have been made based on data that may have been out of date."
+        },
+        "1": {
+          "string": "Please review this summary of the parallel updates."
+        }
+      },
+      "footer": {
+        "0": {
+          "string": "If any values need to be adjusted, you can edit the Entity data directly."
+        },
+        "1": {
+          "string": "If everything looks okay, click “Mark as resolved” to dismiss this warning."
+        }
+      },
+      "markAsResolved": {
+        "string": "Mark as resolved"
+      },
+      "confirmation": {
+        "title": {
+          "string": "Is this Entity okay?"
+        },
+        "body": {
+          "string": "After you have reviewed the possibly conflicting updates and made any updates you need to, you can click on Confirm below to clear the parallel update warning."
+        },
+        "confirm": {
+          "string": "Confirm"
+        }
+      },
+      "conflictResolved": {
+        "string": "Conflict warning resolved."
+      }
+    },
     "EntityData": {
       "title": {
         "string": "Entity Data",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1523,9 +1523,6 @@
           "string": "If everything looks okay, click “Mark as resolved” to dismiss this warning."
         }
       },
-      "markAsResolved": {
-        "string": "Mark as resolved"
-      },
       "confirmation": {
         "title": {
           "string": "Is this Entity okay?"


### PR DESCRIPTION
Closes getodk/central#530, closes getodk/central#535

<img src="https://github.com/getodk/central-frontend/assets/447837/4ebb3f87-018e-4c58-839a-afe1c2708407" width="600"/>


#### What has been done to verify that this works as intended?

Tested locally and wrote integration tests

#### Why is this the best possible solution? Were any other approaches considered?

I have created `confirmation` component with the intend that this can be used by other pages to show confirmation dialog. I could have created specific modal here like we have done for other cases but I think it's time for a common reusable confirmation component.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Should be done as part of release user documentation

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced