### PR TITLE
Make changes to appearance of upload modal during request

### DIFF
--- a/src/components/entity/upload.vue
+++ b/src/components/entity/upload.vue
@@ -14,13 +14,15 @@ except according to the terms contained in the LICENSE file.
     size="full" backdrop @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
-      <entity-upload-file-select v-show="file == null" @change="selectFile">
-        <div>
-          <span>{{ $t('headersNote') }}</span>
-          <sentence-separator/>
-          <entity-upload-data-template/>
-        </div>
-      </entity-upload-file-select>
+      <div :class="{ backdrop: awaitingResponse }">
+        <entity-upload-file-select v-show="file == null" @change="selectFile">
+          <div>
+            <span>{{ $t('headersNote') }}</span>
+            <sentence-separator/>
+            <entity-upload-data-template/>
+          </div>
+        </entity-upload-file-select>
+      </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-primary"
           :aria-disabled="file == null || awaitingResponse" @click="upload">
@@ -94,6 +96,13 @@ const upload = () => {
 @keyframes tocorner {
   0% { transform: translate(-70px, -70px); }
   100% { transform: translate(0, 0); }
+}
+
+#entity-upload {
+  .backdrop {
+    opacity: 0.27;
+    pointer-events: none;
+  }
 }
 
 #entity-upload-popups {

--- a/src/components/entity/upload.vue
+++ b/src/components/entity/upload.vue
@@ -26,7 +26,7 @@ except according to the terms contained in the LICENSE file.
       <div class="modal-actions">
         <button type="button" class="btn btn-primary"
           :aria-disabled="file == null || awaitingResponse" @click="upload">
-          {{ $t('action.append') }} <spinner :state="awaitingResponse"/>
+          {{ $t('action.append') }}
         </button>
         <button type="button" class="btn btn-link"
           :aria-disabled="awaitingResponse" @click="$emit('hide')">
@@ -51,7 +51,6 @@ import EntityUploadFileSelect from './upload/file-select.vue';
 import EntityUploadPopup from './upload/popup.vue';
 import Modal from '../modal.vue';
 import SentenceSeparator from '../sentence-separator.vue';
-import Spinner from '../spinner.vue';
 
 import useRequest from '../../composables/request';
 import { apiPaths } from '../../util/request';

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -121,7 +121,8 @@ describe('EntityUpload', () => {
       .testStandardButton({
         button: '.modal-actions .btn-primary',
         disabled: ['.btn-link'],
-        modal: true
+        modal: true,
+        spinner: false
       });
   });
 

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -125,6 +125,24 @@ describe('EntityUpload', () => {
       });
   });
 
+  it('shows a backdrop during the request', () => {
+    testData.extendedDatasets.createPast(1);
+    return mockHttp()
+      .mount(EntityUpload, mountOptions())
+      .request(async (modal) => {
+        modal.find('.backdrop').exists().should.be.false();
+        await setFiles(modal.get('input'), [csv()]);
+        return modal.get('.modal-actions .btn-primary').trigger('click');
+      })
+      .beforeAnyResponse(modal => {
+        modal.find('.backdrop').exists().should.be.true();
+      })
+      .respondWithProblem()
+      .afterResponse(modal => {
+        modal.find('.backdrop').exists().should.be.false();
+      });
+  });
+
   describe('after a successful upload', () => {
     const upload = () => {
       testData.extendedDatasets.createPast(1);

--- a/test/util/http/common.js
+++ b/test/util/http/common.js
@@ -94,21 +94,20 @@ export function testModalToggles({
 ////////////////////////////////////////////////////////////////////////////////
 // STANDARD BUTTON THINGS
 
-export const assertStandardButton = (
-  component,
-  buttonSelector,
-  disabledSelectors,
+const assertStandardButton = (component, {
+  button: buttonSelector,
+  disabled: disabledSelectors,
   modal,
+  spinner: hasSpinner,
   awaitingResponse,
-  showsAlert
-) => {
+  alert: showsAlert
+}) => {
   const button = component.get(buttonSelector);
   (button.attributes('aria-disabled') === 'true').should.equal(awaitingResponse);
 
-  const spinners = component.findAllComponents(Spinner).filter(spinner =>
-    button.element.contains(spinner.element));
-  spinners.length.should.equal(1);
-  spinners[0].props().state.should.equal(awaitingResponse);
+  const spinner = button.findComponent(Spinner);
+  spinner.exists().should.equal(hasSpinner);
+  if (hasSpinner) spinner.props().state.should.equal(awaitingResponse);
 
   for (const selector of disabledSelectors) {
     const wrapper = component.get(selector);
@@ -140,10 +139,16 @@ export function testStandardButton({
   // Specifies a modal that should not be hideable during the request. If the
   // series' component is a modal, specify `true`. Otherwise, specify the modal
   // component.
-  modal = undefined
+  modal = undefined,
+  // `true` if the button is expected to contain a spinner and `false` if not.
+  spinner = true
 }) {
-  const assert = (awaitingResponse, showsModal) => (component) =>
-    assertStandardButton(component, button, disabled, modal, awaitingResponse, showsModal);
+  const assert = (awaitingResponse, alert) => (component) => {
+    assertStandardButton(
+      component,
+      { button, disabled, modal, spinner, awaitingResponse, alert }
+    );
+  };
   let series = this;
   if (request != null) {
     series = series.request(component => {


### PR DESCRIPTION
This PR makes progress on getodk/central#589. It makes a couple of changes to how the modal appears during the upload request:

- The content of the modal is grayed out during the request.
- A spinner is not shown in the "Append data" button during the request.
  - This is consistent with the release criteria, which don't show a spinner in the button. It makes sense to me that there isn't a spinner in the button, since the pop-up has a more visible spinner.

#### What has been done to verify that this works as intended?

New tests. Currently, the modal doesn't show any content during the request, so it's not easy to verify the first change manually.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced