### PR TITLE
Make dataset resource reactive so that entity count is updated

### DIFF
--- a/src/request-data/resources.js
+++ b/src/request-data/resources.js
@@ -63,7 +63,9 @@ export default ({ i18n }, createResource) => {
     transformResponse: ({ data }) => shallowReactive(transformForm(data))
   }));
 
-  createResource('dataset');
+  createResource('dataset', () => ({
+    transformResponse: ({ data }) => shallowReactive(data)
+  }));
 
   const formDraft = createResource('formDraft', () =>
     setupOption(data => shallowReactive(transformForm(data))));

--- a/test/components/dataset/show.spec.js
+++ b/test/components/dataset/show.spec.js
@@ -16,11 +16,13 @@ describe('DatasetShow', () => {
     ]);
   });
 
-  it('shows the correct title', () =>
-    load('/projects/1/entity-lists/trees').then(app => {
+  it('shows the correct title', () => {
+    testData.extendedDatasets.createPast(1);
+    return load('/projects/1/entity-lists/trees').then(app => {
       const title = app.get('#page-head-title');
       title.text().should.be.equal('trees');
-    }));
+    });
+  });
 
   it('re-renders the router view after a route change', () => {
     testData.extendedDatasets
@@ -43,6 +45,7 @@ describe('DatasetShow', () => {
   });
 
   it('renders a back link', async () => {
+    testData.extendedDatasets.createPast(1);
     const component = await load('/projects/1/entity-lists/trees');
     const { to } = component.getComponent(PageBack).props();
     to.should.eql(['/projects/1', '/projects/1/entity-lists']);

--- a/test/components/entity/list.spec.js
+++ b/test/components/entity/list.spec.js
@@ -50,6 +50,28 @@ describe('EntityList', () => {
     ]);
   });
 
+  it('updates dataset.entities using the OData count', () => {
+    testData.extendedEntities.createPast(1);
+    return load('/projects/1/entity-lists/trees')
+      .afterResponses(() => {
+        testData.extendedEntities.createNew();
+      })
+      .load('/projects/1/entity-lists/trees/entities', {
+        project: false,
+        dataset: false
+      })
+      .beforeAnyResponse(app => {
+        app.vm.$container.requestData.dataset.entities.should.equal(1);
+        const text = app.get('#entity-download-button').text();
+        text.should.equal('Download 1 Entity');
+      })
+      .afterResponse(app => {
+        app.vm.$container.requestData.dataset.entities.should.equal(2);
+        const text = app.get('#entity-download-button').text();
+        text.should.equal('Download 2 Entities');
+      });
+  });
+
   it('shows a message if there are no entities', async () => {
     testData.extendedDatasets.createPast(1, { name: 'trees' });
     const component = await load(


### PR DESCRIPTION
We use `dataset.entities` to show the entity count. On the entity Data page, that allows us to show the entity count in the download button even before the OData response has been received. I don't think we show `dataset.entities` outside the Data page, but we could in the future. `odataEntities` is a resource local to the Data page, but `dataset` is available on all dataset pages.

The OData count is more likely to be up-to-date than `dataset.entities`: the dataset is requested before the OData and may have been requested some time ago. If the two counts differ, then `dataset.entities` is updated to match the OData count:

https://github.com/getodk/central-frontend/blob/294323e7f5a239fc0043a5bb001b205db41539ae/src/components/entity/list.vue#L99-L103

We do something similar with `form.submissions` and the OData count on the Submissions page, as well as with `formDraft.get().submissions` and the OData count on the Draft Testing page.

However, while looking into getodk/central#560, it seems clear that this mechanism isn't fully working. Backend can return an incorrect count for `dataset.entities` (getodk/central-backend#1062), yet even then, `dataset.entities` doesn't seem to be updated with the correct OData count.

Actually, it turns out that `dataset.entities` is updated, but that update isn't reflected in the DOM, because `dataset` isn't reactive. For performance reasons, resources have to opt into reactivity. I made `dataset` reactive, and after that, the count started being updated in the DOM.

#### What has been done to verify that this works as intended?

I tried it locally and wrote a new test.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Anytime something is made reactive, it could theoretically have performance implications. However, I can't think of anywhere where that would be an issue for `dataset`. I also made `dataset` shallow reactive rather than deeply reactive, which should help with performance.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced