### PR TITLE
Fix css for FieldKeyQrPanel shown outside FieldKeyNew

### DIFF
--- a/src/components/field-key/new.vue
+++ b/src/components/field-key/new.vue
@@ -182,11 +182,14 @@ export default {
     width: 80%;
     margin-bottom: 0px;
   }
+
+  + .field-key-qr-panel {
+    margin: 15px auto 30px;
+  }
 }
 
 .field-key-qr-panel {
   box-shadow: $box-shadow-popover;
-  margin: 15px auto 30px;
 }
 </style>
 

--- a/src/components/field-key/new.vue
+++ b/src/components/field-key/new.vue
@@ -185,12 +185,10 @@ export default {
 
   + .field-key-qr-panel {
     margin: 15px auto 30px;
+    box-shadow: $box-shadow-popover;
   }
 }
 
-.field-key-qr-panel {
-  box-shadow: $box-shadow-popover;
-}
 </style>
 
 <i18n lang="json5">


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/663

Fixes some CSS issues that came from supporting a longer app user name and caused weird padding to appear behind the app user QR popover. 

Looks better now!

<img width="565" alt="Screenshot 2024-05-21 at 12 15 49 PM" src="https://github.com/getodk/central-frontend/assets/76205/5e4d3481-307b-466d-abd8-e4a2e4476e52">

Looks ok here, too.
<img width="646" alt="Screenshot 2024-05-21 at 12 15 34 PM" src="https://github.com/getodk/central-frontend/assets/76205/649b9cb7-9a1f-428b-9116-d99e007677ad">



<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

visually inspecting it.

#### Why is this the best possible solution? Were any other approaches considered?

The element for saying the new app user/QR code was successfully created is now a sibling of the element with the actual QR code in it, instead of the parent. Changed the CSS a bit to support the QR code element being shown in two places a) the success modal, and b) the normal re-viewing of a QR code in the popover.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Fixes a bug.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced