### PR TITLE
Refresh keys when refreshing submissions

### DIFF
--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -60,7 +60,7 @@ except according to the terms contained in the LICENSE file.
 
     <loading :state="keys.initiallyLoading"/>
     <submission-list v-show="keys.dataExists" :project-id="projectId"
-      :xml-form-id="xmlFormId" draft/>
+      :xml-form-id="xmlFormId" draft @fetch-keys="fetchData"/>
   </div>
 </template>
 

--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -23,7 +23,7 @@ except according to the terms contained in the LICENSE file.
           @analyze="showModal('analyze')"/>
       </template>
       <template #body>
-        <submission-list :project-id="projectId" :xml-form-id="xmlFormId"/>
+        <submission-list :project-id="projectId" :xml-form-id="xmlFormId" @fetch-keys="fetchData"/>
       </template>
     </page-section>
     <odata-analyze v-bind="analyze" :odata-url="odataUrl"

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -276,6 +276,13 @@ export default {
       })
         .finally(() => { this.refreshing = false; })
         .catch(noop);
+
+      // refresh keys when refreshing submissions (keys initially loaded in form/submissions)
+      if (refresh) {
+        this.keys.request({
+          url: apiPaths.submissionKeys(this.projectId, this.xmlFormId)
+        }).catch(noop);
+      }
     },
     fetchData() {
       this.fields.request({

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -111,6 +111,7 @@ export default {
       default: (loaded) => (loaded < 1000 ? 250 : 1000)
     }
   },
+  emits: ['fetch-keys'],
   setup(props) {
     const { form, keys, resourceView } = useRequestData();
     const formVersion = props.draft
@@ -277,12 +278,9 @@ export default {
         .finally(() => { this.refreshing = false; })
         .catch(noop);
 
-      // refresh keys when refreshing submissions (keys initially loaded in form/submissions)
-      if (refresh) {
-        this.keys.request({
-          url: apiPaths.submissionKeys(this.projectId, this.xmlFormId)
-        }).catch(noop);
-      }
+      // emit event to parent component to re-fetch keys if needed
+      if (refresh && this.formVersion.keyId != null && this.keys.length === 0)
+        this.$emit('fetch-keys');
     },
     fetchData() {
       this.fields.request({

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -1,5 +1,6 @@
 import Spinner from '../../../src/components/spinner.vue';
 import SubmissionDataRow from '../../../src/components/submission/data-row.vue';
+import SubmissionDownload from '../../../src/components/submission/download.vue';
 import SubmissionList from '../../../src/components/submission/list.vue';
 import SubmissionMetadataRow from '../../../src/components/submission/metadata-row.vue';
 
@@ -93,11 +94,12 @@ describe('SubmissionList', () => {
           .afterResponses(assertRowCount(1))
           .request(component =>
             component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeEachResponse(assertRowCount(1))
+          .beforeAnyResponse(assertRowCount(1))
           .respondWithData(() => {
             testData.extendedSubmissions.createNew();
             return testData.submissionOData();
           })
+          .respondWithData(() => testData.standardKeys.sorted())
           .afterResponse(assertRowCount(2));
       });
 
@@ -110,7 +112,8 @@ describe('SubmissionList', () => {
           .beforeEachResponse(component => {
             component.get('#odata-loading-message').should.be.hidden();
           })
-          .respondWithData(testData.submissionOData);
+          .respondWithData(testData.submissionOData)
+          .respondWithData(() => testData.standardKeys.sorted());
       });
 
       it('should show correct row number after refresh', () => {
@@ -124,6 +127,7 @@ describe('SubmissionList', () => {
             component.get('#odata-loading-message').should.be.hidden();
           })
           .respondWithData(testData.submissionOData)
+          .respondWithData(() => testData.standardKeys.sorted())
           .afterResponse(component => {
             component.findAllComponents(SubmissionMetadataRow).forEach((r, i) => {
               r.props().rowNumber.should.be.equal(2 - i);
@@ -203,9 +207,11 @@ describe('SubmissionList', () => {
           .request(component =>
             component.get('#submission-list-refresh-button').trigger('click'))
           .beforeEachResponse((_, config) => {
-            checkTop(config, 2, 0);
+            if (config.url.startsWith('/v1/projects/1/forms/f.svc/Submission'))
+              checkTop(config, 2, 0);
           })
           .respondWithData(() => testData.submissionOData(2, 0))
+          .respondWithData(() => testData.standardKeys.sorted())
           .afterResponse(component => {
             checkIds(component, 2);
           });
@@ -330,9 +336,11 @@ describe('SubmissionList', () => {
             .request(component =>
               component.get('#submission-list-refresh-button').trigger('click'))
             .beforeEachResponse((_, config) => {
-              checkTop(config, 2, 0);
+              if (config.url.startsWith('/v1/projects/1/forms/f.svc/Submission'))
+                checkTop(config, 2, 0);
             })
             .respondWithData(() => testData.submissionOData(2, 0))
+            .respondWithData(() => testData.standardKeys.sorted())
             .afterResponse(component => {
               checkIds(component, 2);
             })
@@ -361,7 +369,8 @@ describe('SubmissionList', () => {
               component.get('#submission-list-refresh-button').trigger('click'))
             // Should not send a request.
             .beforeAnyResponse(scroll)
-            .respondWithData(() => testData.submissionOData(2, 0));
+            .respondWithData(() => testData.submissionOData(2, 0))
+            .respondWithData(() => testData.standardKeys.sorted());
         });
 
         it('scrolling has no effect after all submissions have been loaded', () => {
@@ -371,6 +380,63 @@ describe('SubmissionList', () => {
           })
             .complete()
             .testNoRequest(scroll);
+        });
+      });
+
+      describe('refreshing keys', () => {
+        it('sends request for encryption keys on submission refresh', () => {
+          createSubmissions(2);
+          return loadSubmissionList({
+            props: { top: () => 2 }
+          })
+            .complete()
+            .request(component =>
+              component.get('#submission-list-refresh-button').trigger('click'))
+            .beforeAnyResponse(() => {
+              testData.standardKeys.createPast(1, { managed: true });
+            })
+            .respondWithData(() => testData.submissionOData(2, 0))
+            .respondWithData(() => testData.standardKeys.sorted());
+        });
+
+        it('sends request for encryption keys on submission refresh in draft page', () => {
+          testData.extendedForms.createPast(1, { xmlFormId: 'a b', draft: true });
+          return loadSubmissionList({
+            props: { top: () => 2 }
+          })
+            .complete()
+            .request(component =>
+              component.get('#submission-list-refresh-button').trigger('click'))
+            .beforeAnyResponse(() => {
+              testData.standardKeys.createPast(1, { managed: true });
+            })
+            .respondWithData(() => testData.submissionOData(2, 0))
+            .respondWithData(() => testData.standardKeys.sorted());
+        });
+
+        it('changes download modal to ask for password for managed encryption', () => {
+          createSubmissions(2);
+          return loadSubmissionList({
+            props: { top: () => 2 }
+          })
+            .complete()
+            .request(async (app) => {
+              await app.get('#submission-download-button').trigger('click');
+              const modal = app.getComponent(SubmissionDownload);
+              await modal.find('input[type="password"]').exists().should.be.false();
+              return app.get('#submission-list-refresh-button').trigger('click');
+            })
+            .beforeAnyResponse(() => {
+              testData.standardKeys.createPast(1, { managed: true });
+            })
+            .respondWithData(() => testData.submissionOData(2, 0))
+            .respondWithData(() => testData.standardKeys.sorted())
+            .complete()
+            .request(async (app) => {
+              await app.get('#submission-download-button').trigger('click');
+              const modal = app.getComponent(SubmissionDownload);
+              await modal.find('input[type="password"]').exists().should.be.true();
+            });
         });
       });
 
@@ -491,9 +557,11 @@ describe('SubmissionList', () => {
         .request(component =>
           component.get('#submission-list-refresh-button').trigger('click'))
         .beforeEachResponse((_, { url }) => {
-          $select(url).should.equal('__id,__system,g/s1,s2,s3,s4,s5,s6,s7,s8,s9,s10');
+          if (url.includes('.svc/Submissions'))
+            $select(url).should.equal('__id,__system,g/s1,s2,s3,s4,s5,s6,s7,s8,s9,s10');
         })
-        .respondWithData(() => testData.submissionOData(1, 0)));
+        .respondWithData(() => testData.submissionOData(1, 0))
+        .respondWithData(() => testData.standardKeys.sorted()));
 
     it('specifies $select if a filter is changed', () =>
       load('/projects/1/forms/f/submissions', { attachTo: document.body })

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -1,5 +1,6 @@
 import Spinner from '../../../src/components/spinner.vue';
 import SubmissionDataRow from '../../../src/components/submission/data-row.vue';
+import SubmissionDownload from '../../../src/components/submission/download.vue';
 import SubmissionList from '../../../src/components/submission/list.vue';
 import SubmissionMetadataRow from '../../../src/components/submission/metadata-row.vue';
 
@@ -375,14 +376,64 @@ describe('SubmissionList', () => {
       });
 
       describe('refreshing keys', () => {
-        it('sends request for encryption keys on submission refresh', () => {
+        it('opens modal with encrpytion password after refreshing keys', () => {
+          // create project with managed encryption, form, and 0 submissions to start
           testData.extendedProjects.createPast(1, {
-            key: testData.standardKeys.createPast(1).last(),
-            forms: 1
+            key: testData.standardKeys.createPast(1, { managed: true }).last()
           });
-          testData.extendedForms.createPast(1, {
-            submissions: 1
+          testData.extendedForms.createPast(1);
+          return load('/projects/1/forms/f/submissions', { root: false }, {
+            keys: () => [] // if there are 0 submissions, backend returns empty key array
+          })
+            .complete()
+            .request(async (app) => {
+              await app.get('#submission-download-button').trigger('click');
+              const modal = app.getComponent(SubmissionDownload);
+              await modal.find('input[type="password"]').exists().should.be.false();
+              return app.get('#submission-list-refresh-button').trigger('click');
+            })
+            .beforeAnyResponse(() => {
+              testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
+            })
+            .respondWithData(() => testData.submissionOData(1, 0))
+            .respondWithData(() => testData.standardKeys.sorted())
+            .complete()
+            .request(async (app) => {
+              await app.get('#submission-download-button').trigger('click');
+              const modal = app.getComponent(SubmissionDownload);
+              await modal.find('input[type="password"]').exists().should.be.true();
+            });
+        });
+
+        it('sends request for encryption keys on draft/testing submission refresh', () => {
+          // create project with managed encryption, form, and 0 submissions to start
+          testData.extendedProjects.createPast(1, {
+            key: testData.standardKeys.createPast(1, { managed: true }).last()
           });
+          testData.extendedForms.createPast(1, { xmlFormId: 'e', draft: true });
+          return load('/projects/1/forms/e/draft/testing', { root: false }, {
+            keys: () => [] // if there are 0 submissions, backend returns empty key array
+          })
+            .complete()
+            .request(component =>
+              component.get('#submission-list-refresh-button').trigger('click'))
+            .beforeAnyResponse(() => {
+              testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
+            })
+            .respondWithData(() => testData.submissionOData(1, 0))
+            .respondWithData(() => testData.standardKeys.sorted())
+            .testRequests([
+              null,
+              { url: '/v1/projects/1/forms/e/draft/submissions/keys' }
+            ]);
+        });
+
+        it('sends request for encryption keys on published submission refresh', () => {
+          // create project with managed encryption, form, and 0 submissions to start
+          testData.extendedProjects.createPast(1, {
+            key: testData.standardKeys.createPast(1, { managed: true }).last()
+          });
+          testData.extendedForms.createPast(1);
           return load('/projects/1/forms/f/submissions', { root: false }, {
             keys: () => [] // if there are 0 submissions, backend returns empty key array
           })
@@ -393,7 +444,11 @@ describe('SubmissionList', () => {
               testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
             })
             .respondWithData(() => testData.submissionOData(1, 0))
-            .respondWithData(() => testData.standardKeys.sorted());
+            .respondWithData(() => testData.standardKeys.sorted())
+            .testRequests([
+              null,
+              { url: '/v1/projects/1/forms/f/submissions/keys' }
+            ]);
         });
       });
 


### PR DESCRIPTION
Closes https://github.com/getodk/central-frontend/issues/521

When submissions are refreshed, if we might need to refetch an encryption key (if the form is encrypted and we have no keys at the moment), then the submission list component will emit an event to the parent component, which is already responsible for the initial key request, to refetch the key.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests

#### Why is this the best possible solution? Were any other approaches considered?

Keys are loaded in two places, maybe that's not great.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should fix an issue, shouldn't really be any risks. Keys (a small chunk of data) are fetched more often now, but in a way that seems necessary and useful.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced