### PR TITLE
improv: Nginx dev tweaks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 vue: vue-cli-service build --mode development --watch
-nginx: nginx -c "$PWD/main.nginx.conf" -p "$PWD"
+nginx: nginx -c "$PWD/main.nginx.conf" -p "$PWD" -e stderr

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -19,7 +19,7 @@ events {
 }
 http {
   access_log ./.nginx/nginx-access.log;
-  client_body_temp_path ./.nginx;
+  client_body_temp_path ./.nginx/client_body_temp;
 
   types {
       text/html                             html htm shtml;

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -20,6 +20,7 @@ events {
 http {
   access_log ./.nginx/nginx-access.log;
   client_body_temp_path ./.nginx/client_body_temp;
+  proxy_temp_path ./.nginx/proxy_temp 1 2;
 
   types {
       text/html                             html htm shtml;

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -12,7 +12,6 @@
 # https://github.com/getodk/central.
 
 daemon off;
-error_log stderr;
 pid ./.nginx/nginx.pid;
 
 events {


### PR DESCRIPTION
Related: #621 

I had some problems running nginx the way it was run with `npm run dev`.
I'm running 

```shell
$ nginx -v
nginx version: nginx/1.26.1
```

### Original problem:

```
2:10:05 PM nginx.1 |  nginx: [alert] could not open error log file: open() "/var/log/nginx/error_log" failed (13: Permission denied)
2:10:05 PM nginx.1 |  2024/08/03 14:10:05 [emerg] 1991673#1991673: mkdir() "/var/lib/nginx/tmp/proxy" failed (13: Permission denied)
```

The first complaint is odd as stderr is specified as the error log destination.
The second complaint can be fixed by defining a `proxy_temp_path` in the writable location (6068b0d), and in the name of tidiness I then also redefine `client_body_temp_path` as a dedicated location (397c9c7).

This gets things going again, that is, nginx is up and running, yet the warning about the error log location that can't be written to remains. Odd! Yet it goes away when invoking nginx with `-e stderr` which then makes the config file `error_log` declaration redundant, leading to 4527b7b.

#### What has been done to verify that this works as intended?
Running the frontend (`npm run dev`) and backend (`node lib/bin/run-server.js`) and verifying whether I can log out and log in.

#### Why is this the best possible solution? Were any other approaches considered?
Theoretically we could do without 4527b7b, but that leaves (at least in my case) a warning in the nginx output, which (even though apparently harmless) then either makes people freak out, or can detract from an *actual* problem, or trains people to ignore warnings from nginx, all of which are undesirable.

#### How does this change affect users?
It doesn't. It only affects developers; those who run `npm run dev`.

#### Does this change require updates to user documentation?
No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes (but that doesn't exercise nginx, anyway)
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced