### PR TITLE
Ensure that .modal-actions is visible after entities CSV is selected

### DIFF
--- a/src/components/entity/upload.vue
+++ b/src/components/entity/upload.vue
@@ -65,7 +65,7 @@ except according to the terms contained in the LICENSE file.
         :progress="uploadProgress" @clear="clearFile"
         @animationstart="animatePopup(true)"
         @animationend="animatePopup(false)"/>
-      <div class="modal-actions">
+      <div ref="actions" class="modal-actions">
         <button type="button" class="btn btn-primary"
           :aria-disabled="csvEntities == null || uploading" @click="upload">
           {{ $t('action.append') }}
@@ -349,6 +349,11 @@ const resizeColumnUnlessAnimating = () => {
   if (props.state && !popupAnimating.value) resizeLastColumn();
 };
 useEventListener(window, 'resize', resizeColumnUnlessAnimating);
+
+const actions = ref(null);
+watch(csvEntities, (value) => {
+  if (value != null) nextTick(() => { actions.value.scrollIntoView(); });
+});
 
 watch(() => props.state, (state) => {
   if (!state) {


### PR DESCRIPTION
Closes getodk/central#639.

#### What has been done to verify that this works as intended?

I tried it locally. I don't think we need to write a test for this behavior.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced