### PR TITLE
Prevent EntityMetadataRow actions from wrapping

### DIFF
--- a/src/components/entity/metadata-row.vue
+++ b/src/components/entity/metadata-row.vue
@@ -107,6 +107,10 @@ const { entityPath } = useRoutes();
   .action-cell {
     padding-top: 4px;
     padding-bottom: 4px;
+
+    // Ensure that the column is wide enough that the .btn-group does not wrap.
+    min-width: 170px;
+    &:lang(id) { min-width: 215px; }
   }
 
   .col-content {


### PR DESCRIPTION
Closes getodk/central#620.

#### What has been done to verify that this works as intended?

I tried it locally.

#### Why is this the best possible solution? Were any other approaches considered?

I increased the min width of the "Last Updated / Actions" column so that there is always enough room for the actions.

I also tried keeping the min width like it was, but allowing the actions to spill into the "Created at" column to the left. However, that didn't look better to me and seemed potentially confusing.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced