### PR TITLE
Remove use of submissionCreate from entity audit event

### DIFF
--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -64,10 +64,12 @@ const feed = computed(() => {
     } else if (audit.action === 'entity.create') {
       const group = [{ entry: audit }];
       const { details } = audit;
+      // this will insert a feed entry for the submission approval event
       if (details.sourceEvent?.action === 'submission.update')
         group.push({ entry: details.sourceEvent });
-      if (details.submissionCreate != null)
-        group.push({ entry: details.submissionCreate, submission: details.submission });
+      // this will insert a feed entry for the submission creation
+      if (details.submission != null)
+        group.push({ entry: { action: 'submission.create', loggedAt: details.submission.createdAt }, submission: details.submission });
       groups.push(group);
     } else {
       groups.push([{ entry: audit }]);

--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -57,7 +57,7 @@ const feed = computed(() => {
   let versionIndex = entityVersions.length - 1;
   for (const audit of audits) {
     if (audit.action === 'entity.update.version') {
-      const { submission } = audit.details;
+      const { submission } = audit.details.source;
       const entityVersion = entityVersions[versionIndex];
       versionIndex -= 1;
       groups.push([{ entry: audit, submission, entityVersion }]);
@@ -65,11 +65,15 @@ const feed = computed(() => {
       const group = [{ entry: audit }];
       const { details } = audit;
       // this will insert a feed entry for the submission approval event
-      if (details.sourceEvent?.action === 'submission.update')
-        group.push({ entry: details.sourceEvent });
+      if (details.source?.event?.action === 'submission.update')
+        group.push({ entry: details.source.event });
       // this will insert a feed entry for the submission creation
-      if (details.submission != null)
-        group.push({ entry: { action: 'submission.create', loggedAt: details.submission.createdAt }, submission: details.submission });
+      if (details.source?.submission != null) {
+        group.push({
+          entry: { action: 'submission.create', loggedAt: details.source.submission.createdAt },
+          submission: details.source.submission
+        });
+      }
       groups.push(group);
     } else {
       groups.push([{ entry: audit }]);

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -18,16 +18,16 @@ except according to the terms contained in the LICENSE file.
           <dt>{{ $t('entity.entityId') }}</dt>
           <dd>{{ entity.uuid }}</dd>
         </div>
-        <div v-if="instanceId != null">
+        <div v-if="submission != null">
           <dt>{{ $t('creatingSubmission') }}</dt>
           <dd id="entity-basic-details-creating-submission">
             <router-link v-if="submission.currentVersion != null"
-              :to="submissionPath(projectId, submission.xmlFormId, instanceId)">
-              {{ submission.currentVersion.instanceName ?? instanceId }}
+              :to="submissionPath(projectId, submission.xmlFormId, submission.instanceId)">
+              {{ submission.currentVersion.instanceName ?? submission.instanceId }}
             </router-link>
             <template v-else>
               <span class="icon-trash" v-tooltip.sr-only></span>
-              <span>{{ instanceId }}</span>
+              <span>{{ submission.instanceId }}</span>
               <span class="sr-only">&nbsp;{{ $t('submissionDeleted') }}</span>
             </template>
           </dd>
@@ -65,24 +65,16 @@ const projectId = inject('projectId');
 // created.
 const { entity, audits } = useRequestData();
 
-// Using `ref` and watchEffect() for instanceId and `submission` rather than
-// `computed` so that they don't change whenever `audits` is refreshed.
-const instanceId = ref(undefined);
+// Using `ref` and watchEffect() for `submission` rather than
+// `computed` so that it doesn't change whenever `audits` is refreshed.
 const submission = ref(undefined);
 watchEffect(() => {
-  if (instanceId.value !== undefined || !audits.dataExists) return;
+  if (submission.value !== undefined || !audits.dataExists) return;
   const audit = audits.find(({ action }) => action === 'entity.create');
   // `audit` should always exist in production, but it doesn't always exist in
   // testing.
   if (audit == null) return;
-  // TODO refactor
-  const submissionFromCreateEvent = audit.details.submission;
-  if (submissionFromCreateEvent != null) {
-    instanceId.value = submissionFromCreateEvent.instanceId;
-    submission.value = submissionFromCreateEvent;
-  } else {
-    instanceId.value = null;
-  }
+  submission.value = audit.details.submission;
 });
 const { submissionPath } = useRoutes();
 </script>

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -21,7 +21,7 @@ except according to the terms contained in the LICENSE file.
         <div v-if="instanceId != null">
           <dt>{{ $t('creatingSubmission') }}</dt>
           <dd id="entity-basic-details-creating-submission">
-            <router-link v-if="submission != null"
+            <router-link v-if="submission.currentVersion != null"
               :to="submissionPath(projectId, submission.xmlFormId, instanceId)">
               {{ submission.currentVersion.instanceName ?? instanceId }}
             </router-link>
@@ -75,10 +75,11 @@ watchEffect(() => {
   // `audit` should always exist in production, but it doesn't always exist in
   // testing.
   if (audit == null) return;
-  const { submissionCreate } = audit.details;
-  if (submissionCreate != null) {
-    instanceId.value = submissionCreate.details.instanceId;
-    submission.value = audit.details.submission;
+  // TODO refactor
+  const submissionFromCreateEvent = audit.details.submission;
+  if (submissionFromCreateEvent != null) {
+    instanceId.value = submissionFromCreateEvent.instanceId;
+    submission.value = submissionFromCreateEvent;
   } else {
     instanceId.value = null;
   }

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -74,7 +74,7 @@ watchEffect(() => {
   // `audit` should always exist in production, but it doesn't always exist in
   // testing.
   if (audit == null) return;
-  submission.value = audit.details.submission;
+  submission.value = audit.details.source?.submission;
 });
 const { submissionPath } = useRoutes();
 </script>

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -63,7 +63,7 @@ except according to the terms contained in the LICENSE file.
       <template v-else-if="entry.action === 'entity.update.version'">
         <span class="icon-pencil"></span>
         <span class="title">
-        <template v-if="entry.details.source?.submission != null">
+        <template v-if="submission != null">
           <i18n-t v-if="submission.currentVersion != null"
             keypath="title.entity.update_version.submission.notDeleted">
             <template #instanceName>
@@ -148,16 +148,11 @@ const creatingSubmissionPath = computed(() => submissionPath(
 ));
 const { t } = useI18n();
 
-// This function pulls out the submission instance ID when the event
-// is about a submission (creation, approval) and the ID is directly
-// in the event details.
 const deletedSubmission = computed(() => {
   const id = props.submission.instanceId;
   return t('title.submission.create.deleted.deletedSubmission', { id });
 });
 
-// This function pulls out the submission instance ID in events about
-// entities
 const deletedSubmissionEntityEvent = computed(() => {
   const id = props.submission.instanceId;
   return t('title.entity.update_version.submission.deleted.deletedSubmission', { id });

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -15,20 +15,20 @@ except according to the terms contained in the LICENSE file.
     <template #title>
       <template v-if="entry.action === 'submission.create'">
         <span class="icon-cloud-upload"></span>
-        <i18n-t v-if="submission != null"
+        <i18n-t v-if="submission.currentVersion != null"
           keypath="title.submission.create.notDeleted">
           <template #instanceName>
             <router-link :to="creatingSubmissionPath">
               {{ submission.currentVersion.instanceName ?? submission.instanceId }}
             </router-link>
           </template>
-          <template #submitter><actor-link :actor="entry.actor"/></template>
+          <template #submitter><actor-link :actor="submission.submitter"/></template>
         </i18n-t>
         <i18n-t v-else keypath="title.submission.create.deleted.full">
           <template #deletedSubmission>
             <span class="deleted-submission">{{ deletedSubmission }}</span>
           </template>
-          <template #name><actor-link :actor="entry.actor"/></template>
+          <template #name><actor-link :actor="submission.submitter"/></template>
         </i18n-t>
       </template>
       <template v-else-if="entry.action === 'submission.update'">
@@ -44,7 +44,7 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template v-else-if="entry.action === 'entity.create'">
         <span class="icon-magic-wand"></span>
-        <i18n-t v-if="entry.details.submissionCreate != null"
+        <i18n-t v-if="entry.details.submission != null"
           keypath="title.entity.create.submission">
           <template #label>
             <span class="entity-label">{{ entity.currentVersion.label }}</span>
@@ -63,8 +63,8 @@ except according to the terms contained in the LICENSE file.
       <template v-else-if="entry.action === 'entity.update.version'">
         <span class="icon-pencil"></span>
         <span class="title">
-        <template v-if="entry.details.submissionCreate != null">
-          <i18n-t v-if="submission != null"
+        <template v-if="entry.details.submission != null">
+          <i18n-t v-if="submission.currentVersion != null"
             keypath="title.entity.update_version.submission.notDeleted">
             <template #instanceName>
               <router-link :to="creatingSubmissionPath">
@@ -152,14 +152,14 @@ const { t } = useI18n();
 // is about a submission (creation, approval) and the ID is directly
 // in the event details.
 const deletedSubmission = computed(() => {
-  const id = props.entry.details.instanceId;
+  const id = props.submission.instanceId;
   return t('title.submission.create.deleted.deletedSubmission', { id });
 });
 
 // This function pulls out the submission instance ID in events about
-// entities, where the instance ID is found deep inside the submissionCreate event.
+// entities
 const deletedSubmissionEntityEvent = computed(() => {
-  const id = props.entry.details.submissionCreate.details.instanceId;
+  const id = props.submission.instanceId;
   return t('title.entity.update_version.submission.deleted.deletedSubmission', { id });
 });
 const { reviewStateIcon } = useReviewState();

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -44,7 +44,7 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template v-else-if="entry.action === 'entity.create'">
         <span class="icon-magic-wand"></span>
-        <i18n-t v-if="entry.details.submission != null"
+        <i18n-t v-if="entry.details.source?.submission != null"
           keypath="title.entity.create.submission">
           <template #label>
             <span class="entity-label">{{ entity.currentVersion.label }}</span>
@@ -63,7 +63,7 @@ except according to the terms contained in the LICENSE file.
       <template v-else-if="entry.action === 'entity.update.version'">
         <span class="icon-pencil"></span>
         <span class="title">
-        <template v-if="entry.details.submission != null">
+        <template v-if="entry.details.source?.submission != null">
           <i18n-t v-if="submission.currentVersion != null"
             keypath="title.entity.update_version.submission.notDeleted">
             <template #instanceName>

--- a/src/components/entity/version-link.vue
+++ b/src/components/entity/version-link.vue
@@ -46,7 +46,7 @@ const text = computed(() => {
   const { source } = props.version;
   const { submission } = source;
   if (submission != null) {
-    const nameOrId = submission?.currentVersion?.instanceName ??
+    const nameOrId = submission.currentVersion?.instanceName ??
       submission.instanceId;
     return t('submission', { instanceName: nameOrId });
   }

--- a/src/components/entity/version-link.vue
+++ b/src/components/entity/version-link.vue
@@ -44,10 +44,10 @@ const versionPath = computed(() => {
 const { t } = useI18n();
 const text = computed(() => {
   const { source } = props.version;
-  const { submissionCreate } = source;
-  if (submissionCreate != null) {
-    const nameOrId = source.submission?.currentVersion?.instanceName ??
-      submissionCreate.details.instanceId;
+  const { submission } = source;
+  if (submission != null) {
+    const nameOrId = submission?.currentVersion?.instanceName ??
+      submission.instanceId;
     return t('submission', { instanceName: nameOrId });
   }
   return t('api', { name: props.version.creator.displayName });

--- a/test/components/entity/activity.spec.js
+++ b/test/components/entity/activity.spec.js
@@ -38,17 +38,17 @@ const resolveConflict = () => {
   testData.extendedEntities.createPast(1, { uuid: 'e' });
   testData.extendedAudits.createPast(1, {
     action: 'entity.create',
-    details: {}
+    details: { source: {} }
   });
   testData.extendedEntityVersions.createPast(1);
   testData.extendedAudits.createPast(1, {
     action: 'entity.update.version',
-    details: {}
+    details: { source: {} }
   });
   testData.extendedEntityVersions.createPast(1, { baseVersion: 1 });
   testData.extendedAudits.createPast(1, {
     action: 'entity.update.version',
-    details: {}
+    details: { source: {} }
   });
   testData.extendedEntities.resolve(-1);
   testData.extendedAudits.createPast(1, { action: 'entity.update.resolve' });
@@ -102,7 +102,7 @@ describe('EntityActivity', () => {
       testData.extendedEntities.createPast(1);
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
-        details: sourceDetails
+        details: { source: sourceDetails }
       });
       const component = mountComponent();
       component.findAll('.feed-entry-group').length.should.equal(1);
@@ -119,7 +119,7 @@ describe('EntityActivity', () => {
       testData.extendedEntities.createPast(1);
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
-        details: sourceDetails
+        details: { source: sourceDetails }
       });
       const component = mountComponent();
       component.findAll('.feed-entry-group').length.should.equal(1);
@@ -137,7 +137,7 @@ describe('EntityActivity', () => {
       testData.extendedEntities.createPast(1);
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
-        details: sourceDetails
+        details: { source: sourceDetails }
       });
       const component = mountComponent();
       component.findAll('.feed-entry-group').length.should.equal(1);
@@ -187,13 +187,13 @@ describe('EntityActivity', () => {
       });
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
-        details: {}
+        details: { source: {} }
       });
       for (let version = 2; version <= 50; version += 1) {
         testData.extendedEntityVersions.createPast(1);
         testData.extendedAudits.createPast(1, {
           action: 'entity.update.version',
-          details: {}
+          details: { source: {} }
         });
       }
     };
@@ -258,7 +258,7 @@ describe('EntityActivity', () => {
           });
           testData.extendedAudits.createPast(1, {
             action: 'entity.update.version',
-            details: {}
+            details: { source: {} }
           });
           return testData.standardEntities.last();
         })

--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -47,20 +47,17 @@ describe('EntityBasicDetails', () => {
       const submission = testData.extendedSubmissions
         .createPast(1, { instanceId: 's', ...submissionOptions })
         .last();
-      const submissionCreate = testData.extendedAudits
-        .createPast(1, {
-          action: 'submission.create',
-          details: { instanceId: submission.instanceId }
-        })
-        .last();
-
       testData.extendedEntities.createPast(1, { uuid: 'e' });
       const details = {
         entity: { uuid: 'e' },
-        submissionCreate
       };
       if (!submissionDeleted)
-        details.submission = { ...submission, xmlFormId: 'f' };
+        details.submission = { ...submission, xmlFormId: 'f' }; // Use entire submission, augmented with form id
+      else {
+        // If submission is deleted, these are the only fields we pass through in the audit log
+        const { instanceId, submitter, createdAt } = submission;
+        details.submission = { instanceId, submitter, createdAt };
+      }
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
         details

--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -50,13 +50,14 @@ describe('EntityBasicDetails', () => {
       testData.extendedEntities.createPast(1, { uuid: 'e' });
       const details = {
         entity: { uuid: 'e' },
+        source: {}
       };
       if (!submissionDeleted)
-        details.submission = { ...submission, xmlFormId: 'f' }; // Use entire submission, augmented with form id
+        details.source = { submission: { ...submission, xmlFormId: 'f' } }; // Use entire submission, augmented with form id
       else {
         // If submission is deleted, these are the only fields we pass through in the audit log
         const { instanceId, submitter, createdAt } = submission;
-        details.submission = { instanceId, submitter, createdAt };
+        details.source = { submission: { instanceId, submitter, createdAt } };
       }
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
@@ -144,7 +145,7 @@ describe('EntityBasicDetails', () => {
           });
           testData.extendedAudits.createPast(1, {
             action: 'entity.update.version',
-            details: {}
+            details: { source: {} }
           });
           return testData.standardEntities.last();
         })

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -167,11 +167,12 @@ describe('EntityFeedEntry', () => {
     // entity.create event.
     const createEntity = (options = {}) => {
       const details = {
-        entity: { uuid: 'e' }
+        entity: { uuid: 'e' },
+        source: {}
       };
       if (options.submission === true) {
         const submission = testData.extendedSubmissions.createPast(1);
-        details.submission = { ...submission, xmlFormId: 'f' };
+        details.source = { submission: { ...submission, xmlFormId: 'f' } };
       }
       testData.extendedAudits.createPast(1, {
         action: 'entity.create',
@@ -223,7 +224,7 @@ describe('EntityFeedEntry', () => {
       testData.extendedEntityVersions.createPast(1);
       testData.extendedAudits.createPast(1, {
         action: 'entity.update.version',
-        details: {}
+        details: { source: {} }
       });
     });
 
@@ -267,7 +268,7 @@ describe('EntityFeedEntry', () => {
 
       const details = {
         entity: { uuid: 'e' },
-        submission
+        source: { submission } // source would also have `event` but that is not used in this component
       };
 
       testData.extendedEntityVersions.createPast(1);

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -171,7 +171,7 @@ describe('EntityFeedEntry', () => {
         source: {}
       };
       if (options.submission === true) {
-        const submission = testData.extendedSubmissions.createPast(1);
+        const submission = testData.extendedSubmissions.createPast(1).last();
         details.source = { submission: { ...submission, xmlFormId: 'f' } };
       }
       testData.extendedAudits.createPast(1, {

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -195,8 +195,6 @@ describe('EntityFeedEntry', () => {
         text.should.equal('Created Entity dogwood in trees Entity List');
       });
 
-      // TODO: also check text if sub is deleted
-
       it('links to the dataset', () => {
         const title = mountComponent().get('.feed-entry-title');
         const { to } = title.getComponent(RouterLinkStub).props();

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -86,7 +86,7 @@ describe('EntityShow', () => {
           });
           testData.extendedAudits.createPast(1, {
             action: 'entity.update.version',
-            details: {}
+            details: { source: {} }
           });
           return testData.standardEntities.last();
         })
@@ -151,7 +151,7 @@ describe('EntityShow', () => {
           });
           testData.extendedAudits.createPast(1, {
             action: 'entity.update.version',
-            details: {}
+            details: { source: {} }
           });
 
           return testData.standardEntities.last();

--- a/test/components/entity/version-link.spec.js
+++ b/test/components/entity/version-link.spec.js
@@ -37,25 +37,24 @@ describe('EntityVersionLink', () => {
 
   describe('entity source is a submission', () => {
     it('shows the instance name if the submission has one', () => {
-      const { submission, submissionCreate } = testData.extendedEntities
+      const { submission } = testData.extendedEntities
         .createSourceSubmission('submission.create', {
           meta: { instanceName: 'Some Name' }
         });
       testData.extendedEntities.createPast(1, {
-        source: { submission, submissionCreate }
+        source: { submission }
       });
       mountComponent().text().should.equal('Submission Some Name');
     });
 
-    it('falls back to the instance ID', () => {
-      const { submissionCreate } = testData.extendedEntities
+    it('falls back to the instance ID if submission deleted', () => {
+      testData.extendedEntities
         .createSourceSubmission('submission.create', { instanceId: 's' });
       testData.extendedEntities.createPast(1, {
-        // Don't specify source.submission, matching the response if the
-        // submission is deleted.
-        source: { submissionCreate }
+        // Specify partial submission (with only instance id) if deleted
+        source: { submission: { instanceId: 'x' } }
       });
-      mountComponent().text().should.equal('Submission s');
+      mountComponent().text().should.equal('Submission x');
     });
   });
 });

--- a/test/components/entity/version-link.spec.js
+++ b/test/components/entity/version-link.spec.js
@@ -47,12 +47,21 @@ describe('EntityVersionLink', () => {
       mountComponent().text().should.equal('Submission Some Name');
     });
 
-    it('falls back to the instance ID if submission deleted', () => {
-      testData.extendedEntities
+    it('shows the instance ID if the submission has no instance name', () => {
+      const { submission } = testData.extendedEntities
         .createSourceSubmission('submission.create', { instanceId: 's' });
       testData.extendedEntities.createPast(1, {
-        // Specify partial submission (with only instance id) if deleted
-        source: { submission: { instanceId: 'x' } }
+        source: { submission }
+      });
+      mountComponent().text().should.equal('Submission s');
+    });
+
+    it('falls back to the instance ID if submission deleted', () => {
+      // Final argument about source submission: deleted=true
+      const { submission } = testData.extendedEntities
+        .createSourceSubmission('submission.create', { instanceId: 'x' }, true);
+      testData.extendedEntities.createPast(1, {
+        source: { submission }
       });
       mountComponent().text().should.equal('Submission x');
     });

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -281,8 +281,7 @@ extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {},
       action: 'submission.create',
       loggedAt: submission.createdAt,
       ...auditOptions
-    })
-    .last();
+    });
   if (sourceAction === 'submission.update') {
     extendedSubmissions.update(-1, { reviewState: 'approved' });
     extendedAudits.createPast(1, {

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -273,7 +273,7 @@ extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {})
     actee: formVersion,
     details: { instanceId: submission.instanceId }
   };
-  const submissionCreate = extendedAudits
+  extendedAudits
     .createPast(1, {
       action: 'submission.create',
       loggedAt: submission.createdAt,
@@ -297,7 +297,7 @@ extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {})
   }
   const sourceEvent = extendedAudits.last();
 
-  return { submission: submissionWithFormId, submissionCreate, sourceEvent };
+  return { submission: submissionWithFormId, sourceEvent };
 };
 
 extendedEntities.resolve = (index) => {

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -298,9 +298,9 @@ extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {},
   } else if (sourceAction !== 'submission.create') {
     throw new Error('invalid action');
   }
-  const sourceEvent = extendedAudits.last();
+  const event = extendedAudits.last();
 
-  return { submission, sourceEvent };
+  return { submission, event };
 };
 
 extendedEntities.resolve = (index) => {

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -258,15 +258,18 @@ export const entityOData = (top = 250, skip = 0) => {
 };
 
 // Creates a source submission along with submission audit log events.
-extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {}) => {
-  const submission = extendedSubmissions
+extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {}, deleted = false) => {
+  const fullSubmission = extendedSubmissions
     .createPast(1, submissionOptions)
     .last();
   const formVersion = submissionOptions.formVersion ?? extendedForms.first();
-  const submissionWithFormId = {
-    ...submission,
-    xmlFormId: formVersion.xmlFormId
-  };
+  const submission = (!deleted)
+    ? { ...fullSubmission, xmlFormId: formVersion.xmlFormId }
+    : {
+      instanceId: fullSubmission.instanceId,
+      submitter: fullSubmission.submitter,
+      createdAt: fullSubmission.createdAt
+    };
 
   const auditOptions = {
     actor: submission.submitter,
@@ -297,7 +300,7 @@ extendedEntities.createSourceSubmission = (sourceAction, submissionOptions = {})
   }
   const sourceEvent = extendedAudits.last();
 
-  return { submission: submissionWithFormId, sourceEvent };
+  return { submission, sourceEvent };
 };
 
 extendedEntities.resolve = (index) => {


### PR DESCRIPTION
Frontend part of issue https://github.com/getodk/central-backend/issues/1036 and backend PR https://github.com/getodk/central-backend/pull/1072.

It used to be that entity events that were triggered by a Submission (e.g. entity create OR update) would return
- `sourceEvent` (the actual event that caused the entity update, whether it was a submission approval, or submission creation, etc.)
- `submission` (the Submission object, but only if a Submission was part of the event AND the Submission was not deleted)
- a `submissionCreate` object for the Submission (if a Submission was part of the event) that had enough historical information including the creation time and instance ID to describe the Submission even if it was deleted. 

The big change for https://github.com/getodk/central-backend/pull/1072 was to remove `submissionCreate` and always return some kind of Submission object, either the full details, or the instance ID, submitter, and timestamp. 

Flavors of frontend changes: 
- Switch from looking for `submissionCreate` to know if the event was related to a submission to just looking for `submission`. 
- Switch from looking for `submission` to know the submission was not deleted to looking for `submission.currentVersion`
- `submission` and `event` are contained within an entity audit event's `details` nested under `source` and all entity events have a source, though if its an API event, the source is just `{}`

Basic details of an Entity shows the source submission, and because this isn't returned with the Entity itself (though maybe it should be), the basic details component waits for the audit log and checks the entity's creation event for a source submission. 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

I was thinking about refactoring tests to have more of them use `extendedEntities.createSourceSubmission` but existing tests have such specific setups I was finding it hard to refactor.

#### Why is this the best possible solution? Were any other approaches considered?

We've long talked about removing this event detail and using different information instead.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Could change how entity events appear on frontend, but it shouldn't. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced