### PR TITLE
Do not show conflicting property explanation in tooltip of property name

### DIFF
--- a/src/components/entity/diff/row.vue
+++ b/src/components/entity/diff/row.vue
@@ -11,9 +11,9 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <tr class="entity-diff-row">
-    <td :class="{ property: name !== 'label', conflicting }" v-tooltip.text>
-      {{ name === 'label' ? $t('entity.label') : name }}
-      <span v-if="conflicting" class="sr-only">{{ $t('conflictingProp') }}</span>
+    <td :class="{ property: name !== 'label', conflicting }">
+      <span v-tooltip.text>{{ name === 'label' ? $t('entity.label') : name }}</span>
+      <span v-if="conflicting" class="sr-only">&nbsp;{{ $t('conflictingProp') }}</span>
     </td>
 
     <td v-if="oldValue === ''" class="empty">{{ $t('common.emptyValue') }}</td>

--- a/test/components/entity/diff/row.spec.js
+++ b/test/components/entity/diff/row.spec.js
@@ -48,7 +48,7 @@ describe('EntityDiffRow', () => {
       });
       const td = row.get('td');
       td.text().should.equal('height');
-      await td.should.have.textTooltip();
+      await td.get('span').should.have.textTooltip();
       td.classes('property').should.be.true();
     });
   });


### PR DESCRIPTION
In the diff shown on the entity detail page, if a property name is long, then it is truncated with a tooltip. However, right now, if the property is a conflicting property, then the tooltip includes the text of the `.sr-only` element next to the property name. The tooltip should only show the property name: the text of the `.sr-only` element is shown in a different tooltip.

<img width="707" src="https://github.com/getodk/central-frontend/assets/5970131/ee86aeb3-0508-4a04-8a87-62a1ea6ccbc1">

#### What has been done to verify that this works as intended?

The fix involved moving the `v-tooltip.text` from the `<td>` element to a new `<span>` element wrapping the property name. With the introduction of the `<span>`, the selector for the tooltip element had to change in an existing test. Beyond that, I think it's hard to write a meaningful test for this fix, as any test of a tooltip already has to select the specific element that has the tooltip. Here, that element is the new `<span>`, which we know doesn't contain an `.sr-only` element.

I also viewed this change locally and was able to verify it that way.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced