### PR TITLE
Clarify access to requestData properties

### DIFF
--- a/src/request-data/resource.js
+++ b/src/request-data/resource.js
@@ -16,7 +16,18 @@ import { noop } from '../util/util';
 import { setCurrentResource } from './util';
 import { unlessFailure } from '../util/router';
 
+/*
+This file uses Symbols for internal properties. Private properties are usually
+nice, but they don't work well in this case:
+
+  - The _store property is used in subclasses.
+  - Our use of proxies in this file doesn't seem to play well with private
+    properties.
+
+Internal properties are not intended to be used outside this file.
+*/
 const _store = Symbol('store');
+
 // Subclasses must define a property named `data`.
 class BaseResource {
   /*

--- a/src/request-data/resource.js
+++ b/src/request-data/resource.js
@@ -19,12 +19,17 @@ import { unlessFailure } from '../util/router';
 const _store = Symbol('store');
 // Subclasses must define a property named `data`.
 class BaseResource {
+  /*
+  - name. Every resource must be provided a name. This can be helpful for
+    logging/debugging. Resource names do not have to be unique.
+  - store. The reactive state of the resource.
+  */
   constructor(name, store) {
-    // We don't use a Symbol for this property so that it is easy to access it
-    // for display in testing. Not using a Symbol also means that calling
-    // Object.keys() on the resource will return a non-empty array. Vue I18n
-    // uses Object.keys() to determine whether an object is empty.
-    this._name = name;
+    // In addition to logging/debugging, another reason to add this property is
+    // so that calling Object.keys() on the resource will return a non-empty
+    // array. Vue I18n uses Object.keys() to determine whether an object is
+    // empty.
+    this.resourceName = name;
     this[_store] = store;
   }
 
@@ -329,7 +334,7 @@ const _view = Symbol('view');
 class ResourceView extends BaseResource {
   constructor(resource, lens) {
     const store = resource[_store];
-    super(`${resource._name} view`, store);
+    super(`${resource.resourceName} view`, store);
     this[_view] = computed(() =>
       (store.data != null ? lens(store.data) : null));
   }


### PR DESCRIPTION
`requestData` classes have a number of internal properties. However, I don't think it's as clear as it could be that these properties are internal. This came up recently at https://github.com/getodk/central-frontend/pull/1024#discussion_r1816806460. I tried to make the properties private (that would be really clear), but that didn't work for a couple of reasons. Instead, I added a comment explaining our use of Symbol properties.

I also renamed the `_name` property to `resourceName`. I think it was particularly unclear whether that property was internal. Its name starts with `_`, but it's not a Symbol, and it's also intended to be used outside the file it's defined in. (Or if not used, at least included in `console.log()` output.) I think it doesn't hurt to remove the underscore and make it explicit how the property is meant to be used and that it's OK to use the property outside the file.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced