### PR TITLE
Show error if selected CSV file contains null character

### DIFF
--- a/src/components/entity/upload.vue
+++ b/src/components/entity/upload.vue
@@ -257,6 +257,7 @@ const parseEntities = async (file, headerResults, signal) => {
   warnings.value = results.warnings;
 };
 const selectFile = (file) => {
+  alert.blank();
   headerErrors.value = null;
   dataError.value = null;
 

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -436,7 +436,7 @@
     "csv": {
       // {message} is a description of the problem.
       "readError": "There was a problem reading your file: {message}",
-      "nullChar": "The file “{name}” is not a valid .csv file. It cannot be read.",
+      "invalidCSV": "The file “{name}” is not a valid .csv file. It cannot be read.",
       // {row} is a row number. {message} is a description of the problem.
       "rowError": "There is a problem on row {row} of the file: {message}",
       // This is an error that is shown for a spreadsheet. The field may be any

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -436,6 +436,7 @@
     "csv": {
       // {message} is a description of the problem.
       "readError": "There was a problem reading your file: {message}",
+      "nullChar": "The file “{name}” is not a valid .csv file. It cannot be read.",
       // {row} is a row number. {message} is a description of the problem.
       "rowError": "There is a problem on row {row} of the file: {message}",
       // This is an error that is shown for a spreadsheet. The field may be any

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -82,6 +82,8 @@ export const parseCSVHeader = async (i18n, file, signal = undefined) => {
     preview: 1
   });
   const columns = data.length !== 0 ? data[0] : [];
+  if (columns.some(column => column.includes('\0')))
+    throw new Error(i18n.t('util.csv.nullChar', { name: file.name }));
   const unhandledErrors = errors.filter(error =>
     error.code !== 'UndetectableDelimiter');
   if (unhandledErrors.length === 0) {
@@ -200,6 +202,12 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
       throw new Error(i18n.tc('util.csv.dataWithoutHeader', columns.length, counts));
     }
 
+    if (values.some(value => value.includes('\0'))) {
+      const error = new Error(i18n.t('util.csv.nullChar', { name: file.name }));
+      error.row = NaN;
+      throw error;
+    }
+
     data.push(transformRow(values, columns));
     for (const warning of warnings) warning.pushRow(values, index, columns);
   };
@@ -235,6 +243,9 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
       worker: true
     });
   } catch (error) {
+    // Mention the row number in the error message unless the error has
+    // set its `row` property to NaN.
+    if (Number.isNaN(error.row)) throw error;
     throw new Error(i18n.t('util.csv.rowError', {
       message: error.message,
       row: i18n.n((error.row ?? rowIndex) + 1, 'default')

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -82,8 +82,12 @@ export const parseCSVHeader = async (i18n, file, signal = undefined) => {
     preview: 1
   });
   const columns = data.length !== 0 ? data[0] : [];
+  // Make a simple try at detecting a binary file by searching for a null
+  // character. We do that in order to avoid displaying unintelligible binary
+  // data to the user. Also, Backend would probably reject a null character
+  // that's sent to it.
   if (columns.some(column => column.includes('\0')))
-    throw new Error(i18n.t('util.csv.nullChar', { name: file.name }));
+    throw new Error(i18n.t('util.csv.invalidCSV', { name: file.name }));
   const unhandledErrors = errors.filter(error =>
     error.code !== 'UndetectableDelimiter');
   if (unhandledErrors.length === 0) {
@@ -203,7 +207,7 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
     }
 
     if (values.some(value => value.includes('\0'))) {
-      const error = new Error(i18n.t('util.csv.nullChar', { name: file.name }));
+      const error = new Error(i18n.t('util.csv.invalidCSV', { name: file.name }));
       error.row = NaN;
       throw error;
     }
@@ -243,8 +247,8 @@ export const parseCSV = async (i18n, file, columns, options = {}) => {
       worker: true
     });
   } catch (error) {
-    // Mention the row number in the error message unless the error has
-    // set its `row` property to NaN.
+    // Mention the row number in the error message unless the `row` property of
+    // the error has been set to NaN.
     if (Number.isNaN(error.row)) throw error;
     throw new Error(i18n.t('util.csv.rowError', {
       message: error.message,

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -197,6 +197,9 @@ describe('EntityUpload', () => {
       modal.findComponent(EntityUploadPopup).exists().should.be.true();
     });
 
+    // This is not necessarily the ideal behavior. Showing an alert would be
+    // more consistent with what happens for a null character in the header.
+    // This test documents the current expected behavior.
     it('renders EntityUploadDataError for a null character after header', async () => {
       const modal = await showModal();
       await selectFile(modal, createCSV('label\nf\0o'));

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -177,6 +177,35 @@ describe('EntityUpload', () => {
     });
   });
 
+  describe('binary file', () => {
+    beforeEach(() => {
+      testData.extendedDatasets.createPast(1);
+    });
+
+    it('shows an alert for a null character in the header', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('f\0o'));
+      modal.should.alert('danger', 'The file “my_data.csv” is not a valid .csv file. It cannot be read.');
+      modal.findComponent(EntityUploadHeaderErrors).exists().should.be.false();
+    });
+
+    it('hides the alert after a valid file is selected', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('f\0o'));
+      await selectFile(modal);
+      modal.should.not.alert();
+      modal.findComponent(EntityUploadPopup).exists().should.be.true();
+    });
+
+    it('renders EntityUploadDataError for a null character after header', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('label\nf\0o'));
+      const { message } = modal.getComponent(EntityUploadDataError).props();
+      message.should.equal('The file “my_data.csv” is not a valid .csv file. It cannot be read.');
+      modal.should.not.alert();
+    });
+  });
+
   describe('warnings', () => {
     beforeEach(() => {
       testData.extendedDatasets.createPast(1, {

--- a/test/unit/csv.spec.js
+++ b/test/unit/csv.spec.js
@@ -48,7 +48,12 @@ describe('util/csv', () => {
       });
     });
 
-    describe('error', () => {
+    it('returns a rejected promise if there is a null character', () => {
+      const promise = parseCSVHeader(i18n, createCSV('f\0o,bar'));
+      return promise.should.be.rejectedWith('The file “my_data.csv” is not a valid .csv file. It cannot be read.');
+    });
+
+    describe('Papa Parse error', () => {
       it('returns an error for a missing quote', async () => {
         const { errors } = await parseCSVHeader(i18n, createCSV('"a\n1'));
         errors.length.should.equal(1);
@@ -117,6 +122,11 @@ describe('util/csv', () => {
         const promise = parseCSV(i18n, createCSV('a\n"1"2"\n"3"4"'), ['a']);
         return promise.should.be.rejectedWith(/^There is a problem on row 2 /);
       });
+    });
+
+    it('returns a rejected promise if there is a null character', () => {
+      const promise = parseCSV(i18n, createCSV('a\nf\0o'), ['a']);
+      return promise.should.be.rejectedWith('The file “my_data.csv” is not a valid .csv file. It cannot be read.');
     });
 
     describe('number of cells', () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -918,6 +918,9 @@
         "string": "There was a problem reading your file: {message}",
         "developer_comment": "{message} is a description of the problem."
       },
+      "nullChar": {
+        "string": "The file “{name}” is not a valid .csv file. It cannot be read."
+      },
       "rowError": {
         "string": "There is a problem on row {row} of the file: {message}",
         "developer_comment": "{row} is a row number. {message} is a description of the problem."

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -918,7 +918,7 @@
         "string": "There was a problem reading your file: {message}",
         "developer_comment": "{message} is a description of the problem."
       },
-      "nullChar": {
+      "invalidCSV": {
         "string": "The file “{name}” is not a valid .csv file. It cannot be read."
       },
       "rowError": {


### PR DESCRIPTION
In getodk/central#589, we [briefly](https://github.com/getodk/central/issues/589#issuecomment-2015893641) [discussed](https://github.com/getodk/central/issues/589#issuecomment-2021276677) what would happen if the user uses the entity upload modal to select a binary file. This PR tries to detect that case and show a better error message.

The "choose one" button to select a file limits the selection to .csv and .tsv files. However, a user could rename an Excel file to .csv to try to get it to pass. Also, the drop zone doesn't have a similar restriction, so a user could drag-and-drop an Excel file. This is what it looks like if an Excel file is dropped in:

<img width="1141" src="https://github.com/getodk/central-frontend/assets/5970131/8b1f2cc5-85ea-4514-8943-a894083f3ec1">

You can see that Papa Parse is so confused that it concludes that the file is tab-delimited. 😅 But you can see that Papa Parse isn't throwing an error here: it's returning binary data parsed as text. Here's an example of how Papa Parse is perfectly happy to accept a null character:

```
> Papa.parse('f\0o,bar')
{
  data: [ [ 'f\x00o', 'bar' ] ],
  errors: [],
  meta: {
    ...
  }
}
```

I also tried what happened if the header was valid, but the data after it contained a null character. It looked like the null character was inserted into the DOM, but wasn't displayed. The null character was sent to Backend: it looks like JSON is perfectly capable of encoding a null character. However, Backend returned a 500, and I saw a Postgres error in the Backend logs. The Postgres error was different depending on whether the null character was in the label or in a data property.

- For the label, the error was:
  - error: invalid byte sequence for encoding "UTF8": 0x00
- For a data property, the error was:
  - error: unsupported Unicode escape sequence

I found this article helpful in understanding how Postgres handles null characters: https://www.commandprompt.com/blog/null-characters-workarounds-arent-good-enough/. It sounds like the "unsupported Unicode escape sequence" error is associated with JSON data types.

All that said, I think it'd be nice to avoid showing binary data in Frontend as in the screenshot above. It'd be nice to show a better error instead. It doesn't seem completely trivial to determine whether a file is binary. However, I figure that most binary files will contain a null character. In this PR, I check for a null character when parsing the header, then check for a null character when parsing the rest of the data. Some corners of the Internet say that a null character is valid in a text file, but I can't think of a real use case.

If the header contains a null character, I show a simple error alert. I'm not rendering `EntityUploadHeaderErrors` because I don't want it to show the binary data from the header. Here's an example of selecting an Excel file:

<img width="1200" src="https://github.com/getodk/central-frontend/assets/5970131/e6c9c187-a859-4246-87e8-d9b42ea6d512">

Note that it's possible for a binary file not to contain a null character in its first line. That was true of a .pdf file I tried. In that case, `EntityUploadHeaderErrors` will be rendered (assuming the first line doesn't match the expected header).

<img width="1174" src="https://github.com/getodk/central-frontend/assets/5970131/5cb4d6a2-a759-4ccf-a833-7280a5f8e3c8">

If the file matches the expected header, but there's a null character in the data, then we will show the error in the "Data error" panel. It would've been more consistent to show the error at the top of the modal in an alert, but that's not easy to do with the way things are correctly plumbed. I also think this case is very unlikely.

<img width="1173" src="https://github.com/getodk/central-frontend/assets/5970131/d72bdea5-c3ee-43c7-a6f1-30a511a88b65">

#### What has been done to verify that this works as intended?

I wrote tests and tried it locally.

#### Why is this the best possible solution? Were any other approaches considered?

One thing I'm wondering is whether we should check for control characters other than a null character. It sounds like Postgres is uniquely displeased by a null character, which is maybe a reason to check for that specifically. All the binary files I tried contained a null character, and my understanding is that that's typical.

Instead of checking for a null character, we could take a totally different approach and check the MIME type of the file. However, apparently browsers determine the MIME type just by looking at the file extension ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Blob/type)). It wouldn't help in the case where a user renames an Excel file to .csv.

In a similar vein, we could use an npm package like [`file-type`](https://github.com/sindresorhus/file-type) that actually reads a portion of the file to determine whether the file is a common binary format. However, I'd prefer to avoid an additional package if we don't really need it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The change to src/ is pretty small. I implemented the check as just an additional validation step. It shouldn't break existing code.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced