### PR TITLE
Serve local client-config.json if it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ npm-debug.log*
 !/.nginx/.gitkeep
 
 /.eslintcache
+
+/client-config.json

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -95,7 +95,10 @@ http {
     }
 
     location = /client-config.json {
-      include ./common-headers.nginx.conf;
+      root .;
+      try_files $uri @empty_json;
+    }
+    location @empty_json {
       return 200 "{}";
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "dev": "nf start",
-    "dev:oidc": "VUE_APP_OIDC_ENABLED=true npm run dev",
     "build": "vue-cli-service build",
     "lint": "eslint --max-warnings 0 --cache --ext .js,.vue src/ bin/ test/ *.js",
     "lint:fix": "eslint --max-warnings 0 --fix --cache --ext .js,.vue src/ bin/ test/ *.js",

--- a/src/config.js
+++ b/src/config.js
@@ -19,8 +19,6 @@ export default {
     title: null,
     body: null
   },
-  // VUE_APP_OIDC_ENABLED is not set in production. It can be set during local
-  // development to facilitate work on SSO.
-  oidcEnabled: process.env.VUE_APP_OIDC_ENABLED === 'true',
+  oidcEnabled: false,
   showsFeedbackButton: false
 };


### PR DESCRIPTION
Now that we request client-config.json, I've been wondering whether it'd be possible to remove `npm run dev:oidc`. That command sets a single option in the config (`oidcEnabled`), but there are several other options in the config that a developer might want to set. The idea of this PR is that a developer can create a local client-config.json to match whatever they're working on, and those options won't show up in version control. Modifying src/config.js would have much the same effect, but it has the downside that it shows up in version control.

Related: #1034

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced