### PR TITLE
Entity version tag on update events in entity feed

### DIFF
--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -62,6 +62,7 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template v-else-if="entry.action === 'entity.update.version'">
         <span class="icon-pencil"></span>
+        <span class="title">
         <template v-if="entry.details.submissionCreate != null">
           <i18n-t v-if="submission != null"
             keypath="title.entity.update_version.submission.notDeleted">
@@ -82,6 +83,8 @@ except according to the terms contained in the LICENSE file.
         <i18n-t v-else keypath="title.entity.update_version.api">
           <template #name><actor-link :actor="entry.actor"/></template>
         </i18n-t>
+        </span>
+        <span class="entity-version-tag"><router-link :to="versionAnchor(entityVersion.version)">v{{ entityVersion.version }}</router-link></span>
       </template>
       <template v-else-if="entry.action === 'entity.update.resolve'">
         <span class="icon-random"></span>
@@ -155,10 +158,13 @@ const deletedSubmissionEntityEvent = computed(() => {
   return t('title.entity.update_version.submission.deleted.deletedSubmission', { id });
 });
 const { reviewStateIcon } = useReviewState();
+
+const versionAnchor = (v) => `#v${v}`;
 </script>
 
 <style lang="scss">
 @import '../../assets/scss/variables';
+@import '../../assets/scss/mixins';
 
 .entity-feed-entry {
   .icon-cloud-upload { color: #bbb; }
@@ -172,6 +178,19 @@ const { reviewStateIcon } = useReviewState();
   .deleted-submission, .entity-label { font-weight: normal; }
   .deleted-submission { color: $color-danger; }
   .approval { color: $color-success; }
+
+  .entity-version-tag {
+    background-color: #ddd;
+    font-size: 12px;
+    margin: 5px;
+    padding: 3px;
+    border-radius: 2px;
+
+    a {
+      @include text-link;
+      font-weight: bold;
+    }
+  }
 }
 </style>
 

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -224,7 +224,7 @@ describe('EntityFeedEntry', () => {
 
     it('shows the correct text', () => {
       const component = mountComponent();
-      const text = component.get('.feed-entry-title').text();
+      const text = component.get('.feed-entry-title .title').text();
       text.should.equal('Data updated by Alice');
     });
 
@@ -233,6 +233,12 @@ describe('EntityFeedEntry', () => {
       const title = component.get('.feed-entry-title');
       const actorLink = title.getComponent(ActorLink);
       actorLink.props().actor.displayName.should.equal('Alice');
+    });
+
+    it('shows the version number', () => {
+      const component = mountComponent();
+      const version = component.get('.feed-entry-title .entity-version-tag').text();
+      version.should.equal('v2');
     });
   });
 
@@ -276,26 +282,26 @@ describe('EntityFeedEntry', () => {
 
     it('shows the correct text with submission instance ID', () => {
       const component = mountComponent({ props: updateEntityFromSubmission() });
-      const text = component.get('.feed-entry-title').text();
+      const text = component.get('.feed-entry-title .title').text();
       text.should.equal('Data updated by Submission s');
     });
 
     it('shows the correct text with submission instance name', () => {
       const component = mountComponent({ props: updateEntityFromSubmission({ meta: { instanceName: 'Some Name' } }) });
-      const text = component.get('.feed-entry-title').text();
+      const text = component.get('.feed-entry-title  .title').text();
       text.should.equal('Data updated by Submission Some Name');
     });
 
     it('links to the submission', () => {
       const component = mountComponent({ props: updateEntityFromSubmission() });
-      const title = component.get('.feed-entry-title');
+      const title = component.get('.feed-entry-title .title');
       const { to } = title.getComponent(RouterLinkStub).props();
       to.should.equal('/projects/1/forms/f/submissions/s');
     });
 
     it('shows the correct text with deleted submission instance id', () => {
       const component = mountComponent({ props: updateEntityFromSubmission({ deleted: true }) });
-      const text = component.get('.feed-entry-title').text();
+      const text = component.get('.feed-entry-title .title').text();
       text.should.equal('Data updated by (deleted Submission x)');
     });
 
@@ -304,7 +310,13 @@ describe('EntityFeedEntry', () => {
         props: updateEntityFromSubmission({ deleted: true })
       });
       const links = component.findAllComponents(RouterLinkStub);
-      links.length.should.equal(0);
+      links.length.should.equal(1); // only link is anchor link on version tag
+    });
+
+    it('shows the version number', () => {
+      const component = mountComponent({ props: updateEntityFromSubmission() });
+      const version = component.get('.feed-entry-title .entity-version-tag').text();
+      version.should.equal('v2');
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/533

Adds version tags to update events in the entity feed: 

<img width="892" alt="Screenshot 2023-11-16 at 4 45 36 PM" src="https://github.com/getodk/central-frontend/assets/76205/a62560a1-551a-4e00-a2bd-b8511cc198b9">

Also made the tags into links that go to `#v<version>` the anchor tag for that version. Not sure if this is useful or distracting. 

<img width="1273" alt="Screenshot 2023-11-16 at 4 46 25 PM" src="https://github.com/getodk/central-frontend/assets/76205/3d433b4a-e103-4881-b62a-cdd54110a61a">

I didn't add the version to the first entity create event. I could, I'm just not sure it flows as well after "Created Entity <label> in <list name> Entity List" .

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

tests and trying it

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced