### PR TITLE
Show bulk upload source on entity detail page

### DIFF
--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -102,9 +102,9 @@ watch(() => audits.awaitingResponse, (awaitingResponse) => {
 });
 const scrollData = (entryData) => {
   const { action } = entryData.entry;
-  if (!(action === 'entity.create' || action === 'entity.update.version'))
+  if (!(action === 'entity.create' || action === 'entity.bulk.create' || action === 'entity.update.version'))
     return {};
-  const version = action === 'entity.create' ? 1 : entryData.entityVersion.version;
+  const version = (action === 'entity.create' || action === 'entity.bulk.create') ? 1 : entryData.entityVersion.version;
   return {
     'data-version': version,
     class: version === scrollTarget.value ? 'scroll-target' : null

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -34,7 +34,7 @@ except according to the terms contained in the LICENSE file.
         </div>
         <div v-if="source?.name != null">
           <dt>{{ $t('creatingSource') }}</dt>
-          <dd>{{ $t('upload') }}</dd>
+          <dd id="entity-basic-details-creating-source">{{ $t('upload') }}</dd>
         </div>
         <div>
           <dt>{{ $t('header.createdAt') }}</dt>

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -32,6 +32,10 @@ except according to the terms contained in the LICENSE file.
             </template>
           </dd>
         </div>
+        <div v-if="source?.name != null">
+          <dt>{{ $t('creatingSource') }}</dt>
+          <dd>{{ $t('upload') }}</dd>
+        </div>
         <div>
           <dt>{{ $t('header.createdAt') }}</dt>
           <dd><date-time :iso="entity.createdAt"/></dd>
@@ -65,17 +69,21 @@ const projectId = inject('projectId');
 // created.
 const { entity, audits } = useRequestData();
 
-// Using `ref` and watchEffect() for `submission` rather than
+// Using `ref` and watchEffect() for `source` rather than
 // `computed` so that it doesn't change whenever `audits` is refreshed.
-const submission = ref(undefined);
+const source = ref(undefined);
+const submission = ref(undefined); // submission is contained within source
 watchEffect(() => {
-  if (submission.value !== undefined || !audits.dataExists) return;
-  const audit = audits.find(({ action }) => action === 'entity.create');
+  // if we don't have the audit data yet, or if we have already found the source, return.
+  if ((!audits.dataExists || source.value !== undefined)) return;
+  const audit = audits.find(({ action }) => action === 'entity.create' || action === 'entity.bulk.create');
   // `audit` should always exist in production, but it doesn't always exist in
   // testing.
   if (audit == null) return;
   submission.value = audit.details.source?.submission;
+  source.value = audit.details.source;
 });
+
 const { submissionPath } = useRoutes();
 </script>
 
@@ -95,6 +103,10 @@ const { submissionPath } = useRoutes();
   "en": {
     // This is shown above the Submission that created the Entity.
     "creatingSubmission": "Creating Submission",
+    // This is shown above the source (e.g. a CSV file) that created the entity
+    "creatingSource": "Creating Source",
+    // This describes an "upload" being a generic source of an entity
+    "upload": "Upload",
     "submissionDeleted": "This Submission has been deleted."
   }
 }

--- a/src/components/entity/basic-details.vue
+++ b/src/components/entity/basic-details.vue
@@ -32,7 +32,7 @@ except according to the terms contained in the LICENSE file.
             </template>
           </dd>
         </div>
-        <div v-if="source?.name != null">
+        <div v-else-if="source?.name != null">
           <dt>{{ $t('creatingSource') }}</dt>
           <dd id="entity-basic-details-creating-source">{{ $t('upload') }}</dd>
         </div>
@@ -104,7 +104,7 @@ const { submissionPath } = useRoutes();
     // This is shown above the Submission that created the Entity.
     "creatingSubmission": "Creating Submission",
     // This is shown above the source (e.g. a CSV file) that created the entity
-    "creatingSource": "Creating Source",
+    "creatingSource": "Creating source",
     // This describes an "upload" being a generic source of an entity
     "upload": "Upload",
     "submissionDeleted": "This Submission has been deleted."

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -60,6 +60,26 @@ except according to the terms contained in the LICENSE file.
           <template #name><actor-link :actor="entry.actor"/></template>
         </i18n-t>
       </template>
+      <template v-else-if="entry.action === 'entity.bulk.create'">
+        <span class="icon-cloud-upload"></span>
+        <!--use same title template as entity created by submission-->
+        <i18n-t keypath="title.entity.create.submission">
+          <template #label>
+            <span class="entity-label">{{ entity.currentVersion.label }}</span>
+          </template>
+          <template #dataset>
+            <router-link :to="datasetPath()">{{ datasetName }}</router-link>
+          </template>
+        </i18n-t>
+        <div class="bulk-source">
+          <i18n-t keypath="title.entity.create.bulkSource">
+            <template #name>
+              <span class="source-name">{{ entry.details.source.name }}</span>
+            </template>
+            <template #actor><actor-link :actor="entry.actor"/></template>
+          </i18n-t>
+        </div>
+      </template>
       <template v-else-if="entry.action === 'entity.update.version'">
         <span class="icon-pencil"></span>
         <span class="title">
@@ -137,7 +157,7 @@ const { entity } = useRequestData();
 // Allow titles that contain more than one string to wrap.
 const wrapTitle = computed(() => {
   const { action } = props.entry;
-  return action === 'submission.create' || action === 'entity.create' || action === 'entity.update.version';
+  return action === 'submission.create' || action === 'entity.create' || action === 'entity.bulk.create' || action === 'entity.update.version';
 });
 
 const { submissionPath, datasetPath } = useRoutes();
@@ -175,7 +195,7 @@ const versionAnchor = (v) => `#v${v}`;
     vertical-align: -2px;
   }
 
-  .deleted-submission, .entity-label { font-weight: normal; }
+  .deleted-submission, .entity-label, .source-name { font-weight: normal; }
   .deleted-submission { color: $color-danger; }
   .approval { color: $color-success; }
 
@@ -190,6 +210,10 @@ const versionAnchor = (v) => `#v${v}`;
       @include text-link;
       font-weight: bold;
     }
+  }
+
+  .bulk-source {
+    text-indent: 0px;
   }
 }
 </style>
@@ -224,7 +248,8 @@ const versionAnchor = (v) => `#v${v}`;
           "submission": "Created Entity {label} in {dataset} Entity List",
           // This text is shown in a list of events. {name} is the name of a Web
           // User.
-          "api": "Entity {label} created by {name}"
+          "api": "Entity {label} created by {name}",
+          "bulkSource": "File {name} uploaded by {actor}"
         },
         "update_version": {
           "submission": {

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -254,6 +254,8 @@ const versionAnchor = (v) => `#v${v}`;
           // This text is shown in a list of events. {name} is the name of a Web
           // User.
           "api": "Entity {label} created by {name}",
+          // This text is shown in a list of events. {name} is a filename, e.g.
+          // myfile.csv, and {actor} is a name/link to a Web User.
           "bulkSource": "File {name} uploaded by {actor}"
         },
         "update_version": {

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -62,15 +62,16 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template v-else-if="entry.action === 'entity.bulk.create'">
         <span class="icon-cloud-upload"></span>
-        <!--use same title template as entity created by submission-->
-        <i18n-t keypath="title.entity.create.submission">
-          <template #label>
-            <span class="entity-label">{{ entity.currentVersion.label }}</span>
-          </template>
-          <template #dataset>
-            <router-link :to="datasetPath()">{{ datasetName }}</router-link>
-          </template>
-        </i18n-t>
+        <div class="bulk-event">
+          <i18n-t keypath="title.entity.create.submission">
+            <template #label>
+              <span class="entity-label">{{ entity.currentVersion.label }}</span>
+            </template>
+            <template #dataset>
+              <router-link :to="datasetPath()">{{ datasetName }}</router-link>
+            </template>
+          </i18n-t>
+        </div>
         <div class="bulk-source">
           <i18n-t keypath="title.entity.create.bulkSource">
             <template #name>
@@ -210,6 +211,10 @@ const versionAnchor = (v) => `#v${v}`;
       @include text-link;
       font-weight: bold;
     }
+  }
+
+  .bulk-event {
+    display: inline;
   }
 
   .bulk-source {

--- a/src/components/entity/version-link.vue
+++ b/src/components/entity/version-link.vue
@@ -44,11 +44,14 @@ const versionPath = computed(() => {
 const { t } = useI18n();
 const text = computed(() => {
   const { source } = props.version;
-  const { submission } = source;
+  const { submission, name } = source;
   if (submission != null) {
     const nameOrId = submission.currentVersion?.instanceName ??
       submission.instanceId;
     return t('submission', { instanceName: nameOrId });
+  }
+  if (name != null) {
+    return t('bulk', { filename: name, name: props.version.creator.displayName });
   }
   return t('api', { name: props.version.creator.displayName });
 });
@@ -61,7 +64,10 @@ const text = computed(() => {
     // of the Submission.
     "submission": "Submission {instanceName}",
     // This refers to an update to an Entity. {name} is the name of a Web User.
-    "api": "Update by {name}"
+    "api": "Update by {name}",
+    // This refers to creation of an Entity. {filename} is the name of
+    // an uploaded file containing the Entity. {name} is the name of a Web User.
+    "bulk": "File {filename} uploaded by {name}"
   }
 }
 </i18n>

--- a/src/components/entity/version-link.vue
+++ b/src/components/entity/version-link.vue
@@ -67,7 +67,7 @@ const text = computed(() => {
     "api": "Update by {name}",
     // This refers to creation of an Entity. {filename} is the name of
     // an uploaded file containing the Entity. {name} is the name of a Web User.
-    "bulk": "File {filename} uploaded by {name}"
+    "bulk": "File {filename} upload by {name}"
   }
 }
 </i18n>

--- a/test/components/entity/basic-details.spec.js
+++ b/test/components/entity/basic-details.spec.js
@@ -156,6 +156,20 @@ describe('EntityBasicDetails', () => {
           dd.text().should.equal('s');
         });
     });
+  });
+
+  describe('entity created using single entity API', () => {
+    it('does not show any block about entity creation', () => {
+      testData.extendedEntities.createPast(1, { uuid: 'e' });
+      testData.extendedAudits.createPast(1, {
+        action: 'entity.create',
+        details: {
+          entity: { uuid: 'e' }
+        }
+      });
+      const component = mountComponent();
+      component.findAll('dd').length.should.equal(3);
+    });
 
     it('does not show creating submission for entity created using API', () => {
       testData.extendedEntities.createPast(1, { uuid: 'e' });
@@ -168,6 +182,21 @@ describe('EntityBasicDetails', () => {
       const component = mountComponent();
       const dd = component.find('#entity-basic-details-creating-submission');
       dd.exists().should.be.false();
+    });
+  });
+
+  describe('entity created using bulk upload', () => {
+    it('shows the creating source as the word upload', () => {
+      testData.extendedEntities.createPast(1, { uuid: 'e' });
+      testData.extendedAudits.createPast(1, {
+        action: 'entity.create',
+        details: {
+          source: { name: 'my_file.csv' }
+        }
+      });
+      const component = mountComponent();
+      const dd = component.find('#entity-basic-details-creating-source');
+      dd.text().should.equal('Upload');
     });
   });
 

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -219,6 +219,46 @@ describe('EntityFeedEntry', () => {
     });
   });
 
+  describe('entity.bulk.create audit event', () => {
+    beforeEach(() => {
+      testData.extendedAudits.createPast(1, {
+        action: 'entity.bulk.create',
+        details: { source: { name: 'my_file.csv' } }
+      });
+    });
+
+    it('shows the correct icon', () => {
+      const component = mountComponent();
+      const icon = component.find('.feed-entry-title .icon-cloud-upload');
+      icon.exists().should.be.true();
+    });
+
+    it('shows the correct text in top of event block', () => {
+      const component = mountComponent();
+      const text = component.get('.feed-entry-title .bulk-event').text();
+      text.should.equal('Created Entity dogwood in trees Entity List');
+    });
+
+    it('links to the dataset in the top of the event block', () => {
+      const title = mountComponent().get('.feed-entry-title .bulk-event');
+      const { to } = title.getComponent(RouterLinkStub).props();
+      to.should.equal('/projects/1/entity-lists/trees');
+    });
+
+    it('shows the correct text in bottom of event block', () => {
+      const component = mountComponent();
+      const text = component.get('.feed-entry-title .bulk-source').text();
+      text.should.equal('File my_file.csv uploaded by Alice');
+    });
+
+    it('links to actor in bottom of event block', () => {
+      const component = mountComponent();
+      const title = component.get('.feed-entry-title .bulk-source');
+      const actorLink = title.getComponent(ActorLink);
+      actorLink.props().actor.displayName.should.equal('Alice');
+    });
+  });
+
   describe('entity.update.version (via API) audit event', () => {
     beforeEach(() => {
       testData.extendedEntityVersions.createPast(1);

--- a/test/components/entity/version-link.spec.js
+++ b/test/components/entity/version-link.spec.js
@@ -35,6 +35,14 @@ describe('EntityVersionLink', () => {
     mountComponent().text().should.equal('Update by Alice');
   });
 
+  it('shows the filename and actor if the entity source is bulk upload', () => {
+    testData.extendedUsers.createPast(1, { displayName: 'Alice' });
+    testData.extendedEntities.createPast(1, {
+      source: { name: 'my_file.csv', size: 100 } // size not used
+    });
+    mountComponent().text().should.equal('File my_file.csv uploaded by Alice');
+  });
+
   describe('entity source is a submission', () => {
     it('shows the instance name if the submission has one', () => {
       const { submission } = testData.extendedEntities

--- a/test/components/entity/version-link.spec.js
+++ b/test/components/entity/version-link.spec.js
@@ -40,7 +40,7 @@ describe('EntityVersionLink', () => {
     testData.extendedEntities.createPast(1, {
       source: { name: 'my_file.csv', size: 100 } // size not used
     });
-    mountComponent().text().should.equal('File my_file.csv uploaded by Alice');
+    mountComponent().text().should.equal('File my_file.csv upload by Alice');
   });
 
   describe('entity source is a submission', () => {

--- a/test/data/audits.js
+++ b/test/data/audits.js
@@ -10,6 +10,7 @@ import { toActor } from './actors';
 const actionsWithDefaultActor = new Set([
   'config.set',
   'entity.create',
+  'entity.bulk.create',
   'entity.update.version',
   'entity.update.resolve',
   'submission.create',

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1729,6 +1729,9 @@
             "api": {
               "string": "Entity {label} created by {name}",
               "developer_comment": "This text is shown in a list of events. {name} is the name of a Web User."
+            },
+            "bulkSource": {
+              "string": "File {name} uploaded by {actor}"
             }
           },
           "update_version": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1956,6 +1956,10 @@
       "api": {
         "string": "Update by {name}",
         "developer_comment": "This refers to an update to an Entity. {name} is the name of a Web User."
+      },
+      "bulk": {
+        "string": "File {filename} uploaded by {name}",
+        "developer_comment": "This refers to creation of an Entity. {filename} is the name of an uploaded file containing the Entity. {name} is the name of a Web User."
       }
     },
     "FieldKeyList": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1542,6 +1542,14 @@
         "string": "Creating Submission",
         "developer_comment": "This is shown above the Submission that created the Entity."
       },
+      "creatingSource": {
+        "string": "Creating Source",
+        "developer_comment": "This is shown above the source (e.g. a CSV file) that created the entity"
+      },
+      "upload": {
+        "string": "Upload",
+        "developer_comment": "This describes an \"upload\" being a generic source of an entity"
+      },
       "submissionDeleted": {
         "string": "This Submission has been deleted."
       }

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1543,7 +1543,7 @@
         "developer_comment": "This is shown above the Submission that created the Entity."
       },
       "creatingSource": {
-        "string": "Creating Source",
+        "string": "Creating source",
         "developer_comment": "This is shown above the source (e.g. a CSV file) that created the entity"
       },
       "upload": {
@@ -1739,7 +1739,8 @@
               "developer_comment": "This text is shown in a list of events. {name} is the name of a Web User."
             },
             "bulkSource": {
-              "string": "File {name} uploaded by {actor}"
+              "string": "File {name} uploaded by {actor}",
+              "developer_comment": "This text is shown in a list of events. {name} is a filename, e.g. myfile.csv, and {actor} is a name/link to a Web User."
             }
           },
           "update_version": {
@@ -1966,7 +1967,7 @@
         "developer_comment": "This refers to an update to an Entity. {name} is the name of a Web User."
       },
       "bulk": {
-        "string": "File {filename} uploaded by {name}",
+        "string": "File {filename} upload by {name}",
         "developer_comment": "This refers to creation of an Entity. {filename} is the name of an uploaded file containing the Entity. {name} is the name of a Web User."
       }
     },


### PR DESCRIPTION
Closes getodk/central#583

### Activity Feed
Entity create event from bulk upload:
<img width="670" alt="Screenshot 2024-02-28 at 10 58 13 AM" src="https://github.com/getodk/central-frontend/assets/76205/dd3cfa19-b64f-4b7e-a3c2-ba69219e4b05">

I wanted to point out that an entity created from a submission looks like this:
<img width="667" alt="Screenshot 2024-02-28 at 10 58 19 AM" src="https://github.com/getodk/central-frontend/assets/76205/4d2ad83d-c8a8-4834-bbce-2597c309302f">

In the submission case, there really is a separate source event to show. In the bulk entity upload case, it is literally the same event. We get the submission event off the entity create event and artificially insert it into the activity feed.

We _could_ pretend there are two events, but I wasn't sure how the one event should be broken down or if it was even worth it.

Possibility (show size, too):
<img width="847" alt="Screenshot 2024-02-28 at 10 55 33 AM" src="https://github.com/getodk/central-frontend/assets/76205/3655bafb-897f-4240-ad23-9c8121b448d9">

### Conflict Tables

<img width="838" alt="Screenshot 2024-02-28 at 11 31 47 AM" src="https://github.com/getodk/central-frontend/assets/76205/1b5428ea-feb5-4353-a06c-a464ed80b3d8">

<img width="834" alt="Screenshot 2024-02-28 at 11 34 44 AM" src="https://github.com/getodk/central-frontend/assets/76205/a28bd732-0e5d-47cd-93c7-f194bf62f9e4">

### Basic Information

<img width="296" alt="Screenshot 2024-02-28 at 1 15 26 PM" src="https://github.com/getodk/central-frontend/assets/76205/478ecf34-50f0-4d30-a553-0c69c39589a9">



<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced