### PR TITLE
Indicate which entity versions are offline updates

### DIFF
--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -26,7 +26,8 @@ except according to the terms contained in the LICENSE file.
           @resolve="$emit('resolve')"/>
         <div v-for="(group, i) of feed" :key="feed.length - i"
           class="feed-entry-group" v-bind="scrollData(group[0])">
-          <entity-feed-entry v-for="(data, j) of group" :key="j" v-bind="data"/>
+          <entity-feed-entry v-for="(data, j) of group" :key="j" v-bind="data"
+            @branch-data="$emit('branch-data', $event)"/>
         </div>
       </template>
     </template>
@@ -48,7 +49,7 @@ import { useScrollBehavior } from '../../scroll-behavior';
 defineOptions({
   name: 'EntityActivity'
 });
-defineEmits(['delete', 'resolve']);
+defineEmits(['delete', 'resolve', 'branch-data']);
 
 // The component does not assume that this data will exist when the component is
 // created.
@@ -67,7 +68,7 @@ const feed = computed(() => {
       versionIndex -= 1;
       groups.push([{ entry: audit, submission, entityVersion }]);
     } else if (audit.action === 'entity.create') {
-      const group = [{ entry: audit }];
+      const group = [{ entry: audit, entityVersion: entityVersions[0] }];
       const { details } = audit;
       // this will insert a feed entry for the submission approval event
       if (details.source?.event?.action === 'submission.update')

--- a/src/components/entity/activity.vue
+++ b/src/components/entity/activity.vue
@@ -62,12 +62,13 @@ const feed = computed(() => {
   const groups = [];
   let versionIndex = entityVersions.length - 1;
   for (const audit of audits) {
-    if (audit.action === 'entity.update.version') {
+    const { action } = audit;
+    if (action === 'entity.update.version') {
       const { submission } = audit.details.source;
       const entityVersion = entityVersions[versionIndex];
       versionIndex -= 1;
       groups.push([{ entry: audit, submission, entityVersion }]);
-    } else if (audit.action === 'entity.create') {
+    } else if (action === 'entity.create' || action === 'entity.bulk.create') {
       const group = [{ entry: audit, entityVersion: entityVersions[0] }];
       const { details } = audit;
       // this will insert a feed entry for the submission approval event
@@ -102,14 +103,13 @@ watch(() => audits.awaitingResponse, (awaitingResponse) => {
   if (awaitingResponse) scrollTarget.value = null;
 });
 const scrollData = (entryData) => {
-  const { action } = entryData.entry;
-  if (!(action === 'entity.create' || action === 'entity.bulk.create' || action === 'entity.update.version'))
-    return {};
-  const version = (action === 'entity.create' || action === 'entity.bulk.create') ? 1 : entryData.entityVersion.version;
-  return {
-    'data-version': version,
-    class: version === scrollTarget.value ? 'scroll-target' : null
-  };
+  const version = entryData.entityVersion?.version;
+  return version == null
+    ? {}
+    : {
+      'data-version': version,
+      class: version === scrollTarget.value ? 'scroll-target' : null
+    };
 };
 const scrollTo = useScrollBehavior();
 watchEffect(() => {

--- a/src/components/entity/branch-data.vue
+++ b/src/components/entity/branch-data.vue
@@ -1,0 +1,175 @@
+<!--
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <modal id="entity-branch-data" :state="state" hideable size="large" backdrop
+    @hide="$emit('hide')" @click="updateHighlight">
+    <template #title>Offline Branch Data</template>
+    <template #body>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>
+              <div>
+                <span>Version</span>
+                <button type="button" class="btn btn-link" @click="reverseOrder">
+                  <span v-if="asc" class="icon-angle-down"></span>
+                  <span v-else class="icon-angle-up"></span>
+                </button>
+              </div>
+            </th>
+            <th>Server base version</th>
+            <th>Branch ID</th>
+            <th>Trunk version</th>
+            <th>Branch base version</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody v-if="entityVersions.dataExists">
+          <tr v-for="version of sorted" :key="version.version"
+            :class="{ highlight: highlighted.has(version.version) }"
+            :data-version="version.version">
+            <td>v{{ version.version }}</td>
+            <td>
+              <a v-if="version.baseVersion != null" href="#">
+                v{{ version.baseVersion }}
+              </a>
+            </td>
+            <td>
+              <template v-if="version.branch != null">
+                <a href="#">{{ version.branch.id }}</a>
+                <span v-if="version.branchId == null" class="icon-info-circle" v-tooltip.no-aria="'This branch ID was inferred.'">
+                </span>
+              </template>
+            </td>
+            <td>
+              <a v-if="version.trunkVersion != null" href="#">
+                v{{ version.trunkVersion }}
+              </a>
+            </td>
+            <td>
+              <template v-if="version.branchBaseVersion != null">
+                v{{ version.branchBaseVersion }}
+              </template>
+            </td>
+            <td>
+              <button type="button" class="btn btn-default" @click="view">
+                <span class="icon-eye"></span>View in feed
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="modal-actions">
+        <button type="button" class="btn btn-primary" @click="$emit('hide')">
+          {{ $t('action.close') }}
+        </button>
+      </div>
+    </template>
+  </modal>
+</template>
+
+<script setup>
+import { computed, nextTick, reactive, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+
+import Modal from '../modal.vue';
+
+import { noop } from '../../util/util';
+import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'EntityBranchData'
+});
+const props = defineProps({
+  state: Boolean,
+  // The version number of the version to initially highlight
+  highlight: Number,
+});
+const emit = defineEmits(['hide']);
+
+const { entityVersions } = useRequestData();
+
+// The version numbers of the versions to highlight
+const highlighted = reactive(new Set());
+const updateHighlight = (event) => {
+  const { target } = event;
+  // We never need to update `highlighted` after a button click, and in some
+  // cases, we actively don't want to do so.
+  if (target.closest('button') != null) return;
+  highlighted.clear();
+  if (target.tagName === 'A') {
+    event.preventDefault();
+    const text = target.textContent.trim();
+    if (text.startsWith('v')) {
+      highlighted.add(Number.parseInt(text.replace('v', ''), 10));
+    } else {
+      for (const version of entityVersions) {
+        if (version.branch?.id === text) highlighted.add(version.version);
+      }
+    }
+  } else {
+    const tr = event.target.closest('tr');
+    if (tr != null) highlighted.add(Number.parseInt(tr.dataset.version, 10));
+  }
+};
+
+const asc = ref(true);
+const sorted = computed(() =>
+  (asc.value ? entityVersions.data : entityVersions.toReversed()));
+const reverseOrder = () => { asc.value = !asc.value; };
+
+const router = useRouter();
+const view = (event) => {
+  emit('hide');
+  const { version } = event.target.closest('tr').dataset;
+  nextTick(() => { router.push(`#v${version}`).catch(noop); });
+};
+
+watch(() => props.state, (state) => {
+  if (state) {
+    if (props.highlight != null) highlighted.add(props.highlight);
+  } else {
+    highlighted.clear();
+    asc.value = true;
+  }
+});
+</script>
+
+<style lang="scss">
+@import '../../assets/scss/mixins';
+
+#entity-branch-data {
+  .modal-body { padding: 0; }
+  .modal-actions { margin: 0; }
+
+  table {
+    margin-bottom: 0;
+    table-layout: fixed;
+  }
+  th:nth-child(3) { width: 312px; }
+  td { vertical-align: middle; }
+
+  th:first-child {
+    div {
+      align-items: flex-end;
+      display: flex;
+    }
+    .btn-link {
+      @include text-link;
+      top: 4px;
+    }
+    [class^="icon-"] { margin-right: 0; }
+  }
+
+  .icon-info-circle { margin-left: $margin-right-icon; }
+}
+</style>

--- a/src/components/entity/branch-data.vue
+++ b/src/components/entity/branch-data.vue
@@ -46,8 +46,7 @@ except according to the terms contained in the LICENSE file.
             <td>
               <template v-if="version.branch != null">
                 <a href="#">{{ version.branch.id }}</a>
-                <span v-if="version.branchId == null" class="icon-info-circle" v-tooltip.no-aria="'This branch ID was inferred.'">
-                </span>
+                <span v-if="version.branchId == null" class="icon-info-circle" v-tooltip.no-aria="'This branch ID was inferred.'"></span>
               </template>
             </td>
             <td>
@@ -92,7 +91,7 @@ defineOptions({
 const props = defineProps({
   state: Boolean,
   // The version number of the version to initially highlight
-  highlight: Number,
+  highlight: Number
 });
 const emit = defineEmits(['hide']);
 
@@ -100,6 +99,13 @@ const { entityVersions } = useRequestData();
 
 // The version numbers of the versions to highlight
 const highlighted = reactive(new Set());
+const state = computed(() => props.state);
+watch(state, (newState) => {
+  if (newState)
+    highlighted.add(props.highlight);
+  else
+    highlighted.clear();
+});
 const updateHighlight = (event) => {
   const { target } = event;
   // We never need to update `highlighted` after a button click, and in some
@@ -126,6 +132,7 @@ const asc = ref(true);
 const sorted = computed(() =>
   (asc.value ? entityVersions.data : entityVersions.toReversed()));
 const reverseOrder = () => { asc.value = !asc.value; };
+watch(state, (newState) => { if (!newState) asc.value = true; });
 
 const router = useRouter();
 const view = (event) => {
@@ -133,15 +140,6 @@ const view = (event) => {
   const { version } = event.target.closest('tr').dataset;
   nextTick(() => { router.push(`#v${version}`).catch(noop); });
 };
-
-watch(() => props.state, (state) => {
-  if (state) {
-    if (props.highlight != null) highlighted.add(props.highlight);
-  } else {
-    highlighted.clear();
-    asc.value = true;
-  }
-});
 </script>
 
 <style lang="scss">

--- a/src/components/entity/conflict-table.vue
+++ b/src/components/entity/conflict-table.vue
@@ -128,7 +128,7 @@ const summary = computed(() => {
   let lastGoodVersion;
   // The keys of dataReceived from each unresolved conflict
   const allReceived = new Set();
-  // Offline branches to show in the table
+  // The offline branches to show in the table
   const branches = new Set();
   for (const [i, version] of props.versions.entries()) {
     if (version.lastGoodVersion) lastGoodVersion = version.version;
@@ -139,10 +139,15 @@ const summary = computed(() => {
     }
 
     const { branch } = version;
-    if (branch != null && version === branch.first && branch.length !== 1) {
-      // We only show the branch if it is contiguous, and if all the versions
-      // from the branch are shown in the table. lastIndex is the expected index
-      // of the last version from the branch if both those conditions are true.
+    if (branch != null && version === branch.first && branch.length !== 1 &&
+      // The versions from the branch must all be contiguous. It's OK if they're
+      // not contiguous with the trunk version.
+      branch.last.version === branch.first.version + branch.length - 1) {
+      // We only show the branch if all the versions from the branch are shown
+      // in the table. Otherwise, it may be unclear how long the branch was and
+      // that there were other versions that were part of it. lastIndex is the
+      // expected index of the last version from the branch if all the versions
+      // from the branch are shown.
       const lastIndex = i + branch.length - 1;
       if (lastIndex < props.versions.length &&
         props.versions[lastIndex] === branch.last)
@@ -247,14 +252,6 @@ defineExpose({ resize });
   thead th { font-size: 14px; }
   th:first-child { text-align: right; }
 
-  tbody tr { background-color: $background-color-feed-entry; }
-  tbody tr:first-child,
-  tr:nth-child(2),
-  #entity-conflict-table-status-row,
-  #entity-conflict-table-branch-row {
-    background-color: #f4f4f4;
-  }
-
   th, td { @include text-overflow-ellipsis; }
   td { border-left: 1px solid #bbb; }
 
@@ -286,6 +283,16 @@ defineExpose({ resize });
   .icon-check-circle { color: $color-success; }
   .icon-question-circle { color: $color-warning-dark; }
   .icon-warning { color: $color-danger-dark; }
+}
+
+#entity-conflict-table tbody tr {
+  background-color: $background-color-feed-entry;
+}
+#entity-conflict-table tbody tr:first-child,
+#entity-conflict-table tr:nth-child(2),
+#entity-conflict-table-status-row,
+#entity-conflict-table-branch-row {
+  background-color: #f4f4f4;
 }
 
 #entity-conflict-table #entity-conflict-table-status-row {
@@ -340,7 +347,7 @@ defineExpose({ resize });
       "softConflict": "This version may have been made based on old data.",
       "hardConflict": "This version was made in parallel with other updates, some of which attempt to write to the same properties as this update."
     },
-    // A chain of updates that were made offline
+    // A series of updates that were made offline
     "branch": "Offline update chain"
   }
 }

--- a/src/components/entity/conflict-table.vue
+++ b/src/components/entity/conflict-table.vue
@@ -84,9 +84,7 @@ except according to the terms contained in the LICENSE file.
           </td>
         </tr>
         <tr v-if="branches.size !== 0" id="entity-conflict-table-branch-row">
-          <th>
-            <span class="sr-only">{{ $t('offlineUpdate') }}</span>
-          </th>
+          <th></th>
           <template v-for="version of versions" :key="version.version">
             <td v-if="!branches.has(version.branch)"></td>
             <td v-else-if="version === version.branch.first"
@@ -311,10 +309,10 @@ defineExpose({ resize });
   td > div {
     @include text-overflow-ellipsis;
     background-color: #888;
-    border-radius: 5px;
+    border-radius: 6px;
     color: #fff;
     font-size: 12px;
-    padding: 1px 3px;
+    padding: 2px 4px;
   }
 }
 </style>
@@ -342,8 +340,6 @@ defineExpose({ resize });
       "softConflict": "This version may have been made based on old data.",
       "hardConflict": "This version was made in parallel with other updates, some of which attempt to write to the same properties as this update."
     },
-    // @transifexKey component.EntityFeedEntry.offlineUpdate
-    "offlineUpdate": "Offline update",
     // A chain of updates that were made offline
     "branch": "Offline update chain"
   }

--- a/src/components/entity/diff/table.vue
+++ b/src/components/entity/diff/table.vue
@@ -142,7 +142,9 @@ const showsAccuracyWarning = computed(() =>
   }
   .offline-update {
     @include italic;
+    color: #888;
     font-size: 12px;
+    margin-bottom: -3px;
   }
 
   td:nth-child(3) { text-align: center; }

--- a/src/components/entity/diff/table.vue
+++ b/src/components/entity/diff/table.vue
@@ -29,7 +29,8 @@ except according to the terms contained in the LICENSE file.
       <tr v-if="entityVersion.conflict != null" class="comparing">
         <td>{{ $t('comparing') }}</td>
         <td>
-          <i18n-t tag="div" keypath="version" v-tooltip.text>
+          <i18n-t tag="div" keypath="version" class="version-and-source"
+            v-tooltip.text>
             <template #version>
               <span class="version-string">{{ $t('common.versionShort', oldVersion) }}</span>
             </template>
@@ -40,7 +41,8 @@ except according to the terms contained in the LICENSE file.
         </td>
         <td aria-hidden="true"><span class="icon-arrow-circle-right"></span></td>
         <td>
-          <i18n-t tag="div" keypath="version" v-tooltip.text>
+          <i18n-t tag="div" keypath="version" class="version-and-source"
+            v-tooltip.text>
             <template #version>
               <span class="version-string">{{ $t('common.versionShort', entityVersion) }}</span>
             </template>
@@ -53,11 +55,9 @@ except according to the terms contained in the LICENSE file.
           </div>
         </td>
       </tr>
-      <tr v-if="showsAccuracyWarning" class="entity-diff-table-accuracy-warning">
+      <tr v-if="showsAccuracyWarning" class="accuracy-warning">
         <td colspan="4">
-          <p>
-            <span class="icon-warning"></span>{{ $t('accuracyWarning') }}
-          </p>
+          <p><span class="icon-warning"></span>{{ $t('accuracyWarning') }}</p>
         </td>
       </tr>
       <entity-diff-row v-for="name of diff" :key="name"
@@ -106,15 +106,15 @@ const showsAccuracyWarning = computed(() =>
   entityVersion.conflict != null &&
   // There's only an issue with offline updates.
   entityVersion.branch != null &&
-  // There's never an issue with the first update from the branch.
+  // There's never an issue with the first version from the branch.
   entityVersion !== entityVersion.branch.first &&
-  /* If the branch stopped being contiguous before the base version, that means
-  that the base version incorporates an update from outside the branch, which
-  means that baseDiff may differ from the true author's view. It's OK if there
-  was an update from outside the branch between the base version and this
-  version, but it's not OK if there was such an update between the trunk version
-  and the base version. */
-  entityVersion.branch.lastContiguous < entityVersion.baseVersion);
+  /* If the branch stopped being contiguous with the trunk version sometime
+  before the base version, that means that the base version incorporates an
+  update from outside the branch. In that case, baseDiff may differ from the
+  true author's view. It's OK if there was an update from outside the branch
+  between the base version and this version, but it's not OK if there was such
+  an update between the trunk version and the base version. */
+  entityVersion.branch.lastContiguousWithTrunk < entityVersion.baseVersion);
 </script>
 
 <style lang="scss">
@@ -137,9 +137,9 @@ const showsAccuracyWarning = computed(() =>
   tr:first-child td { border-top: none; }
 
   .comparing {
-    td > div { @include text-overflow-ellipsis; }
     td:first-child, .version-string { font-weight: bold; }
   }
+  .version-and-source { @include text-overflow-ellipsis; }
   .offline-update {
     @include italic;
     color: #888;
@@ -149,18 +149,18 @@ const showsAccuracyWarning = computed(() =>
 
   td:nth-child(3) { text-align: center; }
   .icon-arrow-circle-right { color: #888; }
-}
 
-.entity-diff-table-accuracy-warning {
-  p {
-    @include italic;
-    margin-bottom: -2px;
-    margin-top: -2px;
-  }
+  .accuracy-warning {
+    p {
+      @include italic;
+      margin-bottom: -2px;
+      margin-top: -2px;
+    }
 
-  .icon-warning {
-    color: $color-warning;
-    margin-right: $margin-right-icon;
+    .icon-warning {
+      color: $color-warning;
+      margin-right: $margin-right-icon;
+    }
   }
 }
 </style>

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -26,7 +26,9 @@ except according to the terms contained in the LICENSE file.
         </i18n-t>
         <i18n-t v-else keypath="title.submission.create.deleted.full">
           <template #deletedSubmission>
-            <span class="deleted-submission">{{ deletedSubmission }}</span>
+            <span class="deleted-submission">
+              {{ deletedSubmission('title.submission.create.deleted.deletedSubmission') }}
+            </span>
           </template>
           <template #name><actor-link :actor="submission.submitter"/></template>
         </i18n-t>
@@ -59,6 +61,16 @@ except according to the terms contained in the LICENSE file.
           </template>
           <template #name><actor-link :actor="entry.actor"/></template>
         </i18n-t>
+        <span class="entity-version-tag">
+          <router-link :to="versionAnchor(1)">
+            {{ $t('common.versionShort', entityVersion) }}
+          </router-link>
+        </span>
+        <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
+        <span v-if="entityVersion.branch != null" class="offline-update"
+          @click="showBranchData">
+          {{ $t('offlineUpdate') }}
+        </span>
       </template>
       <template v-else-if="entry.action === 'entity.bulk.create'">
         <span class="icon-cloud-upload"></span>
@@ -83,7 +95,6 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template v-else-if="entry.action === 'entity.update.version'">
         <span class="icon-pencil"></span>
-        <span class="title">
         <template v-if="submission != null">
           <i18n-t v-if="submission.currentVersion != null"
             keypath="title.entity.update_version.submission.notDeleted">
@@ -96,7 +107,7 @@ except according to the terms contained in the LICENSE file.
           <i18n-t v-else keypath="title.entity.update_version.submission.deleted.full">
             <template #deletedSubmission>
               <span class="deleted-submission">
-                {{ deletedSubmissionEntityEvent }}
+                {{ deletedSubmission('title.entity.update_version.submission.deleted.deletedSubmission') }}
               </span>
             </template>
           </i18n-t>
@@ -104,9 +115,15 @@ except according to the terms contained in the LICENSE file.
         <i18n-t v-else keypath="title.entity.update_version.api">
           <template #name><actor-link :actor="entry.actor"/></template>
         </i18n-t>
-        </span>
         <span class="entity-version-tag">
-          <router-link :to="versionAnchor(entityVersion.version)">{{ $t('common.versionShort', entityVersion) }}</router-link>
+          <router-link :to="versionAnchor(entityVersion.version)">
+            {{ $t('common.versionShort', entityVersion) }}
+          </router-link>
+        </span>
+        <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
+        <span v-if="entityVersion.branch != null" class="offline-update"
+          @click="showBranchData">
+          {{ $t('offlineUpdate') }}
         </span>
       </template>
       <template v-else-if="entry.action === 'entity.update.resolve'">
@@ -145,6 +162,7 @@ const props = defineProps({
   submission: Object,
   entityVersion: Object
 });
+const emit = defineEmits(['branch-data']);
 const projectId = inject('projectId');
 const datasetName = inject('datasetName');
 // The provided entityVersion won't be reactive, but that should be OK given how
@@ -161,6 +179,7 @@ const wrapTitle = computed(() => {
   return action === 'submission.create' || action === 'entity.create' || action === 'entity.bulk.create' || action === 'entity.update.version';
 });
 
+// submission.create, entity.update.version
 const { submissionPath, datasetPath } = useRoutes();
 const creatingSubmissionPath = computed(() => submissionPath(
   projectId,
@@ -168,19 +187,16 @@ const creatingSubmissionPath = computed(() => submissionPath(
   props.submission.instanceId
 ));
 const { t } = useI18n();
+const deletedSubmission = (key) => t(key, { id: props.submission.instanceId });
 
-const deletedSubmission = computed(() => {
-  const id = props.submission.instanceId;
-  return t('title.submission.create.deleted.deletedSubmission', { id });
-});
-
-const deletedSubmissionEntityEvent = computed(() => {
-  const id = props.submission.instanceId;
-  return t('title.entity.update_version.submission.deleted.deletedSubmission', { id });
-});
+// submission.update
 const { reviewStateIcon } = useReviewState();
 
+// entity.create, entity.update.version
 const versionAnchor = (v) => `#v${v}`;
+const showBranchData = () => {
+  emit('branch-data', props.entityVersion.version);
+};
 </script>
 
 <style lang="scss">
@@ -200,17 +216,24 @@ const versionAnchor = (v) => `#v${v}`;
   .deleted-submission { color: $color-danger; }
   .approval { color: $color-success; }
 
-  .entity-version-tag {
-    background-color: #ddd;
+  .entity-version-tag, .feed-entry-title .offline-update {
     font-size: 12px;
-    margin: 5px;
     padding: 3px;
     border-radius: 2px;
+  }
+  .entity-version-tag {
+    background-color: #ddd;
+    margin-left: 5px;
 
     a {
       @include text-link;
       font-weight: bold;
     }
+  }
+  .feed-entry-title .offline-update {
+    background-color: #eee;
+    font-weight: normal;
+    margin-left: 5px;
   }
 
   .bulk-event {
@@ -274,7 +297,10 @@ const versionAnchor = (v) => `#v${v}`;
         // User.
         "update_resolve": "Conflict warning resolved by {name}"
       }
-    }
+    },
+    // This is shown for an update to an Entity when the update was made offline
+    // as part of a chain of updates.
+    "offlineUpdate": "Offline update"
   }
 }
 </i18n>

--- a/src/components/entity/feed-entry.vue
+++ b/src/components/entity/feed-entry.vue
@@ -18,7 +18,7 @@ except according to the terms contained in the LICENSE file.
         <i18n-t v-if="submission.currentVersion != null"
           keypath="title.submission.create.notDeleted">
           <template #instanceName>
-            <router-link :to="creatingSubmissionPath">
+            <router-link :to="sourceSubmissionPath">
               {{ submission.currentVersion.instanceName ?? submission.instanceId }}
             </router-link>
           </template>
@@ -99,7 +99,7 @@ except according to the terms contained in the LICENSE file.
           <i18n-t v-if="submission.currentVersion != null"
             keypath="title.entity.update_version.submission.notDeleted">
             <template #instanceName>
-              <router-link :to="creatingSubmissionPath">
+              <router-link :to="sourceSubmissionPath">
                 {{ submission.currentVersion.instanceName ?? submission.instanceId }}
               </router-link>
             </template>
@@ -134,7 +134,7 @@ except according to the terms contained in the LICENSE file.
       </template>
     </template>
     <template #body>
-      <entity-diff v-if="entityVersion != null"/>
+      <entity-diff v-if="entityVersion != null && entityVersion.version !== 1"/>
     </template>
   </feed-entry>
 </template>
@@ -181,7 +181,7 @@ const wrapTitle = computed(() => {
 
 // submission.create, entity.update.version
 const { submissionPath, datasetPath } = useRoutes();
-const creatingSubmissionPath = computed(() => submissionPath(
+const sourceSubmissionPath = computed(() => submissionPath(
   projectId,
   props.submission.xmlFormId,
   props.submission.instanceId
@@ -239,7 +239,6 @@ const showBranchData = () => {
   .bulk-event {
     display: inline;
   }
-
   .bulk-source {
     text-indent: 0px;
   }

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -27,7 +27,8 @@ except according to the terms contained in the LICENSE file.
         </div>
         <div class="col-xs-8">
           <entity-activity @delete="deleteModal.show()"
-            @resolve="fetchActivityData"/>
+            @resolve="fetchActivityData"
+            @branch-data="branchData.show({ highlight: $event })"/>
         </div>
       </div>
     </page-body>
@@ -39,6 +40,7 @@ except according to the terms contained in the LICENSE file.
       :label="entity.dataExists ? entity.currentVersion.label : ''"
       :awaiting-response="awaitingResponse" @hide="deleteModal.hide()"
       @delete="requestDelete"/>
+    <entity-branch-data v-bind="branchData" @hide="branchData.hide()"/>
   </div>
 </template>
 
@@ -49,6 +51,7 @@ import { useRouter } from 'vue-router';
 
 import EntityActivity from './activity.vue';
 import EntityBasicDetails from './basic-details.vue';
+import EntityBranchData from './branch-data.vue';
 import EntityData from './data.vue';
 import EntityDelete from './delete.vue';
 import EntityUpdate from './update.vue';
@@ -153,6 +156,8 @@ const requestDelete = () => {
     })
     .catch(noop);
 };
+
+const branchData = modalData();
 </script>
 
 <i18n lang="json5">

--- a/src/components/entity/update.vue
+++ b/src/components/entity/update.vue
@@ -169,17 +169,9 @@ const currentVersion = computed(() =>
     overflow-y: auto;
   }
 
-  .modal-body {
-    padding-left: 0;
-    padding-right: 0;
-    padding-top: 0;
-  }
+  .modal-body { padding: 0; }
   table { margin-bottom: 0; }
-  .modal-actions {
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: 0;
-  }
+  .modal-actions { margin: 0; }
 
   table { table-layout: fixed; }
   thead {

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -66,6 +66,7 @@ const props = defineProps({
   // Indicates whether the user is able to hide the modal by clicking ×,
   // pressing escape, or clicking outside the modal.
   hideable: Boolean,
+  // 'normal', 'large', or 'full'
   size: {
     type: String,
     default: 'normal'

--- a/src/request-data/entity-versions.js
+++ b/src/request-data/entity-versions.js
@@ -11,11 +11,85 @@ except according to the terms contained in the LICENSE file.
 */
 import { useRequestData } from './index';
 
+// Offline branch
+class Branch {
+  constructor(firstUpdate, versions) {
+    if (firstUpdate.trunkVersion != null) {
+      // The first version from the branch to be processed (not necessarily the
+      // first in branch order).
+      this.first = firstUpdate;
+      // How many versions that have been processed are from the branch?
+      this.length = 1;
+      // Was firstUpdate processed in branch order, or was it processed before
+      // an earlier change in the branch?
+      this.firstInOrder = firstUpdate.branchBaseVersion === firstUpdate.trunkVersion;
+      /* this.lastContiguous is the version number of the last version from the
+      branch for which the branch has been contiguous, i.e., the last version
+      since the trunk version for which there has been no update from outside
+      the branch. If the base version of firstUpdate is the trunk version, then
+      the branch is at least partially contiguous. this.lastContinguous is not
+      related to branch order: as long as there hasn't been an update from
+      outside the branch, the branch is contiguous, regardless of the order of
+      the updates within it. */
+      this.lastContiguous = firstUpdate.baseVersion === firstUpdate.trunkVersion
+        ? firstUpdate.version
+        : 0;
+    } else {
+      // If the entity was both created and updated offline before being sent to
+      // the server, then we treat the creation as part of the same branch as
+      // the update(s). The creation doesn't have a branch ID, but we treat it
+      // as part of the branch anyway.
+      this.first = versions[0]; // eslint-disable-line prefer-destructuring
+      // If the creating submission was received late and processed out of
+      // order, then firstUpdate === versions[0]. In that case, we can't
+      // reliably determine which entity version corresponds to the entity
+      // creation, so we don't treat the creation as part of the branch.
+      this.length = firstUpdate === versions[0] ? 1 : 2;
+      this.firstInOrder = this.length === 2 &&
+        firstUpdate.branchBaseVersion === 1;
+      this.lastContiguous = this.length === 2 && firstUpdate !== versions[1]
+        ? 1
+        : firstUpdate.version;
+    }
+
+    this.id = firstUpdate.branchId;
+    // The last version from the branch to be processed
+    this.last = firstUpdate;
+  }
+
+  add(version) {
+    this.length += 1;
+    this.last = version;
+    if (version.baseVersion === this.lastContiguous &&
+      version.version === version.baseVersion + 1)
+      this.lastContiguous = version.version;
+  }
+}
+
 export default () => {
   const { createResource } = useRequestData();
   return createResource('entityVersions', () => ({
-    transformResponse: ({ data }) => {
-      for (const version of data) {
+    transformResponse: ({ data: versions }) => {
+      const branches = new Map();
+      for (const version of versions) {
+        // Track offline branches.
+        const { branchId } = version;
+        if (branchId != null && version.branchBaseVersion != null) {
+          const existingBranch = branches.get(branchId);
+          if (existingBranch == null) {
+            const newBranch = new Branch(version, versions);
+            branches.set(branchId, newBranch);
+            version.branch = newBranch;
+            // If the entity was created offline, then add the branch to the
+            // entity creation.
+            version.branch.first.branch = newBranch;
+          } else {
+            existingBranch.add(version);
+            version.branch = existingBranch;
+          }
+        }
+
+        // Convert some arrays to sets.
         version.baseDiff = new Set(version.baseDiff);
         version.serverDiff = new Set(version.serverDiff);
         const { conflictingProperties } = version;
@@ -23,7 +97,14 @@ export default () => {
           ? new Set(conflictingProperties)
           : new Set();
       }
-      return data;
+
+      // Ignore single-updated "branches."
+      for (const branch of branches.values()) {
+        if (branch.length === 1 && branch.firstInOrder)
+          delete branch.first.branch;
+      }
+
+      return versions;
     }
   }));
 };

--- a/test/components/entity/activity.spec.js
+++ b/test/components/entity/activity.spec.js
@@ -170,7 +170,7 @@ describe('EntityActivity', () => {
     resolveConflict();
     mountComponent().findAllComponents(EntityFeedEntry)
       .map(entry => entry.props().entityVersion?.version)
-      .should.eql([undefined, 3, 2, undefined]);
+      .should.eql([undefined, 3, 2, 1]);
   });
 
   describe('scroll behavior', () => {

--- a/test/components/entity/feed-entry.spec.js
+++ b/test/components/entity/feed-entry.spec.js
@@ -27,12 +27,11 @@ const mountComponent = (options = undefined) => {
     })
   });
   const entry = testData.extendedAudits.last();
+  const { action } = entry;
   const { entityVersions } = container.requestData.localResources;
-  const entityVersion = entry.action === 'entity.create'
+  const entityVersion = action === 'entity.create' || action === 'entity.bulk.create'
     ? entityVersions[0]
-    : (entry.action === 'entity.update.version'
-      ? last(entityVersions)
-      : undefined);
+    : (entityVersions.length > 1 ? last(entityVersions) : undefined);
   return mount(EntityFeedEntry, mergeMountOptions(options, {
     global: {
       provide: { projectId: '1', datasetName: 'trees', uuid: entity.uuid }
@@ -329,7 +328,6 @@ describe('EntityFeedEntry', () => {
         submission
       };
     };
-
 
     it('shows the correct icon', () => {
       const component = mountComponent({ props: updateEntityFromSubmission() });

--- a/test/util/dom.js
+++ b/test/util/dom.js
@@ -1,13 +1,13 @@
+// Returns the text in a Vue Test Utils wrapper, excluding text in elements
+// selected by `selector`.
 export const textWithout = (wrapper, selector) => {
   const without = wrapper.element.cloneNode(true);
-  for (const descendant of without.querySelectorAll(selector))
-    descendant.remove();
+  for (const element of without.querySelectorAll(selector)) element.remove();
   return without.textContent.trim();
 };
 
 // Searches a component for a nav tab whose text matches the specified text. The
 // component must contain a PageBody component.
-// eslint-disable-next-line import/prefer-default-export
 export const findTab = (component, text) => {
   // The component may contain multiple .nav-tabs.
   const navs = component.findAll('.nav-tabs');

--- a/test/util/dom.js
+++ b/test/util/dom.js
@@ -1,3 +1,10 @@
+export const textWithout = (wrapper, selector) => {
+  const without = wrapper.element.cloneNode(true);
+  for (const descendant of without.querySelectorAll(selector))
+    descendant.remove();
+  return without.textContent.trim();
+};
+
 // Searches a component for a nav tab whose text matches the specified text. The
 // component must contain a PageBody component.
 // eslint-disable-next-line import/prefer-default-export

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1750,7 +1750,7 @@
       },
       "branch": {
         "string": "Offline update chain",
-        "developer_comment": "A chain of updates that were made offline"
+        "developer_comment": "A series of updates that were made offline"
       }
     },
     "EntityData": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1747,6 +1747,10 @@
         "hardConflict": {
           "string": "This version was made in parallel with other updates, some of which attempt to write to the same properties as this update."
         }
+      },
+      "branch": {
+        "string": "Offline update chain",
+        "developer_comment": "A chain of updates that were made offline"
       }
     },
     "EntityData": {
@@ -1833,6 +1837,10 @@
       "version": {
         "string": "{version} ({source})",
         "developer_comment": "{version} is a short identifier of an Entity version, for example, \"v3\". {source} indicates what created the Entity version, for example, \"Update by Alice\"."
+      },
+      "accuracyWarning": {
+        "string": "In this case, the author’s view may not be accurate.",
+        "developer_comment": "The author's view is a comparison between two versions of an Entity, from the point of view of the data collector (the author)."
       }
     },
     "EntityFeedEntry": {
@@ -1892,6 +1900,10 @@
             "developer_comment": "This text is shown in a list of events. {name} is the name of a Web User."
           }
         }
+      },
+      "offlineUpdate": {
+        "string": "Offline update",
+        "developer_comment": "This is shown for an update to an Entity when the update was made offline as part of a chain of updates."
       }
     },
     "EntityFiltersConflict": {


### PR DESCRIPTION
This PR implements most of getodk/central#683, though it doesn't include tests. This PR also adds a modal that shows the branch-related properties of entity versions (`branchId`, `trunkVersion`, `branchBaseVersion`). Click the "Offline update" tag to see the modal.

#### What has been done to verify that this works as intended?

Trying it out locally. I want to get this code on staging sooner rather than later, so I'll follow up with tests in a later PR.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced