### PR TITLE
Fix rejectedWith assertion

### DIFF
--- a/test/unit/csv.spec.js
+++ b/test/unit/csv.spec.js
@@ -169,11 +169,11 @@ describe('util/csv', () => {
         data.should.eql([{ a: '1', b: '2' }, { a: '3', b: '4' }]);
       });
 
-      it('returns a rejected promise if function throws an error', async () => {
+      it('returns a rejected promise if function throws an error', () => {
         const promise = parseCSV(i18n, createCSV('a\n1'), ['a'], {
           transformRow: () => { throw new Error('foo'); }
         });
-        promise.should.be.rejectedWith('There is a problem on row 2 of the CSV file: foo');
+        return promise.should.be.rejectedWith('There is a problem on row 2 of the file: foo');
       });
     });
 


### PR DESCRIPTION
This PR fixes a `rejectedWith` assertion that was being ignored. The assertion was called, but it needs to be returned or `await`-ed.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced