### PR TITLE
Replace jQuery in FormAttachmentPopups

### DIFF
--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -155,7 +155,7 @@ export default {
   },
   updated() {
     if (this.shownAfterSelection)
-      $(this.$refs.popups).find('.btn-primary').focus();
+      this.$refs.popups.querySelector('.btn-primary').focus();
   }
 };
 </script>


### PR DESCRIPTION
I was looking at `FormAttachmentPopups` for inspiration while working on the pop-ups for getodk/central#589. I noticed a line of jQuery in `FormAttachmentPopups` that was easy to replace. I think this is one of our last lines of jQuery outside of our use of Bootstrap plugins.

#### What has been done to verify that this works as intended?

I didn't check things locally, but tests continue to pass. It does look like there are tests that assert that the button is focused.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced