### PR TITLE
Check submission.delete verb before listing deleted submissions

### DIFF
--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -19,7 +19,7 @@ except according to the terms contained in the LICENSE file.
           <span class="icon-plus-circle"></span>{{ $t('action.createSubmission') }}
         </enketo-fill>
         <template v-if="deletedSubmissionCount.dataExists">
-          <button v-if="canUpdate && (deletedSubmissionCount.value > 0 || deleted)" type="button"
+          <button v-if="canDelete && (deletedSubmissionCount.value > 0 || deleted)" type="button"
             class="btn toggle-deleted-submissions" :class="{ 'btn-danger': deleted, 'btn-link': !deleted }"
             @click="toggleDeleted">
             <span class="icon-trash"></span>{{ $tcn('action.toggleDeletedSubmissions', deletedSubmissionCount.value) }}
@@ -98,15 +98,15 @@ export default {
       })
     });
 
-    const canUpdate = computed(() => project.dataExists && project.permits('submission.update'));
+    const canDelete = computed(() => project.dataExists && project.permits('submission.delete'));
 
     watchEffect(() => {
-      if (deleted.value && project.dataExists && !canUpdate.value) router.push('/');
+      if (deleted.value && project.dataExists && !canDelete.value) router.push('/');
     });
 
     return {
       project, form, keys, analyzeModal: modalData(),
-      deletedSubmissionCount, canUpdate, deleted
+      deletedSubmissionCount, canDelete, deleted
     };
   },
   computed: {


### PR DESCRIPTION
Right now, `FormSubmissions` checks whether the user can `submission.update` before allowing them to see deleted submissions. However, issa clarified that the verb to check is `submission.delete`. This was [mentioned](https://docs.google.com/document/d/1sjAB68yy17Aw0gu5UYtAuadlg8mftsEJmVJD3el54QI/edit?disco=AAABX7sil4s) in the release criteria and was [discussed](https://github.com/getodk/central-frontend/pull/1043#discussion_r1823669260) briefly on the original PR.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

In practice, there's no change, because any role that can `submission.update` can also `submission.delete` (and vice versa). It would only come up if one day we add a role that can do one verb but not the other.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced