### PR TITLE
Prevent submission row actions from wrapping in Indonesian

### DIFF
--- a/src/components/submission/metadata-row.vue
+++ b/src/components/submission/metadata-row.vue
@@ -159,7 +159,11 @@ export default {
     max-width: 250px;
   }
 
-  .state-and-actions { min-width: 205px; }
+  .state-and-actions {
+    // Ensure that the column is wide enough that the .btn-group does not wrap.
+    min-width: 205px;
+    &:lang(id) { min-width: 221px; }
+  }
   .col-content {
     align-items: flex-start;
     display: flex;


### PR DESCRIPTION
We've added a new submission row action for deletion, which means that there are several buttons now. One of the buttons (the More button) contains text, so the width of the `.btn-group` is variable depending on the locale. That's an issue with Indonesian, where you can see that the row actions are wrapping:

<img width="463" src="https://github.com/user-attachments/assets/ef70b6bb-2d16-4ecc-bd37-548722a1b821">

This PR increases the width of the column for Indonesian only. Indonesian needs the extra width, but I didn't want to widen the column unnecessarily for all users.

This is how it looks after I increase the column width:

<img width="476" src="https://github.com/user-attachments/assets/586dc941-710e-444b-9792-ae19615824fe">

#### What has been done to verify that this works as intended?

I viewed the change locally.

I also checked all locales other than Indonesian and didn't see a problem.

#### Why is this the best possible solution? Were any other approaches considered?

This came up previously for entity row actions. I'm basing this PR off the solution for that:

https://github.com/getodk/central-frontend/blob/acd5cf674f3460335438f428ed280996676f4823/src/components/entity/metadata-row.vue#L111-L113

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced