### PR TITLE
Add modalData() to replace modal mixin

### DIFF
--- a/src/components/dataset/entities.vue
+++ b/src/components/dataset/entities.vue
@@ -16,10 +16,10 @@ except according to the terms contained in the LICENSE file.
         <span>{{ $t('resource.entities') }}</span>
         <button v-if="project.dataExists && project.permits('entity.create')"
           id="dataset-entities-upload-button" type="button"
-          class="btn btn-primary" @click="showModal('upload')">
+          class="btn btn-primary" @click="upload.show()">
           <span class="icon-upload"></span>{{ $t('action.upload') }}
         </button>
-        <odata-data-access @analyze="showModal('analyze')"/>
+        <odata-data-access @analyze="analyze.show()"/>
       </template>
       <template #body>
         <entity-list :project-id="projectId" :dataset-name="datasetName"/>
@@ -27,8 +27,8 @@ except according to the terms contained in the LICENSE file.
     </page-section>
 
     <entity-upload v-if="dataset.dataExists" v-bind="upload"
-      @hide="hideModal('upload')" @success="afterUpload"/>
-    <odata-analyze v-bind="analyze" :odata-url="odataUrl" @hide="hideModal('analyze')"/>
+      @hide="upload.hide()" @success="afterUpload"/>
+    <odata-analyze v-bind="analyze" :odata-url="odataUrl" @hide="analyze.hide()"/>
   </div>
 </template>
 
@@ -40,9 +40,9 @@ import OdataAnalyze from '../odata/analyze.vue';
 import OdataDataAccess from '../odata/data-access.vue';
 import PageSection from '../page/section.vue';
 
-import modal from '../../mixins/modal';
 import { apiPaths } from '../../util/request';
 import { loadAsync } from '../../util/load-async';
+import { modalData } from '../../util/reactivity';
 import { useRequestData } from '../../request-data';
 
 export default {
@@ -54,7 +54,6 @@ export default {
     EntityUpload: defineAsyncComponent(loadAsync('EntityUpload')),
     PageSection
   },
-  mixins: [modal({ upload: 'EntityUpload' })],
   inject: ['alert'],
   props: {
     projectId: {
@@ -72,12 +71,8 @@ export default {
   },
   data() {
     return {
-      upload: {
-        state: false
-      },
-      analyze: {
-        state: false
-      }
+      upload: modalData('EntityUpload'),
+      analyze: modalData()
     };
   },
   computed: {
@@ -88,7 +83,7 @@ export default {
   },
   methods: {
     afterUpload() {
-      this.hideModal('upload');
+      this.upload.hide();
       this.alert.success('Entities were imported successfully! [TODO: i18n]');
     }
   }

--- a/src/components/dataset/pending-submissions.vue
+++ b/src/components/dataset/pending-submissions.vue
@@ -73,7 +73,7 @@ defineProps({
   },
   pendingSubmissions: {
     type: Number,
-    required: true
+    default: 0
   }
 });
 defineEmits(['hide', 'success']);

--- a/src/components/dataset/settings.vue
+++ b/src/components/dataset/settings.vue
@@ -52,6 +52,7 @@ import { useI18n } from 'vue-i18n';
 import DatasetPendingSubmissions from './pending-submissions.vue';
 
 import { apiPaths, isProblem } from '../../util/request';
+import { modalData } from '../../util/reactivity';
 import { useRequestData } from '../../request-data';
 
 defineOptions({
@@ -66,10 +67,7 @@ const { project, dataset } = useRequestData();
 
 const approvalRequired = ref(dataset.approvalRequired);
 
-const pendingSubmissionModal = ref({
-  state: false,
-  pendingSubmissions: 0
-});
+const pendingSubmissionModal = modalData();
 
 watch(() => dataset.dataExists, () => {
   approvalRequired.value = dataset.approvalRequired;
@@ -85,8 +83,7 @@ const update = (convert) => {
     fulfillProblem: ({ code }) => code === 400.29,
     patch: ({ data }) => {
       if (isProblem(data)) {
-        pendingSubmissionModal.value.pendingSubmissions = data.details.count;
-        pendingSubmissionModal.value.state = true;
+        pendingSubmissionModal.show({ pendingSubmissions: data.details.count });
       } else {
         dataset.approvalRequired = data.approvalRequired;
         alert.success(dataset.approvalRequired ? t('onApproval.successMessage') : t('onReceipt.successMessage'));
@@ -99,12 +96,12 @@ const update = (convert) => {
 };
 
 const hideAndUpdate = (convert) => {
-  pendingSubmissionModal.value.state = false;
+  pendingSubmissionModal.hide();
   update(convert);
 };
 
 const hideAndReset = () => {
-  pendingSubmissionModal.value.state = false;
+  pendingSubmissionModal.hide();
   approvalRequired.value = dataset.approvalRequired;
 };
 </script>

--- a/src/components/entity/delete.vue
+++ b/src/components/entity/delete.vue
@@ -12,10 +12,10 @@ except according to the terms contained in the LICENSE file.
 <template>
   <modal id="entity-delete" :state="state" :hideable="!awaitingResponse"
     backdrop @hide="$emit('hide')" @shown="checkbox.focus()">
-    <template #title>{{ $t('title', { label: label ?? '' }) }}</template>
+    <template #title>{{ $t('title', { label }) }}</template>
     <template #body>
       <p class="modal-introduction">
-        <span>{{ $t('introduction[0]', { label: label ?? '' }) }}</span>
+        <span>{{ $t('introduction[0]', { label }) }}</span>
         <sentence-separator/>
         <span>{{ $t('common.noUndo') }}</span>
       </p>
@@ -54,7 +54,10 @@ defineOptions({
 });
 const props = defineProps({
   state: Boolean,
-  label: String,
+  label: {
+    type: String,
+    default: ''
+  },
   awaitingResponse: Boolean
 });
 defineEmits(['hide', 'delete']);

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -23,7 +23,7 @@ except according to the terms contained in the LICENSE file.
       <div v-show="entity.dataExists" class="row">
         <div class="col-xs-4">
           <entity-basic-details/>
-          <entity-data @update="update.state = true"/>
+          <entity-data @update="update.show()"/>
         </div>
         <div class="col-xs-8">
           <entity-activity @resolve="fetchActivityData"/>
@@ -31,13 +31,13 @@ except according to the terms contained in the LICENSE file.
       </div>
     </page-body>
     <entity-update v-bind="update"
-      :entity="entity.dataExists ? entity.data : null"
-      @hide="update.state = false" @success="afterUpdate"/>
+      :entity="entity.dataExists ? entity.data : null" @hide="update.hide()"
+      @success="afterUpdate"/>
   </div>
 </template>
 
 <script setup>
-import { inject, provide, reactive } from 'vue';
+import { inject, provide } from 'vue';
 
 import EntityActivity from './activity.vue';
 import EntityBasicDetails from './basic-details.vue';
@@ -52,7 +52,7 @@ import useEntity from '../../request-data/entity';
 import useEntityVersions from '../../request-data/entity-versions';
 import useRoutes from '../../composables/routes';
 import { apiPaths } from '../../util/request';
-import { setDocumentTitle } from '../../util/reactivity';
+import { modalData, setDocumentTitle } from '../../util/reactivity';
 import { useRequestData } from '../../request-data';
 
 defineOptions({
@@ -108,11 +108,11 @@ fetchActivityData();
 
 setDocumentTitle(() => [entity.dataExists ? entity.currentVersion.label : null]);
 
-const update = reactive({ state: false });
+const update = modalData();
 const { i18n, alert } = inject('container');
 const afterUpdate = (updatedEntity) => {
   fetchActivityData();
-  update.state = false;
+  update.hide();
   alert.success(i18n.t('alert.updateEntity'));
   entity.patch(() => {
     // entity.currentVersion will no longer have extended metadata, but we don't

--- a/src/mixins/modal.js
+++ b/src/mixins/modal.js
@@ -11,6 +11,8 @@ except according to the terms contained in the LICENSE file.
 */
 
 /*
+This mixin is deprecated. Use modalData() instead.
+
 A component that contains one or more modals may use this mixin, which includes
 methods for toggling a modal.
 

--- a/src/util/reactivity.js
+++ b/src/util/reactivity.js
@@ -9,7 +9,9 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-import { watch, watchEffect } from 'vue';
+import { shallowReactive, watch, watchEffect } from 'vue';
+
+import { loadedAsync } from './load-async';
 
 export const watchSync = (source, callback, options = undefined) =>
   watch(source, callback, { ...options, flush: 'sync' });
@@ -19,3 +21,42 @@ export const setDocumentTitle = (title) => watchEffect(() => {
   // name before the project object was loaded), join with separator.
   document.title = title().concat('ODK Central').filter(x => x).join(' | ');
 });
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// modalData()
+
+const _asyncComponent = Symbol('asyncComponent');
+class ModalData {
+  constructor(asyncComponent = undefined) {
+    this.state = false;
+    // Using a Symbol so that the property is not enumerable. We don't want
+    // v-bind to pass this property to the modal component as a prop.
+    this[_asyncComponent] = asyncComponent;
+  }
+
+  // Shows the modal by setting the `state` prop to `true`. Optionally sets
+  // other props.
+  show(data = undefined) {
+    if (this[_asyncComponent] != null && !loadedAsync(this[_asyncComponent]))
+      return;
+    Object.assign(this, data);
+    this.state = true;
+  }
+
+  // Hides the modal by setting the `state` prop to `false`. Also removes other
+  // props unless specified otherwise.
+  hide(clear = true) {
+    if (clear) {
+      for (const name of Object.keys(this)) delete this[name];
+    }
+    this.state = false;
+  }
+}
+
+// modalData() returns an object that holds props to pass to a modal component.
+// The object can be passed to the modal component using v-bind. If the modal
+// component is loaded async, specify the component's name.
+export const modalData = (asyncComponent = undefined) =>
+  shallowReactive(new ModalData(asyncComponent));

--- a/test/unit/reactivity.spec.js
+++ b/test/unit/reactivity.spec.js
@@ -1,0 +1,98 @@
+import { nextTick, watch } from 'vue';
+
+import { loadAsync, setLoader } from '../../src/util/load-async';
+import { modalData } from '../../src/util/reactivity';
+
+describe('util/reactivity', () => {
+  describe('modalData()', () => {
+    it('initializes the state prop as false', () => {
+      modalData().state.should.be.false();
+    });
+
+    describe('show()', () => {
+      it('sets the state prop to true', () => {
+        const modal = modalData();
+        modal.show();
+        modal.state.should.be.true();
+      });
+
+      it('sets other props', () => {
+        const modal = modalData();
+        modal.show({ foo: 'bar' });
+        modal.foo.should.equal('bar');
+      });
+
+      it('triggers reactive effects', async () => {
+        const modal = modalData();
+        let count = 0;
+        watch(() => modal.state, () => { count += 1; });
+        watch(() => modal.foo, () => { count += 1; });
+        modal.show({ foo: 'bar' });
+        await nextTick();
+        count.should.equal(2);
+      });
+
+      describe('async component', () => {
+        before(() => {
+          setLoader('MyModal', async () => ({
+            default: { foo: 'bar' }
+          }));
+        });
+
+        it('does not set state prop to true if component has not loaded', () => {
+          const modal = modalData('MyModal');
+          modal.show();
+          modal.state.should.be.false();
+        });
+
+        it('sets state prop to true if component has loaded', async () => {
+          const modal = modalData('MyModal');
+          await loadAsync('MyModal')();
+          modal.show();
+          modal.state.should.be.true();
+        });
+      });
+    });
+
+    describe('hide()', () => {
+      it('sets the state prop to false', () => {
+        const modal = modalData();
+        modal.show();
+        modal.hide();
+        modal.state.should.be.false();
+      });
+
+      it('clears other props', () => {
+        const modal = modalData();
+        modal.show({ foo: 'bar' });
+        modal.hide();
+        modal.should.not.have.property('foo');
+      });
+
+      it('does not clear other props if specified', () => {
+        const modal = modalData();
+        modal.show({ foo: 'bar' });
+        modal.hide(false);
+        modal.state.should.be.false();
+        modal.foo.should.equal('bar');
+      });
+
+      it('triggers reactive effects', async () => {
+        const modal = modalData();
+        modal.show({ foo: 'bar' });
+        let count = 0;
+        watch(() => modal.state, () => { count += 1; });
+        watch(() => modal.foo, () => { count += 1; });
+        modal.hide();
+        await nextTick();
+        count.should.equal(2);
+      });
+    });
+
+    it('only enumerates over props', () => {
+      const modal = modalData();
+      modal.show({ foo: 'bar' });
+      Object.keys(modal).should.eql(['state', 'foo']);
+    });
+  });
+});


### PR DESCRIPTION
This PR makes progress on #676, adding a replacement for the `modal` mixin. The new `modalData()` returns a reactive object that is similar to the modal object data properties that we've used in the past. However, a `modalData()` object has its own `show()` and `hide()` methods, meaning that a separate mixin (or composable) isn't needed for those actions.

This PR introduces `modalData()`, but it doesn't use it everywhere: it doesn't replace all existing uses of the `modal` mixin. Instead, I replaced the `modal` mixin in a few different types of components:

- `FieldKeyList`. This component has three modals. The use of `modalData()` allows us to remove two component methods related to toggling a specific modal (`showRevoke()` and `hideRevoke()`).
- `EntityList`. This component has some of our most complex modal logic. For example, you can move between the parallel updates modal and the update modal.
- `DatasetEntities`. This component has an async modal component.

I also introduced `modalData()` to Composition API components that have modals, but that weren't able to use the `modal` mixin: `DatasetSettings` and `EntityShow`. We're about to add a new modal to `EntityShow` (the `EntityDelete` modal), so it will be nice to have `modalData()` available for use.

#### What has been done to verify that this works as intended?

Tests continue to pass. I also added unit tests of `modalData()`.

#### Why is this the best possible solution? Were any other approaches considered?

I considered replacing the mixin with a composable, but I think a reactive object with `show()` and `hide()` methods is more ergonomic. We need reactivity, but we don't need anything else that a composable would provide (e.g., lifecycle hooks).

I thought about different ways to structure the `modalData()` object. I considered storing the props for the modal component in a nested object named `data`, but I ended up feeling that it was more ergonomic to store them as top-level properties on the `modalData()` object. That also keeps `modalData()` objects more similar to how modal object data properties have worked in the past.

Lastly, I thought about having the `modalData()` object automatically specify a `hide` event handler to the modal component (by adding a property to the object named `onHide`). However, different modals have different hide logic. (And I don't see any documented support in Vue for adding multiple event handlers for the same event or for having one event handler override a previous one.) I also think that pattern would be quite magical-seeming. I think it's better that the `modalData()` object is a simple reactive object with `show()` and `hide()` methods.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced