### PR TITLE
Companion PR to getodk/central-backend#1205

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -280,7 +280,7 @@ const routes = [
         loading: 'tab',
         meta: {
           validateData: {
-            project: () => project.permits('form.list') || project.permits('open_form.list')
+            project: () => project.permits('form.list') || project.permits('form.list_open')
           },
           title: () => [i18n.t('resource.forms'), project.name]
         }

--- a/test/data/seed.js
+++ b/test/data/seed.js
@@ -111,7 +111,7 @@ export default () => {
       name: 'Data Collector',
       system: 'formfill',
       verbs: [
-        'open_form.list',
+        'form.list_open',
         'form.read',
         'submission.create'
       ]


### PR DESCRIPTION
Related: getodk/central-backend#1205

Companion to getodk/central-backend#1205, related to the authz verb renames therein.

Companion PR, which means that it makes no sense without its protagonist — yet if the protagonist gets merged, then this PR also needs to be merged, otherwise the frontend will break on the changed backend.