### PR TITLE
Don't italicize Japanese or Chinese

### DIFF
--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -1,5 +1,14 @@
 @import './variables';
 
+@mixin italic {
+  font-style: italic;
+
+  &:lang(ja), &:lang(zh) {
+    font-style: normal;
+    font-weight: bold;
+  }
+}
+
 @mixin text-overflow-ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -93,12 +93,7 @@ code {
 
 .text-monospace { font-family: $font-family-monospace; }
 
-em {
-  &:lang(ja), &:lang(zh) {
-    font-style: normal;
-    font-weight: bold;
-  }
-}
+em { @include italic; }
 
 .tooltip {
   /* v-tooltip.aria-describedby tooltips are rendered before they are shown

--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -120,9 +120,7 @@ export default {
     overflow-wrap: break-word;
   }
 
-  .no-properties {
-    font-style: italic;
-  }
+  .no-properties { @include italic; }
 }
 </style>
 

--- a/src/components/dataset/overview/dataset-properties.vue
+++ b/src/components/dataset/overview/dataset-properties.vue
@@ -89,8 +89,8 @@ const { publishedFormPath } = useRoutes();
   }
 
   .empty-update-form {
+    @include italic;
     color: #888;
-    font-style: italic;
   }
 }
 </style>

--- a/src/components/dataset/summary/row.vue
+++ b/src/components/dataset/summary/row.vue
@@ -91,7 +91,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../../assets/scss/_variables.scss';
 @import '../../../assets/scss/mixins';
 
 .dataset-summary-row {
@@ -144,9 +143,7 @@ export default {
       hyphens: auto;
       overflow-wrap: break-word;
 
-      .no-properties {
-        font-style: italic;
-      }
+      .no-properties { @include italic; }
     }
 }
 

--- a/src/components/entity/conflict-table.vue
+++ b/src/components/entity/conflict-table.vue
@@ -247,7 +247,9 @@ defineExpose({ resize });
 
   .unchanged {
     color: #888;
+
     font-style: italic;
+    &:lang(ja), &:lang(zh) { font-style: normal; }
   }
 
   [class^="icon-"] {

--- a/src/components/entity/data.vue
+++ b/src/components/entity/data.vue
@@ -71,8 +71,8 @@ const data = computed(() => entity.currentVersion.data);
   }
 
   .empty {
+    @include italic;
     color: #888;
-    font-style: italic;
   }
 }
 </style>

--- a/src/components/entity/diff/row.vue
+++ b/src/components/entity/diff/row.vue
@@ -74,8 +74,8 @@ const newValue = name === 'label' ? entityVersion.label : entityVersion.data[nam
   .conflicting { color: $color-danger; }
 
   .empty {
+    @include italic;
     color: #888;
-    font-style: italic;
   }
   .value {
     overflow-wrap: break-word;

--- a/src/components/entity/update/row.vue
+++ b/src/components/entity/update/row.vue
@@ -127,8 +127,8 @@ defineExpose({ textarea: computed(() => ({ ...textarea.value, resize })) });
     white-space: break-spaces;
 
     &.empty {
+      @include italic;
       color: #999;
-      font-style: italic;
     }
   }
 

--- a/src/components/multiselect.vue
+++ b/src/components/multiselect.vue
@@ -440,6 +440,12 @@ const emptyMessage = computed(() => (searchValue.value === ''
         color: #666;
         font-style: italic;
       }
+      &:lang(ja), &:lang(zh) {
+        &::placeholder {
+          font-style: normal;
+          font-weight: bold;
+        }
+      }
     }
 
     .close {

--- a/src/components/project/overview/description.vue
+++ b/src/components/project/overview/description.vue
@@ -82,7 +82,7 @@ export default {
 }
 
 #project-overview-description-update {
-  font-style: italic;
+  @include italic;
 
   .instructions {
     font-size: 16px;

--- a/src/components/submission/data-row.vue
+++ b/src/components/submission/data-row.vue
@@ -174,7 +174,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../assets/scss/variables';
+@import '../../assets/scss/mixins';
 
 #submission-table {
   .int-field, .decimal-field { text-align: right; }
@@ -215,7 +215,7 @@ export default {
       vertical-align: -2px;
     }
 
-    .encryption-message { font-style: italic; }
+    .encryption-message { @include italic; }
 
     ~ .encrypted-submission {
       .encrypted-data { position: relative; }


### PR DESCRIPTION
For Japanese, we use bold instead of italics for `<em>` elements. [Apparently](https://aqworks.com/en/blog/2016/09/20/perfect-japanese-typography/), italics aren't used in Japanese. That was something I [mentioned](https://github.com/getodk/central-frontend/pull/468#issuecomment-847345225) when I added Japanese in the first place. However, as I'm adding Chinese just now, I'm realizing that there are elements outside `<em>` where we italicize using CSS. This PR makes a similar change as for `<em>` elements, making those elements bold instead of italic for Japanese.

In #1006, I made Chinese bold instead of italic, similar to Japanese. I've [read](https://drwhispers.com/2021/11/16/italics-in-chinese/) that italics also aren't used in Chinese. I'm not sure that bold is the very best option (the article suggests underdots in some cases), but it sounds like it's an improvement over italic. The article makes it clear that multiple options are better than italic. If we receive feedback from the Chinese translator or from users, I'd be happy to do something different.

#### What has been done to verify that this works as intended?

I spot-checked a few of these changes.

#### Why is this the best possible solution? Were any other approaches considered?

I added a mixin for this, which I think is the most ergonomic.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced