### PR TITLE
Change background color of tab badges

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -871,7 +871,7 @@ becomes more complicated.
   }
 
   .badge {
-    background-color: #aaa;
+    background-color: #999;
     vertical-align: baseline;
   }
 }

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -870,7 +870,10 @@ becomes more complicated.
     }
   }
 
-  .badge { vertical-align: baseline; }
+  .badge {
+    background-color: #aaa;
+    vertical-align: baseline;
+  }
 }
 
 .chip {


### PR DESCRIPTION
This PR updates the background color of `.badge` elements in nav tabs to match what's shown in the [release criteria](https://docs.google.com/document/d/1SXQjHFfOL4q2_5rOd0stLq3FGHnzJPJNv6VECfVkwLw/edit) for v2024.2.

#### What has been done to verify that this works as intended?

I viewed the change locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced