### PR TITLE
Add note for encrypted projects in new entity list modal

### DIFF
--- a/src/components/dataset/new.vue
+++ b/src/components/dataset/new.vue
@@ -22,6 +22,9 @@ except according to the terms contained in the LICENSE file.
               <doc-link to="central-entities/">{{ $t('moreInfo.helpArticle.helpArticle') }}</doc-link>
             </template>
           </i18n-t>
+          <p v-if="project.keyId">
+            <span class="icon-exclamation-triangle"></span>{{ $t('encrypted') }}
+          </p>
         </div>
         <form @submit.prevent="submit">
           <form-group ref="nameGroup" v-model.trim="name"
@@ -138,6 +141,11 @@ const hideOrComplete = () => {
 @import '../../assets/scss/variables';
 @import '../../assets/scss/mixins';
 
+.icon-exclamation-triangle {
+  color: $color-warning;
+  margin-right: $margin-right-icon;
+}
+
 #dataset-new-success {
   display: flex;
   align-items: center;
@@ -165,6 +173,8 @@ const hideOrComplete = () => {
       // @transifexKey component.DatasetList.heading.0
       "Entities let you share information between Forms so you can collect longitudinal data, manage cases over time, and represent other workflows with multiple steps."
     ],
+    // This is shown in the introduction as a usage note/warning when the proejct is encrypted.
+    "encrypted": "This Project is encrypted. Forms and Submissions will not be able to modify any Entities in this List. Entities must be managed through Central or the API.",
     // This appears above a text input field for the name of an Entity List
     "entityListName": "Entity List name",
     "success": [

--- a/src/components/dataset/new.vue
+++ b/src/components/dataset/new.vue
@@ -173,7 +173,7 @@ const hideOrComplete = () => {
       // @transifexKey component.DatasetList.heading.0
       "Entities let you share information between Forms so you can collect longitudinal data, manage cases over time, and represent other workflows with multiple steps."
     ],
-    // This is shown in the introduction as a usage note/warning when the proejct is encrypted.
+    // This is shown in the introduction as a usage note/warning when the project is encrypted.
     "encrypted": "This Project is encrypted. Forms and Submissions will not be able to modify any Entities in this List. Entities must be managed through Central or the API.",
     // This appears above a text input field for the name of an Entity List
     "entityListName": "Entity List name",

--- a/test/components/dataset/new.spec.js
+++ b/test/components/dataset/new.spec.js
@@ -34,6 +34,19 @@ describe('DatasetPropertyNew', () => {
     modal.get('input').should.be.focused();
   });
 
+  it('does not shows message about entity manipulation if project is not encrypted', () => {
+    const modal = mount(DatasetNew, mountOptions({ attachTo: document.body }));
+    modal.find('.icon-exclamation-triangle').exists().should.be.false();
+  });
+
+  it('shows message about entity manipulation in encrypted project', () => {
+    const key = testData.standardKeys.createPast(1, { managed: true }).last();
+    testData.extendedProjects.createPast(1, { key });
+    const modal = mount(DatasetNew, mountOptions({ attachTo: document.body }));
+    modal.find('.icon-exclamation-triangle').exists().should.be.true();
+    modal.get('.modal-introduction').text().should.containEql('This Project is encrypted');
+  });
+
   it('implements some standard button things', () =>
     mockHttp()
       .mount(DatasetNew, mountOptions())

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1415,7 +1415,7 @@
       },
       "encrypted": {
         "string": "This Project is encrypted. Forms and Submissions will not be able to modify any Entities in this List. Entities must be managed through Central or the API.",
-        "developer_comment": "This is shown in the introduction as a usage note/warning when the proejct is encrypted."
+        "developer_comment": "This is shown in the introduction as a usage note/warning when the project is encrypted."
       },
       "entityListName": {
         "string": "Entity List name",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1413,6 +1413,10 @@
         "string": "Create Entity List",
         "developer_comment": "This is the title at the top of a pop-up."
       },
+      "encrypted": {
+        "string": "This Project is encrypted. Forms and Submissions will not be able to modify any Entities in this List. Entities must be managed through Central or the API.",
+        "developer_comment": "This is shown in the introduction as a usage note/warning when the proejct is encrypted."
+      },
       "entityListName": {
         "string": "Entity List name",
         "developer_comment": "This appears above a text input field for the name of an Entity List"


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/631

<img width="694" alt="Screenshot 2024-04-18 at 3 08 14 PM" src="https://github.com/getodk/central-frontend/assets/76205/e222e350-f1ea-4d15-80c8-8b8be295d85d">

Current text:

> This Project is encrypted. Forms and Submissions will not be able to modify any Entities in this List. Entities must be managed through Central or the API.


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced