### PR TITLE
Improve how lastEntity is used in tests

### DIFF
--- a/test/components/project/dataset-row.spec.js
+++ b/test/components/project/dataset-row.spec.js
@@ -58,9 +58,8 @@ describe('ProjectDatasetRow', () => {
   });
 
   it('shows the correct icon for timestamp', () => {
-    setLuxon({ defaultZoneName: 'UTC' });
     const lastEntity = '2023-01-01T00:00:00Z';
-    testData.extendedDatasets.createPast(1, { name: 'people', lastEntity, entities: 0 });
+    testData.extendedDatasets.createPast(1, { name: 'people', lastEntity });
     const cell = mountComponent().get('.last-entity');
     cell.find('.icon-clock-o').exists().should.be.true();
   });
@@ -73,9 +72,8 @@ describe('ProjectDatasetRow', () => {
   });
 
   it('last entity has the correct links', () => {
-    setLuxon({ defaultZoneName: 'UTC' });
     const lastEntity = '2023-01-01T00:00:00Z';
-    testData.extendedDatasets.createPast(1, { name: 'people', lastEntity, entities: 0 });
+    testData.extendedDatasets.createPast(1, { name: 'people', lastEntity });
     const link = mountComponent().getComponent('.last-entity a');
     link.props().to.should.equal('/projects/1/entity-lists/people/entities');
   });

--- a/test/data/datasets.js
+++ b/test/data/datasets.js
@@ -3,6 +3,21 @@ import { comparator } from 'ramda';
 import { dataStore } from './data-store';
 import { extendedProjects } from './projects';
 
+// Returns summary statistics about entities that try to be internally
+// consistent. The stats will not necessarily match testData.extendedEntities or
+// the project's lastEntity property.
+const normalizeEntityStats = (stats) => {
+  const result = { ...stats };
+  if (result.entities == null) {
+    result.entities = result.conflicts !== 0
+      ? result.conflicts
+      : (result.lastEntity != null ? 1 : 0);
+  }
+  if (result.lastEntity == null && result.entities !== 0)
+    result.lastEntity = new Date().toISOString();
+  return result;
+};
+
 const normalizeProperty = (property) => ({
   odataName: property.name,
   forms: [],
@@ -14,29 +29,31 @@ export const extendedDatasets = dataStore({
   factory: ({
     id,
 
-    project = extendedProjects.size !== 0
-      ? extendedProjects.first()
-      : extendedProjects.createPast(1, { datasets: 1 }).last(),
+    project: projectOption = extendedProjects.first(),
     name = 'trees',
-    entities = 0,
-    lastEntity = null,
     properties = [],
-    linkedForms = [],
     approvalRequired = false,
-    sourceForms = [],
-    conflicts = 0
-  }) => ({
-    id,
-    projectId: project.id,
-    name,
-    entities,
-    lastEntity,
-    properties: properties.map(normalizeProperty),
-    linkedForms,
-    approvalRequired,
-    sourceForms,
-    conflicts
-  }),
+    entities = undefined,
+    lastEntity = undefined,
+    conflicts = 0,
+    linkedForms = [],
+    sourceForms = []
+  }) => {
+    const entityStats = normalizeEntityStats({ entities, lastEntity, conflicts });
+    const project = projectOption ?? extendedProjects
+      .createPast(1, { datasets: 1, lastEntity: entityStats.lastEntity })
+      .last();
+    return {
+      id,
+      projectId: project.id,
+      name,
+      properties: properties.map(normalizeProperty),
+      approvalRequired,
+      ...entityStats,
+      linkedForms,
+      sourceForms
+    };
+  },
   sort: comparator((dataset1, dataset2) => dataset1.name < dataset2.name)
 });
 

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -151,7 +151,8 @@ entities = dataStore({
     source = undefined,
     creator: creatorOption = undefined
   }) => {
-    if (extendedDatasets.size === 0) {
+    const newDataset = extendedDatasets.size === 0;
+    if (newDataset) {
       const properties = data != null
         ? Object.keys(data).map(name => ({ name, forms: [] }))
         : [];
@@ -166,6 +167,7 @@ entities = dataStore({
         lastCreatedAt,
         creator.createdAt
       ]);
+    if (newDataset) extendedDatasets.update(0, { lastEntity: createdAt });
     const entity = {
       uuid,
       creatorId: creator.id,

--- a/test/data/forms.js
+++ b/test/data/forms.js
@@ -66,7 +66,6 @@ const forms = dataStore({
       : extendedUsers.createPast(1).last(),
     fields = [testDataFields.string('/s')],
     entityRelated = false,
-    lastEntity = undefined,
     publicLinks = 0,
 
     ...extraVersionOptions
@@ -106,8 +105,7 @@ const forms = dataStore({
       enketoId,
       submissions,
       lastSubmission,
-      reviewStates,
-      lastEntity
+      reviewStates
     });
     Object.assign(form, submissionStats(form));
     if (inPast)
@@ -149,8 +147,7 @@ formVersions = dataStore({
     lastSubmission = undefined,
     reviewStates = undefined,
     publishedBy = undefined,
-    draftToken = draft ? faker.random.alphaNumeric(64) : null,
-    lastEntity = undefined
+    draftToken = draft ? faker.random.alphaNumeric(64) : null
   }) => {
     if (form === undefined) throw new Error('form not found');
     const result = {
@@ -179,8 +176,7 @@ formVersions = dataStore({
     } else {
       Object.assign(result, {
         publishedAt: publishedAt != null ? publishedAt : result.createdAt,
-        publishedBy: publishedBy != null ? toActor(publishedBy) : form.createdBy,
-        lastEntity
+        publishedBy: publishedBy != null ? toActor(publishedBy) : form.createdBy
       });
     }
     return result;
@@ -245,7 +241,7 @@ export const extendedForms = view(
       ),
       ...pick([...basicVersionProps, 'excelContentType'], version),
       ...pick(
-        ['submissions', 'lastSubmission', 'reviewStates', 'lastEntity'],
+        ['submissions', 'lastSubmission', 'reviewStates'],
         version.publishedAt == null ? version : form
       )
     };

--- a/test/data/projects.js
+++ b/test/data/projects.js
@@ -19,6 +19,28 @@ const verbsForUserAndRole = (extendedUser, roleSystem) => {
   return Array.from(verbs);
 };
 
+// Returns extended metadata that tries to be internally consistent. The
+// extended metadata will not necessarily match other test data stores.
+const normalizeMetadata = (metadata) => {
+  const result = { ...metadata };
+
+  if (result.datasets == null) {
+    result.datasets = result.datasetList != null
+      ? result.datasetList.length
+      : (result.lastEntity != null ? 1 : 0);
+  }
+  if (result.datasetList == null) result.datasetList = [];
+
+  if (result.forms == null) {
+    result.forms = result.formList != null
+      ? result.formList.length
+      : (result.lastSubmission != null || result.datasets !== 0 ? 1 : 0);
+  }
+  if (result.formList == null) result.formList = [];
+
+  return result;
+};
+
 export const extendedProjects = dataStore({
   factory: ({
     inPast,
@@ -28,27 +50,25 @@ export const extendedProjects = dataStore({
     name = faker.name.findName(),
     description = '',
     archived = false,
-    // The default value of this property does not necessarily match
-    // testData.extendedDatasets.
-    datasets = 0,
-    // The default value of this property does not necessarily match
-    // testData.extendedForms.
-    forms = datasets === 0 ? 0 : 1,
+    key = null,
     // The default value of this property does not necessarily match
     // testData.extendedFieldKeys.
     appUsers = 0,
+    forms = undefined,
     // The default value of this property does not necessarily match
     // testData.extendedForms or testData.extendedSubmissions.
     lastSubmission = null,
-    key = null,
+    datasets = undefined,
+    // The default value of this property does not necessarily match
+    // testData.extendedDatasets or testData.extendedEntities.
+    lastEntity = null,
+    formList = undefined,
+    datasetList = undefined,
     currentUser = extendedUsers.size !== 0
       ? extendedUsers.first()
       : extendedUsers.createPast(1).last(),
     // The current user's role on the project
-    role = 'none',
-    formList = [],
-    datasetList = [],
-    lastEntity
+    role = 'none'
   }) => ({
     id,
     name,
@@ -60,19 +80,21 @@ export const extendedProjects = dataStore({
       : new Date().toISOString(),
     updatedAt: null,
     // Extended metadata
-    forms,
-    lastSubmission,
-    datasets,
-    appUsers,
-    verbs: verbsForUserAndRole(currentUser, role),
-    formList,
-    datasetList,
-    lastEntity
+    ...normalizeMetadata({
+      appUsers,
+      forms,
+      lastSubmission,
+      datasets,
+      lastEntity,
+      formList,
+      datasetList,
+      verbs: verbsForUserAndRole(currentUser, role)
+    })
   }),
   sort: (project1, project2) => project1.name.localeCompare(project2.name)
 });
 
 export const standardProjects = view(
   extendedProjects,
-  omit(['forms', 'lastSubmission', 'datasets', 'appUsers', 'verbs', 'formList'])
+  omit(['appUsers', 'forms', 'lastSubmission', 'datasets', 'lastEntity', 'formList', 'datasetList', 'verbs'])
 );

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -17,13 +17,13 @@ describe('util/sort', () => {
       testData.extendedForms.createPast(1, { name: 'C', lastSubmission: ago({ days: 15 }).toISO() });
       testData.extendedForms.createPast(1, { name: 'D', lastSubmission: ago({ days: 20 }).toISO() });
       testData.extendedForms.createPast(1, { name: 'E', lastSubmission: ago({ days: 10 }).toISO() });
-      testData.extendedForms.createPast(1, { name: 'F', lastSubmission: ago({ days: 10 }).toISO(), lastEntity: ago({ days: 5 }).toISO() });
-      testData.extendedForms.createPast(1, { name: 'G', lastSubmission: ago({ days: 12 }).toISO(), lastEntity: ago({ days: 20 }).toISO() });
+      testData.extendedForms.createPast(1, { name: 'F', lastSubmission: ago({ days: 5 }).toISO() });
+      testData.extendedForms.createPast(1, { name: 'G', lastSubmission: ago({ days: 12 }).toISO() });
       testData.extendedForms.createPast(1, { name: 'A' });
       testData.extendedForms.createPast(1, { name: 'B' });
     });
 
-    it('can sort forms by latest activity including breaking ties (null submissions/enitities) alphabetically', () => {
+    it('can sort forms by latest activity including breaking ties (null submissions) alphabetically', () => {
       const forms = testData.extendedForms.sorted();
       forms.sort(sortFunctions.latest);
       forms.map((form) => form.name).should.eql(['F', 'E', 'G', 'C', 'D', 'A', 'B']);


### PR DESCRIPTION
As part of #1004, I added a new property to `testData.extendedForms` (`publicLinks`). I randomly noticed that `testData.extendedForms` has the property `lastEntity`, but I don't think that Backend actually returns that property. This PR removes `lastEntity` from `testData.extendedForms`. It also makes a few other changes related to `lastEntity`, mostly making it more consistent with other `testData` properties. See the commit message for details.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

I think it's good to try to make `testData` as similar to Backend as possible. Where it's easy to do, I also think it's nice to try to make `testData` internally consistent.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced