### PR TITLE
Show custom alert message for 404.1 Problem

### DIFF
--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -435,7 +435,12 @@
       "noRequest": "Something went wrong: there was no request.",
       "noResponse": "Something went wrong: there was no response to your request.",
       // {status} is an HTTP status code, for example, 404.
-      "errorNotProblem": "Something went wrong: error code {status}."
+      "errorNotProblem": "Something went wrong: error code {status}.",
+      "problem": {
+        // A "resource" is a generic term for something in Central, for example,
+        // a Project, a Web User, or a Form.
+        "404_1": "The resource you are looking for cannot be found. The resource may have been deleted."
+      }
     },
     "session": {
       "alert": {

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -231,7 +231,8 @@ export const requestAlertMessage = (i18n, axiosError, problemToAlert = undefined
   const problem = response.data;
   if (problemToAlert != null) {
     const message = problemToAlert(problem);
-    return message != null ? message : problem.message;
+    if (message != null) return message;
   }
+  if (problem.code === 404.1) return i18n.t('util.request.problem.404_1');
   return problem.message;
 };

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -632,6 +632,13 @@ describe('util/request', () => {
       message.should.equal('Message from API');
     });
 
+    describe('custom messages for specific Problems', () => {
+      it('returns a message for a 404.1', () => {
+        const message = requestAlertMessage(i18n, errorWithProblem(404.1));
+        message.should.equal('The resource you are looking for cannot be found. The resource may have been deleted.');
+      });
+    });
+
     describe('problemToAlert', () => {
       it('returns the message from the function', () => {
         const message = requestAlertMessage(
@@ -643,7 +650,7 @@ describe('util/request', () => {
         message.should.equal('Message from problemToAlert: Message from API (500.1)');
       });
 
-      it('returns the Problem message if the function returns null', () => {
+      it('falls back to default message if function returns a nullish value', () => {
         const message = requestAlertMessage(
           i18n,
           errorWithProblem(),

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -913,6 +913,12 @@
       "errorNotProblem": {
         "string": "Something went wrong: error code {status}.",
         "developer_comment": "{status} is an HTTP status code, for example, 404."
+      },
+      "problem": {
+        "404_1": {
+          "string": "The resource you are looking for cannot be found. The resource may have been deleted.",
+          "developer_comment": "A \"resource\" is a generic term for something in Central, for example, a Project, a Web User, or a Form."
+        }
       }
     },
     "session": {


### PR DESCRIPTION
@srujner found at getodk/central#591 that with entity deletion in place, there are cases in which a user will see a 404.1 Problem in Frontend. Example: two users are viewing the entities table; the first user deletes an entity; then the second clicks More for the same entity; the second user will see a 404.1 Problem on the entity details page. @srujner and I discussed that it'd be helpful to explicitly mention in the 404.1 Problem the possibility that the resource has been deleted. In this PR, Frontend will show a custom alert message along those lines if it receives a 404.1 Problem. I asked @alyblenkin about the specific text of the message. A nice side effect of this PR is that the message will also be translated.

#### What has been done to verify that this works as intended?

A new unit test. I also verified locally that the custom message was shown for a 404.1 Problem. I don't think this change needs to be verified by the QA team.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced