### PR TITLE
Add ability to download data template for uploading entities

### DIFF
--- a/src/components/entity/upload/data-template.vue
+++ b/src/components/entity/upload/data-template.vue
@@ -1,0 +1,49 @@
+<!--
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <i18n-t tag="span" keypath="text.full">
+    <template #downloadTemplate>
+      <a class="btn btn-default" :href="href"
+        :download="`${dataset.name} template.csv`">
+        <span class="icon-download"></span>{{ $t('text.downloadTemplate') }}
+      </a>
+    </template>
+  </i18n-t>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import { useRequestData } from '../../../request-data';
+
+// The component assumes that this data will exist when the component is
+// created.
+const { dataset } = useRequestData();
+
+const href = computed(() => {
+  const headers = dataset.properties.map(({ name }) => name);
+  headers.unshift('label');
+  const csv = headers.join(',');
+  return `data:text/csv;charset=UTF-8,${encodeURIComponent(csv)}`;
+});
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    "text": {
+      "full": "If you aren’t sure, you can {downloadTemplate}",
+      "downloadTemplate": "Download a data template (.csv)"
+    }
+  }
+}
+</i18n>

--- a/test/components/entity/upload/data-template.spec.js
+++ b/test/components/entity/upload/data-template.spec.js
@@ -1,0 +1,29 @@
+import EntityUploadDataTemplate from '../../../../src/components/entity/upload/data-template.vue';
+
+import testData from '../../../data';
+import { mount } from '../../../util/lifecycle';
+
+const mountComponent = () => mount(EntityUploadDataTemplate, {
+  container: {
+    requestData: { dataset: testData.extendedDatasets.last() }
+  }
+});
+
+describe('EntityUploadDataTemplate', () => {
+  it('has the correct data URL', () => {
+    testData.extendedDatasets.createPast(1, {
+      properties: [{ name: 'hauteur' }, { name: 'circonférence' }]
+    });
+    const { href } = mountComponent().get('a').attributes();
+    const expectedStart = 'data:text/csv;charset=UTF-8,';
+    href.should.startWith(expectedStart);
+    const content = decodeURIComponent(href.replace(expectedStart, ''));
+    content.should.equal('label,hauteur,circonférence');
+  });
+
+  it('has the correct filename', () => {
+    testData.extendedDatasets.createPast(1);
+    const { download } = mountComponent().get('a').attributes();
+    download.should.equal('trees template.csv');
+  });
+});

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1875,6 +1875,18 @@
         }
       }
     },
+    "EntityUploadDataTemplate": {
+      "text": {
+        "full": {
+          "string": "If you aren’t sure, you can {downloadTemplate}",
+          "developer_comment": "{downloadTemplate} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nDownload a data template (.csv)"
+        },
+        "downloadTemplate": {
+          "string": "Download a data template (.csv)",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {downloadTemplate} is in the following text:\n\nIf you aren’t sure, you can {downloadTemplate}"
+        }
+      }
+    },
     "EntityVersionLink": {
       "submission": {
         "string": "Submission {instanceName}",


### PR DESCRIPTION
Part of getodk/central#589.

#### What has been done to verify that this works as intended?

New tests, as well as trying out the button locally. I observed that a CSV file was downloaded with the expected content.

#### Why is this the best possible solution? Were any other approaches considered?

I thought about using `URL.createObjectURL()`, but a data URL seemed a little simpler.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced