### PR TITLE
Make improvements to requestData getters

### DIFF
--- a/src/request-data/index.js
+++ b/src/request-data/index.js
@@ -74,8 +74,11 @@ export const createRequestData = (container) => {
     requestData.localResources = localResources;
 
   // Getters allow you to create a computed ref in one component, then access it
-  // from useRequestData() in a descendant component. Getters are only really
-  // needed for computed refs that reference multiple resources.
+  // from useRequestData() in a descendant component. Getters are very similar
+  // to provide/inject, but they're a little easier to use in testing: getters
+  // are automatically `provide`-d to components that are mounted in testing.
+  // Getters are only really needed for computed refs that reference multiple
+  // resources.
   const getters = Object.create(null);
   const createGetter = (name, f) => {
     const getter = computed(() => f(requestData));

--- a/src/request-data/index.js
+++ b/src/request-data/index.js
@@ -77,11 +77,13 @@ export const createRequestData = (container) => {
   // from useRequestData() in a descendant component. Getters are only really
   // needed for computed refs that reference multiple resources.
   const getters = Object.create(null);
-  const createGetter = (name, ref) => {
-    provide(`requestData.getters.${name}`, ref);
-    getters[name] = ref;
-    onUnmounted(() => { if (getters[name] === ref) delete getters[name]; });
-    return ref;
+  const createGetter = (name, f) => {
+    const getter = computed(() => f(requestData));
+    provide(`requestData.getters.${name}`, getter);
+    getters[name] = getter;
+    // eslint-disable-next-line vue/no-ref-as-operand
+    onUnmounted(() => { if (getters[name] === getter) delete getters[name]; });
+    return getter;
   };
 
   // useRequestData()

--- a/src/request-data/project.js
+++ b/src/request-data/project.js
@@ -9,7 +9,7 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-import { computed, watchSyncEffect } from 'vue';
+import { watchSyncEffect } from 'vue';
 
 import { computeIfExists, transformForms } from './util';
 import { useRequestData } from './index';
@@ -43,7 +43,7 @@ export default () => {
   // Returns a set containing just the form names that appear more than once
   // in a project. Used on forms page to show form ID next to form name
   // when form names are duplicated.
-  const duplicateFormNames = createGetter('duplicateFormNames', computed(() => {
+  const duplicateFormNames = createGetter('duplicateFormNames', () => {
     if (!(forms.dataExists && deletedForms.dataExists)) return null;
     const allForms = [...forms, ...deletedForms];
     const seenNames = new Set();
@@ -54,7 +54,7 @@ export default () => {
       seenNames.add(formName);
     }
     return dupeNames;
-  }));
+  });
 
   return {
     project, projectAssignments, forms, deletedForms, formSummaryAssignments,


### PR DESCRIPTION
This PR is a follow-up to the comment at https://github.com/getodk/central-frontend/pull/1051#discussion_r1841364832. I no longer think that we should remove `requestData` getters, but I think better code comments would be useful. I also think there's an opportunity to make `createGetter()` slightly more ergonomic by just passing it a function rather than a computed ref.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced