### PR TITLE
Do not show warning if CSV delimiter is not a comma

### DIFF
--- a/src/components/entity/upload/header-errors.vue
+++ b/src/components/entity/upload/header-errors.vue
@@ -145,7 +145,7 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
       "unknownProperty": "If you want to add properties to this Entity List, you can do so in the Entity Properties section on the Overview page of this Entity List, or you can upload and publish a Form that references the property.",
       "duplicateColumn": "It looks like two or more columns have the same header. Please make sure column headers are unique.",
       "emptyColumn": "It looks like you have an empty cell in the header. Please remove any empty columns in your file.",
-      "delimiterNotComma": "It’s not clear what delimiter separates cells in a row from each other in your file. Based on analysis, {delimiter} was used as the best guess."
+      "delimiterNotComma": "This might be because we got the cell delimiter wrong. We used {delimiter}."
     }
   }
 }

--- a/src/components/entity/upload/warnings.vue
+++ b/src/components/entity/upload/warnings.vue
@@ -19,44 +19,26 @@ except according to the terms contained in the LICENSE file.
       @rows="$emit('rows', $event)">
       {{ $t('row.largeCell') }}
     </entity-upload-warning>
-    <entity-upload-warning v-if="delimiter != null">
-      <i18n-t keypath="delimiterNotComma">
-        <template #delimiter>
-          <code>{{ formattedDelimiter }}</code>
-        </template>
-      </i18n-t>
-    </entity-upload-warning>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
-
 import EntityUploadWarning from './warning.vue';
-
-import { formatCSVDelimiter } from '../../../util/csv';
 
 defineOptions({
   name: 'EntityUploadWarnings'
 });
-const props = defineProps({
-  delimiter: String,
+defineProps({
   raggedRows: Array,
   largeCell: Number
 });
 defineEmits(['rows']);
-
-const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
 </script>
 
 <style lang="scss">
-@import '../../../assets/scss/variables';
-
 #entity-upload-warnings {
   background-color: #deedf3;
   padding: 9px 6px;
-
-  code { border: 1px solid $color-text; }
 }
 </style>
 
@@ -67,9 +49,7 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
     "row": {
       "raggedRows": "Fewer columns were found than expected in some rows:",
       "largeCell": "Some cells are abnormally large, which can indicate difficulties reading your file:"
-    },
-    // @transifexKey component.EntityUploadHeaderErrors.suggestions.delimiterNotComma
-    "delimiterNotComma": "It’s not clear what delimiter separates cells in a row from each other in your file. Based on analysis, {delimiter} was used as the best guess."
+    }
   }
 }
 </i18n>

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -251,10 +251,6 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
       warningResults.details[warning.type] = warning.details;
     }
   }
-  if (delimiter !== ',') {
-    warningResults.count += 1;
-    warningResults.details.delimiter = delimiter;
-  }
 
   return { data, warnings: warningResults };
 };

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -142,36 +142,32 @@ describe('EntityUpload', () => {
   });
 
   describe('warnings', () => {
-    it('shows warnings', async () => {
-      testData.extendedDatasets.createPast(1, {
-        properties: [{ name: 'height' }, { name: 'circumference' }]
-      });
-      const modal = await showModal();
-      const csv = createCSV('label;height;circumference\nx\ny\n"12345;67890";"";""');
-      await selectFile(modal, csv);
-      modal.getComponent(EntityUploadWarnings).props().should.eql({
-        raggedRows: [[1, 2]],
-        largeCell: 3,
-        delimiter: ';'
-      });
-      modal.getComponent(EntityUploadPopup).props().warnings.should.equal(3);
-    });
-
-    it('does not show warnings if there is a data error', async () => {
+    beforeEach(() => {
       testData.extendedDatasets.createPast(1, {
         properties: [{ name: 'height' }]
       });
+    });
+
+    it('shows warnings', async () => {
       const modal = await showModal();
-      await selectFile(modal, createCSV('label;height\n"";1'));
+      const csv = createCSV('label,height\nx\ny\n"12345,67890",""');
+      await selectFile(modal, csv);
+      modal.getComponent(EntityUploadWarnings).props().should.eql({
+        raggedRows: [[1, 2]],
+        largeCell: 3
+      });
+      modal.getComponent(EntityUploadPopup).props().warnings.should.equal(2);
+    });
+
+    it('does not show warnings if there is a data error', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('label,height\nx\ny,""\n"",1'));
       const error = modal.getComponent(EntityUploadDataError).props().message;
-      error.should.startWith('There is a problem on row 2');
+      error.should.startWith('There is a problem on row 4');
       modal.findComponent(EntityUploadWarnings).exists().should.be.false();
     });
 
     it('shows rows to which a warning applies after they are selected', async () => {
-      testData.extendedDatasets.createPast(1, {
-        properties: [{ name: 'height' }]
-      });
       const modal = await showModal();
       const data = [
         ['1', ''],
@@ -202,9 +198,6 @@ describe('EntityUpload', () => {
     });
 
     it('does not highlight rows after a new file is selected', async () => {
-      testData.extendedDatasets.createPast(1, {
-        properties: [{ name: 'height' }]
-      });
       const modal = await showModal();
       const csvString = 'label,height\nx\ny\nz,""';
       await selectFile(modal, createCSV(csvString));

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import EntityFilters from '../../../src/components/entity/filters.vue';
 import EntityUpload from '../../../src/components/entity/upload.vue';
 import EntityUploadDataError from '../../../src/components/entity/upload/data-error.vue';
+import EntityUploadHeaderErrors from '../../../src/components/entity/upload/header-errors.vue';
 import EntityUploadPopup from '../../../src/components/entity/upload/popup.vue';
 import EntityUploadTable from '../../../src/components/entity/upload/table.vue';
 import EntityUploadWarnings from '../../../src/components/entity/upload/warnings.vue';
@@ -138,6 +139,37 @@ describe('EntityUpload', () => {
       button.attributes('aria-disabled').should.equal('true');
       await selectFile(modal);
       button.attributes('aria-disabled').should.equal('false');
+    });
+  });
+
+  describe('header errors', () => {
+    beforeEach(() => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [{ name: 'height' }]
+      });
+    });
+
+    it('shows errors', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('foo,,foo\n1,2,3'));
+      modal.getComponent(EntityUploadHeaderErrors).props().should.eql({
+        filename: 'my_data.csv',
+        header: 'foo,,foo',
+        delimiter: ',',
+        invalidQuotes: false,
+        missingLabel: true,
+        missingProperty: true,
+        unknownProperty: true,
+        duplicateColumn: true,
+        emptyColumn: true
+      });
+    });
+
+    it('uses the delimiter from the file', async () => {
+      const modal = await showModal();
+      const csv = createCSV('label;height;circumference\ndogwood;1;2');
+      await selectFile(modal, csv);
+      modal.getComponent(EntityUploadHeaderErrors).props().delimiter.should.equal(';');
     });
   });
 

--- a/test/components/entity/upload/header-errors.spec.js
+++ b/test/components/entity/upload/header-errors.spec.js
@@ -1,0 +1,84 @@
+import EntityUploadHeaderErrors from '../../../../src/components/entity/upload/header-errors.vue';
+
+import testData from '../../../data';
+import { mergeMountOptions, mount } from '../../../util/lifecycle';
+
+const mountComponent = (options) =>
+  mount(EntityUploadHeaderErrors, mergeMountOptions(options, {
+    props: { filename: 'my_data.csv', delimiter: ',' },
+    container: {
+      requestData: { dataset: testData.extendedDatasets.last() }
+    }
+  }));
+
+describe('EntityUploadHeaderErrors', () => {
+  describe('expected header', () => {
+    beforeEach(() => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [{ name: 'height' }]
+      });
+    });
+
+    it('shows the expected header', () => {
+      const component = mountComponent({
+        props: { header: 'label', missingProperty: true }
+      });
+      component.get('dd').text().should.equal('label,height');
+    });
+
+    it('uses the delimiter from the CSV file', () => {
+      const component = mountComponent({
+        props: { header: 'label', delimiter: ';', missingProperty: true }
+      });
+      component.get('dd').text().should.equal('label;height');
+    });
+  });
+
+  describe('suggestions', () => {
+    const getSuggestion = (component) => {
+      const p = component.findAll('#entity-upload-header-errors-suggestions p');
+      p.length.should.equal(1);
+      return p[0];
+    };
+
+    it('does not show a suggestion for a missing property', () => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [{ name: 'height' }]
+      });
+      const component = mountComponent({
+        props: { header: 'label', missingProperty: true }
+      });
+      component.find('#entity-upload-header-errors-suggestions').exists().should.be.false();
+    });
+
+    describe('delimiter is not a comma', () => {
+      beforeEach(() => {
+        testData.extendedDatasets.createPast(1, {
+          properties: [{ name: 'height' }, { name: 'circumference' }]
+        });
+      });
+
+      it('shows a suggestion if the delimiter is not a comma', () => {
+        const component = mountComponent({
+          props: {
+            header: 'label;height',
+            delimiter: ';',
+            missingProperty: true
+          }
+        });
+        getSuggestion(component).text().should.endWith('We used ;.');
+      });
+
+      it('shows ⇥ for tab', () => {
+        const component = mountComponent({
+          props: {
+            header: 'label\theight',
+            delimiter: '\t',
+            missingProperty: true
+          }
+        });
+        getSuggestion(component).get('code').text().should.equal('⇥');
+      });
+    });
+  });
+});

--- a/test/components/entity/upload/warnings.spec.js
+++ b/test/components/entity/upload/warnings.spec.js
@@ -24,32 +24,15 @@ describe('EntityUploadWarnings', () => {
     warning.props().ranges.should.eql([[1, 1]]);
   });
 
-  describe('delimiter is not a comma', () => {
-    it('shows a warning', () => {
-      const component = mountComponent({
-        props: { delimiter: ';' }
-      });
-      const text = component.getComponent(EntityUploadWarning).text();
-      text.should.containEql('Based on analysis, ; was used');
-    });
-
-    it('shows ⇥ for tab', () => {
-      const component = mountComponent({
-        props: { delimiter: '\t' }
-      });
-      component.get('.entity-upload-warning code').text().should.equal('⇥');
-    });
-  });
-
   it('shows multiple warnings', () => {
     const component = mountComponent({
-      props: { raggedRows: [[1, 2]], delimiter: ';' }
+      props: { raggedRows: [[1, 2]], largeCell: 3 }
     });
     const warnings = component.findAllComponents(EntityUploadWarning);
     warnings.length.should.equal(2);
     const text = warnings.map(warning => warning.text());
     text[0].should.containEql('Fewer columns were found than expected');
-    text[1].should.containEql('Based on analysis, ; was used');
+    text[1].should.containEql('Some cells are abnormally large');
   });
 
   it('emits a rows event after a row range is clicked', async () => {

--- a/test/unit/csv.spec.js
+++ b/test/unit/csv.spec.js
@@ -205,17 +205,6 @@ describe('util/csv', () => {
         });
       });
 
-      it('returns the delimiter if it is not a comma', async () => {
-        const csv = createCSV('a;b\n1;2');
-        const { warnings } = await parseCSV(i18n, csv, ['a', 'b'], {
-          delimiter: ';'
-        });
-        warnings.should.eql({
-          count: 1,
-          details: { delimiter: ';' }
-        });
-      });
-
       describe('ragged row', () => {
         it('returns ragged rows if another row is padded', async () => {
           const csv = createCSV('a,b\n1\n2,""\n4');
@@ -275,8 +264,8 @@ describe('util/csv', () => {
             delimiter: ';'
           });
           warnings.should.eql({
-            count: 2,
-            details: { delimiter: ';', largeCell: 2 }
+            count: 1,
+            details: { largeCell: 2 }
           });
         });
 
@@ -309,13 +298,11 @@ describe('util/csv', () => {
       });
 
       it('returns multiple warnings', async () => {
-        const csv = createCSV('a;b\n1\n"12345;67890";""');
-        const { warnings } = await parseCSV(i18n, csv, ['a', 'b'], {
-          delimiter: ';'
-        });
+        const csv = createCSV('a,b\n1\n"12345,67890",""');
+        const { warnings } = await parseCSV(i18n, csv, ['a', 'b']);
         warnings.should.eql({
-          count: 3,
-          details: { delimiter: ';', raggedRows: [[1, 1]], largeCell: 2 }
+          count: 2,
+          details: { raggedRows: [[1, 1]], largeCell: 2 }
         });
       });
     });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2123,7 +2123,7 @@
           "string": "It looks like you have an empty cell in the header. Please remove any empty columns in your file."
         },
         "delimiterNotComma": {
-          "string": "It’s not clear what delimiter separates cells in a row from each other in your file. Based on analysis, {delimiter} was used as the best guess."
+          "string": "This might be because we got the cell delimiter wrong. We used {delimiter}."
         }
       }
     },


### PR DESCRIPTION
This PR changes what happens if something other than a comma is used as the CSV delimiter. A non-comma delimiter will continue to be shown in `EntityHeaderErrors` if the header row is invalid. However, it will not be returned in the warnings from `parseCSV()` or shown in `EntityUploadWarnings`.

#### What has been done to verify that this works as intended?

I updated tests to match the new behavior.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced