### PR TITLE
Use Vitest names for testing globals

### DIFF
--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,8 +1,14 @@
 module.exports = {
-  env: {
-    mocha: true
-  },
   globals: {
+    // Vitest
+    describe: 'readonly',
+    it: 'readonly',
+    test: 'readonly',
+    beforeAll: 'readonly',
+    afterAll: 'readonly',
+    beforeEach: 'readonly',
+    afterEach: 'readonly',
+
     should: 'readonly'
   },
   rules: {

--- a/test/components/app.spec.js
+++ b/test/components/app.spec.js
@@ -198,10 +198,10 @@ describe('App', () => {
     beforeEach(mockLogin);
 
     const preventDefault = (event) => { event.preventDefault(); };
-    before(() => {
+    beforeAll(() => {
       document.addEventListener('click', preventDefault);
     });
-    after(() => {
+    afterAll(() => {
       document.removeEventListener('click', preventDefault);
     });
 

--- a/test/components/form-group.spec.js
+++ b/test/components/form-group.spec.js
@@ -95,7 +95,7 @@ describe('FormGroup', () => {
     children[2].textContent.should.equal('Some span text');
   });
 
-  specify('focus() focuses the input', () => {
+  test('focus() focuses the input', () => {
     const formGroup = mountComponent({ attachTo: document.body });
     formGroup.vm.focus();
     formGroup.get('input').should.be.focused();

--- a/test/composables/disabled.spec.js
+++ b/test/composables/disabled.spec.js
@@ -27,8 +27,8 @@ describe('useDisabled()', () => {
     for (const type of ['click', 'beforeinput', 'mousedown', 'keydown'])
       document[method](type, storeEvent, true);
   };
-  before(() => { toggleEventListeners(true); });
-  after(() => { toggleEventListeners(false); });
+  beforeAll(() => { toggleEventListeners(true); });
+  afterAll(() => { toggleEventListeners(false); });
 
   it('disables a button that has the attribute aria-disabled="true"', () => {
     const [component, handler] = mountComponent(`<div>

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ import './assertions';
 
 window.beforeAll = before; // eslint-disable-line no-undef
 window.afterAll = after; // eslint-disable-line no-undef
+window.test = it;
 
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,9 @@ import { loadAsyncRouteComponents } from './util/load-async';
 import { mockLogin } from './util/session';
 import './assertions';
 
+window.beforeAll = before; // eslint-disable-line no-undef
+window.afterAll = after; // eslint-disable-line no-undef
+
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -18,7 +21,7 @@ import './assertions';
 
 // Even if a route is lazy-loaded, load() will need synchronous access to the
 // async components associated with the route.
-before(loadAsyncRouteComponents);
+beforeAll(loadAsyncRouteComponents);
 
 beforeEach(testData.seed);
 

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -11,7 +11,7 @@ import { mockResponse } from './util/axios';
 
 describe('createCentralRouter()', () => {
   describe('i18n', () => {
-    before(() => {
+    beforeAll(() => {
       const has = Object.prototype.hasOwnProperty.call(navigator, 'language');
       has.should.be.false();
     });

--- a/test/unit/i18n.spec.js
+++ b/test/unit/i18n.spec.js
@@ -49,7 +49,7 @@ describe('util/i18n', () => {
     for (const [locale, [path, casesForLocale]] of Object.entries(cases)) {
       describe(locale, () => {
         const container = createTestContainer();
-        before(() => loadLocale(container, locale));
+        beforeAll(() => loadLocale(container, locale));
 
         const { i18n } = container;
         for (const [count, form] of casesForLocale) {

--- a/test/unit/reactivity.spec.js
+++ b/test/unit/reactivity.spec.js
@@ -33,7 +33,7 @@ describe('util/reactivity', () => {
       });
 
       describe('async component', () => {
-        before(() => {
+        beforeAll(() => {
           setLoader('MyModal', async () => ({
             default: { foo: 'bar' }
           }));


### PR DESCRIPTION
Vitest offers much of the functionality that Mocha does. It provides a `describe()` function, `it()`, as well as hooks like `beforeEach()` and `afterEach()`. However, there are some differences:

- The Mocha `before()` hook maps to Vitest `beforeAll()`.
- The Mocha `after()` hook maps to Vitest `afterAll()`.
- In Mocha, `it()` and `specify()` are synonyms. In Vitest, it's `it()` and `test()`. We use `specify()` for one test where it was awkward to start the test title with "it". I've replaced that use of `specify()` with `test()`.

A future PR will actually replace Mocha with Vitest. However, it'll reduce the size of that PR to start renaming these globals now. This PR uses Vitest names for testing globals, making replacements along the lines of what's described above. It then specifies those names in the ESLint config. Related issue: #671

#### What has been done to verify that this works as intended?

Testing and linting continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced