### PR TITLE
Don't use Pinia for requestData even in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "marked": "~4",
         "pako": "~1.0",
         "papaparse": "^5.4.1",
-        "pinia": "^2.0.23",
         "qrcode-generator": "~1",
         "ramda": "~0.27",
         "vue": "~3",
@@ -9128,56 +9127,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pinia": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.23.tgz",
-      "integrity": "sha512-N15hFf4o5STrxpNrib1IEb1GOArvPYf1zPvQVRGOO1G1d74Ak0J0lVyalX/SmrzdT4Q0nlEFjbURsmBmIGUR5Q==",
-      "dependencies": {
-        "@vue/devtools-api": "^6.4.4",
-        "vue-demi": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/posva"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.4.0",
-        "typescript": ">=4.4.4",
-        "vue": "^2.6.14 || ^3.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pinia/node_modules/vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/portfinder": {
@@ -19889,23 +19838,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
-    },
-    "pinia": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.23.tgz",
-      "integrity": "sha512-N15hFf4o5STrxpNrib1IEb1GOArvPYf1zPvQVRGOO1G1d74Ak0J0lVyalX/SmrzdT4Q0nlEFjbURsmBmIGUR5Q==",
-      "requires": {
-        "@vue/devtools-api": "^6.4.4",
-        "vue-demi": "*"
-      },
-      "dependencies": {
-        "vue-demi": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-          "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-          "requires": {}
-        }
-      }
     },
     "portfinder": {
       "version": "1.0.32",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "marked": "~4",
     "pako": "~1.0",
     "papaparse": "^5.4.1",
-    "pinia": "^2.0.23",
     "qrcode-generator": "~1",
     "ramda": "~0.27",
     "vue": "~3",

--- a/src/components/async-route.vue
+++ b/src/components/async-route.vue
@@ -70,15 +70,10 @@ export default {
       // The main use of this.$attrs is to pass along event listeners to the
       // component.
       return { ...this.props, ...this.$attrs, key: this.k };
-    },
-    componentNameAndKey() {
-      return [this.componentName, this.k];
     }
   },
   watch: {
-    componentNameAndKey([newComponentName], [oldComponentName]) {
-      if (newComponentName !== oldComponentName) this.load();
-    }
+    componentName: 'load'
   },
   created() {
     this.load();

--- a/src/components/async-route.vue
+++ b/src/components/async-route.vue
@@ -12,12 +12,12 @@ except according to the terms contained in the LICENSE file.
 <template>
   <div v-if="loading === 'tab'">
     <loading :state="showsLoading"/>
-    <component :is="component" v-if="component != null" v-bind="propsAndAttrs"/>
+    <component :is="component" v-if="component != null" v-bind="bindings"/>
   </div>
   <page-body v-else-if="showsLoading">
     <loading :state="true"/>
   </page-body>
-  <component :is="component" v-else-if="component != null" v-bind="propsAndAttrs"/>
+  <component :is="component" v-else-if="component != null" v-bind="bindings"/>
 </template>
 
 <script>
@@ -66,7 +66,7 @@ export default {
     };
   },
   computed: {
-    propsAndAttrs() {
+    bindings() {
       // The main use of this.$attrs is to pass along event listeners to the
       // component.
       return { ...this.props, ...this.$attrs, key: this.k };

--- a/src/components/async-route.vue
+++ b/src/components/async-route.vue
@@ -69,7 +69,7 @@ export default {
     propsAndAttrs() {
       // The main use of this.$attrs is to pass along event listeners to the
       // component.
-      return { ...this.props, ...this.$attrs };
+      return { ...this.props, ...this.$attrs, key: this.k };
     },
     componentNameAndKey() {
       return [this.componentName, this.k];
@@ -77,32 +77,7 @@ export default {
   },
   watch: {
     componentNameAndKey([newComponentName], [oldComponentName]) {
-      if (newComponentName !== oldComponentName) {
-        this.load();
-      } else if (this.component != null) {
-        /*
-        If this.k has changed, then we need to re-render the component (unless
-        this.component == null, in which case there is no component to
-        re-render). We will cause a re-render by setting this.component to
-        `null` for a tick.
-
-        Previously, we used the `key` attribute to cause the component to
-        re-render. However, that results in the following lifecycle stages:
-
-          - `beforeUnmount` for the old component
-          - `setup` for the new component
-          - `unmounted` for the old component
-
-        Because we use `unmounted` hooks with requestData, we need `unmounted`
-        for the old component to happen before `setup` for the new component.
-        Otherwise, the new component might try to create a local resource with
-        the same name as one created by the old component, whose local resources
-        haven't been removed yet.
-        */
-        const { component } = this;
-        this.component = null;
-        this.$nextTick(() => { this.component = component; });
-      }
+      if (newComponentName !== oldComponentName) this.load();
     }
   },
   created() {

--- a/src/components/entity/conflict-summary.vue
+++ b/src/components/entity/conflict-summary.vue
@@ -109,10 +109,10 @@ const markAsResolved = () => {
     .then(({ data }) => {
       hideConfirm();
       alert.success(t('conflictResolved'));
-      entity.patch(() => {
-        entity.conflict = data.conflict;
-        entity.updatedAt = data.updatedAt;
-      });
+
+      entity.conflict = data.conflict;
+      entity.updatedAt = data.updatedAt;
+
       emit('resolve');
     })
     .catch(noop);

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -133,8 +133,8 @@ const afterUpdate = (updatedEntity) => {
   // need it to.
   entity.currentVersion = updatedEntity.currentVersion;
   entity.updatedAt = updatedEntity.updatedAt;
-  // Update entity.conflict in case a conflict has been resolved by another
-  // user or in another tab.
+  // Update entity.conflict in case a conflict has been resolved by another user
+  // or in another tab.
   entity.conflict = updatedEntity.conflict;
 };
 

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -128,15 +128,14 @@ const afterUpdate = (updatedEntity) => {
   fetchActivityData();
   updateModal.hide();
   alert.success(i18n.t('alert.updateEntity'));
-  entity.patch(() => {
-    // entity.currentVersion will no longer have extended metadata, but we don't
-    // need it to.
-    entity.currentVersion = updatedEntity.currentVersion;
-    entity.updatedAt = updatedEntity.updatedAt;
-    // Update entity.conflict in case a conflict has been resolved by another
-    // user or in another tab.
-    entity.conflict = updatedEntity.conflict;
-  });
+
+  // entity.currentVersion will no longer have extended metadata, but we don't
+  // need it to.
+  entity.currentVersion = updatedEntity.currentVersion;
+  entity.updatedAt = updatedEntity.updatedAt;
+  // Update entity.conflict in case a conflict has been resolved by another
+  // user or in another tab.
+  entity.conflict = updatedEntity.conflict;
 };
 
 const deleteModal = modalData();

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -337,17 +337,17 @@ export default {
           if (this.$route !== initialRoute) return;
           if (updates.length === this.uploadStatus.total)
             this.alert.success(this.$tcn('alert.success', updates.length));
-          this.attachments.patch(() => {
-            for (const [name, updatedAt] of updates) {
-              const attachment = this.attachments.get(name);
-              attachment.blobExists = true;
-              attachment.datasetExists = false;
-              attachment.exists = true;
-              attachment.updatedAt = updatedAt;
 
-              this.updatedAttachments.add(name);
-            }
-          });
+          for (const [name, updatedAt] of updates) {
+            const attachment = this.attachments.get(name);
+            attachment.blobExists = true;
+            attachment.datasetExists = false;
+            attachment.exists = true;
+            attachment.updatedAt = updatedAt;
+
+            this.updatedAttachments.add(name);
+          }
+
           this.uploadStatus = { total: 0, remaining: 0, current: null, progress: 0 };
         });
       this.plannedUploads = [];
@@ -367,11 +367,9 @@ export default {
         attachmentName: attachment.name
       }));
 
-      this.attachments.patch(() => {
-        attachment.datasetExists = true;
-        attachment.blobExists = false;
-        attachment.exists = true;
-      });
+      attachment.datasetExists = true;
+      attachment.blobExists = false;
+      attachment.exists = true;
     }
   }
 };

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -362,7 +362,6 @@ export default {
     afterLinkDataset() {
       const { attachment } = this.linkDatasetModal;
       this.linkDatasetModal.hide();
-
       this.alert.success(this.$t('alert.link', {
         attachmentName: attachment.name
       }));

--- a/src/container.js
+++ b/src/container.js
@@ -11,7 +11,6 @@ except according to the terms contained in the LICENSE file.
 */
 import axios from 'axios';
 import { Translation } from 'vue-i18n';
-import { createPinia } from 'pinia';
 
 import createAlert from './alert';
 import createCentralI18n from './i18n';
@@ -19,7 +18,6 @@ import createCentralRouter from './router';
 import createUnsavedChanges from './unsaved-changes';
 import { $tcn } from './util/i18n';
 import { createRequestData } from './request-data';
-import { noop } from './util/util';
 
 const provide = [
   'alert',
@@ -28,8 +26,6 @@ const provide = [
   'http',
   'logger'
 ];
-
-const piniaMock = { install: noop };
 
 export default ({
   // `router` must be a function that returns an object. The function will be
@@ -47,7 +43,6 @@ export default ({
   logger = console
 } = {}) => {
   const container = {
-    pinia: process.env.NODE_ENV === 'development' ? createPinia() : piniaMock,
     i18n: i18n.global,
     alert,
     unsavedChanges,
@@ -64,7 +59,6 @@ export default ({
     // eslint-disable-next-line no-param-reassign
     app.config.globalProperties.$tcn = $tcn;
 
-    app.use(container.pinia);
     app.use(container.requestData);
     if (container.router != null) app.use(container.router);
 

--- a/src/request-data/user.js
+++ b/src/request-data/user.js
@@ -23,7 +23,7 @@ export default () => {
   watchSyncEffect(() => {
     // currentUser won't have data immediately after logout.
     if (user.dataExists && currentUser.dataExists && user.id === currentUser.id)
-      currentUser.patch(user.data);
+      Object.assign(currentUser.data, user.data);
   });
   return user;
 };

--- a/test/components/async-route.spec.js
+++ b/test/components/async-route.spec.js
@@ -69,8 +69,6 @@ describe('AsyncRoute', () => {
     await wait();
     const { vm } = asyncRoute.getComponent(TestUtilP);
     await asyncRoute.setProps({ k: '1' });
-    await asyncRoute.vm.$nextTick();
-    await asyncRoute.vm.$nextTick();
     expect(asyncRoute.getComponent(TestUtilP).vm).to.not.equal(vm);
   });
 


### PR DESCRIPTION
This PR removes Pinia from `requestData` entirely. `requestData` was designed to use Pinia in development (never production). However, we haven't been using Pinia for a while due to #787. That means that this PR doesn't have a huge practical effect. However, it simplifies `requestData` and opens the door to some extensions to it. For example, for #1044, I want to be able to create an arbitrary number of `requestData` resources, yet I'm not sure that that's something that would play well with our Pinia setup.

I think it's helpful to remember why we're using Pinia in the first place. We don't need Pinia for reactivity, because we get that out of the box with Vue 3. Instead, the main value-add of Pinia is logging. Specifically, Pinia provides a nice interface within Vue DevTools to see what changes have been made to `requestData` and which components specifically made those changes.

When I created `requestData`, it felt important for it to offer robust logging. `requestData` was a replacement for Vuex, which had its own mechanism for logging changes. At first, I started out writing my own logging mechanism. However, once I realized that Pinia integrated with Vue DevTools, using Pinia seemed like a reasonably straightforward and feature-rich way to incorporate logging into `requestData`.

It's been a while since then, and it's now clear that Pinia's logging hasn't proven to be especially useful. I expected there to be more issues with `requestData`, but thankfully, they just haven't come up that often. Given the infrequency of issues, it's uncommon that we need to troubleshoot `requestData`. When we do, `console.log()` is usually enough to do the job.

So it doesn't seem like Pinia is particularly useful. Yet at the same time, it also comes with costs:

- The additional maintenance around one more Vue library. [#787](https://github.com/getodk/central-frontend/issues/787) is an example of that.
- The `patch()` pattern that's removed in this PR exists only for the sake of logging. It helps to group together multiple changes as a single event within Pinia logging. However, it requires explanation, especially for newcomers to the codebase.
- Pinia requires us to jump through some hoops in order for it to track which component is using which resource. The result is that the core logic underlying `requestData` is harder to follow.
- Local resources aren't strictly isolated from one other, running counter to the whole concept of _local_ resources. Two local resources with the same name would end up using the same Pinia store, which doesn't work. We were able to work around this issue, because it was never the case that different components on the same page would create local resources with the same name. However, it required some subtle management of `requestData` resources. The `AsyncRoute` component is an example of that that you can see in this PR.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced