### PR TITLE
Add feedback button

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -33,7 +33,6 @@ import { START_LOCATION } from 'vue-router';
 
 import Alert from './alert.vue';
 import Navbar from './navbar.vue';
-import FeedbackButton from './feedback-button.vue';
 
 import useCallWait from '../composables/call-wait';
 import useDisabled from '../composables/disabled';

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
     will affect how the navbar is rendered. -->
     <navbar v-show="routerReady"/>
     <alert id="app-alert"/>
-    <feedback-button/>
+    <feedback-button v-if="loggedIn"/>
     <!-- Specifying .capture so that an alert is not hidden immediately if it
     was shown after the click. -->
     <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
@@ -53,6 +53,10 @@ export default {
   computed: {
     routerReady() {
       return this.$route !== START_LOCATION;
+    },
+
+    loggedIn() {
+      return useRequestData().currentUser.dataExists && this.$route.path !== '/login';
     }
   },
   created() {

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -15,6 +15,7 @@ except according to the terms contained in the LICENSE file.
     will affect how the navbar is rendered. -->
     <navbar v-show="routerReady"/>
     <alert id="app-alert"/>
+    <feedback-button/>
     <!-- Specifying .capture so that an alert is not hidden immediately if it
     was shown after the click. -->
     <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
@@ -30,6 +31,7 @@ import { START_LOCATION } from 'vue-router';
 
 import Alert from './alert.vue';
 import Navbar from './navbar.vue';
+import FeedbackButton from './feedback-button.vue';
 
 import useCallWait from '../composables/call-wait';
 import useDisabled from '../composables/disabled';
@@ -38,7 +40,7 @@ import { useSessions } from '../util/session';
 
 export default {
   name: 'App',
-  components: { Alert, Navbar },
+  components: { Alert, Navbar, FeedbackButton },
   inject: ['alert'],
   setup() {
     useSessions();

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -45,20 +45,19 @@ export default {
   components: { Alert, Navbar, FeedbackButton: defineAsyncComponent(loadAsync('FeedbackButton')) },
   inject: ['alert', 'config'],
   setup() {
-    useSessions();
+    const { visiblyLoggedIn } = useSessions();
     useDisabled();
 
-    const { centralVersion, currentUser } = useRequestData();
+    const { centralVersion } = useRequestData();
     const { callWait } = useCallWait();
-    return { centralVersion, currentUser, callWait };
+    return { visiblyLoggedIn, centralVersion, callWait };
   },
   computed: {
     routerReady() {
       return this.$route !== START_LOCATION;
     },
-
     showsFeedbackButton() {
-      return this.config.showsFeedbackButton && this.currentUser.dataExists && this.$route.path !== '/login'
+      return this.config.showsFeedbackButton && this.visiblyLoggedIn;
     },
   },
   created() {

--- a/src/components/feedback-button.vue
+++ b/src/components/feedback-button.vue
@@ -28,12 +28,12 @@ const route = useRoute();
 
 const surveyLink = computed(() => {
   const query = queryString({
-    'st': '9hflqGrodnpWyS8g69dbORJ3RD8jSQChTBMaf7zpE5gaPElyDtKgAjI79y$zqctG',
+    st: '9hflqGrodnpWyS8g69dbORJ3RD8jSQChTBMaf7zpE5gaPElyDtKgAjI79y$zqctG',
     'd[/data/host]': window.location.host,
     'd[/data/page]': route.name
   });
 
- return `https://data.getodk.cloud/-/single/JLdODTs84WWsgibw4JOh0krbDenObgi${query}`;
+  return `https://data.getodk.cloud/-/single/JLdODTs84WWsgibw4JOh0krbDenObgi${query}`;
 });
 </script>
 

--- a/src/components/feedback-button.vue
+++ b/src/components/feedback-button.vue
@@ -16,14 +16,25 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { queryString } from '../util/request';
+
 defineOptions({
   name: 'FeedbackButton'
 });
 
-import { computed } from 'vue';
-import { useRoute } from 'vue-router';
+const route = useRoute();
 
-const surveyLink = computed(() => `https://data.getodk.cloud/-/single/JLdODTs84WWsgibw4JOh0krbDenObgi?st=9hflqGrodnpWyS8g69dbORJ3RD8jSQChTBMaf7zpE5gaPElyDtKgAjI79y$zqctG&d[/data/host]=${window.location.host}&d[/data/page]=${useRoute().name}`);
+const surveyLink = computed(() => {
+  const query = queryString({
+    'st': '9hflqGrodnpWyS8g69dbORJ3RD8jSQChTBMaf7zpE5gaPElyDtKgAjI79y$zqctG',
+    'd[/data/host]': window.location.host,
+    'd[/data/page]': route.name
+  });
+
+ return `https://data.getodk.cloud/-/single/JLdODTs84WWsgibw4JOh0krbDenObgi${query}`;
+});
 </script>
 
 <style lang="scss">

--- a/src/components/feedback-button.vue
+++ b/src/components/feedback-button.vue
@@ -1,0 +1,70 @@
+<!--
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+    <div id="feedback-button">
+      <a :href="surveyLink" target="_blank"><span>{{ $t('feedback') }}</span></a>
+    </div>
+</template>
+
+<script setup>
+defineOptions({
+  name: 'FeedbackButton'
+});
+
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+
+const surveyLink = computed(() => `https://data.getodk.cloud/-/single/JLdODTs84WWsgibw4JOh0krbDenObgi?st=9hflqGrodnpWyS8g69dbORJ3RD8jSQChTBMaf7zpE5gaPElyDtKgAjI79y$zqctG&d[/data/host]=${window.location.host}&d[/data/page]=${useRoute().name}`);
+</script>
+
+<style lang="scss">
+@import '../assets/scss/variables';
+
+#feedback-button span {
+  display: block;
+  background-color: white;
+  position: fixed;
+  z-index: 99999;
+  right: 0;
+  bottom: 100px;
+  height: 4em;
+  border: 2px solid;
+  border-color: #e3e4e4;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  text-align: center;
+  line-height: 2em;
+  cursor: pointer;
+  transform-origin: 50% 50%;
+  transform: translateX(50%) rotate(-90deg);
+  transition: right 0.25s;
+
+  color: $color-accent-primary;
+  font-size: 1em;
+  padding: 0em 1.25em 0 1.25em;
+}
+
+#feedback-button span:hover,
+#feedback-button span:focus {
+  right: 10px;
+}
+</style>
+
+  <i18n lang="json5">
+  {
+    "en": {
+      // Text for a hovering feedback button shown anchored to right of screen. If your language doesn't have a single word or short
+      // phrase for "feedback", consider something like "comments" or "reactions".
+      "feedback": "Feedback"
+    }
+  }
+  </i18n>

--- a/src/components/feedback-button.vue
+++ b/src/components/feedback-button.vue
@@ -65,7 +65,7 @@ const surveyLink = computed(() => {
 }
 
 #feedback-button span:hover,
-#feedback-button span:focus {
+#feedback-button:focus-within span {
   right: 10px;
 }
 </style>

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -25,7 +25,7 @@ except according to the terms contained in the LICENSE file.
           <router-link to="/" class="navbar-brand">ODK Central</router-link>
         </div>
         <div class="collapse navbar-collapse">
-          <navbar-links v-if="loggedIn"/>
+          <navbar-links v-if="visiblyLoggedIn"/>
           <div class="navbar-right">
             <a v-show="showsAnalyticsNotice" id="navbar-analytics-notice"
               href="#" @click.prevent="analyticsIntroduction.show()">
@@ -34,7 +34,7 @@ except according to the terms contained in the LICENSE file.
             <ul class="nav navbar-nav">
               <navbar-help-dropdown/>
               <navbar-locale-dropdown/>
-              <navbar-actions :logged-in="loggedIn"/>
+              <navbar-actions/>
             </ul>
           </div>
         </div>
@@ -67,7 +67,7 @@ export default {
     NavbarLinks,
     NavbarLocaleDropdown
   },
-  inject: ['config'],
+  inject: ['config', 'visiblyLoggedIn'],
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.
@@ -81,16 +81,8 @@ export default {
     };
   },
   computed: {
-    // Usually once the user is logged in (either after their session has been
-    // restored or after they have submitted the login form), we render a fuller
-    // navbar. However, if after submitting the login form, the user is
-    // redirected to outside Frontend, they will remain on /login until they are
-    // redirected. In that case, we do not render the fuller navbar.
-    loggedIn() {
-      return this.currentUser.dataExists && this.$route.path !== '/login';
-    },
     showsAnalyticsNotice() {
-      return this.config.showsAnalytics && this.loggedIn &&
+      return this.config.showsAnalytics && this.visiblyLoggedIn &&
         this.canRoute('/system/analytics') && this.analyticsConfig.dataExists &&
         this.analyticsConfig.isEmpty() &&
         Date.now() - Date.parse(this.currentUser.createdAt) >= /* 14 days */ 1209600000;

--- a/src/components/navbar/actions.vue
+++ b/src/components/navbar/actions.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <li v-if="!loggedIn" id="navbar-actions">
+  <li v-if="!visiblyLoggedIn" id="navbar-actions">
     <a href="#" @click.prevent>
       <span class="icon-user-circle-o"></span>{{ $t('notLoggedIn') }}
     </a>
@@ -44,13 +44,7 @@ import { useRequestData } from '../../request-data';
 
 export default {
   name: 'NavbarActions',
-  inject: ['container', 'alert', 'unsavedChanges'],
-  props: {
-    loggedIn: {
-      type: Boolean,
-      default: false
-    }
-  },
+  inject: ['container', 'alert', 'unsavedChanges', 'visiblyLoggedIn'],
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.

--- a/src/config.js
+++ b/src/config.js
@@ -16,5 +16,6 @@ export default {
     title: null,
     body: null
   },
-  oidcEnabled: process.env.VUE_APP_OIDC_ENABLED === 'true'
+  oidcEnabled: process.env.VUE_APP_OIDC_ENABLED === 'true',
+  showsFeedbackButton: true
 };

--- a/src/config.js
+++ b/src/config.js
@@ -17,5 +17,5 @@ export default {
     body: null
   },
   oidcEnabled: process.env.VUE_APP_OIDC_ENABLED === 'true',
-  showsFeedbackButton: true
+  showsFeedbackButton: false
 };

--- a/src/util/load-async.js
+++ b/src/util/load-async.js
@@ -87,6 +87,10 @@ const loaders = new Map()
     /* webpackChunkName: "component-entity-upload" */
     '../components/entity/upload.vue'
   )))
+  .set('FeedbackButton', loader(() => import(
+    /* webpackChunkName: "component-feedback-button" */
+    '../components/feedback-button.vue'
+  )))
   .set('FieldKeyList', loader(() => import(
     /* webpackChunkName: "component-field-key-list" */
     '../components/field-key/list.vue'

--- a/test/components/app.spec.js
+++ b/test/components/app.spec.js
@@ -6,6 +6,7 @@ import { logOut } from '../../src/util/session';
 
 import { load } from '../util/http';
 import { mockLogin } from '../util/session';
+import FeedbackButton from '../../src/components/feedback-button.vue';
 
 describe('App', () => {
   describe('change in Central version', () => {
@@ -221,4 +222,35 @@ describe('App', () => {
       app.should.alert();
     });
   });
+
+  describe('feedback button', () => {
+    it('is shown if a user is logged in and config is true', async () => {
+      const container = {
+        config: { showsFeedbackButton: true }
+      };
+      mockLogin();
+
+      const app = await load('/', { container })
+      app.findComponent(FeedbackButton).exists().should.be.true();
+    });
+
+    it('is hidden if a user is logged in and config is false', async () => {
+      const container = {
+        config: { showsFeedbackButton: false }
+      };
+      mockLogin();
+
+      const app = await load('/', { container })
+      app.findComponent(FeedbackButton).exists().should.be.false();
+    });
+
+    it('is hidden if no user is logged in and config is true', async () => {
+      const container = {
+        config: { showsFeedbackButton: true }
+      };
+
+      const app = await load('/', { container })
+      app.findComponent(FeedbackButton).exists().should.be.false();
+    });
+  })
 });

--- a/test/components/app.spec.js
+++ b/test/components/app.spec.js
@@ -230,7 +230,7 @@ describe('App', () => {
       };
       mockLogin();
 
-      const app = await load('/', { container })
+      const app = await load('/', { container });
       app.findComponent(FeedbackButton).exists().should.be.true();
     });
 
@@ -240,7 +240,7 @@ describe('App', () => {
       };
       mockLogin();
 
-      const app = await load('/', { container })
+      const app = await load('/', { container });
       app.findComponent(FeedbackButton).exists().should.be.false();
     });
 
@@ -249,8 +249,8 @@ describe('App', () => {
         config: { showsFeedbackButton: true }
       };
 
-      const app = await load('/', { container })
+      const app = await load('/', { container });
       app.findComponent(FeedbackButton).exists().should.be.false();
     });
-  })
+  });
 });

--- a/test/components/app.spec.js
+++ b/test/components/app.spec.js
@@ -249,7 +249,7 @@ describe('App', () => {
         config: { showsFeedbackButton: true }
       };
 
-      const app = await load('/', { container });
+      const app = await load('/login', { container }).restoreSession(false);
       app.findComponent(FeedbackButton).exists().should.be.false();
     });
   });

--- a/test/components/navbar/actions.spec.js
+++ b/test/components/navbar/actions.spec.js
@@ -1,35 +1,23 @@
 import sinon from 'sinon';
 
-import Navbar from '../../../src/components/navbar.vue';
 import NavbarActions from '../../../src/components/navbar/actions.vue';
 
 import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
-import { mockRouter } from '../../util/router';
-import { mount } from '../../util/lifecycle';
 
 describe('NavbarActions', () => {
-  it('indicates if the user is not logged in', () => {
-    const navbar = mount(Navbar, {
-      container: { router: mockRouter('/login') },
-      global: {
-        // Stubbing AnalyticsIntroduction because of its custom <router-link>
-        stubs: { AnalyticsIntroduction: true }
-      }
-    });
-    const text = navbar.getComponent(NavbarActions).get('a').text();
-    text.should.equal('Not logged in');
-  });
+  it('indicates if the user is not logged in', () =>
+    load('/login')
+      .restoreSession(false)
+      .afterResponses(app => {
+        const text = app.getComponent(NavbarActions).get('a').text();
+        text.should.equal('Not logged in');
+      }));
 
   it("shows the user's display name", async () => {
     mockLogin({ displayName: 'Alice Allison' });
-    const navbar = mount(Navbar, {
-      container: { router: mockRouter('/') },
-      global: {
-        stubs: { AnalyticsIntroduction: true }
-      }
-    });
-    const a = navbar.getComponent(NavbarActions).get('a');
+    const app = await load('/');
+    const a = app.getComponent(NavbarActions).get('a');
     a.text().should.equal('Alice Allison');
     await a.get('span:nth-child(2)').should.have.textTooltip();
   });

--- a/test/components/navbar/links.spec.js
+++ b/test/components/navbar/links.spec.js
@@ -1,23 +1,19 @@
 import { RouterLinkStub } from '@vue/test-utils';
 
-import Navbar from '../../../src/components/navbar.vue';
 import NavbarLinks from '../../../src/components/navbar/links.vue';
 
+import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 import { mockRouter } from '../../util/router';
 import { mount } from '../../util/lifecycle';
 
 describe('NavbarLinks', () => {
-  it('does not render the links before login', () => {
-    const navbar = mount(Navbar, {
-      container: { router: mockRouter('/login') },
-      global: {
-        // Stubbing AnalyticsIntroduction because of its custom <router-link>
-        stubs: { AnalyticsIntroduction: true }
-      }
-    });
-    navbar.findComponent(NavbarLinks).exists().should.be.false();
-  });
+  it('does not render the links before login', () =>
+    load('/login')
+      .restoreSession(false)
+      .afterResponses(app => {
+        app.findComponent(NavbarLinks).exists().should.be.false();
+      }));
 
   it('renders the correct links for a sitewide administrator', () => {
     mockLogin();

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -7,7 +7,7 @@ import createTestContainer from '../util/container';
 import testData from '../data';
 import { load, mockHttp } from '../util/http';
 import { mockLogin } from '../util/session';
-import { mockRouter } from '../util/router';
+import { mockRouter, testRouter } from '../util/router';
 import { setRequestData } from '../util/request-data';
 import { withSetup } from '../util/lifecycle';
 
@@ -870,6 +870,55 @@ describe('util/session', () => {
             url: window.location.href
           }));
         });
+    });
+  });
+
+  describe('visiblyLoggedIn', () => {
+    it('equals true after navigation from /login', () => {
+      const user = testData.extendedUsers.createPast(1).last();
+      const container = {
+        // Prevent a request for the analytics config.
+        config: { showsAnalytics: false }
+      };
+      let correctBeforeNavigation = false;
+      return load('/login', { container })
+        .restoreSession(false)
+        .afterResponses(app => {
+          app.vm.visiblyLoggedIn.should.be.false();
+        })
+        .request(async (app) => {
+          const form = app.get('#account-login form');
+          await form.get('input[type="email"]').setValue('alice@getodk.org');
+          await form.get('input[type="password"]').setValue('foo');
+          app.vm.$router.beforeEach(() => {
+            const { currentUser } = app.vm.$container.requestData;
+            // Even though data exists from login, the user shouldn't be visibly
+            // logged in until after the navigation.
+            correctBeforeNavigation = currentUser.dataExists && !app.vm.visiblyLoggedIn;
+          });
+          return form.trigger('submit');
+        })
+        .respondWithData(() => testData.sessions.createNew())
+        .respondWithData(() => user)
+        .respondFor('/')
+        .afterResponses(app => {
+          correctBeforeNavigation.should.be.true();
+          app.vm.visiblyLoggedIn.should.be.true();
+        });
+    });
+
+    it('equals false during the initial navigation', async () => {
+      mockLogin();
+      const container = createTestContainer({ router: testRouter() });
+      const { visiblyLoggedIn } = withSetup(useSessions, { container });
+      const { router, requestData: { currentUser } } = container;
+      let correctBeforeNavigation = false;
+      router.beforeEach(() => {
+        correctBeforeNavigation = currentUser.dataExists && !visiblyLoggedIn.value;
+      });
+      await router.push('/');
+      correctBeforeNavigation.should.be.true();
+      visiblyLoggedIn.value.should.be.true();
     });
   });
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2011,6 +2011,12 @@
         "developer_comment": "This refers to creation of an Entity. {filename} is the name of an uploaded file containing the Entity. {name} is the name of a Web User."
       }
     },
+    "FeedbackButton": {
+      "feedback": {
+        "string": "Feedback",
+        "developer_comment": "Text for a hovering feedback button shown anchored to right of screen. If your language doesn't have a single word or short phrase for \"feedback\", consider something like \"comments\" or \"reactions\"."
+      }
+    },
     "FieldKeyList": {
       "action": {
         "create": {


### PR DESCRIPTION
Closes getodk/central#616

Opening this as draft so the new component can be reviewed and the general approach can be discussed.

<img width="1070" alt="Screenshot 2024-03-20 at 5 26 59 PM" src="https://github.com/getodk/central-frontend/assets/967540/716d3b47-0fab-4492-ab01-9206aa92a046">

## Design
* Button is intended to be easy to access but not distracting
    * Initially had magenta color but @alyblenkin and I paired and worked to make it less eye-catching
    * Position is fixed at the right and almost the bottom. It's intended to be of the way but still easy to click
    * Almost all sizes are relative so it can be scaled up or down as the rest of the design changes
* [Form](https://docs.google.com/spreadsheets/d/1eV_--hSYebQxDYxuEdsBJxAdpgQp82VPlvqecYJar2A/edit#gid=1068911091) is intended to be short and easy to fill out while providing nudges on the kind of feedback we want
    * Captures host and current generic page name (no form titles, instance ids, etc)

## Proposed plan
* Merge in only the feedback button component
* Apply the changes to use the button on ODK Cloud only initially; self-hosters could choose to do the same if they want; we could even check for .getodk.cloud in the hostname
* See what kind of feedback we get, consider always adding it and/or making it configurable

#### What has been done to verify that this works as intended?
Manual verification only. Made some test submissions.

#### Why is this the best possible solution? Were any other approaches considered?
I considered doing this as a blob of markup we'd paste in just for ODK Cloud users initially or keeping the component private. However, I think it's simpler to have it in the code base. We don't particularly mind if self-hosters want to enable this using our public survey or their own -- we just want to roll it out to Cloud customers only initially to test out the idea ("meta-feedback").

One possible downside of this approach is that someone ill-intentioned could use the public form to spam us. We have mitigations in place for that and worse case we could close the form.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The feedback button component is new so should be very low risk. We need to decide exactly how we want to enable it for Cloud and that could carry some risk because it has logic.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced