### PR TITLE
Hide problem alerts after successful new dataset/property requests

### DIFF
--- a/src/components/dataset/new.vue
+++ b/src/components/dataset/new.vue
@@ -59,7 +59,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { inject, ref, watch } from 'vue';
 import { equals } from 'ramda';
 import { useI18n } from 'vue-i18n';
 
@@ -91,6 +91,7 @@ const step = ref(0);
 const createdDataset = ref(null);
 
 const emit = defineEmits(['hide', 'success']);
+const alert = inject('alert');
 
 watch(() => props.state, (state) => {
   if (!state) name.value = '';
@@ -108,6 +109,8 @@ const submit = () => {
         : null)
   })
     .then(({ data }) => {
+      // Reset the alert
+      alert.blank();
       // Reset the form
       name.value = '';
       step.value = 1;

--- a/src/components/dataset/overview/new-property.vue
+++ b/src/components/dataset/overview/new-property.vue
@@ -38,6 +38,8 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { inject, ref, watch } from 'vue';
+import { equals } from 'ramda';
+import { useI18n } from 'vue-i18n';
 
 import Modal from '../../modal.vue';
 import FormGroup from '../../form-group.vue';
@@ -70,11 +72,16 @@ watch(() => props.state, (state) => {
   if (!state) name.value = '';
 });
 
+const { t } = useI18n();
 const submit = () => {
   request({
     method: 'POST',
     url: apiPaths.datasetProperties(project.id, dataset.name),
-    data: { name: name.value }
+    data: { name: name.value },
+    problemToAlert: ({ code, details }) =>
+      (code === 409.3 && equals(details.fields, ['name', 'datasetId'])
+        ? t('problem.409_3', { propertyName: details.values[0] })
+        : null)
   })
     .then(() => {
       alert.blank();
@@ -93,7 +100,10 @@ const submit = () => {
       "To add an Entity property, choose a unique property name below.",
       "You can also add new properties by uploading a Form that references them, in which case the properties are created when the Form is published."
     ],
-    "newPropertyName": "New property name"
+    "newPropertyName": "New property name",
+    "problem": {
+      "409_3": "A property already exists in this Entity List with the name of “{propertyName}”."
+    },
   }
 }
 </i18n>

--- a/src/components/dataset/overview/new-property.vue
+++ b/src/components/dataset/overview/new-property.vue
@@ -37,7 +37,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { inject, ref, watch } from 'vue';
 
 import Modal from '../../modal.vue';
 import FormGroup from '../../form-group.vue';
@@ -64,6 +64,7 @@ const nameGroup = ref(null);
 const name = ref('');
 
 const emit = defineEmits(['hide', 'success']);
+const alert = inject('alert');
 
 watch(() => props.state, (state) => {
   if (!state) name.value = '';
@@ -76,6 +77,7 @@ const submit = () => {
     data: { name: name.value }
   })
     .then(() => {
+      alert.blank();
       emit('success');
     })
     .catch(noop);

--- a/test/components/dataset/overview/property-new.spec.js
+++ b/test/components/dataset/overview/property-new.spec.js
@@ -105,4 +105,25 @@ describe('DatasetPropertyNew', () => {
       connections.find('.caption-cell').text().should.equal('1 of 2 properties');
     });
   });
+
+  it('shows a custom message for a duplicate property name', () =>
+    mockHttp()
+      .mount(DatasetPropertyNew, mountOptions())
+      .request(async (modal) => {
+        await modal.get('input').setValue('my_new_property');
+        return modal.get('form').trigger('submit');
+      })
+      .respondWithProblem({
+        code: 409.3,
+        message: 'A resource already exists with name,datasetId value(s) of my_new_property,1.',
+        details: {
+          fields: ['name', 'datasetId'],
+          values: ['my_new_property', 1]
+        }
+      })
+      .afterResponse(modal => {
+        modal.should.alert('danger', (message) => {
+          message.should.startWith('A property already exists in this Entity List with the name of “my_new_property”.');
+        });
+      }));
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1481,6 +1481,11 @@
       },
       "newPropertyName": {
         "string": "New property name"
+      },
+      "problem": {
+        "409_3": {
+          "string": "A property already exists in this Entity List with the name of “{propertyName}”."
+        }
       }
     },
     "DatasetPendingSubmissions": {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/624 and closes https://github.com/getodk/central/issues/626

Also add custom error message for property name conflict similar to message for dataset name conflict in PR https://github.com/getodk/central-frontend/pull/966 for issue https://github.com/getodk/central/issues/625. Doing so closes getodk/central#634.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced