### PR TITLE
Clarify how encryption keys are used

### DIFF
--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -82,15 +82,19 @@ export default {
       return this.project.dataExists &&
         this.project.permits('submission.create') && this.form.dataExists;
     },
+    /*
+    Disable the "Analyze via OData" button if:
+
+      - There are encrypted submissions, or
+      - There are no submissions yet, but the form is encrypted. In that case,
+        there will never be decrypted submissions available to OData (as long as
+        the form remains encrypted).
+    */
     analyzeDisabled() {
-      // Used to disable odata access button if criteria met:
-      // If an encrypted form has no submissions, then there will never be
-      // decrypted submissions available to OData (as long as the form remains
-      // encrypted).
+      if (this.keys.dataExists && this.keys.length !== 0) return true;
       if (this.form.dataExists && this.form.keyId != null &&
         this.form.submissions === 0)
         return true;
-      if (this.keys.dataExists && this.keys.length !== 0) return true;
       return false;
     },
     analyzeDisabledMessage() {

--- a/src/components/submission/download.vue
+++ b/src/components/submission/download.vue
@@ -153,6 +153,8 @@ export default {
     };
   },
   computed: {
+    // At the moment, there can only be a single managed key at most: once
+    // encrypted, a project cannot be decrypted.
     managedKey() {
       return this.keys.dataExists ? this.keys.find(key => key.managed) : null;
     },


### PR DESCRIPTION
Reworking comments and a little code in order to add clarity around the `keys` resource. There should be no behavior change. I thought it'd be useful to make this change after reviewing #910 and remembering how `keys` works.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced