### PR TITLE
Style "no conflicts" message in EntityConflictTable

### DIFF
--- a/src/components/entity/conflict-summary.vue
+++ b/src/components/entity/conflict-summary.vue
@@ -154,6 +154,12 @@ const markAsResolved = () => {
     // Align the leftmost text of the first column with the icon in the
     // .panel-heading.
     :deep(th:first-child) { padding-left: 15px; }
+
+    :deep(.empty-table-message) {
+      margin-bottom: 15px;
+      margin-left: 15px;
+      margin-top: 15px;
+    }
   }
 
   .panel-footer {

--- a/src/components/entity/conflict-table.vue
+++ b/src/components/entity/conflict-table.vue
@@ -11,7 +11,9 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div id="entity-conflict-table" ref="el">
-    <p v-if="versions.length === 0">{{ $t('noConflicts') }}</p>
+    <p v-if="versions.length === 0" class="empty-table-message">
+      {{ $t('noConflicts') }}
+    </p>
     <table v-else ref="table" class="table">
       <thead>
         <tr>

--- a/src/components/entity/resolve.vue
+++ b/src/components/entity/resolve.vue
@@ -200,6 +200,7 @@ watch(() => props.entity, (entity) => {
 #entity-resolve #entity-conflict-table {
   tbody tr { background-color: transparent; }
   th:first-child { padding-left: $padding-modal-body; }
+  .empty-table-message { margin-left: $padding-modal-body; }
 }
 #entity-resolve-table-toggle { margin-bottom: 15px; }
 </style>


### PR DESCRIPTION
This PR aligns and otherwise styles the "There are no conflicts to show." message in `EntityConflictTable`. Related: https://github.com/getodk/central/issues/506#issuecomment-1840024104

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced