### PR TITLE
Change Overview tab to Forms and add badge

### DIFF
--- a/src/components/form-draft/abandon.vue
+++ b/src/components/form-draft/abandon.vue
@@ -60,9 +60,9 @@ export default {
   setup() {
     // The component assumes that this data will exist when the component is
     // created.
-    const { form } = useRequestData();
+    const { project, form } = useRequestData();
     const { request, awaitingResponse } = useRequest();
-    return { form, request, awaitingResponse };
+    return { project, form, request, awaitingResponse };
   },
   computed: {
     title() {
@@ -80,9 +80,10 @@ export default {
           : apiPaths.form(this.form.projectId, this.form.xmlFormId)
       })
         .then(() => {
-          // project.forms and project.lastSubmission may now be out-of-date. If
-          // the user navigates to ProjectOverview, project.forms should be
-          // updated. project.lastSubmission is not used within ProjectShow.
+          if (this.form.publishedAt == null) this.project.forms -= 1;
+          // project.lastSubmission may now be out-of-date. However,
+          // project.lastSubmission is not used within ProjectShow.
+
           this.$emit('success');
         })
         .catch(noop);

--- a/src/components/form-draft/abandon.vue
+++ b/src/components/form-draft/abandon.vue
@@ -58,8 +58,6 @@ export default {
   },
   emits: ['hide', 'success'],
   setup() {
-    // The component assumes that this data will exist when the component is
-    // created.
     const { project, form } = useRequestData();
     const { request, awaitingResponse } = useRequest();
     return { project, form, request, awaitingResponse };
@@ -81,9 +79,6 @@ export default {
       })
         .then(() => {
           if (this.form.publishedAt == null) this.project.forms -= 1;
-          // project.lastSubmission may now be out-of-date. However,
-          // project.lastSubmission is not used within ProjectShow.
-
           this.$emit('success');
         })
         .catch(noop);

--- a/src/components/form/delete.vue
+++ b/src/components/form/delete.vue
@@ -61,9 +61,9 @@ export default {
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.
-    const { form } = useRequestData();
+    const { project, form } = useRequestData();
     const { request, awaitingResponse } = useRequest();
-    return { form, request, awaitingResponse };
+    return { project, form, request, awaitingResponse };
   },
   methods: {
     del() {
@@ -72,9 +72,10 @@ export default {
         url: apiPaths.form(this.form.projectId, this.form.xmlFormId)
       })
         .then(() => {
-          // project.forms and project.lastSubmission may now be out-of-date. If
-          // the user navigates to ProjectOverview, project.forms should be
-          // updated. project.lastSubmission is not used within ProjectShow.
+          this.project.forms -= 1;
+          // project.lastSubmission may now be out-of-date. However,
+          // project.lastSubmission is not used within ProjectShow.
+
           this.$emit('success');
         })
         .catch(noop);

--- a/src/components/form/list.vue
+++ b/src/components/form/list.vue
@@ -71,12 +71,15 @@ export default {
     }
   },
   methods: {
-    afterCreate(form) {
+    async afterCreate(form) {
       const message = this.$t('alert.create', {
         name: form.name != null ? form.name : form.xmlFormId
       });
-      this.$router.push(this.formPath(form.projectId, form.xmlFormId, 'draft'))
-        .then(() => { this.alert.success(message); });
+      await this.$router.push(this.formPath(form.projectId, form.xmlFormId, 'draft'));
+      // Increment the count so that if the user returns to a project page, they
+      // will see the new count.
+      this.project.forms += 1;
+      this.alert.success(message);
     }
   }
 };

--- a/src/components/form/new.vue
+++ b/src/components/form/new.vue
@@ -226,9 +226,6 @@ export default {
             this.alert.blank();
             this.warnings = data.details.warnings;
           } else {
-            // project.forms may now be out-of-date. However, if the user
-            // navigates to the project overview, it should be updated.
-
             this.$emit('success', data);
           }
         })

--- a/src/components/form/table.vue
+++ b/src/components/form/table.vue
@@ -72,19 +72,15 @@ export default {
     formsToShow() {
       if (!this.forms.dataExists)
         return [];
-      // Hide any form without a published version from a Data Collector.
       const filteredForms = this.showClosed
         ? this.forms.filter(form => form.state === 'closed')
         : this.forms.filter(form => form.state !== 'closed');
       filteredForms.sort(this.sortFunc);
-      return this.project.permits('submission.list') && this.project.permits('form.update')
-        ? filteredForms
-        : filteredForms.filter(form => form.publishedAt != null);
+      return filteredForms;
     }
   }
 };
 </script>
-
 
 <style lang="scss">
 .form-table {

--- a/src/components/form/trash-list.vue
+++ b/src/components/form/trash-list.vue
@@ -79,7 +79,7 @@ export default {
       // refresh trashed forms list
       this.fetchDeletedForms(true);
 
-      // tell parent component (project overview) to refresh regular forms list
+      // tell parent component (ProjectOverview) to refresh regular forms list
       // (by emitting event to that component's parent)
       this.$emit('restore');
     }

--- a/src/components/project/show.vue
+++ b/src/components/project/show.vue
@@ -17,9 +17,14 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template #tabs>
         <!-- Everyone with access to the project should be able to navigate to
-        the project overview. -->
+        the forms page. -->
         <li :class="tabClass('')" role="presentation">
-          <router-link :to="tabPath('')">{{ $t('common.tab.overview') }}</router-link>
+          <router-link :to="tabPath('')">
+            {{ $t('resource.forms') }}
+            <span v-if="project.dataExists" class="badge">
+              {{ $n(project.forms, 'default') }}
+            </span>
+          </router-link>
         </li>
         <li v-if="canRoute(tabPath('entity-lists'))" :class="tabClass('entity-lists')"
           role="presentation">

--- a/src/request-data/project.js
+++ b/src/request-data/project.js
@@ -41,7 +41,7 @@ export default () => {
   });
 
   // Returns a set containing just the form names that appear more than once
-  // in a project. Used on project overview to show form ID next to form name
+  // in a project. Used on forms page to show form ID next to form name
   // when form names are duplicated.
   const duplicateFormNames = createGetter('duplicateFormNames', computed(() => {
     if (!(forms.dataExists && deletedForms.dataExists)) return null;

--- a/src/routes.js
+++ b/src/routes.js
@@ -272,7 +272,7 @@ const routes = [
           validateData: {
             project: () => project.permits('form.list') || project.permits('open_form.list')
           },
-          title: () => [project.name]
+          title: () => [i18n.t('resource.forms'), project.name]
         }
       }),
       asyncRoute({

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -165,9 +165,15 @@ describe('FormDraftAbandon', () => {
         app.should.alert('success', 'The Form “My Form” was deleted.');
       }));
 
-    it('redirects to the project overview', () =>
+    it('redirects to the forms page', () =>
       abandon().then(app => {
         app.vm.$route.path.should.equal('/projects/1');
+      }));
+
+    it('decreases the form count even before the forms response', () =>
+      abandon().beforeEachResponse((app, _, i) => {
+        if (i === 0) return;
+        app.get('#page-head-tabs li.active .badge').text().should.equal('0');
       }));
 
     it('does not show the form in the table', () =>

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -1,5 +1,4 @@
 import FormDraftAbandon from '../../../src/components/form-draft/abandon.vue';
-import FormRow from '../../../src/components/form/row.vue';
 
 import testData from '../../data';
 import { load, mockHttp } from '../../util/http';
@@ -174,11 +173,6 @@ describe('FormDraftAbandon', () => {
       abandon().beforeEachResponse((app, _, i) => {
         if (i === 0) return;
         app.get('#page-head-tabs li.active .badge').text().should.equal('0');
-      }));
-
-    it('does not show the form in the table', () =>
-      abandon().then(app => {
-        app.findComponent(FormRow).exists().should.be.false();
       }));
   });
 });

--- a/test/components/form/delete.spec.js
+++ b/test/components/form/delete.spec.js
@@ -69,7 +69,7 @@ describe('FormDelete', () => {
         .respondWithData(() => []); // Empty list of deleted forms
     };
 
-    it('navigates to the project overview', async () => {
+    it('navigates to the forms page', async () => {
       const app = await del();
       app.vm.$route.path.should.equal('/projects/1');
     });

--- a/test/components/form/delete.spec.js
+++ b/test/components/form/delete.spec.js
@@ -78,5 +78,11 @@ describe('FormDelete', () => {
       const app = await del();
       app.should.alert('success');
     });
+
+    it('decreases the form count even before the forms response', () =>
+      del().beforeEachResponse((app, _, i) => {
+        if (i === 0) return;
+        app.get('#page-head-tabs li.active .badge').text().should.equal('0');
+      }));
   });
 });

--- a/test/components/form/new.spec.js
+++ b/test/components/form/new.spec.js
@@ -7,7 +7,6 @@ import FormVersionString from '../../../src/components/form-version/string.vue';
 
 import testData from '../../data';
 import { dragAndDrop, setFiles } from '../../util/trigger';
-import { findTab } from '../../util/dom';
 import { load, mockHttp } from '../../util/http';
 import { mockLogin } from '../../util/session';
 import { mockRouter } from '../../util/router';
@@ -286,13 +285,11 @@ describe('FormNew', () => {
     it('increments the form count', () =>
       createForm()
         .complete()
-        // Navigate to a page that does not request the form list. Once the form
-        // list is received, the form count will be updated to match it.
-        .load('/projects/1/settings', { project: false })
-        .afterResponses(app => {
-          findTab(app, 'Forms').get('.badge').text().should.equal('2');
-          // Check that the form list was not requested.
-          app.vm.$container.requestData.localResources.forms.dataExists.should.be.false();
+        .load('/projects/1', { project: false })
+        .beforeAnyResponse(app => {
+          // The form count should be seen to be incremented even before the
+          // updated form list is received.
+          app.get('#page-head-tabs li.active .badge').text().should.equal('2');
         }));
   });
 

--- a/test/components/form/new.spec.js
+++ b/test/components/form/new.spec.js
@@ -3,11 +3,11 @@ import { clone } from 'ramda';
 import ChecklistStep from '../../../src/components/checklist-step.vue';
 import FileDropZone from '../../../src/components/file-drop-zone.vue';
 import FormNew from '../../../src/components/form/new.vue';
-import FormRow from '../../../src/components/form/row.vue';
 import FormVersionString from '../../../src/components/form-version/string.vue';
 
 import testData from '../../data';
 import { dragAndDrop, setFiles } from '../../util/trigger';
+import { findTab } from '../../util/dom';
 import { load, mockHttp } from '../../util/http';
 import { mockLogin } from '../../util/session';
 import { mockRouter } from '../../util/router';
@@ -283,12 +283,16 @@ describe('FormNew', () => {
         app.should.alert('success', 'Your new Form “Form 2” has been created as a Draft. Take a look at the checklist below, and when you feel it’s ready, you can publish the Form for use.');
       }));
 
-    it('renders the correct number of rows in the forms table', () =>
+    it('increments the form count', () =>
       createForm()
         .complete()
-        .load('/projects/1', { project: false })
+        // Navigate to a page that does not request the form list. Once the form
+        // list is received, the form count will be updated to match it.
+        .load('/projects/1/settings', { project: false })
         .afterResponses(app => {
-          app.findAllComponents(FormRow).length.should.equal(2);
+          findTab(app, 'Forms').get('.badge').text().should.equal('2');
+          // Check that the form list was not requested.
+          app.vm.$container.requestData.localResources.forms.dataExists.should.be.false();
         }));
   });
 

--- a/test/components/form/table.spec.js
+++ b/test/components/form/table.spec.js
@@ -65,50 +65,6 @@ describe('FormTable', () => {
     });
   });
 
-  describe('number of rows', () => {
-    it('shows a form without a published version to an administrator', async () => {
-      mockLogin({ role: 'admin' });
-      testData.extendedProjects.createPast(1, { forms: 2 });
-      testData.extendedForms.createPast(1, { name: 'My Published Form', state: 'open' });
-      testData.extendedForms.createPast(1, {
-        name: 'My Draft Form',
-        draft: true,
-        state: 'open'
-      });
-      const app = await load('/projects/1');
-      const text = app.findAll('.form-row .name').map(td => td.text());
-      text.should.eql(['My Draft Form', 'My Published Form']);
-    });
-
-    it('does not show a form without a published version to a project viewer', async () => {
-      mockLogin({ role: 'none' });
-      testData.extendedProjects.createPast(1, { role: 'viewer', forms: 2 });
-      testData.extendedForms.createPast(1, { name: 'My Published Form', state: 'open' });
-      testData.extendedForms.createPast(1, {
-        name: 'My Draft Form',
-        draft: true,
-        state: 'open'
-      });
-      const app = await load('/projects/1', {}, { deletedForms: false });
-      const text = app.findAll('.form-row .name').map(td => td.text());
-      text.should.eql(['My Published Form']);
-    });
-
-    it('does not show form without published version to Data Collector', async () => {
-      mockLogin({ role: 'none' });
-      testData.extendedProjects.createPast(1, { role: 'formfill', forms: 2 });
-      testData.extendedForms.createPast(1, { name: 'My Published Form', state: 'open' });
-      testData.extendedForms.createPast(1, {
-        name: 'My Draft Form',
-        draft: true,
-        state: 'open'
-      });
-      const app = await load('/projects/1', {}, { deletedForms: false });
-      const text = app.findAll('.form-row .name').map(td => td.text());
-      text.should.eql(['My Published Form']);
-    });
-  });
-
   describe('sorting', () => {
     it('applies sorting to forms in table', () => {
       mockLogin();

--- a/test/components/project/archive.spec.js
+++ b/test/components/project/archive.spec.js
@@ -51,12 +51,12 @@ describe('ProjectArchive', () => {
         .respondWithData(() => []);
     };
 
-    it('redirects the user to the project overview', async () => {
+    it('redirects the user to the forms page', async () => {
       const app = await submit();
       app.vm.$route.path.should.equal('/projects/1');
     });
 
-    it("appends (archived) to project's name in project overview", async () => {
+    it("appends (archived) to the project's name", async () => {
       const app = await submit();
       app.get('#page-head-title').text().should.equal('My Project (archived)');
     });

--- a/test/components/project/new.spec.js
+++ b/test/components/project/new.spec.js
@@ -86,7 +86,7 @@ describe('ProjectNew', () => {
         .respondFor('/projects/2');
     };
 
-    it('redirects to the project overview', async () => {
+    it('redirects to the project', async () => {
       const app = await submit();
       app.vm.$route.path.should.equal('/projects/2');
     });

--- a/test/components/project/overview.spec.js
+++ b/test/components/project/overview.spec.js
@@ -47,7 +47,7 @@ describe('ProjectOverview', () => {
     });
   });
 
-  // These tests are in project overview because this component
+  // These tests are in ProjectOverview because this component
   // does/does not include the trashed forms component based on
   // permissions of the given user and project. (And those
   // permissions may not be immediately available.)

--- a/test/components/project/show.spec.js
+++ b/test/components/project/show.spec.js
@@ -141,7 +141,7 @@ describe('ProjectShow', () => {
       const app = await load('/projects/1', { attachTo: document.body });
       const li = app.findAll('#page-head-tabs li');
       li.map(wrapper => wrapper.get('a').text()).should.eql([
-        'Overview',
+        'Forms 1',
         'Entities 1',
         'Project Roles',
         'App Users',
@@ -167,7 +167,7 @@ describe('ProjectShow', () => {
         });
         const li = app.findAll('#page-head-tabs li');
         const text = li.map(wrapper => wrapper.get('a').text());
-        text.should.eql(['Overview', 'Entities 1']);
+        text.should.eql(['Forms 1', 'Entities 1']);
         li[0].should.be.visible(true);
       });
     });
@@ -181,6 +181,14 @@ describe('ProjectShow', () => {
       const li = app.findAll('#page-head-tabs li');
       li.length.should.equal(1);
       li[0].should.be.hidden(true);
+    });
+
+    it('shows the form count', async () => {
+      mockLogin();
+      testData.extendedProjects.createPast(1, { forms: 1000 });
+      // Navigate to a page that does not request the form list.
+      const app = await load('/projects/1/settings');
+      findTab(app, 'Forms').get('.badge').text().should.equal('1,000');
     });
 
     it('shows the count of entity lists', async () => {

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -234,7 +234,7 @@ describe('createCentralRouter()', () => {
         testData.extendedForms.createPast(1);
       });
 
-      it('preserves data while navigating to/from the project overview', () =>
+      it('preserves data while navigating to/from the forms page', () =>
         load('/projects/1/form-access')
           .complete()
           .load('/projects/1', { project: false, forms: false }) // allow deletedForms to be fetched
@@ -526,7 +526,7 @@ describe('createCentralRouter()', () => {
           testData.extendedFieldKeys.createPast(1);
         });
 
-        it('does not redirect the user from the project overview', async () => {
+        it('does not redirect the user from the forms page', async () => {
           const app = await load('/projects/1', {}, { deletedForms: false });
           app.vm.$route.path.should.equal('/projects/1');
         });
@@ -683,7 +683,7 @@ describe('createCentralRouter()', () => {
         testData.extendedDatasets.createPast(1, { name: 'trees' });
       });
 
-      it('does not redirect the user from the project overview', async () => {
+      it('does not redirect the user from the forms page', async () => {
         const app = await load('/projects/1', {}, { deletedForms: false });
         app.vm.$route.path.should.equal('/projects/1');
       });
@@ -1012,10 +1012,10 @@ describe('createCentralRouter()', () => {
     it('inspects title before and after project data loaded', () =>
       load('/projects/1')
         .beforeAnyResponse(() => {
-          document.title.should.equal('ODK Central');
+          document.title.should.equal('Forms | ODK Central');
         })
         .afterResponses(() => {
-          document.title.should.equal('My Project Name | ODK Central');
+          document.title.should.equal('Forms | My Project Name | ODK Central');
         }));
 
     it('shows project name in title for /projects/1/user', async () => {
@@ -1041,13 +1041,6 @@ describe('createCentralRouter()', () => {
     it('shows project name in title for /projects/1/settings', async () => {
       await load('/projects/1/settings');
       document.title.should.equal('Settings | My Project Name | ODK Central');
-    });
-
-    // Special cases of project routes
-    it('does not show project name if null for /projects/1', async () => {
-      testData.extendedProjects.createPast(1, { name: null });
-      await load('/projects/2');
-      document.title.should.equal('ODK Central');
     });
 
     // Form routes


### PR DESCRIPTION
This PR makes progress on getodk/central#671, adding a badge to one more nav tab. We will rename the project "Overview" tab to "Forms", then show the form count in a badge on the tab.

#### What has been done to verify that this works as intended?

Trying it out some locally, new tests.

#### Why is this the best possible solution? Were any other approaches considered?

One thing I wanted to make sure was the case was that the form count in the badge matches the number of forms in the forms table. I thought that might not be the case, because the `FormTable` component had logic to filter the form list. Specifically, the component wouldn't show draft forms to Data Collector users and would filter them out. However, it looks like that logic is no longer needed in Frontend. Backend seems to be doing that filtering now, which means that the form count in the badge should match the table without additional effort. Actually, it does look like there is a related Backend issue in this area (getodk/central#687), but we can fix that in Backend, and in general, I don't think we need to do anything extra in Frontend. We just show the `forms` property from the project response in the badge, and we also update that property if for some reason it differs from the form list.

Another thing this PR does is update the `forms` property when an action can be expected to have changed it. When a form is created, the property is incremented, and when a form is deleted, it is decremented.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced