### PR TITLE
Reset conflict filter after entities are uploaded

### DIFF
--- a/src/components/dataset/entities.vue
+++ b/src/components/dataset/entities.vue
@@ -85,7 +85,7 @@ export default {
     afterUpload(count) {
       this.upload.hide();
       this.alert.success(this.$t('alert.upload'));
-      this.$refs.list.refreshWithClear();
+      this.$refs.list.reset();
       // Update dataset.entities so that the count in the OData loading message
       // reflects the new entities.
       this.dataset.entities += count;

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -160,10 +160,12 @@ export default {
     }
   },
   watch: {
-    odataFilter: 'refreshWithClear'
+    odataFilter() {
+      this.fetchChunk(true);
+    }
   },
   created() {
-    this.refreshWithClear();
+    this.fetchChunk(true);
   },
   mounted() {
     document.addEventListener('scroll', this.afterScroll);
@@ -199,8 +201,13 @@ export default {
         .catch(noop);
     },
     // This method is called directly by DatasetEntities.
-    refreshWithClear() {
-      this.fetchChunk(true);
+    reset() {
+      if (this.odataFilter == null)
+        this.fetchChunk(true);
+      else
+        // This change will cause the watcher on this.odataFilter to fetch
+        // entities.
+        this.conflict = [true, false];
     },
     showUpdate(index) {
       if (this.refreshing) return;


### PR DESCRIPTION
This PR makes progress on getodk/central#589. It resets the conflict filter after entities are uploaded. That way, the new entities will be shown in the table.

#### What has been done to verify that this works as intended?

New test. Currently, the modal doesn't send entity data, so this change isn't easy to verify manually.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced