### PR TITLE
Add CSV utility functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "luxon": "~1",
         "marked": "~4",
         "pako": "~1.0",
+        "papaparse": "^5.4.1",
         "pinia": "^2.0.23",
         "qrcode-generator": "~1",
         "ramda": "~0.27",
@@ -8824,6 +8825,11 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -19574,6 +19580,11 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "luxon": "~1",
     "marked": "~4",
     "pako": "~1.0",
+    "papaparse": "^5.4.1",
     "pinia": "^2.0.23",
     "qrcode-generator": "~1",
     "ramda": "~0.27",

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -436,6 +436,9 @@
       "readError": "There was a problem reading your CSV file: {message}",
       // {row} is a row number. {message} is a description of the problem.
       "rowError": "There is a problem on row {row} of the CSV file: {message}",
+      // This is an error that is shown for a CSV file. The field may be any
+      // cell in the file.
+      "invalidQuotes": "A quoted field is invalid.",
       // This is an error that is shown for a data file. {expected} and {actual}
       // are each a number of columns. The string will be pluralized based on
       // {expected}.

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -438,7 +438,7 @@
       "rowError": "There is a problem on row {row} of the CSV file: {message}",
       // This is an error that is shown for a CSV file. The field may be any
       // cell in the file.
-      "invalidQuotes": "A quoted field is invalid.",
+      "invalidQuotes": "A quoted field is invalid. Check the row to see if there are any unusual values.",
       // This is an error that is shown for a data file. {expected} and {actual}
       // are each a number of columns. The string will be pluralized based on
       // {expected}.

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -431,6 +431,16 @@
     }
   },
   "util": {
+    "csv": {
+      // {message} is a description of the problem.
+      "readError": "There was a problem reading your CSV file: {message}",
+      // {row} is a row number. {message} is a description of the problem.
+      "rowError": "There is a problem on row {row} of the CSV file: {message}",
+      // This is an error that is shown for a data file. {expected} and {actual}
+      // are each a number of columns. The string will be pluralized based on
+      // {expected}.
+      "dataWithoutHeader": "Expected {expected} column, but found {actual}. | Expected {expected} columns, but found {actual}."
+    },
     "request": {
       "noRequest": "Something went wrong: there was no request.",
       "noResponse": "Something went wrong: there was no response to your request.",

--- a/src/util/abort.js
+++ b/src/util/abort.js
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+import { always } from 'ramda';
+import { noop } from './util';
+
+export const rejectOnAbort = (signal, reject) => {
+  if (signal.aborted) {
+    reject(new Error('aborted'));
+    return noop;
+  }
+
+  const listener = () => {
+    reject(new Error('aborted'));
+    signal.removeEventListener('abort', listener);
+  };
+  signal.addEventListener('abort', listener);
+  return () => { signal.removeEventListener('abort', listener); };
+};
+
+export const mockSignal = always({
+  aborted: false,
+  addEventListener: noop,
+  removeEventListener: noop
+});

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -48,7 +48,8 @@ const promiseParse = (i18n, file, signal = mockSignal(), papaOptions = {}) => {
       complete: (maybeResults) => {
         removeAbortListener();
         if (!(hasError || signal.aborted)) resolve(maybeResults);
-      }
+      },
+      ...papaOptions
     };
     const streamOption = 'step' in papaOptions
       ? 'step'

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -180,11 +180,17 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
   try {
     await promiseParse(i18n, file, signal, {
       chunk: ({ data: chunkData, errors }) => {
-        // I'm not sure that an error is actually possible here.
-        // UndectableDelimiter, TooFewFields, and TooManyFields shouldn't be
-        // possible. I've also only ever seen Papa Parse return a MissingQuotes
-        // or InvalidQuotes error for the header.
-        if (errors.length !== 0) throw errors[0];
+        if (errors.length !== 0) {
+          const error = errors[0];
+          // I think MissingQuotes and InvalidQuotes are the only errors that
+          // are possible here: UndetectableDelimiter, TooFewFields, and
+          // TooManyFields should not be possible.
+          const i18nError = new Error(error.type === 'Quotes'
+            ? i18n.t('util.csv.invalidQuotes')
+            : error.message);
+          i18nError.row = error.row;
+          throw i18nError;
+        }
 
         // Skip the header.
         if (rowIndex === 0) {

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -1,0 +1,241 @@
+/*
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+import Papa from 'papaparse';
+import { identity, last } from 'ramda';
+
+import { mockSignal, rejectOnAbort } from './abort';
+
+/*
+promiseParse() calls Papa.parse(), returning a promise. It sets up basic error
+handling: if there is a file read error, or if the AbortSignal is aborted, then
+the promise will be rejected. Other errors from Papa Parse will not result in a
+rejected promise, as they are sometimes needed alongside the data. Instead, they
+are returned in the Papa Parse results object. If streaming is used, then
+additional error handling is possible: if an error is thrown in the step() or
+chunk() callback, then the promise will be rejected.
+*/
+const promiseParse = (i18n, file, signal = mockSignal(), papaOptions = {}) => {
+  if (papaOptions.complete != null)
+    throw new Error('Option complete not allowed: call then() on the promise instead.');
+  if (papaOptions.error != null)
+    throw new Error('Option error not allowed: call catch() on the promise instead');
+
+  return new Promise((resolve, reject) => {
+    const removeAbortListener = rejectOnAbort(signal, reject);
+    if (signal.aborted) return;
+    let hasError = false;
+    const fullOptions = {
+      delimiter: ',',
+      // Called for a FileReader error.
+      error: (error) => {
+        if (signal.aborted) return;
+        hasError = true;
+        // I can't tell whether complete() will be called, so let's clean up
+        // here.
+        removeAbortListener();
+        reject(new Error(i18n.t('util.csv.readError', error)));
+      },
+      // Results are not passed in if streaming is used.
+      complete: (maybeResults) => {
+        removeAbortListener();
+        if (!(hasError || signal.aborted)) resolve(maybeResults);
+      }
+    };
+    const streamOption = 'step' in papaOptions
+      ? 'step'
+      : ('chunk' in papaOptions ? 'chunk' : null);
+    if (streamOption != null) {
+      const callback = papaOptions[streamOption];
+      fullOptions[streamOption] = (results, parser) => {
+        if (hasError || signal.aborted) {
+          // This seems to call complete() immediately.
+          parser.abort();
+          return;
+        }
+
+        try {
+          callback(results);
+        } catch (error) {
+          hasError = true;
+          parser.abort();
+          reject(error);
+        }
+      };
+    }
+    Papa.parse(file, fullOptions);
+  });
+};
+
+// `signal` is an AbortSignal.
+export const parseCSVHeader = async (i18n, file, signal = undefined) => {
+  const { data, errors } = await promiseParse(i18n, file, signal, {
+    preview: 1
+  });
+  const columns = data[0];
+  if (errors.length === 0) {
+    // Trailing empty cells are not uncommon, so we remove them. But if there
+    // was an error, we preserve the empty cells so that the user can be shown
+    // something closer to the exact header as it is.
+    while (columns.length !== 0 && last(columns) === '') columns.pop();
+  }
+  return { columns, errors };
+};
+
+// Each of these warning functions returns an object to check a CSV file for a
+// particular warning. After the object is passed each row, it will indicate
+// whether the warning applies and return details about it.
+const raggedRowsWarning = (columns) => {
+  // 0-indexed row numbers of rows where commas are skipped when the last values
+  // are empty
+  const ragged = [];
+  // Is there a row where commas are present when the last values are empty?
+  let anyPadded = false;
+  const pushRow = (values, i) => {
+    if (values.length < columns.length) {
+      if (ragged.length <= 100) ragged.push(i);
+    } else if (values.length === columns.length && last(values) === '') {
+      anyPadded = true;
+    }
+  };
+  return {
+    type: 'raggedRows',
+    pushRow,
+    hasWarning: () => ragged.length !== 0 && anyPadded,
+    get details() { return ragged; }
+  };
+};
+const largeCellWarning = () => {
+  // The size and 0-indexed row number of the largest cell containing a comma or
+  // newline
+  const largestCell = { size: 0, row: -1 };
+  // The sizes of the two largest rows (descending order)
+  const maxRowSizes = [0, 0];
+  const pushRow = (values, i) => {
+    let rowSize = 0;
+    for (const value of values) {
+      rowSize += value.length;
+      if (value.length > largestCell.size && value.search(/[,\n\r]/) !== -1) {
+        largestCell.size = value.length;
+        largestCell.row = i;
+      }
+    }
+    if (rowSize > maxRowSizes[1]) {
+      if (rowSize > maxRowSizes[0]) {
+        // eslint-disable-next-line prefer-destructuring
+        maxRowSizes[1] = maxRowSizes[0];
+        maxRowSizes[0] = rowSize;
+      } else {
+        maxRowSizes[1] = rowSize;
+      }
+    }
+  };
+  return {
+    type: 'largeCell',
+    pushRow,
+    hasWarning: () => largestCell.size > maxRowSizes[1],
+    get details() { return largestCell.row; }
+  };
+};
+
+// `columns` is the CSV header as an array.
+export const parseCSV = async (i18n, file, columns, options = {}) => {
+  const {
+    // Function to validate and transform the data of a row. If the function
+    // throws an error, it will result in a rejected promise.
+    transformRow = identity,
+    // An AbortSignal
+    signal = undefined
+  } = options;
+
+  const data = [];
+  const warnings = [raggedRowsWarning(columns), largeCellWarning()];
+
+  let rowIndex = 0;
+  const processRow = (values) => {
+    // Remove trailing empty cells.
+    while (values.length > columns.length && last(values) === '') values.pop();
+    if (values.length > columns.length) {
+      const counts = {
+        expected: i18n.n(columns.length, 'default'),
+        actual: i18n.n(values.length, 'default')
+      };
+      throw new Error(i18n.t('util.csv.dataWithoutHeader', counts, columns.length));
+    }
+
+    data.push(transformRow(values, columns));
+    for (const warning of warnings) warning.pushRow(values, rowIndex, columns);
+    rowIndex += 1;
+  };
+
+  try {
+    await promiseParse(i18n, file, signal, {
+      chunk: ({ data: chunkData, errors }) => {
+        // I'm not sure that an error is actually possible here.
+        // UndectableDelimiter, TooFewFields, and TooManyFields shouldn't be
+        // possible. I've also only ever seen Papa Parse return a MissingQuotes
+        // or InvalidQuotes error for the header.
+        if (errors.length !== 0) throw errors[0];
+
+        // Skip the header.
+        if (rowIndex === 0) {
+          chunkData.shift();
+          rowIndex += 1;
+        }
+
+        for (const values of chunkData) processRow(values);
+      },
+      worker: true
+    });
+  } catch (error) {
+    throw new Error(i18n.t('util.csv.rowError', {
+      message: error.message,
+      row: i18n.n((error.row ?? rowIndex) + 1, 'default')
+    }));
+  }
+
+  const warningDetails = { count: 0 };
+  for (const warning of warnings) {
+    if (warning.hasWarning()) {
+      warningDetails.count += 1;
+      warningDetails[warning.type] = warning.details;
+    }
+  }
+
+  return { data, warnings: warningDetails };
+};
+
+// truncateRow() truncates an array of strings, returning a new array whose
+// number of elements and combined size do not exceed the maximum.
+const truncateRow = (values, { maxLength = 100000, maxSize = 1000000 }) => {
+  // The length of the truncated array
+  let length = 0;
+  const minMaxLength = Math.min(values.length, maxLength);
+  let size = 0;
+  while (length < minMaxLength && size < maxSize) {
+    size += values[length].length;
+    length += 1;
+  }
+  const truncated = values.slice(0, length);
+  if (size > maxSize) {
+    truncated[length - 1] = truncated[length - 1]
+      .slice(0, maxSize - size)
+      .concat('…');
+  } else if (length < values.length) {
+    truncated.push('…');
+  }
+  return truncated;
+};
+
+// formatCSVRow() formats an array of strings as a CSV row. It is intended for
+// display purposes only: the data may be truncated.
+export const formatCSVRow = (values, options = {}) =>
+  Papa.unparse([truncateRow(values, options)]);

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -222,7 +222,7 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
 
 // truncateRow() truncates an array of strings, returning a new array whose
 // number of elements and combined size do not exceed the maximum.
-const truncateRow = (values, { maxLength = 100000, maxSize = 1000000 }) => {
+const truncateRow = (values, { maxLength = 10000, maxSize = 10000 }) => {
   // The length of the truncated array
   let length = 0;
   const minMaxLength = Math.min(values.length, maxLength);

--- a/test/unit/abort.spec.js
+++ b/test/unit/abort.spec.js
@@ -1,0 +1,35 @@
+import sinon from 'sinon';
+
+import { rejectOnAbort } from '../../src/util/abort';
+
+describe('util/abort', () => {
+  describe('rejectOnAbort()', () => {
+    it('rejects if the signal is already aborted', () => {
+      const controller = new AbortController();
+      controller.abort();
+      const reject = sinon.fake();
+      rejectOnAbort(controller.signal, reject);
+      reject.callCount.should.equal(1);
+      reject.firstArg.should.be.an.Error();
+    });
+
+    it('rejects if the signal becomes aborted', () => {
+      const controller = new AbortController();
+      const reject = sinon.fake();
+      rejectOnAbort(controller.signal, reject);
+      reject.callCount.should.equal(0);
+      controller.abort();
+      reject.callCount.should.equal(1);
+      reject.firstArg.should.be.an.Error();
+    });
+
+    it('returns a function to remove the event listener', () => {
+      const controller = new AbortController();
+      const reject = sinon.fake();
+      const removeListener = rejectOnAbort(controller.signal, reject);
+      removeListener();
+      controller.abort();
+      reject.callCount.should.equal(0);
+    });
+  });
+});

--- a/test/unit/csv.spec.js
+++ b/test/unit/csv.spec.js
@@ -78,17 +78,17 @@ describe('util/csv', () => {
     describe('quote error', () => {
       it('returns a rejected promise', () => {
         const promise = parseCSV(i18n, createCSV('a\n"1"2"'), ['a']);
-        return promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: A quoted field is invalid.');
+        return promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: A quoted field is invalid. Check the row to see if there are any unusual values.');
       });
 
       it('indicates correct row number if error is not in first row', () => {
         const promise = parseCSV(i18n, createCSV('a\n1\n"2"3"'), ['a']);
-        return promise.should.be.rejectedWith('There is a problem on row 3 of the CSV file: A quoted field is invalid.');
+        return promise.should.be.rejectedWith(/^There is a problem on row 3 /);
       });
 
       it('indicates the first row with an error', () => {
         const promise = parseCSV(i18n, createCSV('a\n"1"2"\n"3"4"'), ['a']);
-        return promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: A quoted field is invalid.');
+        return promise.should.be.rejectedWith(/^There is a problem on row 2 /);
       });
     });
 

--- a/test/unit/csv.spec.js
+++ b/test/unit/csv.spec.js
@@ -1,0 +1,206 @@
+import sinon from 'sinon';
+import { identity } from 'ramda';
+
+import createCentralI18n from '../../src/i18n';
+import { formatCSVRow, parseCSV, parseCSVHeader } from '../../src/util/csv';
+import { noop } from '../../src/util/util';
+
+const i18n = createCentralI18n().global;
+const createCSV = (text) => new File([text], 'my_data.csv');
+
+describe('util/csv', () => {
+  describe('parseCSVHeader()', () => {
+    it('returns the values of the first row', async () => {
+      const csv = createCSV('a,"b,c","d\ne"\n1,2,3');
+      const { columns } = await parseCSVHeader(i18n, csv);
+      columns.should.eql(['a', 'b,c', 'd\ne']);
+    });
+
+    it('does not return trailing empty cells', async () => {
+      const { columns } = await parseCSVHeader(i18n, createCSV('a,"",'));
+      columns.should.eql(['a']);
+    });
+
+    it('returns an error for a missing quote', async () => {
+      const { errors } = await parseCSVHeader(i18n, createCSV('"a\n1'));
+      errors.length.should.equal(1);
+      errors[0].code.should.equal('MissingQuotes');
+    });
+
+    describe('abort signal', () => {
+      it('returns a rejected promise if the signal is already aborted', () => {
+        const abortController = new AbortController();
+        abortController.abort();
+        const { signal } = abortController;
+        const promise = parseCSVHeader(i18n, createCSV('a'), signal);
+        return promise.should.be.rejected();
+      });
+
+      it('returns a rejected promise if the signal becomes aborted', () => {
+        const abortController = new AbortController();
+        const { signal } = abortController;
+        const promise = parseCSVHeader(i18n, createCSV('a'), signal);
+        abortController.abort();
+        return promise.should.be.rejected();
+      });
+    });
+  });
+
+  describe('parseCSV()', () => {
+    it('returns the data', async () => {
+      const csv = createCSV('a,b\n1,2\n"3,4","5\n6"');
+      const { data } = await parseCSV(i18n, csv, ['a', 'b']);
+      data.should.eql([['1', '2'], ['3,4', '5\n6']]);
+    });
+
+    describe('number of cells', () => {
+      it('allows a row to be ragged', async () => {
+        const csv = createCSV('a,b\n1,2\n3');
+        const { data } = await parseCSV(i18n, csv, ['a', 'b']);
+        data.should.eql([['1', '2'], ['3']]);
+      });
+
+      it('returns a rejected promise if there are too many cells', async () => {
+        const promise = parseCSV(i18n, createCSV('a\n1,2'), ['a']);
+        return promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: Expected 1 column, but found 2.');
+      });
+
+      it('does not reject for an empty cell after last column', async () => {
+        const { data } = await parseCSV(i18n, createCSV('a\n1,""'), ['a']);
+        data.should.eql([['1']]);
+      });
+
+      it('returns an empty cell in the last column', async () => {
+        const csv = createCSV('a,b\n1,""');
+        const { data } = await parseCSV(i18n, csv, ['a', 'b']);
+        data.should.eql([['1', '']]);
+      });
+    });
+
+    describe('transformRow option', () => {
+      it('transforms the data', async () => {
+        const csv = createCSV('a,b\n1,2\n3,4');
+        const { data } = await parseCSV(i18n, csv, ['a', 'b'], {
+          transformRow: ([a, b]) => ({ a, b })
+        });
+        data.should.eql([{ a: '1', b: '2' }, { a: '3', b: '4' }]);
+      });
+
+      it('returns a rejected promise if function throws an error', async () => {
+        const promise = parseCSV(i18n, createCSV('a\n1'), ['a'], {
+          transformRow: () => { throw new Error('foo'); }
+        });
+        promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: foo');
+      });
+    });
+
+    describe('abort signal', () => {
+      it('returns a rejected promise if the signal is already aborted', () => {
+        const abortController = new AbortController();
+        abortController.abort();
+        const { signal } = abortController;
+        const promise = parseCSV(i18n, createCSV('a\n1'), ['a'], { signal });
+        return promise.should.be.rejected();
+      });
+
+      it('returns a rejected promise if the signal becomes aborted', () => {
+        const abortController = new AbortController();
+        const { signal } = abortController;
+        const promise = parseCSV(i18n, createCSV('a\n1'), ['a'], { signal });
+        abortController.abort();
+        return promise.should.be.rejected();
+      });
+
+      it('does not call transformRow if the signal is aborted', async () => {
+        const csv = createCSV('a\n1');
+        const transformRow = sinon.fake(identity);
+        const abortController = new AbortController();
+        const { signal } = abortController;
+        const promise = parseCSV(i18n, csv, ['a'], { transformRow, signal });
+        abortController.abort();
+        await promise.catch(noop);
+        transformRow.called.should.be.false();
+      });
+    });
+
+    describe('warnings', () => {
+      it('returns a count of zero if there are no warnings', async () => {
+        const { warnings } = await parseCSV(i18n, createCSV('a\n1'), ['a']);
+        warnings.should.eql({ count: 0 });
+      });
+
+      describe('ragged row', () => {
+        it('returns ragged rows if another row is padded', async () => {
+          const csv = createCSV('a,b\n1\n2,""\n4');
+          const { warnings } = await parseCSV(i18n, csv, ['a', 'b']);
+          warnings.should.eql({ count: 1, raggedRows: [1, 3] });
+        });
+
+        it('does not return ragged rows if no row is padded', async () => {
+          const csv = createCSV('a,b\n1\n2,3\n4');
+          const { warnings } = await parseCSV(i18n, csv, ['a', 'b']);
+          warnings.should.eql({ count: 0 });
+        });
+      });
+
+      describe('large cell', () => {
+        it('returns the row of a relatively large cell that contains a comma', async () => {
+          const csv = createCSV('a\n1\n"2,3"');
+          const { warnings } = await parseCSV(i18n, csv, ['a']);
+          warnings.should.eql({ count: 1, largeCell: 2 });
+        });
+
+        it('returns the row of a relatively large cell that contains a newline', async () => {
+          const csv = createCSV('a\n1\n"2\n3"');
+          const { warnings } = await parseCSV(i18n, csv, ['a']);
+          warnings.should.eql({ count: 1, largeCell: 2 });
+        });
+
+        it('ignores cells that do not contain a comma or newline', async () => {
+          const csv = createCSV('a\n1\n"2.3"');
+          const { warnings } = await parseCSV(i18n, csv, ['a']);
+          warnings.should.eql({ count: 0 });
+        });
+
+        it('ignores cells that are not relatively large', async () => {
+          const csv = createCSV('a,b,c\n1,2,3\n"4,5",6');
+          const { warnings } = await parseCSV(i18n, csv, ['a', 'b', 'c']);
+          warnings.should.eql({ count: 0 });
+        });
+      });
+    });
+  });
+
+  describe('formatCSVRow()', () => {
+    it('returns a CSV string', () => {
+      formatCSVRow(['1', '2']).should.eql('1,2');
+    });
+
+    it('encloses commas in quotes', () => {
+      formatCSVRow(['1', '2,3', '4']).should.eql('1,"2,3",4');
+    });
+
+    it('escapes quotes', () => {
+      formatCSVRow(['1', '2"3', '4']).should.eql('1,"2""3",4');
+    });
+
+    it('truncates the string if there are too many elements', () => {
+      formatCSVRow(['1', '2', '3'], { maxLength: 2 }).should.eql('1,2,…');
+    });
+
+    it('truncates the string if it is too large', () => {
+      const values = ['1', '23', '456'];
+      formatCSVRow(values, { maxSize: 6 }).should.eql('1,23,456');
+      formatCSVRow(values, { maxSize: 5 }).should.eql('1,23,45…');
+      formatCSVRow(values, { maxSize: 4 }).should.eql('1,23,4…');
+      formatCSVRow(values, { maxSize: 3 }).should.eql('1,23,…');
+      formatCSVRow(values, { maxSize: 2 }).should.eql('1,2…');
+      formatCSVRow(values, { maxSize: 1 }).should.eql('1,…');
+    });
+
+    it('truncates the string if both are true', () => {
+      const values = ['1', '23', '456'];
+      formatCSVRow(values, { maxLength: 2, maxSize: 2 }).should.eql('1,2…');
+    });
+  });
+});

--- a/test/unit/csv.spec.js
+++ b/test/unit/csv.spec.js
@@ -75,6 +75,23 @@ describe('util/csv', () => {
       data.should.eql([['1', '2'], ['3', '4']]);
     });
 
+    describe('quote error', () => {
+      it('returns a rejected promise', () => {
+        const promise = parseCSV(i18n, createCSV('a\n"1"2"'), ['a']);
+        return promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: A quoted field is invalid.');
+      });
+
+      it('indicates correct row number if error is not in first row', () => {
+        const promise = parseCSV(i18n, createCSV('a\n1\n"2"3"'), ['a']);
+        return promise.should.be.rejectedWith('There is a problem on row 3 of the CSV file: A quoted field is invalid.');
+      });
+
+      it('indicates the first row with an error', () => {
+        const promise = parseCSV(i18n, createCSV('a\n"1"2"\n"3"4"'), ['a']);
+        return promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: A quoted field is invalid.');
+      });
+    });
+
     describe('number of cells', () => {
       it('allows a row to be ragged', async () => {
         const csv = createCSV('a,b\n1,2\n3');

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -913,7 +913,7 @@
         "developer_comment": "{row} is a row number. {message} is a description of the problem."
       },
       "invalidQuotes": {
-        "string": "A quoted field is invalid.",
+        "string": "A quoted field is invalid. Check the row to see if there are any unusual values.",
         "developer_comment": "This is an error that is shown for a CSV file. The field may be any cell in the file."
       },
       "dataWithoutHeader": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -912,6 +912,10 @@
         "string": "There is a problem on row {row} of the CSV file: {message}",
         "developer_comment": "{row} is a row number. {message} is a description of the problem."
       },
+      "invalidQuotes": {
+        "string": "A quoted field is invalid.",
+        "developer_comment": "This is an error that is shown for a CSV file. The field may be any cell in the file."
+      },
       "dataWithoutHeader": {
         "string": "{count, plural, one {Expected {expected} column, but found {actual}.} other {Expected {expected} columns, but found {actual}.}}",
         "developer_comment": "This is an error that is shown for a data file. {expected} and {actual} are each a number of columns. The string will be pluralized based on {expected}."

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -903,6 +903,20 @@
     }
   },
   "util": {
+    "csv": {
+      "readError": {
+        "string": "There was a problem reading your CSV file: {message}",
+        "developer_comment": "{message} is a description of the problem."
+      },
+      "rowError": {
+        "string": "There is a problem on row {row} of the CSV file: {message}",
+        "developer_comment": "{row} is a row number. {message} is a description of the problem."
+      },
+      "dataWithoutHeader": {
+        "string": "{count, plural, one {Expected {expected} column, but found {actual}.} other {Expected {expected} columns, but found {actual}.}}",
+        "developer_comment": "This is an error that is shown for a data file. {expected} and {actual} are each a number of columns. The string will be pluralized based on {expected}."
+      }
+    },
     "request": {
       "noRequest": {
         "string": "Something went wrong: there was no request."


### PR DESCRIPTION
This PR makes progress on getodk/central#589, adding utility functions related to CSV files. `parseCSVHeader()` parses the header row of a CSV file, `parseCSV()` parses the data, and `formatRow()` displays a row in CSV format.

#### What has been done to verify that this works as intended?

This PR just adds utility functions; it doesn't make user-facing changes. I've added unit tests of the utility functions.

#### Why is this the best possible solution? Were any other approaches considered?

##### npm package

One important decision was around which npm package to use for CSV parsing. I first tried `csv-parse`, since that's what we use on Backend. However, I ran into a couple of issues:

- I didn't see an easy way to stream the CSV file in the browser. In the examples of `csv-parse` use in the browser, a CSV _string_ is passed to the `parse()` function. Ideally, we'd be able to pass a `File` or a `FileReader` or a `ReadableStream` from `Blob.prototype.stream()`. It looks like there may be a way to convert a `File` to a Node-style stream that could be used with `csv-parse`, but I was hoping for something simpler. Related: adaltas/node-csv#242
- I had trouble parsing just the header row. When I tried using option `to`, I saw an error in the browser console: "Uncaught TypeError: "listener" argument must be a function". I think that error stems from adaltas/node-csv#333. That said, it looked like parsing was able to complete despite the error logging. But to avoid the error, I tried doing some preliminary parsing, grabbing the substring of the CSV string before the first newline character and passing that to `csv-parse`. That approach allowed me to avoid option `to`, but it's again at odds with streaming. It also won't return the correct result if a column header contains a newline.

I gave a different package Papa Parse a try instead, and I've been liking it. It's easy to stream the file, and I didn't have trouble parsing the header row. It also seems markedly faster than what I was doing with `csv-parse` (where I was calling `text()` on the `File`, then passing the resulting string to the `parse()` function). I tried parsing a file with 4 columns (3 properties + label):

\# rows | size | `csv-parse` time | Papa Parse time
--: | --: | :-- | :--
100,000 | 8 MB | 1.5s | 0.4s
1,000,000 | 80 MB | 14s | 2s

Another little benefit of Papa Parse is the ability to easily abort parsing. I'm planning to set it up so that if the user leaves the upload modal, any ongoing CSV parsing is aborted.

##### Parsing the header and data separately

As mentioned above, there are separate functions for parsing the header vs. parsing the data. `parseCSV()` parses the data and expects to receive an array of column headers. That array comes from parsing the header row using `parseCSVHeader()`.

I've set it up this way so that if there is an error in the header, the rest of the CSV file is not parsed. The upload modal will show errors about the header, and I want those to be shown as soon as the header has been parsed and validated.

That could still have been done in a single function, say, by passing a `validateHeader` option to the function. However, `parseCSV()` is already fairly complex, and I didn't want to make it even more so. `parseCSVHeader()` and `parseCSV()` also handle errors pretty differently. If Papa Parse finds errors in the header (of code `MissingQuotes` or `InvalidQuotes`), `parseCSVHeader()` will not return a rejected promise and will instead return the errors along with Papa Parse's best attempt to parse the header. That's because the upload modal will display both the errors and the header: the two are needed together. On the other hand, `parseCSV()` returns a rejected promise if there is an error with the data. In that case, the upload modal simply shows a danger alert. `parseCSV()` only returns data if it was successful. At that point, it may also return warnings about the data. `parseCSVHeader()` has no concept of warnings.

I don't think we lose much by separating `parseCSVHeader()` and `parseCSV()`. There end up being some conceptual differences between the two, so I think it's useful to do so.

##### Returning promises

Another part of the approach I took was to wrap Papa Parse in a promise. Papa Parse follows more of a callback pattern, but it is more convenient to work with promises. `parseCSVHeader()` and `parseCSV()` return promises, using Papa Parse callbacks under the hood. Also, Papa Parse provides its own API for aborting parsing, but in other places in Frontend (around requests), we use `AbortSignal`s. `parseCSVHeader()` and `parseCSV()` will accept an optional `AbortSignal`, then use the `AbortSignal` to trigger the abort mechanism in Papa Parse. That way, most code can just use promises and `AbortSignal`s, and for the most part, only src/util/csv.js needs to be concerned with the mechanics of Papa Parse.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced