### PR TITLE
Use requestData resources in UserPreferences

### DIFF
--- a/src/request-data/resources.js
+++ b/src/request-data/resources.js
@@ -12,20 +12,22 @@ except according to the terms contained in the LICENSE file.
 import { computed, reactive, shallowReactive, watchSyncEffect } from 'vue';
 import { mergeDeepLeft } from 'ramda';
 
+import UserPreferences from './user-preferences/preferences';
 import configDefaults from '../config';
 import { computeIfExists, hasVerbs, setupOption, transformForm } from './util';
 import { noargs } from '../util/util';
-import UserPreferences from './user-preferences/preferences';
 
-export default ({ i18n, http }, createResource) => {
+export default (container, createResource) => {
+  const { i18n } = container;
+
   // Resources related to the session
-  const session = createResource('session');
+  createResource('session');
   createResource('currentUser', () => ({
     transformResponse: ({ data }) => {
       /* eslint-disable no-param-reassign */
       data.verbs = new Set(data.verbs);
       data.can = hasVerbs;
-      data.preferences = new UserPreferences(data.preferences, session, http);
+      data.preferences = new UserPreferences(data.preferences, container);
       /* eslint-enable no-param-reassign */
       return shallowReactive(data);
     }

--- a/src/request-data/user-preferences/preferences.js
+++ b/src/request-data/user-preferences/preferences.js
@@ -78,6 +78,7 @@ export default class UserPreferences {
         ? apiPaths.userSitePreferences(k)
         : apiPaths.userProjectPreferences(projectId, k),
       data: (v === null) ? undefined : { propertyValue: v },
+      alert: false
     })
       .catch(noop) // Preference didn't get persisted to the backend. Too bad! We're not doing any retrying.
       .finally(() => {


### PR DESCRIPTION
Right now, the `UserPreferences` class sends requests using the `http` object in `container`. However, the more typical pattern is for requests to be sent via a `requestData` resource. It wasn't easy before to do so in `UserPreferences`, but I've made some improvements to `requestData` to make that possible (#1050, #1051).

Right now, `UserPreferences` manually calls `withAuth()`. It also has to manage request cancelation. Those are both things that `requestData` already knows how to do.

This PR also removes `navigator.locks`. It closes #1044.

#### What has been done to verify that this works as intended?

We don't yet have automated tests around user preferences: see #1049. However, I'll do a quick check of the behavior before merging the PR.

@getodk/testers, could you please check the user preference functionality during regression testing? (Maybe you were planning to already.) This PR makes changes to the underlying code, so it'd be good to verify that everything still works as expected.

#### Why is this the best possible solution? Were any other approaches considered?

One reason maybe _not_ to use `requestData` resources is that resources have reactive state, and nothing about the `UserPreferences.prototype.#propagate()` method requires reactivity. However, I think it's fine for there to be a little extra reactivity: I don't expect there to be performance problems due to that. Overall, I think it's clearer to reuse the typical pattern of using `requestData` resources to send requests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced