### PR TITLE
Show "Link Entity List" button after publishing new entity list

### DIFF
--- a/src/components/form-draft/status.vue
+++ b/src/components/form-draft/status.vue
@@ -136,10 +136,10 @@ export default {
   },
   emits: ['fetch-project', 'fetch-form', 'fetch-draft'],
   setup() {
-    const { form, publishedAttachments, formVersions, formDraft, formDatasetDiff, formDraftDatasetDiff } = useRequestData();
+    const { form, publishedAttachments, formVersions, formDraft, datasets, formDatasetDiff, formDraftDatasetDiff } = useRequestData();
     const { projectPath, formPath } = useRoutes();
     return {
-      form, publishedAttachments, formVersions, formDraft, formDatasetDiff, formDraftDatasetDiff,
+      form, publishedAttachments, formVersions, formDraft, datasets, formDatasetDiff, formDraftDatasetDiff,
       projectPath, formPath
     };
   },
@@ -183,14 +183,22 @@ export default {
       // the form didn't already have a published version, then there would be a
       // validateData violation if we didn't clear it.
       this.$emit('fetch-form');
-      this.formDraftDatasetDiff.reset();
-      this.formDatasetDiff.reset();
+
+      // Other resources that may have changed after publish
       this.publishedAttachments.reset();
+      this.datasets.reset();
+      this.formDatasetDiff.reset();
+      this.formDraftDatasetDiff.reset();
+
+      // We will update additional resources, but only after navigating to the
+      // form overview. We need to wait to update these resources because they
+      // are used on this page.
       afterNextNavigation(this.$router, () => {
         // Re-request the project in case its `datasets` property has changed.
         this.$emit('fetch-project', true);
         this.formVersions.data = null;
         this.formDraft.setToNone();
+
         this.alert.success(this.$t('alert.publish'));
       });
       this.$router.push(this.formPath());


### PR DESCRIPTION
Closes #916. I think the issue is that the `datasets` resource needs to be cleared/reset after the form draft is published. That's because publishing a draft can have the effect of publishing a new entity list. In `FormDraftStatus`, the `afterPublish()` method re-requests, resets, or updates many resources, but it doesn't do so for `datasets`. That means that if `FormAttachmentList` requested `datasets` before the draft was published, it won't do so again after the draft is published (unless the page is refreshed or the user navigates away from the form).

#### What has been done to verify that this works as intended?

I wrote two new tests about this scenario (under "linking after publishing new dataset"). The first test involves publishing the project's first entity list, and it passed without any changes. The second test involves publishing a second entity list for the project, and it only passed after I updated `afterPublish()`.

#### Why is this the best possible solution? Were any other approaches considered?

While looking at this issue, it didn't always feel clear when or where resources were re-requested, reset, or updated. There's probably room for improvement there (though I don't have any specific ideas at the moment). However, given that `afterPublish()` is already modifying a lot of resources, I think it makes sense that it should also reset `datasets`.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced