### PR TITLE
Add white margin to QR code image

### DIFF
--- a/src/components/collect-qr.vue
+++ b/src/components/collect-qr.vue
@@ -16,34 +16,36 @@ except according to the terms contained in the LICENSE file.
 </template>
 <!-- eslint-enable vue/no-v-html -->
 
-<script>
+<script setup>
+import { computed } from 'vue';
 import qrcode from 'qrcode-generator';
 import pako from 'pako/lib/deflate';
 
-export default {
-  name: 'CollectQr',
-  props: {
-    settings: {
-      type: Object,
-      required: true
-    },
-    errorCorrectionLevel: {
-      type: String,
-      required: true
-    },
-    cellSize: {
-      type: Number,
-      required: true
-    }
+defineOptions({
+  name: 'CollectQr'
+});
+
+const props = defineProps({
+  settings: {
+    type: Object,
+    required: true
   },
-  computed: {
-    imgHtml() {
-      const code = qrcode(0, this.errorCorrectionLevel);
-      const json = JSON.stringify(this.settings);
-      code.addData(btoa(pako.deflate(json, { to: 'string' })));
-      code.make();
-      return code.createImgTag(this.cellSize, 0);
-    }
+  errorCorrectionLevel: {
+    type: String,
+    required: true
+  },
+  cellSize: {
+    type: Number,
+    required: true
   }
-};
+});
+
+const imgHtml = computed(() => {
+  const code = qrcode(0, props.errorCorrectionLevel);
+  const json = JSON.stringify(props.settings);
+  code.addData(btoa(pako.deflate(json, { to: 'string' })));
+  code.make();
+  return code.createImgTag(props.cellSize, 0);
+});
+
 </script>

--- a/src/components/collect-qr.vue
+++ b/src/components/collect-qr.vue
@@ -45,7 +45,15 @@ const imgHtml = computed(() => {
   const json = JSON.stringify(props.settings);
   code.addData(btoa(pako.deflate(json, { to: 'string' })));
   code.make();
-  return code.createImgTag(props.cellSize, 0);
+  return code.createImgTag(props.cellSize, 15);
 });
 
 </script>
+
+<style lang="scss">
+
+.collect-qr img {
+  margin: -15px;
+}
+
+</style>

--- a/test/components/collect-qr.spec.js
+++ b/test/components/collect-qr.spec.js
@@ -85,6 +85,6 @@ describe('CollectQr', () => {
       10
     );
 
-    width2.should.equal(2 * width1);
+    width2.should.equal(2 * (width1 - 15)); // remove negative padding
   });
 });


### PR DESCRIPTION
Added 15 px white border to QR code image and added -15px margin to image to account for it. 
Also switched this component to the composition API.

<img width="586" alt="Screenshot 2024-02-05 at 11 43 49 AM" src="https://github.com/getodk/central-frontend/assets/76205/b4c8aadb-767e-4909-aed5-877048a360ac">

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Trying it.

#### Why is this the best possible solution? Were any other approaches considered?

Maybe there are better ways to remove the extra padding.... maybe 15px is too large.

I would LOVE to do some html5 canvas tricks to render some other info into the QR code image, but the bootstrap popover that this QR code is shown in was interacting really poorly with any canvas tags I tried to add. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced