### PR TITLE
Show links to FormPreview in FormList

### DIFF
--- a/src/components/enketo/preview.vue
+++ b/src/components/enketo/preview.vue
@@ -11,16 +11,22 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <a v-if="disabledDescription == null" class="enketo-preview btn btn-default"
-    :href="href" target="_blank">
+    :href="enketoPath" target="_blank">
     <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </a>
   <button v-else type="button" class="enketo-preview btn btn-default" aria-disabled="true"
     v-tooltip.aria-describedby="disabledDescription">
     <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </button>
+
+  <router-link class="btn btn-default btn-web-form" :to="webFormsPath"
+    target="_blank">
+    <span class="icon-eye"></span>{{ $t('action.newPreview') }}
+  </router-link>
 </template>
 
 <script>
+import useRoutes from '../../composables/routes';
 import { enketoBasePath } from '../../util/util';
 
 export default {
@@ -31,6 +37,10 @@ export default {
       required: true
     }
   },
+  setup() {
+    const { formPath } = useRoutes();
+    return { formPath };
+  },
   computed: {
     disabledDescription() {
       if (this.formVersion.publishedAt != null &&
@@ -40,15 +50,40 @@ export default {
         return this.$t('disabled.processing');
       return null;
     },
-    href() {
+    enketoPath() {
       // enketoId probably doesn't need to be encoded, but there is also little
       // harm.
       const encodedId = encodeURIComponent(this.formVersion.enketoId);
       return `${enketoBasePath}/preview/${encodedId}`;
+    },
+    webFormsPath() {
+      return this.formPath(
+        this.formVersion.projectId,
+        this.formVersion.xmlFormId,
+        this.formVersion.publishedAt != null ? 'preview' : 'draft/preview'
+      );
     }
   }
 };
 </script>
+
+<style lang="scss">
+.btn-web-form {
+  display: none;
+}
+
+// `new-web-forms` class is added to the root of App component when the
+// new web form feature is enabled.
+.new-web-forms {
+  .enketo-preview {
+    display: none;
+  }
+
+  .btn-web-form {
+    display: inline-block;
+  }
+}
+</style>
 
 <i18n lang="json5">
 {

--- a/src/components/form-version/standard-buttons.vue
+++ b/src/components/form-version/standard-buttons.vue
@@ -14,12 +14,6 @@ except according to the terms contained in the LICENSE file.
 <template>
   <span class="form-version-standard-buttons">
     <enketo-preview :form-version="version"/>
-    <router-link
-      class="btn btn-default btn-web-form"
-      :to="version.publishedAt != null ? formPath('preview') : formPath('draft/preview')"
-      target="_blank">
-      <span class="icon-eye"></span>{{ $t('action.newPreview') }}
-    </router-link>
     <form-version-def-dropdown :version="version"
       @view-xml="$emit('view-xml')"/>
   </span>
@@ -28,7 +22,6 @@ except according to the terms contained in the LICENSE file.
 <script>
 import EnketoPreview from '../enketo/preview.vue';
 import FormVersionDefDropdown from './def-dropdown.vue';
-import useRoutes from '../../composables/routes';
 
 export default {
   name: 'FormVersionStandardButtons',
@@ -39,36 +32,12 @@ export default {
       required: true
     }
   },
-  emits: ['view-xml'],
-  setup() {
-    const { formPath } = useRoutes();
-    return { formPath };
-  }
+  emits: ['view-xml']
 };
 </script>
 
 <style lang="scss">
 .form-version-standard-buttons {
-  .enketo-preview {
-    margin-right: 5px;
-  }
-  .btn-web-form {
-    display: none;
-  }
+  > :not(:last-child) { margin-right: 5px; }
 }
-
-// `new-web-forms` class is added to the root of App component when the
-// new web form feature is enabled.
-.new-web-forms {
-  .form-version-standard-buttons {
-    .enketo-preview {
-      display: none;
-    }
-    .btn-web-form {
-      margin-right: 5px;
-      display: inline-block;
-    }
-  }
-}
-
 </style>

--- a/src/components/form/row.vue
+++ b/src/components/form/row.vue
@@ -199,7 +199,10 @@ export default {
   }
 
   .actions {
-    width: 100px,
+    width: 100px;
+    // Make sure there is enough width for .btn-web-form so that toggling Web
+    // Forms does not change the width of the column.
+    &:has(.enketo-preview) { min-width: 127px; }
   }
 
   .last-submission{

--- a/test/components/enketo/preview.spec.js
+++ b/test/components/enketo/preview.spec.js
@@ -1,16 +1,23 @@
 import EnketoPreview from '../../../src/components/enketo/preview.vue';
 
 import testData from '../../data';
-import { mount } from '../../util/lifecycle';
+import { mergeMountOptions, mount } from '../../util/lifecycle';
+import { mockRouter } from '../../util/router';
+
+const mountComponent = (options) =>
+  mount(EnketoPreview, mergeMountOptions(options, {
+    container: { router: mockRouter('/projects/1/forms/f') }
+  }));
 
 describe('EnketoPreview', () => {
   it('renders correctly for an open form with an enketoId', () => {
     const form = testData.extendedForms
       .createPast(1, { enketoId: 'xyz', state: 'open' })
       .last();
-    const button = mount(EnketoPreview, {
+    const component = mountComponent({
       props: { formVersion: form }
     });
+    const button = component.get('.enketo-preview');
     button.element.tagName.should.equal('A');
     button.attributes().href.should.equal('/-/preview/xyz');
   });
@@ -19,9 +26,10 @@ describe('EnketoPreview', () => {
     const form = testData.extendedForms
       .createPast(1, { enketoId: null, state: 'open' })
       .last();
-    const button = mount(EnketoPreview, {
+    const component = mountComponent({
       props: { formVersion: form }
     });
+    const button = component.get('.enketo-preview');
     button.element.tagName.should.equal('BUTTON');
     button.attributes('aria-disabled').should.equal('true');
     button.should.have.ariaDescription('Preview has not finished processing for this Form. Please refresh later and try again.');
@@ -33,9 +41,10 @@ describe('EnketoPreview', () => {
       const form = testData.extendedForms
         .createPast(1, { enketoId: 'xyz', state: 'closing' })
         .last();
-      const button = mount(EnketoPreview, {
+      const component = mountComponent({
         props: { formVersion: form }
       });
+      const button = component.get('.enketo-preview');
       button.element.tagName.should.equal('BUTTON');
       button.should.have.ariaDescription('In this version of ODK Central, preview is only available for Forms in the Open state.');
       await button.should.have.tooltip();
@@ -48,10 +57,10 @@ describe('EnketoPreview', () => {
         state: 'closing'
       });
       const draft = testData.extendedFormDrafts.last();
-      const button = mount(EnketoPreview, {
+      const component = mountComponent({
         props: { formVersion: draft }
       });
-      button.element.tagName.should.equal('A');
+      component.get('.enketo-preview').element.tagName.should.equal('A');
     });
   });
 });

--- a/test/components/form/row.spec.js
+++ b/test/components/form/row.spec.js
@@ -311,7 +311,7 @@ describe('FormRow', () => {
       mockLogin({ role: 'admin' });
       testData.extendedForms.createPast(1, { state: 'open' });
       const row = mountComponent();
-      row.getComponent(EnketoPreview).should.be.visible();
+      row.get('.enketo-preview').should.be.visible();
       row.findComponent(EnketoFill).exists().should.be.false();
     });
 


### PR DESCRIPTION
As of #1001, pressing the W+F keys shows the "New Preview" button (which links to Web Forms) instead of the default Preview button (which links to Enketo). However, pressing W+F has no effect in the project overview: even though there is a Preview button for each form, "New Preview" is not shown. This PR changes that so that W+F has an effect wherever the Preview button is shown, including the project overview.

#### What has been done to verify that this works as intended?

Trying it locally.

#### Why is this the best possible solution? Were any other approaches considered?

The underlying issue is that the "New Preview" logic appears in `FormVersionStandardButtons`, but `FormRow` renders `EnketoPreview` without `FormVersionStandardButtons`. `FormVersionStandardButtons` and `FormRow` are the only two components that render `EnketoPreview`. My change involves moving the "New Preview" logic from `FormVersionStandardButtons` to `EnketoPreview`. In other words, `EnketoPreview` will manage the form preview button for both Enketo and Web Forms. I'd be happy to rename the `EnketoPreview` component if that'd make things clearer.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced