### PR TITLE
Return a better error message when nginx returns 413 error

### DIFF
--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -421,7 +421,8 @@
   "mixin": {
     "request": {
       "alert": {
-        "fileSize": "The file “{name}” that you are trying to upload is larger than the 100 MB limit."
+        "fileSize": "The file “{name}” that you are trying to upload is larger than the 100 MB limit.",
+        "entityTooLarge":  "The data that you are trying to upload is too large.",
       }
     }
   },

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -226,8 +226,11 @@ export const requestAlertMessage = (i18n, axiosError, problemToAlert = undefined
   if (axiosError.request == null) return i18n.t('util.request.noRequest');
   const { response } = axiosError;
   if (response == null) return i18n.t('util.request.noResponse');
-  if (!(axiosError.config.url.startsWith('/v1/') && isProblem(response.data)))
+  if (!(axiosError.config.url.startsWith('/v1/') && isProblem(response.data))) {
+    if (response.status === 413)
+      return i18n.t('mixin.request.alert.entityTooLarge');
     return i18n.t('util.request.errorNotProblem', response);
+  }
 
   const problem = response.data;
   if (problemToAlert != null) {

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -631,6 +631,15 @@ describe('util/request', () => {
       message.should.equal('Something went wrong: error code 500.');
     });
 
+    it('returns a message about 413 error response that is not a Problem', () => {
+      const message = requestAlertMessage(i18n, mockAxiosError({
+        status: 413,
+        data: '<html><head><title>413 Request Entity Too Large</title></head>...',
+        config: { url: '/v1/projects/1/datasets/trees/entities' }
+      }));
+      message.should.equal('The data that you are trying to upload is too large.');
+    });
+
     it('returns the message of a Problem', () => {
       const message = requestAlertMessage(i18n, errorWithProblem());
       message.should.equal('Message from API');

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -894,6 +894,9 @@
       "alert": {
         "fileSize": {
           "string": "The file “{name}” that you are trying to upload is larger than the 100 MB limit."
+        },
+        "entityTooLarge": {
+          "string": "The data that you are trying to upload is too large."
         }
       }
     }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/610

<img width="862" alt="Screenshot 2024-04-23 at 4 24 18 PM" src="https://github.com/getodk/central-frontend/assets/76205/fad99e35-75d5-4754-bd43-864e78ab55f0">

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I artificially lowered the nginx error to 1mb to trigger this. 

#### Why is this the best possible solution? Were any other approaches considered?

I didn't see any filled in content-length info that I could have used to show the actual size in the error message. Also left the message pretty generic.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced