### PR TITLE
Add full-screen modal

### DIFF
--- a/src/assets/css/bootstrap.css
+++ b/src/assets/css/bootstrap.css
@@ -4284,9 +4284,6 @@ button.close {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   }
-  .modal-sm {
-    width: 300px;
-  }
 }
 @media (min-width: 992px) {
   .modal-lg {

--- a/src/components/analytics/preview.vue
+++ b/src/components/analytics/preview.vue
@@ -10,7 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <modal id="analytics-preview" :state="state" hideable backdrop large @hide="$emit('hide')">
+  <modal id="analytics-preview" :state="state" hideable backdrop size="large"
+    @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <div class="modal-introduction">

--- a/src/components/entity/resolve.vue
+++ b/src/components/entity/resolve.vue
@@ -10,8 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <modal id="entity-resolve" :state="state" :hideable="!awaitingResponse" large
-    backdrop @hide="$emit('hide')">
+  <modal id="entity-resolve" :state="state" :hideable="!awaitingResponse"
+    size="large" backdrop @hide="$emit('hide')">
     <template #title>{{ $t('title', entity) }}</template>
     <template #body>
       <div v-if="!success">

--- a/src/components/entity/update.vue
+++ b/src/components/entity/update.vue
@@ -10,8 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <modal id="entity-update" :state="state" :hideable="!awaitingResponse" large
-    backdrop @shown="afterShown" @hide="$emit('hide')">
+  <modal id="entity-update" :state="state" :hideable="!awaitingResponse"
+    size="large" backdrop @shown="afterShown" @hide="$emit('hide')">
     <template #title>{{ $t('title', currentVersion) }}</template>
     <template #body>
       <form @submit.prevent="submit">

--- a/src/components/entity/upload.vue
+++ b/src/components/entity/upload.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <modal id="entity-upload" :state="state" :hideable="!awaitingResponse"
-    backdrop @hide="$emit('hide')">
+    size="full" backdrop @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <div>

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="modal" :class="{ scroll }" tabindex="-1"
+  <div class="modal" :class="{ 'has-scroll': hasScroll }" tabindex="-1"
     :data-backdrop="backdrop ? 'static' : 'false'" data-keyboard="false"
     role="dialog" :aria-labelledby="titleId" @mousedown="modalMousedown"
     @click="modalClick" @keydown.esc="hideIfCan" @focusout="refocus">
@@ -86,7 +86,7 @@ export default {
       id,
       // `true` if the modal vertically overflows the viewport, causing it to
       // scroll; `false` if not.
-      scroll: false,
+      hasScroll: false,
       // The modal() method of the Boostrap plugin
       bs: null,
       observer: markRaw(new MutationObserver(() => {
@@ -135,21 +135,21 @@ export default {
     if (this.state) this.hide();
   },
   methods: {
-    setScroll() {
-      this.scroll = this.$el.scrollHeight > this.$el.clientHeight;
+    checkScroll() {
+      this.hasScroll = this.$el.scrollHeight > this.$el.clientHeight;
     },
     handleHeightChange() {
       this.bs('handleUpdate');
-      this.setScroll();
+      this.checkScroll();
     },
     handleWindowResize() {
-      // Most of the time, a window resize shouldn't affect the size of the
+      // Most of the time, a window resize shouldn't affect the height of the
       // modal. However, if this.size === 'full', it could.
       if (this.size === 'full') this.handleHeightChange();
     },
     show() {
       this.bs('show');
-      this.setScroll();
+      this.checkScroll();
       this.observer.observe(this.$refs.body, {
         subtree: true,
         childList: true,
@@ -162,7 +162,7 @@ export default {
     hide() {
       this.observer.disconnect();
       this.bs('hide');
-      this.scroll = false;
+      this.hasScroll = false;
       window.removeEventListener('resize', this.handleWindowResize);
 
       const selection = getSelection();
@@ -270,7 +270,7 @@ export default {
   // usually does. However, if the .modal-body is taller than its content, such
   // that the modal does not scroll, then we need to position .modal-actions at
   // the bottom ourselves.
-  .modal:not(.scroll) & .modal-actions {
+  .modal:not(.has-scroll) & .modal-actions {
     bottom: 0;
     left: 0;
     margin: 0;

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -143,8 +143,8 @@ export default {
       this.checkScroll();
     },
     handleWindowResize() {
-      // Most of the time, a window resize shouldn't affect the height of the
-      // modal. However, if this.size === 'full', it could.
+      // Most of the time, a window resize won't affect the height of the modal.
+      // However, if this.size === 'full', it could.
       if (this.size === 'full') this.handleHeightChange();
     },
     show() {
@@ -257,19 +257,19 @@ export default {
 
 .modal-full {
   $margin: 15px;
-  // Because we set margin-left and width, we don't need margin-right.
+  // Because we set margin-left and width, we don't need to set margin-right.
   margin: $margin 0 $margin $margin;
   // Subtract 10px so that there is space between the modal and the scrollbar.
-  width: calc(100vw - #{2 * $margin} - 10px);
+  width: calc(100vw - #{2 * $margin + 10px});
 
   // 50px is the approximate height of .modal-header.
-  .modal-body { min-height: calc(100vh - #{2 * $margin} - 50px); }
+  .modal-body { min-height: calc(100vh - #{2 * $margin + 50px}); }
 
   // If .modal-body has so much content that it causes the modal to scroll, then
   // .modal-actions will naturally appear at the bottom of the modal as it
-  // usually does. However, if the .modal-body is taller than its content, such
-  // that the modal does not scroll, then we need to position .modal-actions at
-  // the bottom ourselves.
+  // usually does. However, if the min height of the .modal-body is greater than
+  // the height of its content, such that the modal doesn't scroll, then we need
+  // to position .modal-actions at the bottom of the modal ourselves.
   .modal:not(.has-scroll) & .modal-actions {
     bottom: 0;
     left: 0;

--- a/src/components/submission/download.vue
+++ b/src/components/submission/download.vue
@@ -10,8 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <modal :state="state" hideable :large="managedKey != null" backdrop
-    @hide="$emit('hide')"
+  <modal :state="state" hideable :size="managedKey == null ? 'normal' : 'large'"
+    backdrop @hide="$emit('hide')"
     @shown="$refs.form.querySelector('input:not([disabled])').focus()">
     <template #title>{{ $t('title') }}</template>
     <template #body>

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import { nextTick } from 'vue';
 
 import Alert from '../../src/components/alert.vue';
 import Modal from '../../src/components/modal.vue';
@@ -104,6 +105,45 @@ describe('Modal', () => {
     });
   });
 
+  describe('size prop', () => {
+    it("adds the correct class if the prop is 'large'", () => {
+      const modal = mountComponent({
+        props: { size: 'large' }
+      });
+      modal.get('.modal-dialog').classes('modal-lg').should.be.true();
+    });
+
+    describe("prop is 'full'", () => {
+      it('adds the correct class', () => {
+        const modal = mountComponent({
+          props: { size: 'full' }
+        });
+        modal.get('.modal-dialog').classes('modal-full').should.be.true();
+      });
+
+      it('adds a class if modal vertically overflows viewport', async () => {
+        const modal = mountComponent({
+          props: { size: 'full' },
+          slots: {
+            body: { template: '<div style="height: 10000px;"></div>' }
+          },
+          attachTo: document.body
+        });
+        await nextTick();
+        modal.classes('scroll').should.be.true();
+      });
+
+      it('does not add the class if the modal does not overflow', async () => {
+        const modal = mountComponent({
+          props: { size: 'full' },
+          attachTo: document.body
+        });
+        await nextTick();
+        modal.classes('scroll').should.be.false();
+      });
+    });
+  });
+
   it("updates the modal's position after its body changes", async () => {
     const modal = mountComponent({
       slots: {
@@ -118,12 +158,5 @@ describe('Modal', () => {
     modal.get('.modal-body p').element.textContent = 'New text';
     await modal.vm.$nextTick();
     bs.args.should.eql([['handleUpdate'], ['handleUpdate']]);
-  });
-
-  it('adds the modal-lg class if the large prop is true', () => {
-    const modal = mountComponent({
-      props: { large: true }
-    });
-    modal.get('.modal-dialog').classes('modal-lg').should.be.true();
   });
 });

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -130,7 +130,7 @@ describe('Modal', () => {
           attachTo: document.body
         });
         await nextTick();
-        modal.classes('scroll').should.be.true();
+        modal.classes('has-scroll').should.be.true();
       });
 
       it('does not add the class if the modal does not overflow', async () => {
@@ -139,7 +139,7 @@ describe('Modal', () => {
           attachTo: document.body
         });
         await nextTick();
-        modal.classes('scroll').should.be.false();
+        modal.classes('has-scroll').should.be.false();
       });
     });
   });

--- a/test/components/submission/download.spec.js
+++ b/test/components/submission/download.spec.js
@@ -62,19 +62,17 @@ describe('SubmissionDownload', () => {
     });
   });
 
-  describe('size', () => {
+  describe('modal size', () => {
     it('is normal size if the form is not encrypted', () => {
       testData.extendedForms.createPast(1);
-      const modal = mountComponent();
-      modal.getComponent(Modal).props().size.should.equal('normal');
+      mountComponent().getComponent(Modal).props().size.should.equal('normal');
     });
 
-    it('is large if the form is encrypted', () => {
+    it('is large if there is a managed key', () => {
       testData.extendedForms.createPast(1, {
         key: testData.standardKeys.createPast(1, { managed: true }).last()
       });
-      const modal = mountComponent();
-      modal.getComponent(Modal).props().size.should.equal('large');
+      mountComponent().getComponent(Modal).props().size.should.equal('large');
     });
   });
 

--- a/test/components/submission/download.spec.js
+++ b/test/components/submission/download.spec.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 
+import Modal from '../../../src/components/modal.vue';
 import SubmissionDownload from '../../../src/components/submission/download.vue';
 
 import useFields from '../../../src/request-data/fields';
@@ -58,6 +59,22 @@ describe('SubmissionDownload', () => {
       modal: SubmissionDownload,
       show: '#submission-download-button',
       hide: '.modal-actions .btn'
+    });
+  });
+
+  describe('size', () => {
+    it('is normal size if the form is not encrypted', () => {
+      testData.extendedForms.createPast(1);
+      const modal = mountComponent();
+      modal.getComponent(Modal).props().size.should.equal('normal');
+    });
+
+    it('is large if the form is encrypted', () => {
+      testData.extendedForms.createPast(1, {
+        key: testData.standardKeys.createPast(1, { managed: true }).last()
+      });
+      const modal = mountComponent();
+      modal.getComponent(Modal).props().size.should.equal('large');
     });
   });
 


### PR DESCRIPTION
This PR makes progress on getodk/central#589, making `EntityUpload` a full-screen modal.

#### Why is this the best possible solution? Were any other approaches considered?

The main difficulty here was positioning `.modal-actions`. In a full-screen modal, `.modal-actions` should be positioned at the bottom of the modal. However, it's not easy to do that given that there aren't guarantees around the viewport height. It's possible for the modal to be taller than the viewport, so we can't simply set `position: fixed;` on `.modal-actions`. We could set `position: absolute;`, but that would lose the margin above `.modal-actions`. I ended up setting `position: absolute;` conditionally, in the case that the modal isn't taller than the viewport. If the modal is taller than the viewport, then `.modal-actions` will already end up at the bottom of the modal with the correct top margin; if the modal isn't taller than the viewport, then setting `position: absolute;` will only increase the space above `.modal-actions`. The downside of this approach is that setting `position: absolute;` conditionally requires JavaScript, and the condition needs to be reevaluated whenever the height of the modal changes. There is already JavaScript homework that the component needs to do when the height of the modal changes, so we're just adding to that, but it is additional code.

I tried to come up with an approach that wouldn't require JavaScript. I thought about increasing the bottom padding of a full-screen modal to include the height of `.modal-actions` and the margin above it. However, I wasn't sure that I should assume that the modal has a `.modal-actions` element, and if it doesn't have one, we wouldn't want to increase the bottom padding. I was also reluctant to make assumptions about the height of `.modal-actions`, since that could vary based on the font. We could add this padding dynamically using JavaScript, but that doesn't seem much better than the current approach.

I also thought about requiring the parent component of `Modal` (here, `EntityUpload`) to set sufficient bottom margin on the element above `.modal-actions`. However, it feels like this really should be a concern of `Modal`. Offloading it to the parent component would require exporting a variable for the top margin of `.modal-actions`. I think it's nicer for the parent component of a full-screen modal to be able to use `.modal-actions` normally, without special requirements.

#### What has been done to verify that this works as intended?

I viewed this change locally to make sure that the modal looked right, both when its content overflows the viewport and when it doesn't. I also tried out a couple of cases locally where `position: absolute;` is toggled on `.modal-actions`. I tried changing the content of the modal, and I tried resizing the window.

We generally don't test CSS, but I added tests of the classes involved in this change (that `.modal-full` is added to `.modal-dialog` and that `.has-scroll` is conditionally added to `.modal`). However, I didn't add tests for all the cases in which `.has-scroll` is toggled: that felt like more effort than it was worth.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced