### PR TITLE
Convert ProjectOverview to Composition API

### DIFF
--- a/src/components/project/overview.vue
+++ b/src/components/project/overview.vue
@@ -18,37 +18,31 @@ except according to the terms contained in the LICENSE file.
   </div>
 </template>
 
-<script>
-import ProjectOverviewDescription from './overview/description.vue';
+<script setup>
+import { computed } from 'vue';
+
 import FormList from '../form/list.vue';
 import FormTrashList from '../form/trash-list.vue';
+import ProjectOverviewDescription from './overview/description.vue';
 
 import { useRequestData } from '../../request-data';
 
-export default {
-  name: 'ProjectOverview',
-  components: { ProjectOverviewDescription, FormList, FormTrashList },
-  props: {
-    projectId: {
-      type: String,
-      required: true
-    }
-  },
-  emits: ['fetch-forms'],
-  setup() {
-    const { project } = useRequestData();
-    return { project };
-  },
-  computed: {
-    canUpdate() {
-      return this.project.dataExists && this.project.permits('project.update');
-    },
-    rendersTrashList() {
-      return this.project.dataExists && this.project.permits('form.restore');
-    }
-  },
-  created() {
-    this.$emit('fetch-forms', false);
+defineOptions({
+  name: 'ProjectOverview'
+});
+defineProps({
+  projectId: {
+    type: String,
+    required: true
   }
-};
+});
+const emit = defineEmits(['fetch-forms']);
+
+const { project } = useRequestData();
+emit('fetch-forms', false);
+
+const canUpdate = computed(() =>
+  project.dataExists && project.permits('project.update'));
+const rendersTrashList = computed(() =>
+  project.dataExists && project.permits('form.restore'));
 </script>


### PR DESCRIPTION
Based on the comment at https://github.com/getodk/central-frontend/pull/1051#discussion_r1841364832, I tried seeing what the code would look like if I removed `requestData` getters. As part of that, I converted `ProjectOverview` to the Composition API so that it could `provide()` a computed ref. I ended up concluding that we shouldn't remove getters. However, I think we might as well commit the conversion of `ProjectOverview` to the Composition API. Composition API > Options API :)

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced