### PR TITLE
Request server data to show in table in EntityUpload

### DIFF
--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -222,17 +222,20 @@ export const standardEntities = view(entities, (entity) =>
   omit(['creator'], combineEntityWithVersions(entity)));
 
 // Converts entity response objects to OData.
-export const entityOData = (top = 250, skip = 0) => {
+export const entityOData = (top = 250, skip = 0, asc = false) => {
   if (extendedDatasets.size === 0) throw new Error('dataset not found');
   // There needs to be exactly one dataset for us to be able to identify the
   // correct one.
   if (extendedDatasets.size > 1) throw new Error('too many datasets');
-  const { properties } = extendedDatasets.last();
 
+  const sorted = extendedEntities.sorted();
+  if (asc) sorted.reverse();
+
+  const { properties } = extendedDatasets.last();
   return {
     '@odata.count': extendedEntities.size,
     '@odata.nextLink': top > 0 && (top + skip < extendedEntities.size) ? `https://test/Entities?$top=${top}&$skipToken=thetoken` : undefined,
-    value: extendedEntities.sorted().slice(skip, skip + top).map(entity => {
+    value: sorted.slice(skip, skip + top).map(entity => {
       const result = {
         label: entity.currentVersion.label,
         __id: entity.uuid,


### PR DESCRIPTION
This PR makes progress on getodk/central#589, sending the request for the server data table.

#### What has been done to verify that this works as intended?

New tests. Currently, the request is sent, but the data isn't shown: the table will be added later.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced