### PR TITLE
Show custom alert for 504 error from nginx

### DIFF
--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -477,6 +477,7 @@
       "error": {
         // @transifexKey mixin.request.alert.entityTooLarge
         "413": "The data that you are trying to upload is too large.",
+        "504": "Your request took too long, and Central stopped waiting for it."
       },
       "problem": {
         // A "resource" is a generic term for something in Central, for example,

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -441,8 +441,7 @@
   "mixin": {
     "request": {
       "alert": {
-        "fileSize": "The file “{name}” that you are trying to upload is larger than the 100 MB limit.",
-        "entityTooLarge":  "The data that you are trying to upload is too large.",
+        "fileSize": "The file “{name}” that you are trying to upload is larger than the 100 MB limit."
       }
     }
   },
@@ -475,6 +474,10 @@
       "noResponse": "Something went wrong: there was no response to your request.",
       // {status} is an HTTP status code, for example, 404.
       "errorNotProblem": "Something went wrong: error code {status}.",
+      "error": {
+        // @transifexKey mixin.request.alert.entityTooLarge
+        "413": "The data that you are trying to upload is too large.",
+      },
       "problem": {
         // A "resource" is a generic term for something in Central, for example,
         // a Project, a Web User, or a Form.

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -231,9 +231,10 @@ export const requestAlertMessage = (i18n, axiosError, problemToAlert = undefined
   const { response } = axiosError;
   if (response == null) return i18n.t('util.request.noResponse');
   if (!(axiosError.config.url.startsWith('/v1/') && isProblem(response.data))) {
-    if (response.status === 413)
-      return i18n.t('util.request.error.413');
-    return i18n.t('util.request.errorNotProblem', response);
+    const key = `util.request.error.${response.status}`;
+    return i18n.te(key)
+      ? i18n.t(key)
+      : i18n.t('util.request.errorNotProblem', response);
   }
 
   const problem = response.data;

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -232,7 +232,7 @@ export const requestAlertMessage = (i18n, axiosError, problemToAlert = undefined
   if (response == null) return i18n.t('util.request.noResponse');
   if (!(axiosError.config.url.startsWith('/v1/') && isProblem(response.data))) {
     if (response.status === 413)
-      return i18n.t('mixin.request.alert.entityTooLarge');
+      return i18n.t('util.request.error.413');
     return i18n.t('util.request.errorNotProblem', response);
   }
 

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -631,13 +631,24 @@ describe('util/request', () => {
       message.should.equal('Something went wrong: error code 500.');
     });
 
-    it('returns a message about 413 error response that is not a Problem', () => {
-      const message = requestAlertMessage(i18n, mockAxiosError({
-        status: 413,
-        data: '<html><head><title>413 Request Entity Too Large</title></head>...',
-        config: { url: '/v1/projects/1/datasets/trees/entities' }
-      }));
-      message.should.equal('The data that you are trying to upload is too large.');
+    describe('custom messages for specific errors when response is not a Problem', () => {
+      it('returns a message for a 413', () => {
+        const message = requestAlertMessage(i18n, mockAxiosError({
+          status: 413,
+          data: '<html><head><title>413 Request Entity Too Large</title></head>...',
+          config: { url: '/v1/projects/1/datasets/trees/entities' }
+        }));
+        message.should.equal('The data that you are trying to upload is too large.');
+      });
+
+      it('returns a message for a 504', () => {
+        const message = requestAlertMessage(i18n, mockAxiosError({
+          status: 504,
+          data: '<html><head><title>504 Gateway Timeout</title></head>...',
+          config: { url: '/v1/projects/1/datasets/trees/entities' }
+        }));
+        message.should.startWith('Your request took too long,');
+      });
     });
 
     it('returns the message of a Problem', () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -982,6 +982,11 @@
         "string": "Something went wrong: error code {status}.",
         "developer_comment": "{status} is an HTTP status code, for example, 404."
       },
+      "error": {
+        "504": {
+          "string": "Your request took too long, and Central stopped waiting for it."
+        }
+      },
       "problem": {
         "404_1": {
           "string": "The resource you are looking for cannot be found. The resource may have been deleted.",


### PR DESCRIPTION
We know that it's possible for users to receive a 504 response from nginx if the request takes too long (more than 2 minutes). We've seen this most recently at https://github.com/getodk/central/issues/171#issuecomment-2470650060, but it's also come up in the past. Right now, a user who receives a 504 will just see, "Something went wrong: error code 504." The goal of this PR is to show a nicer error message instead. The user may still need to contact us for assistance, but at least they won't need to look up what a 504 is.

#### What has been done to verify that this works as intended?

New unit test.

#### Why is this the best possible solution? Were any other approaches considered?

I proposed the new error text as part of the discussion at getodk/central#171.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced