### PR TITLE
Replace null check with check of dataExists

### DIFF
--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -90,7 +90,7 @@ export default {
       if (this.form.dataExists && this.form.keyId != null &&
         this.form.submissions === 0)
         return true;
-      if (this.keys != null && this.keys.length !== 0) return true;
+      if (this.keys.dataExists && this.keys.length !== 0) return true;
       return false;
     },
     analyzeDisabledMessage() {


### PR DESCRIPTION
While reviewing #910, I took a look at how the `keys` resource is used in various components. I noticed a line that uses `keys` and has a small issue. It checks whether `keys` is `null`, but because `keys` is a resource, it can never be `null`. I replaced the `null` check with a check that `keys` has data.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced