### PR TITLE
Exclude revoked public links from tab count

### DIFF
--- a/src/components/public-link/revoke.vue
+++ b/src/components/public-link/revoke.vue
@@ -32,7 +32,7 @@ except according to the terms contained in the LICENSE file.
   </modal>
 </template>
 
-<script>
+<script setup>
 import Modal from '../modal.vue';
 import Spinner from '../spinner.vue';
 
@@ -40,30 +40,22 @@ import useRequest from '../../composables/request';
 import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 
-export default {
-  name: 'PublicLinkRevoke',
-  components: { Modal, Spinner },
-  props: {
-    state: Boolean,
-    publicLink: Object
-  },
-  emits: ['hide', 'success'],
-  setup() {
-    const { request, awaitingResponse } = useRequest();
-    return { request, awaitingResponse };
-  },
-  methods: {
-    revoke() {
-      this.request({
-        method: 'DELETE',
-        url: apiPaths.session(this.publicLink.token)
-      })
-        .then(() => {
-          this.$emit('success', this.publicLink);
-        })
-        .catch(noop);
-    }
-  }
+defineOptions({
+  name: 'PublicLinkRevoke'
+});
+const props = defineProps({
+  state: Boolean,
+  publicLink: Object
+});
+const emit = defineEmits(['hide', 'success']);
+
+const { request, awaitingResponse } = useRequest();
+const revoke = () => {
+  request({ method: 'DELETE', url: apiPaths.session(props.publicLink.token) })
+    .then(() => {
+      emit('success', props.publicLink);
+    })
+    .catch(noop);
 };
 </script>
 

--- a/src/request-data/form.js
+++ b/src/request-data/form.js
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 */
 import { watchSyncEffect } from 'vue';
 
-import { transformForms } from './util';
+import { computeIfExists, transformForms } from './util';
 import { useRequestData } from './index';
 
 export default () => {
@@ -20,15 +20,20 @@ export default () => {
     transformResponse: transformForms
   }));
   const formVersionXml = createResource('formVersionXml');
-  const publicLinks = createResource('publicLinks');
+  const publicLinks = createResource('publicLinks', () => ({
+    activeCount: computeIfExists(() => publicLinks.reduce(
+      (count, { token }) => count + (token != null ? 1 : 0),
+      0
+    ))
+  }));
   const formDraftDatasetDiff = createResource('formDraftDatasetDiff');
   const formDatasetDiff = createResource('formDatasetDiff');
   const publishedAttachments = createResource('publishedAttachments'); // Published Form attachments
 
   watchSyncEffect(() => {
     if (form.dataExists && publicLinks.dataExists &&
-      form.publicLinks !== publicLinks.length)
-      form.publicLinks = publicLinks.length;
+      form.publicLinks !== publicLinks.activeCount)
+      form.publicLinks = publicLinks.activeCount;
   });
 
   return {

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -126,7 +126,7 @@ describe('FormHead', () => {
       findTab(app, 'Submissions').get('.badge').text().should.equal('1,000');
     });
 
-    it('shows the count of public links', async () => {
+    it('shows the number of active public links', async () => {
       mockLogin();
       testData.extendedForms.createPast(1, { publicLinks: 1000 });
       const app = await load('/projects/1/forms/f');

--- a/test/components/public-link/revoke.spec.js
+++ b/test/components/public-link/revoke.spec.js
@@ -75,6 +75,16 @@ describe('PublicLinkRevoke', () => {
           text.should.equal('Revoked');
         }));
 
+    it('decreases the count in the tab', () =>
+      load('/projects/1/forms/f/public-links')
+        .afterResponses(app => {
+          app.get('#form-head .nav-tabs li.active .badge').text().should.equal('1');
+        })
+        .modify(revoke)
+        .afterResponses(app => {
+          app.get('#form-head .nav-tabs li.active .badge').text().should.equal('0');
+        }));
+
     it('no longer highlights a new public link', () =>
       load('/projects/1/forms/f/public-links')
         .complete()

--- a/test/request-data/form.spec.js
+++ b/test/request-data/form.spec.js
@@ -12,13 +12,28 @@ const createResources = (data = {}) => {
 };
 
 describe('useForm()', () => {
-  it('updates form.publicLinks to match publicLinks.length', () => {
+  describe('publicLinks', () => {
+    it('counts the number of active public links', () => {
+      testData.standardPublicLinks
+        .createPast(1)
+        .createPast(1, { token: null });
+      const requestData = createResources({
+        publicLinks: testData.standardPublicLinks.sorted()
+      });
+      requestData.localResources.publicLinks.activeCount.should.equal(1);
+    });
+  });
+
+  it('updates form.publicLinks to match publicLinks.activeCount', () => {
     const requestData = createResources({
       form: testData.extendedForms.createPast(1).last()
     });
     requestData.form.publicLinks.should.equal(0);
+    testData.standardPublicLinks
+      .createPast(1)
+      .createPast(1, { token: null });
     setRequestData(requestData, {
-      publicLinks: testData.standardPublicLinks.createPast(1).sorted()
+      publicLinks: testData.standardPublicLinks.sorted()
     });
     requestData.form.publicLinks.should.equal(1);
   });


### PR DESCRIPTION
This PR makes a fix related to https://github.com/getodk/central/issues/671#issuecomment-2250245211. As returned by Backend, `form.publicLinks` is the number of active public links, which excludes revoked public links. However, once the `publicLinks` list is received, Frontend updates `form.publicLinks` to match `publicLinks.length`, which will include revoked links. Updating `form.publicLinks` like this is intended to keep the count up-to-date and consistent. For example, it means that when a public link is created, the count shown in the tab will automatically increase. That said, we do need to exclude revoked links when updating `form.publicLinks` to match `publicLinks`.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I originally thought this was an issue in `PublicLinkRevoke` and that we needed to decrement `form.publicLinks` in that component. That didn't turn out to be correct: once a public link is revoked, `publicLinks` is refreshed, and that alone should update `form.publicLinks`. That's how creating a public link works in `PublicLinkCreate`. All we need to do is exclude revoked links when reconciling `form.publicLinks` and `publicLinks`.

That said, when I thought the issue was with `PublicLinkRevoke`, I did take the step of converting the component to Composition API. I want to do that for more components, so I think that's a change worth keeping, and I've included it with the PR.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced