### PR TITLE
Add new Web Form preview button under feature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
+        "@getodk/web-forms": "^0.1.1",
         "axios": "^1.6.2",
         "bootstrap": "~3",
         "dompurify": "~2",
@@ -549,6 +550,18 @@
       "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
       "dependencies": {
         "@floating-ui/core": "^1.0.5"
+      }
+    },
+    "node_modules/@getodk/web-forms": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.1.1.tgz",
+      "integrity": "sha512-R1l8glK+0EC4jwQ1RdkZdqzJQaHduJpUVlCNdwGsEwAga5PjVpONoHOM3vSYLc2x/L2+vfGB1LeaAIeApGca9A==",
+      "engines": {
+        "node": "^18.20.3 || ^20.13.1 || ^22.2.0",
+        "yarn": "1.22.19"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -13136,6 +13149,12 @@
       "requires": {
         "@floating-ui/core": "^1.0.5"
       }
+    },
+    "@getodk/web-forms": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.1.1.tgz",
+      "integrity": "sha512-R1l8glK+0EC4jwQ1RdkZdqzJQaHduJpUVlCNdwGsEwAga5PjVpONoHOM3vSYLc2x/L2+vfGB1LeaAIeApGca9A==",
+      "requires": {}
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",
+    "@getodk/web-forms": "^0.1.1",
     "axios": "^1.6.2",
     "bootstrap": "~3",
     "dompurify": "~2",

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -13,7 +13,6 @@ except according to the terms contained in the LICENSE file.
 @import './mixins';
 
 html {
-  background-color: $color-accent-secondary;
   min-height: 100%;
 }
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -10,18 +10,21 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div>
+  <div :class="features">
     <!-- If the user's session is restored during the initial navigation, that
     will affect how the navbar is rendered. -->
-    <navbar v-show="routerReady"/>
+    <navbar v-if="!$route.meta.standalone" v-show="routerReady"/>
     <alert id="app-alert"/>
     <feedback-button v-if="showsFeedbackButton"/>
     <!-- Specifying .capture so that an alert is not hidden immediately if it
     was shown after the click. -->
     <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-    <div class="container-fluid" @click.capture="hideAlertAfterClick">
+    <div v-if="!$route.meta.standalone" class="container-fluid" @click.capture="hideAlertAfterClick">
       <router-view/>
     </div>
+    <template v-if="$route.meta.standalone">
+      <router-view/>
+    </template>
     <div id="tooltips"></div>
   </div>
 </template>
@@ -36,6 +39,7 @@ import Navbar from './navbar.vue';
 
 import useCallWait from '../composables/call-wait';
 import useDisabled from '../composables/disabled';
+import useFeatureFlags from '../composables/feature-flags';
 import { useRequestData } from '../request-data';
 import { useSessions } from '../util/session';
 import { loadAsync } from '../util/load-async';
@@ -47,10 +51,11 @@ export default {
   setup() {
     const { visiblyLoggedIn } = useSessions();
     useDisabled();
+    const { features } = useFeatureFlags();
 
     const { centralVersion } = useRequestData();
     const { callWait } = useCallWait();
-    return { visiblyLoggedIn, centralVersion, callWait };
+    return { visiblyLoggedIn, centralVersion, callWait, features };
   },
   computed: {
     routerReady() {

--- a/src/components/form-version/standard-buttons.vue
+++ b/src/components/form-version/standard-buttons.vue
@@ -24,7 +24,6 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
-import { ref } from 'vue';
 import EnketoPreview from '../enketo/preview.vue';
 import FormVersionDefDropdown from './def-dropdown.vue';
 import useRoutes from '../../composables/routes';

--- a/src/components/form-version/standard-buttons.vue
+++ b/src/components/form-version/standard-buttons.vue
@@ -14,14 +14,20 @@ except according to the terms contained in the LICENSE file.
 <template>
   <span class="form-version-standard-buttons">
     <enketo-preview :form-version="version"/>
+    <RouterLink class="btn btn-default btn-web-form" :to="formPath('preview')" target="_blank">
+      <span class="icon-eye"></span>
+      New Preview
+    </RouterLink>
     <form-version-def-dropdown :version="version"
       @view-xml="$emit('view-xml')"/>
   </span>
 </template>
 
 <script>
+import { ref } from 'vue';
 import EnketoPreview from '../enketo/preview.vue';
 import FormVersionDefDropdown from './def-dropdown.vue';
+import useRoutes from '../../composables/routes';
 
 export default {
   name: 'FormVersionStandardButtons',
@@ -32,12 +38,36 @@ export default {
       required: true
     }
   },
-  emits: ['view-xml']
+  emits: ['view-xml'],
+  setup() {
+    const { formPath } = useRoutes();
+    return { formPath };
+  }
 };
 </script>
 
 <style lang="scss">
-.form-version-standard-buttons .enketo-preview {
-  margin-right: 5px;
+.form-version-standard-buttons {
+  .enketo-preview {
+    margin-right: 5px;
+  }
+  .btn-web-form {
+    display: none;
+  }
 }
+
+// `new-web-forms` class is added to the root of App component when the
+// new web form feature is enabled.
+.new-web-forms {
+  .form-version-standard-buttons {
+    .enketo-preview {
+      display: none;
+    }
+    .btn-web-form {
+      margin-right: 5px;
+      display: inline-block;
+    }
+  }
+}
+
 </style>

--- a/src/components/form/preview.vue
+++ b/src/components/form/preview.vue
@@ -1,0 +1,79 @@
+<template>
+      <template v-if="formVersionXml.dataExists">
+        <OdkWebForm :form-xml="formVersionXml.data" @submit="handleSubmit"/>
+      </template>
+
+      <modal id="owf-submission-preview" :state="previewState" hideable backdrop
+          @hide="previewState = false">
+          <template #title>ODK Web Forms Preview</template>
+          <template #body>
+            This is the preview of new ODK Web Forms, currently you can only view your forms with it.
+          </template>
+      </modal>
+</template>
+
+<script setup>
+import { ref, createApp, getCurrentInstance } from 'vue';
+import { OdkWebForm, webFormsPlugin } from '@getodk/web-forms';
+import useForm from '../../request-data/form';
+import { apiPaths } from '../../util/request';
+import { noop } from '../../util/util';
+import Modal from '../modal.vue';
+
+// Install WebFormsPlugin in the component instead of installing it at the
+// application level so that @getodk/web-forms package is not loaded for every
+// page, thus increasing the initial bundle
+const app = createApp({});
+app.use(webFormsPlugin);
+const inst = getCurrentInstance();
+// webFormsPlugin just adds config property to the appContext
+inst.appContext.config = app._context.config;
+
+
+const props = defineProps({
+  projectId: {
+    type: String,
+    required: true
+  },
+  xmlFormId: {
+    type: String,
+    required: true
+  }
+});
+
+const { form, formVersionXml } = useForm();
+
+const previewState = ref(false);
+
+const defPath = (extension) => {
+  const { projectId, xmlFormId, publishedAt } = form;
+
+  return publishedAt != null
+    ? apiPaths.formVersionDef(projectId, xmlFormId, form.version, extension)
+    : apiPaths.formDraftDef(projectId, xmlFormId, extension);
+};
+
+const fetchForm = () => {
+  const url = apiPaths.form(props.projectId, props.xmlFormId);
+  form.request({ url, extended: true })
+    .then(() => {
+      formVersionXml.request({ url: defPath('.xml') });
+    })
+    .catch(noop);
+};
+
+fetchForm();
+
+const handleSubmit = () => {
+  previewState.value = true;
+};
+</script>
+
+<style lang="scss">
+:root {
+  font-size: 16px;
+}
+html, body {
+  background-color: var(--gray-200);
+}
+</style>

--- a/src/components/form/preview.vue
+++ b/src/components/form/preview.vue
@@ -14,6 +14,7 @@
 
 <script setup>
 import { ref, createApp, getCurrentInstance } from 'vue';
+/* eslint-disable-next-line import/no-unresolved -- not sure why eslint is complaining about it */
 import { OdkWebForm, webFormsPlugin } from '@getodk/web-forms';
 import useForm from '../../request-data/form';
 import { apiPaths } from '../../util/request';

--- a/src/composables/feature-flags.js
+++ b/src/composables/feature-flags.js
@@ -1,0 +1,60 @@
+import { onMounted, onUnmounted, ref } from 'vue';
+
+export default function useFeatureFlags() {
+  const features = ref({
+    'new-web-forms': false
+  });
+
+  const cheatKeys = {
+    w: false,
+    f: false
+  };
+
+  function updateCheatKeys(event, isKeydownEvent) {
+    if (event.key.toLowerCase() === 'w') {
+      cheatKeys.w = isKeydownEvent;
+    }
+    if (event.key.toLowerCase() === 'f') {
+      cheatKeys.f = isKeydownEvent;
+    }
+
+    if (cheatKeys.w && cheatKeys.f) {
+      features.value['new-web-forms'] = true;
+    } else {
+      features.value['new-web-forms'] = false;
+    }
+  }
+
+  function reset() {
+    cheatKeys.w = false;
+    cheatKeys.f = false;
+    features.value['new-web-forms'] = false;
+  }
+
+  const keydownEventHandler = (e) => updateCheatKeys(e, true);
+  const keyupEventHandler = (e) => updateCheatKeys(e, false);
+
+  onMounted(() => {
+    // eslint-disable-next-line no-console
+    console.log(
+      '%c ODK Central Alpha Features: \n\n%c- Press and hold the %cW and F %ckeyboard keys on a screen with a form preview button to access the new %cWeb Forms%c preview.\n\n',
+      'background-color: #009ecc; font-size: 18px; color: white',
+      ';',
+      'font-weight: bold; font-size: 14px;',
+      '',
+      'font-weight: bold; font-size: 14px;',
+      '',
+    );
+    document.addEventListener('keydown', keydownEventHandler);
+    document.addEventListener('keyup', keyupEventHandler);
+    document.addEventListener('focusout', reset);
+  });
+
+  onUnmounted(() => {
+    document.removeEventListener('keydown', keydownEventHandler);
+    document.removeEventListener('keyup', keyupEventHandler);
+    document.removeEventListener('focusout', reset);
+  });
+
+  return { features };
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -515,6 +515,23 @@ const routes = [
     }
   }),
   asyncRoute({
+    path: '/projects/:projectId([1-9]\\d*)/forms/:xmlFormId/preview',
+    component: 'FormPreview',
+    props: true,
+    loading: 'page',
+    meta: {
+      standalone: true,
+      validateData: {
+        project: () => project.permits([
+          'form.read',
+          'form.update',
+          'form.delete'
+        ])
+      },
+      title: () => ['Form Preview', form.nameOrId]
+    }
+  }),
+  asyncRoute({
     path: '/projects/:projectId([1-9]\\d*)/entity-lists/:datasetName',
     component: 'DatasetShow',
     props: true,

--- a/src/util/load-async.js
+++ b/src/util/load-async.js
@@ -123,6 +123,10 @@ const loaders = new Map()
     /* webpackChunkName: "component-form-submissions" */
     '../components/form/submissions.vue'
   )))
+  .set('FormPreview', loader(() => import(
+    /* webpackChunkName: "component-form-preview" */
+    '../components/form/preview.vue'
+  )))
   .set('FormVersionList', loader(() => import(
     /* webpackChunkName: "component-form-version-list" */
     '../components/form-version/list.vue'


### PR DESCRIPTION
Closes # TBA

https://github.com/getodk/central-frontend/assets/447837/0114b2ba-6451-44b7-bc5c-2b0e45a773cf

#### What has been done to verify that this works as intended?

Manually verified it. Will add component tests soon.

I have also verified that initial bundle size doesn't increase with this PR, new assets are only loaded when new Web Form preview page is opened.

#### Why is this the best possible solution? Were any other approaches considered?

We discussed other options like printing URL of the new Web Forms preview in the console, but that would pollute the console log. Current approach just prints the instruction once at the start of the application about how to access new Web Forms preview. 

I have added a new `standalone` meta property to the routes, by default its value is false for all the routes and true for FormPreview. When this property is true, I don't render navigation bar and application's wrapper. Other option was to add new Odk-Web-Forms component in a separate Vue instance, which would be devoid of all the functionality that we already have like auth, request, store, etc. and probably separate build configurations.

I have create FeatureFlags composable that can be extended to include more alpha/beta features in the future. I am open to not go that route and rename this composable to just reflect new Web Forms feature.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Maybe not. We will probably announce this in our Insiders call

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced