### PR TITLE
Remove references to old presenter objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,16 +82,6 @@ If a utility is used in a limited number of components, consider using a mixin i
 
 We use axios to send requests. We set `Vue.prototype.$http` to `axios`, so components can use `this.$http` rather than importing `axios`. That said, components rarely need to access `this.$http` directly. Most of the time, to send a GET request, you can use the [`request` module](/src/store/modules/request.js) of the Vuex store; to send a non-GET request, you can use the [`request` mixin](/src/mixins/request.js). The module and mixin both accept options and complete common tasks like error handling. See the section below on [Response Data](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md#response-data) for more on sending a GET request.
 
-### Presenter Classes
-
-Many ODK Central Backend resources have an associated presenter class in Frontend ([`/src/presenters/`](/src/presenters/)). This class extends the [base presenter class](/src/presenters/base.js).
-
-Each presenter class defines a whitelist of properties that the presenter object can read from the underlying resource data. If a new property is added to a Backend resource, it must also be added to the presenter class before a presenter object can read it.
-
-When you use the [`request` module](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md#response-data) of the Vuex store to send a GET request, then if there is a presenter class associated with the response data, the `request` module will automatically wrap the response data within a presenter object.
-
-Some presenter classes need access to the internationalization object `i18n`. If you retrieve a presenter class from the container rather than importing it, the class will have a static method named `from()` that will create a new presenter object and automatically pass in `i18n`: see [`subclassPresenters()`](/src/presenters/index.js). If you define a new presenter class, you should also add it to `subclassPresenters()`. For more on internationalization, see the section [below](https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md#internationalization).
-
 ### Learning About a Component
 
 To learn how a given component works, one of the best places to start is how the component communicates with its parent component:

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -430,8 +430,9 @@
       }
     }
   },
-  "presenter": {
-    "Project": {
+  "requestData": {
+    "project": {
+      // @transifexKey presenter.Project.nameWithArchived
       // {name} is the name of a Project. We append "(archived)" to the name if
       // the Project is archived.
       "nameWithArchived": "{name} (archived)"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -319,8 +319,8 @@
       }
     }
   },
-  "presenter": {
-    "Project": {
+  "requestData": {
+    "project": {
       "nameWithArchived": "{name} (archivado)"
     }
   },

--- a/src/request-data/resources.js
+++ b/src/request-data/resources.js
@@ -56,7 +56,7 @@ export default ({ i18n }, createResource) => {
     },
     /* eslint-enable no-param-reassign */
     nameWithArchived: computeIfExists(() => (project.archived
-      ? i18n.t('presenter.Project.nameWithArchived', project)
+      ? i18n.t('requestData.project.nameWithArchived', project)
       : project.name))
   }));
   createResource('form', () => ({

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -912,14 +912,6 @@
       }
     }
   },
-  "presenter": {
-    "Project": {
-      "nameWithArchived": {
-        "string": "{name} (archived)",
-        "developer_comment": "{name} is the name of a Project. We append \"(archived)\" to the name if the Project is archived."
-      }
-    }
-  },
   "util": {
     "csv": {
       "readError": {
@@ -4803,6 +4795,14 @@
           "string": "Retire user",
           "developer_comment": "This is the text for an action, for example, the text of a button."
         }
+      }
+    }
+  },
+  "presenter": {
+    "Project": {
+      "nameWithArchived": {
+        "string": "{name} (archived)",
+        "developer_comment": "{name} is the name of a Project. We append \"(archived)\" to the name if the Project is archived."
       }
     }
   }


### PR DESCRIPTION
We used to use presenter objects, defining a class for each Backend resource (e.g., `Project`). We removed those when we introduced `requestData`, but they're still referenced in a couple of places:

- The contribution guide
- A group of i18n messages is named `presenter`.

This PR removes these references in order to avoid confusion.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced