### PR TITLE
Use new i18n path for "Draft" message

### DIFF
--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -71,7 +71,7 @@ except according to the terms contained in the LICENSE file.
           </div>
           <div v-if="rendersDraftNav" id="form-head-draft-nav"
             class="col-xs-6" :class="{ 'draft-exists': formDraft.isDefined() }">
-            <span id="form-head-draft-nav-title">{{ $t('draftNav.title') }}</span>
+            <span id="form-head-draft-nav-title">{{ $t('resource.draft') }}</span>
             <button v-show="formDraft.isEmpty()"
               id="form-head-create-draft-button" type="button"
               class="btn btn-primary" @click="$emit('create-draft')">


### PR DESCRIPTION
In #1001, the `draftNav.title` message in `FormHead` was moved to `resource.draft` in en.json5. Because the path changed, we need to update `FormHead` in one place. (Sorry, I should have thought of that when we were discussing in #1001. 😅)

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced