### PR TITLE
Fix geopoint column width in submission

### DIFF
--- a/src/components/submission/data-row.vue
+++ b/src/components/submission/data-row.vue
@@ -178,7 +178,11 @@ export default {
 
 #submission-table {
   .int-field, .decimal-field { text-align: right; }
-  .geopoint-field { max-width: 500px; }
+
+  // Geopoint width should always have enough room to show full data.
+  // This neeeds an extra CSS selector to not be overwritten by
+  // max-width:250px in submission/table.vue
+  .table-freeze-scrolling .geopoint-field { max-width: 500px; }
 
   .binary-field { text-align: center; }
   .binary-link {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/635

Makes sure geopoint column has room to grow to show entire value. The value is often very close to 250px but this ensures that it can use a bit more if it needs to.

<img width="775" alt="Screenshot 2024-04-22 at 5 07 37 PM" src="https://github.com/getodk/central-frontend/assets/76205/4e6e2827-855e-4d5d-90d8-517c91ee2ad3">

The problem before was a `max-width: 500px` CSS rule that wasn't getting applied because of change in a different file ([submissions/table.vue](https://github.com/getodk/central-frontend/blob/d664e8e1a4ab75f2a2e22282d7d34fd73677b1a5/src/components/submission/table.vue#L93-L94)) that was canceling out the CSS. Using the extra class selector (`.table-freeze-scrolling`) from the other file worked to have this greater max width go into effect again, and provide a clue to CSS effects from this other file.


[This PR](https://github.com/getodk/central-frontend/pull/704) mentions
> We don't add tooltips for field types whose text shouldn't be truncated: int, decimal, date, time, dateTime, and geopoint. (geopoint columns are styled to be up to twice as wide as others.)



<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tried it! 

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced