### PR TITLE
Move text inside <label> in sort components

### DIFF
--- a/src/components/form/sort.vue
+++ b/src/components/form/sort.vue
@@ -12,8 +12,8 @@ except according to the terms contained in the LICENSE file.
 <template>
   <div id="form-sort">
     <form class="form-inline" @submit.prevent>
-      <span id="form-sort-label">{{ $t('action.sort') }}</span>
       <label class="form-group">
+        <span id="form-sort-label">{{ $t('action.sort') }}</span>
         <select :value="modelValue" class="form-control"
           @change="$emit('update:modelValue', $event.target.value)">
           <option value="alphabetical">{{ $t('sortOptions.alphabetical') }}</option>
@@ -39,15 +39,14 @@ defineEmits(['update:modelValue']);
 </script>
 
 <style lang="scss">
-
 #form-sort {
   float: right;
 
   #form-sort-label {
     font-size: 14px;
     padding-right: 8px;
+    vertical-align: middle;
   }
-
 }
 </style>
 

--- a/src/components/project/sort.vue
+++ b/src/components/project/sort.vue
@@ -12,8 +12,8 @@ except according to the terms contained in the LICENSE file.
 <template>
   <div id="project-sort">
     <form class="form-inline" @submit.prevent>
-      <span id="project-sort-label">{{ $t('action.sort') }}</span>
       <label class="form-group">
+        <span id="project-sort-label">{{ $t('action.sort') }}</span>
         <select :value="modelValue" class="form-control"
           @change="$emit('update:modelValue', $event.target.value)">
           <option value="alphabetical">{{ $t('sortOptions.alphabetical') }}</option>
@@ -39,15 +39,14 @@ defineEmits(['update:modelValue']);
 </script>
 
 <style lang="scss">
-
 #project-sort {
   float: right;
 
   #project-sort-label {
     font-size: 14px;
     padding-right: 8px;
+    vertical-align: middle;
   }
-
 }
 </style>
 


### PR DESCRIPTION
This PR makes a small improvement to accessibility, moving label text inside the `<label>` element in two components.

#### What has been done to verify that this works as intended?

I viewed the components locally before and after the change in order to verify that they continue to look the same.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced