### PR TITLE
Add ability to select file in EntityUpload

### DIFF
--- a/src/components/entity/upload.vue
+++ b/src/components/entity/upload.vue
@@ -14,15 +14,17 @@ except according to the terms contained in the LICENSE file.
     backdrop @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
-      <div>
-        <span>{{ $t('headersNote') }}</span>
-        <sentence-separator/>
-        <entity-upload-data-template/>
-      </div>
-
+      <entity-upload-file-select v-show="file == null" @change="selectFile">
+        <div>
+          <span>{{ $t('headersNote') }}</span>
+          <sentence-separator/>
+          <entity-upload-data-template/>
+        </div>
+      </entity-upload-file-select>
+      <div v-if="file != null" id="entity-upload-filename">{{ file.name }}</div>
       <div class="modal-actions">
         <button type="button" class="btn btn-primary"
-          :aria-disabled="awaitingResponse" @click="upload">
+          :aria-disabled="file == null || awaitingResponse" @click="upload">
           {{ $t('action.append') }} <spinner :state="awaitingResponse"/>
         </button>
         <button type="button" class="btn btn-link"
@@ -35,7 +37,10 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import { ref, watch } from 'vue';
+
 import EntityUploadDataTemplate from './upload/data-template.vue';
+import EntityUploadFileSelect from './upload/file-select.vue';
 import Modal from '../modal.vue';
 import SentenceSeparator from '../sentence-separator.vue';
 import Spinner from '../spinner.vue';
@@ -48,12 +53,16 @@ import { useRequestData } from '../../request-data';
 defineOptions({
   name: 'EntityUpload'
 });
-defineProps({
+const props = defineProps({
   state: Boolean
 });
 const emit = defineEmits(['hide', 'success']);
 
 const { dataset } = useRequestData();
+
+const file = ref(null);
+const selectFile = (value) => { file.value = value; };
+watch(() => props.state, () => { if (!props.state) file.value = null; });
 
 const { request, awaitingResponse } = useRequest();
 const upload = () => {
@@ -61,7 +70,7 @@ const upload = () => {
     method: 'POST',
     url: apiPaths.entities(dataset.projectId, dataset.name),
     data: {
-      source: { name: 'TODO' },
+      source: { name: file.value.name, size: file.value.size },
       entities: []
     }
   })

--- a/src/components/entity/upload/file-select.vue
+++ b/src/components/entity/upload/file-select.vue
@@ -1,0 +1,69 @@
+<!--
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <file-drop-zone id="entity-upload-file-select"
+    @drop="$emit('change', $event.dataTransfer.files[0])">
+    <i18n-t tag="div" keypath="text.full">
+      <template #chooseOne>
+        <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
+        <input v-show="false" ref="input" type="file" accept=".csv"
+          @change="changeInput">
+        <button type="button" class="btn btn-primary" @click="input.click()">
+          <span class="icon-folder-open"></span>{{ $t('text.chooseOne') }}
+        </button>
+      </template>
+    </i18n-t>
+    <slot></slot>
+  </file-drop-zone>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+import FileDropZone from '../../file-drop-zone.vue';
+
+defineOptions({
+  name: 'EntityUploadFileSelect'
+});
+const emit = defineEmits(['change']);
+
+const input = ref(null);
+const changeInput = (event) => {
+  emit('change', event.target.files[0]);
+  input.value.value = '';
+};
+</script>
+
+<style lang="scss">
+#entity-upload-file-select {
+  border-radius: 5px;
+  padding-bottom: 10px;
+  padding-top: 10px;
+  text-align: left;
+
+  > :first-child {
+    font-size: 16px;
+    margin-bottom: 1px;
+  }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    "text": {
+      "full": "Drag a .csv file here, or {chooseOne} to import.",
+      "chooseOne": "choose one"
+    }
+  }
+}
+</i18n>

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -3,6 +3,8 @@ import EntityUpload from '../../../src/components/entity/upload.vue';
 import testData from '../../data';
 import { mockHttp, load } from '../../util/http';
 import { mockLogin } from '../../util/session';
+import { mount } from '../../util/lifecycle';
+import { setFiles } from '../../util/trigger';
 
 const mountOptions = () => {
   const dataset = testData.extendedDatasets.last();
@@ -13,6 +15,8 @@ const mountOptions = () => {
     }
   };
 };
+const mountComponent = () => mount(EntityUpload, mountOptions());
+const csv = (text = 'label\ndogwood') => new File([text], 'my_data.csv');
 
 describe('EntityUpload', () => {
   it('toggles the modal', () => {
@@ -37,18 +41,59 @@ describe('EntityUpload', () => {
     button.exists().should.be.false();
   });
 
+  describe('after a file is selected', () => {
+    beforeEach(() => {
+      testData.extendedDatasets.createPast(1);
+    });
+
+    it('shows the filename', async () => {
+      const modal = mountComponent();
+      await setFiles(modal.get('input'), [csv()]);
+      modal.get('#entity-upload-filename').text().should.equal('my_data.csv');
+    });
+
+    it('hides the drop zone', async () => {
+      const modal = mountComponent();
+      const dropZone = modal.get('#entity-upload-file-select');
+      dropZone.should.be.visible();
+      await setFiles(dropZone.get('input'), [csv()]);
+      dropZone.should.be.hidden();
+    });
+
+    it('enables the append button', async () => {
+      const modal = mountComponent();
+      const button = modal.get('.modal-actions .btn-primary');
+      button.attributes('aria-disabled').should.equal('true');
+      await setFiles(modal.get('input'), [csv()]);
+      button.attributes('aria-disabled').should.equal('false');
+    });
+
+    it('resets after the modal is hidden', async () => {
+      const modal = mountComponent();
+      await setFiles(modal.get('input'), [csv()]);
+      await modal.setProps({ state: false });
+      await modal.setProps({ state: true });
+      modal.find('#entity-upload-filename').exists().should.be.false();
+      modal.get('#entity-upload-file-select').should.be.visible();
+      const button = modal.get('.modal-actions .btn-primary');
+      button.attributes('aria-disabled').should.equal('true');
+    });
+  });
+
   it('sends the correct upload request', () => {
     testData.extendedDatasets.createPast(1, { name: 'á' });
     return mockHttp()
       .mount(EntityUpload, mountOptions())
-      .complete()
-      .request(modal => modal.get('.btn-primary').trigger('click'))
+      .request(async (modal) => {
+        await setFiles(modal.get('input'), [csv()]);
+        return modal.get('.modal-actions .btn-primary').trigger('click');
+      })
       .respondWithProblem()
       .testRequests([{
         method: 'POST',
         url: '/v1/projects/1/datasets/%C3%A1/entities',
         data: {
-          source: { name: 'TODO' },
+          source: { name: 'my_data.csv', size: 13 },
           entities: []
         }
       }]);
@@ -58,8 +103,9 @@ describe('EntityUpload', () => {
     testData.extendedDatasets.createPast(1);
     return mockHttp()
       .mount(EntityUpload, mountOptions())
+      .afterResponses(modal => setFiles(modal.get('input'), [csv()]))
       .testStandardButton({
-        button: '.btn-primary',
+        button: '.modal-actions .btn-primary',
         disabled: ['.btn-link'],
         modal: true
       });
@@ -72,7 +118,9 @@ describe('EntityUpload', () => {
         .complete()
         .request(async (component) => {
           await component.get('#dataset-entities-upload-button').trigger('click');
-          return component.get('#entity-upload .btn-primary').trigger('click');
+          const modal = component.getComponent(EntityUpload);
+          await setFiles(modal.get('input'), [csv()]);
+          return modal.get('.modal-actions .btn-primary').trigger('click');
         })
         .respondWithSuccess()
         .afterResponse(component => {

--- a/test/components/entity/upload/file-select.spec.js
+++ b/test/components/entity/upload/file-select.spec.js
@@ -1,0 +1,33 @@
+import EntityUploadFileSelect from '../../../../src/components/entity/upload/file-select.vue';
+
+import { dragAndDrop, setFiles } from '../../../util/trigger';
+import { mount } from '../../../util/lifecycle';
+
+const csv = new File([''], 'my_data.csv');
+
+describe('EntityUploadFileSelect', () => {
+  describe('after a file is selected using the button', () => {
+    it('emits a change event', async () => {
+      const component = mount(EntityUploadFileSelect);
+      await setFiles(component.get('input'), [csv]);
+      const file = component.emitted().change[0][0];
+      file.should.be.an.instanceof(File);
+      file.name.should.equal('my_data.csv');
+    });
+
+    it('resets the input', async () => {
+      const component = mount(EntityUploadFileSelect);
+      const input = component.get('input');
+      await setFiles(input, [csv]);
+      input.element.value.should.equal('');
+    });
+  });
+
+  it('emits a change event after a file is dropped', async () => {
+    const component = mount(EntityUploadFileSelect);
+    await dragAndDrop(component, [csv]);
+    const file = component.emitted().change[0][0];
+    file.should.be.an.instanceof(File);
+    file.name.should.equal('my_data.csv');
+  });
+});

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1945,6 +1945,18 @@
         }
       }
     },
+    "EntityUploadFileSelect": {
+      "text": {
+        "full": {
+          "string": "Drag a .csv file here, or {chooseOne} to import.",
+          "developer_comment": "{chooseOne} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nchoose one"
+        },
+        "chooseOne": {
+          "string": "choose one",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {chooseOne} is in the following text:\n\nDrag a .csv file here, or {chooseOne} to import."
+        }
+      }
+    },
     "EntityVersionLink": {
       "submission": {
         "string": "Submission {instanceName}",


### PR DESCRIPTION
This PR makes progress on getodk/central#589, adding the ability to select a file in `EntityUpload`. As part of this PR, the name and size of the file will be sent to Backend. We will send the entity data once we have CSV parsing in place.

#### What has been done to verify that this works as intended?

New tests, trying it locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced