### PR TITLE
Do not position Spinner absolutely when it is next to <select>

### DIFF
--- a/src/components/project/user/row.vue
+++ b/src/components/project/user/row.vue
@@ -28,9 +28,7 @@ except according to the terms contained in the LICENSE file.
             </option>
             <option value="">{{ $t('role.none') }}</option>
           </select>
-          <span class="spinner-container">
-            <spinner :state="awaitingResponse"/>
-          </span>
+          <spinner :state="awaitingResponse"/>
         </div>
       </form>
     </td>
@@ -136,12 +134,6 @@ export default {
   .form-control {
     display: inline-block;
     width: 215px;
-  }
-
-  .spinner-container {
-    margin-left: 15px;
-    // Spinner is positioned absolutely.
-    position: relative;
   }
 }
 </style>

--- a/src/components/spinner.vue
+++ b/src/components/spinner.vue
@@ -10,25 +10,17 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 
-<!-- `Spinner` toggles a spinner according to its `state` prop. `Spinner` is
-positioned absolutely, so you may need to set the position of an ancestor
-element. -->
+<!-- `Spinner` toggles a spinner according to its `state` prop. -->
 <template>
   <div :class="{ spinner: true, active: state }">
     <div class="spinner-glyph"></div>
   </div>
 </template>
 
-<script>
-export default {
-  name: 'Spinner',
-  props: {
-    state: {
-      type: Boolean,
-      default: false
-    }
-  }
-};
+<script setup>
+defineProps({
+  state: Boolean
+});
 </script>
 
 <style lang="scss">
@@ -45,7 +37,6 @@ $spinner-width: 3px;
 
 .spinner {
   $adjusted-position: calc(50% - #{math.div($spinner-size, 2)});
-  display: block;
   left: $adjusted-position;
   opacity: 0;
   pointer-events: none;
@@ -60,6 +51,15 @@ $spinner-width: 3px;
     animation-timing-function: linear;
     opacity: 1;
     transition-delay: 0.15s;
+  }
+
+  select + & {
+    display: inline-block;
+    left: 0;
+    margin-left: 7px;
+    position: relative;
+    top: 0;
+    vertical-align: text-top;
   }
 }
 .spinner-glyph {

--- a/src/components/user/row.vue
+++ b/src/components/user/row.vue
@@ -26,9 +26,7 @@ except according to the terms contained in the LICENSE file.
             <option value="admin">{{ $t('role.admin') }}</option>
             <option value="">{{ $t('role.none') }}</option>
           </select>
-          <span class="spinner-container">
-            <spinner :state="awaitingResponse"/>
-          </span>
+          <spinner :state="awaitingResponse"/>
         </div>
       </form>
     </td>
@@ -142,12 +140,6 @@ export default {
     .form-control {
       display: inline-block;
       width: 150px;
-    }
-
-    .spinner-container {
-      margin-left: 15px;
-      // Spinner is positioned absolutely.
-      position: relative;
     }
   }
 }


### PR DESCRIPTION
This PR makes it easier to position a spinner next to another element, which we will need to do soon for pagination. Currently, a spinner is always positioned in the middle of its parent.

#### What has been done to verify that this works as intended?

I viewed the spinner in `UserRow` with and without this change in order to verify that it looked the same.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced