### PR TITLE
nginx: revert -e to support older versions

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 vue: vue-cli-service build --mode development --watch
-nginx: nginx -c "$PWD/main.nginx.conf" -p "$PWD" -e stderr
+nginx: nginx -c "$PWD/main.nginx.conf" -p "$PWD"

--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -12,6 +12,7 @@
 # https://github.com/getodk/central.
 
 daemon off;
+error_log stderr;
 pid ./.nginx/nginx.pid;
 
 events {


### PR DESCRIPTION
nginx's -e switch was added in v1.19.5.  Recent Ubuntu LTS versions (20.04, 22.04) bundle nginx version 1.18.0.

See: https://nginx.org/en/CHANGES
See: https://github.com/getodk/central-frontend/pull/1035

nginx 1.18.0, distributed with Ubuntu LTS 20.04 & 22.04

Closes #1033
