### PR TITLE
Move odata loading message and spinner styles to the right place

### DIFF
--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -95,6 +95,29 @@ const message = computed(() => {
 
 </script>
 
+<style lang="scss">
+@import '../assets/scss/variables';
+
+#odata-loading-message {
+  margin-left: 28px;
+  padding-bottom: 38px;
+  position: relative;
+
+  #odata-loading-spinner-container {
+    margin-right: 8px;
+    position: absolute;
+    top: 8px;
+    width: 16px; // eventually probably better not to default spinner to center.
+  }
+
+  #odata-loading-message-text {
+    color: #555;
+    font-size: 12px;
+    padding-left: 24px;
+  }
+}
+</style>
+
 <i18n lang="json5">
   {
     "en": {

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -373,25 +373,6 @@ export default {
   margin-bottom: 10px;
   margin-left: auto;
 }
-
-#submission-list-message {
-  margin-left: 28px;
-  padding-bottom: 38px;
-  position: relative;
-
-  #submission-list-spinner-container {
-    margin-right: 8px;
-    position: absolute;
-    top: 8px;
-    width: 16px; // eventually probably better not to default spinner to center.
-  }
-
-  #submission-list-message-text {
-    color: #555;
-    font-size: 12px;
-    padding-left: 24px;
-  }
-}
 </style>
 
 <i18n lang="json5">


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/603 and closes https://github.com/getodk/central/issues/526 

CSS to style the spinner and message text for the `OdataLoadingMessage` component is now in the right place. This shows up on the Entities page and Submissions page.

<img width="474" alt="Screenshot 2024-05-01 at 11 09 16 AM" src="https://github.com/getodk/central-frontend/assets/76205/eabcbacf-1bcf-4e87-94a4-ba07097d8b8c">

<img width="622" alt="Screenshot 2024-05-01 at 11 17 34 AM" src="https://github.com/getodk/central-frontend/assets/76205/f00763f3-bc84-4868-809f-ca949aebd9e7">

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced