### PR TITLE
Frontend usage metrics strings (offline entities) for 2024.2

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -128,6 +128,11 @@ export default {
       "num_audits_failed": "Number of Audit Log Events that failed at least once",
       "num_audits_failed5": "Number of Audit Log Events that failed completely",
       "num_audits_unprocessed": "Number of Audit Log Events whose processing has been delayed",
+      "num_offline_entity_branches": "Number of Offline Entity branches",
+      "num_offline_entity_interrupted_branches": "Number of interrupted Offline Entity branches",
+      "num_offline_entity_submissions_reprocessed": "Number of reordered Offline Entity submissions",
+      "max_entity_submission_delay": "Maximum Entity Submission processing delay",
+      "avg_entity_submission_delay": "Average Entity Submission processing delay",
     }
   }
 }

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1335,6 +1335,21 @@
         },
         "num_audits_unprocessed": {
           "string": "Number of Audit Log Events whose processing has been delayed"
+        },
+        "num_offline_entity_branches": {
+          "string": "Number of Offline Entity branches"
+        },
+        "num_offline_entity_interrupted_branches": {
+          "string": "Number of interrupted Offline Entity branches"
+        },
+        "num_offline_entity_submissions_reprocessed": {
+          "string": "Number of reordered Offline Entity submissions"
+        },
+        "max_entity_submission_delay": {
+          "string": "Maximum Entity Submission processing delay"
+        },
+        "avg_entity_submission_delay": {
+          "string": "Average Entity Submission processing delay"
         }
       }
     },


### PR DESCRIPTION
Frontend part of https://github.com/getodk/central-backend/pull/1198

<img width="885" alt="Screenshot 2024-09-25 at 2 09 43 PM" src="https://github.com/user-attachments/assets/40a7411e-4fdb-44f5-b747-770ff50788d0">


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced