### PR TITLE
Upgrade web forms v0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
-        "@getodk/web-forms": "^0.1.1",
+        "@getodk/web-forms": "^0.2.0",
         "axios": "^1.6.2",
         "bootstrap": "~3",
         "dompurify": "~2",
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@getodk/web-forms": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.1.1.tgz",
-      "integrity": "sha512-R1l8glK+0EC4jwQ1RdkZdqzJQaHduJpUVlCNdwGsEwAga5PjVpONoHOM3vSYLc2x/L2+vfGB1LeaAIeApGca9A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.2.0.tgz",
+      "integrity": "sha512-FKuvm28hwYDXfmoULLLiLxVS1B3ZBs2j15LObqnz/Ylp46ytJLzwvtxzgqEzOqsunYhONn8Zvy9gQu3C33pAuA==",
       "engines": {
         "node": "^18.20.3 || ^20.13.1 || ^22.2.0",
         "yarn": "1.22.19"
@@ -13151,9 +13151,9 @@
       }
     },
     "@getodk/web-forms": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.1.1.tgz",
-      "integrity": "sha512-R1l8glK+0EC4jwQ1RdkZdqzJQaHduJpUVlCNdwGsEwAga5PjVpONoHOM3vSYLc2x/L2+vfGB1LeaAIeApGca9A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.2.0.tgz",
+      "integrity": "sha512-FKuvm28hwYDXfmoULLLiLxVS1B3ZBs2j15LObqnz/Ylp46ytJLzwvtxzgqEzOqsunYhONn8Zvy9gQu3C33pAuA==",
       "requires": {}
     },
     "@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",
-    "@getodk/web-forms": "^0.1.1",
+    "@getodk/web-forms": "^0.2.0",
     "axios": "^1.6.2",
     "bootstrap": "~3",
     "dompurify": "~2",

--- a/src/assets/css/namespaces.css
+++ b/src/assets/css/namespaces.css
@@ -1,0 +1,1 @@
+@namespace svg "http://www.w3.org/2000/svg";

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -899,3 +899,11 @@ becomes more complicated.
   transition: opacity 0.6s 0.15s;
 }
 [data-mark-rows-deleted="false"] { display: none; }
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Don't let styles defined in Central bleed into new Web Forms Component
+
+.odk-form :not(svg|*) {
+  all: revert;
+}

--- a/src/styles.js
+++ b/src/styles.js
@@ -11,6 +11,7 @@ except according to the terms contained in the LICENSE file.
 */
 
 // Import global styles.
+import './assets/css/namespaces.css';
 import './assets/css/bootstrap.css';
 import './assets/css/icomoon.css';
 import './assets/scss/app.scss';


### PR DESCRIPTION
- Upgraded `getodk/web-forms` to v0.2 which brings in a appearances for Select questions.
- Added a CSS fix for the stopping bootstrap messing up with the styles of new web form component. We could have added this fix in the code of `web-forms` but it was decided that for now it is best to add in Central and update the docs of `web-forms` to let other host applications to do that same.

#### What has been done to verify that this works as intended?
Manually tested it to ensure various select appearances are rendered correctly.

#### Why is this the best possible solution? Were any other approaches considered?

Second commit in this PR reverts all the styling added by bootstrap and other css files for new Web Forms component. The approach felt cleanest to me. Other options were to dynamically removed the `<style>` tags when rending new Web Forms or when `meta.standalone` is true - that would also removed styles for dialog box that we show on "Send" button.


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Not sure we want to update the documentation for this feature or just announce it on the Forum.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
