### PR TITLE
Truncate long display name in navbar

### DIFF
--- a/src/components/navbar/actions.vue
+++ b/src/components/navbar/actions.vue
@@ -19,7 +19,7 @@ except according to the terms contained in the LICENSE file.
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
       aria-haspopup="true" aria-expanded="false">
       <span class="icon-user-circle-o"></span>
-      <span>{{ currentUser.displayName }}</span>
+      <span v-tooltip.text>{{ currentUser.displayName }}</span>
       <span class="caret"></span>
     </a>
     <ul class="dropdown-menu">
@@ -70,6 +70,19 @@ export default {
   }
 };
 </script>
+
+<style lang="scss">
+@import '../../assets/scss/mixins';
+
+#navbar-actions {
+  .dropdown-toggle .icon-user-circle-o + span {
+    @include text-overflow-ellipsis;
+    display: inline-block;
+    max-width: 275px;
+    vertical-align: top;
+  }
+}
+</style>
 
 <i18n lang="json5">
 {

--- a/test/components/navbar/actions.spec.js
+++ b/test/components/navbar/actions.spec.js
@@ -21,15 +21,17 @@ describe('NavbarActions', () => {
     text.should.equal('Not logged in');
   });
 
-  it("shows the user's display name", () => {
-    mockLogin({ displayName: 'Alice' });
+  it("shows the user's display name", async () => {
+    mockLogin({ displayName: 'Alice Allison' });
     const navbar = mount(Navbar, {
       container: { router: mockRouter('/') },
       global: {
         stubs: { AnalyticsIntroduction: true }
       }
     });
-    navbar.getComponent(NavbarActions).get('a').text().should.equal('Alice');
+    const a = navbar.getComponent(NavbarActions).get('a');
+    a.text().should.equal('Alice Allison');
+    await a.get('span:nth-child(2)').should.have.textTooltip();
   });
 
   describe('after the user clicks "Log out"', () => {


### PR DESCRIPTION
Closes #348.

If the user's display name is less than 275px, then it should look exactly like it does today. If it is 275px or more, then it should be truncated:

<img width="984" src="https://github.com/getodk/central-frontend/assets/5970131/35910d8c-3b95-46ff-a5a3-d587247bbbc8">

#### What has been done to verify that this works as intended?

I tried it out locally.

#### Why is this the best possible solution? Were any other approaches considered?

275px is a bit long, but there are places in Central where we allow text to go 250px before truncation. There's room in the navbar, and I think it's nice to avoid truncation in this case, so I opted for a little more than 250px. Especially if we ever add more to the navbar, I think we could also consider removing the name from the navbar and using generic text like "My Account".

In terms of the code, the hardest part was keeping the icon on the left, the text, and the caret on the right aligned. I was initially running into issues there, but `vertical-align: top;` did the trick. I also briefly tried a flexbox strategy, but I found myself having to do some manual alignment.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced