### PR TITLE
New usage metrics strings for 2024.1

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -119,6 +119,8 @@ export default {
       "num_entities_updated": "Number of modified Entities",
       "num_entity_conflicts": "Number of Entities ever with conflict",
       "num_entity_conflicts_resolved": "Number of Entities with conflict now marked as resolved",
+      "num_bulk_create_events": "Number of bulk uploads",
+      "biggest_bulk_upload": "Number of rows in biggest bulk upload",
       "sso_enabled": "SSO enabled on server",
       "num_client_audit_attachments": "Number of Client Audit Attachments",
       "num_client_audit_attachments_failures": "Number of Client Audit processing failures",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1280,6 +1280,12 @@
         "num_entity_conflicts_resolved": {
           "string": "Number of Entities with conflict now marked as resolved"
         },
+        "num_bulk_create_events": {
+          "string": "Number of bulk uploads"
+        },
+        "biggest_bulk_upload": {
+          "string": "Number of rows in biggest bulk upload"
+        },
         "sso_enabled": {
           "string": "SSO enabled on server"
         },


### PR DESCRIPTION
Frontend of https://github.com/getodk/central/issues/572

Usage metrics about bulk entity uploads.

<img width="930" alt="Screenshot 2024-04-23 at 2 12 48 PM" src="https://github.com/getodk/central-frontend/assets/76205/2b853be0-608a-46b9-ba0d-3fc7f06a9564">

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced