### PR TITLE
Add "Test on device" and "Test in browser" buttons

### DIFF
--- a/src/components/collect-qr.vue
+++ b/src/components/collect-qr.vue
@@ -12,16 +12,21 @@ except according to the terms contained in the LICENSE file.
 
 <!-- eslint-disable vue/no-v-html -->
 <template>
-  <span class="collect-qr" v-html="imgHtml"></span>
+  <span class="collect-qr" :class="idClass" v-html="imgHtml"></span>
   <canvas v-show="false" ref="qrCanvas"></canvas>
 </template>
 <!-- eslint-enable vue/no-v-html -->
 
+<script>
+let id = 0;
+</script>
 <script setup>
 import { onMounted, ref } from 'vue';
 import qrcode from 'qrcode-generator';
 import pako from 'pako/lib/deflate';
 import { useI18n } from 'vue-i18n';
+
+import useEventListener from '../composables/event-listener';
 
 const { t } = useI18n();
 
@@ -120,6 +125,15 @@ onMounted(() => {
   imgHtml.value = img.outerHTML;
 });
 
+id += 1;
+// We have to use a class, not an id, because a QR code shown in a popover will
+// be rendered in two places in the DOM. Also due to the popover, we can't use
+// Vue event handlers. See the Popover component for details.
+const idClass = `collect-qr${id}`;
+useEventListener(document.body, 'click', (event) => {
+  if (event.target.parentNode.classList.contains(idClass))
+    console.log(props.settings); // eslint-disable-line no-console
+});
 </script>
 
 <style lang="scss">

--- a/src/components/enketo/fill.vue
+++ b/src/components/enketo/fill.vue
@@ -10,11 +10,11 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <a v-if="disabledDescription == null" class="enketo-fill btn btn-primary"
-    :href="href" target="_blank">
+  <a v-if="disabledDescription == null" :class="htmlClass" :href="href"
+    target="_blank">
     <slot></slot>
   </a>
-  <button v-else type="button" class="enketo-fill btn btn-primary" aria-disabled="true"
+  <button v-else type="button" :class="htmlClass" aria-disabled="true"
     v-tooltip.aria-describedby="disabledDescription">
     <slot></slot>
   </button>
@@ -29,6 +29,10 @@ export default {
     formVersion: {
       type: Object,
       required: true
+    },
+    btn: {
+      type: String,
+      default: 'primary'
     }
   },
   computed: {
@@ -39,6 +43,9 @@ export default {
       if (this.formVersion.enketoId == null)
         return this.$t('disabled.processing');
       return null;
+    },
+    htmlClass() {
+      return `enketo-fill btn btn-${this.btn}`;
     },
     href() {
       const encodedId = encodeURIComponent(this.formVersion.enketoId);

--- a/src/components/field-key/list.vue
+++ b/src/components/field-key/list.vue
@@ -43,7 +43,7 @@ except according to the terms contained in the LICENSE file.
       <tbody v-if="fieldKeys.dataExists">
         <field-key-row v-for="fieldKey of fieldKeys" :key="fieldKey.id"
           :field-key="fieldKey" :highlighted="highlighted"
-          @show-code="showPopover"
+          @toggle-qr="togglePopover"
           @revoke="revokeModal.show({ fieldKey: $event })"/>
       </tbody>
     </table>
@@ -135,9 +135,13 @@ export default {
       this.$emit('fetch-field-keys', resend);
       this.highlighted = null;
     },
-    showPopover(fieldKey, link) {
-      this.popover.target = link;
-      this.popover.fieldKey = fieldKey;
+    togglePopover(fieldKey, link) {
+      if (this.popover.target == null) {
+        this.popover.target = link;
+        this.popover.fieldKey = fieldKey;
+      } else {
+        this.hidePopover();
+      }
     },
     hidePopover() {
       this.popover.target = null;

--- a/src/components/field-key/list.vue
+++ b/src/components/field-key/list.vue
@@ -135,6 +135,10 @@ export default {
       this.$emit('fetch-field-keys', resend);
       this.highlighted = null;
     },
+    hidePopover() {
+      this.popover.target = null;
+      this.popover.fieldKey = null;
+    },
     togglePopover(fieldKey, link) {
       if (this.popover.target == null) {
         this.popover.target = link;
@@ -142,10 +146,6 @@ export default {
       } else {
         this.hidePopover();
       }
-    },
-    hidePopover() {
-      this.popover.target = null;
-      this.popover.fieldKey = null;
     },
     switchCode(event) {
       if (event.target.closest('.field-key-qr-panel .switch-code') == null)

--- a/src/components/field-key/qr-panel.vue
+++ b/src/components/field-key/qr-panel.vue
@@ -10,15 +10,11 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="field-key-qr-panel panel panel-default"
-    :class="{ legacy: !managed }">
-    <div class="panel-heading">
-      <h1 class="panel-title">
-        {{ managed ? $t('title.managed') : $t('title.legacy') }}
-      </h1>
-      <span class="icon-mobile"></span>
-    </div>
-    <div v-if="fieldKey != null" class="panel-body">
+  <qr-panel class="field-key-qr-panel" :class="{ legacy: !managed }">
+    <template #title>
+      {{ managed ? $t('title.managed') : $t('title.legacy') }}
+    </template>
+    <template v-if="fieldKey != null" #body>
       <collect-qr :settings="settings" error-correction-level="L"
         :cell-size="3"/>
       <p>
@@ -62,13 +58,14 @@ except according to the terms contained in the LICENSE file.
         <sentence-separator/>
         <doc-link to="collect-import-export/">{{ $t('moreInfo.learnMore') }}</doc-link>
       </p>
-    </div>
-  </div>
+    </template>
+  </qr-panel>
 </template>
 
 <script>
 import CollectQr from '../collect-qr.vue';
 import DocLink from '../doc-link.vue';
+import QrPanel from '../qr-panel.vue';
 import SentenceSeparator from '../sentence-separator.vue';
 
 import { apiPaths } from '../../util/request';
@@ -76,7 +73,7 @@ import { useRequestData } from '../../request-data';
 
 export default {
   name: 'FieldKeyQrPanel',
-  components: { CollectQr, DocLink, SentenceSeparator },
+  components: { CollectQr, DocLink, QrPanel, SentenceSeparator },
   props: {
     fieldKey: Object,
     managed: Boolean
@@ -108,49 +105,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../assets/scss/variables';
-
 .field-key-qr-panel {
-  margin-bottom: 0;
-  width: 500px;
-
-  .panel-heading {
-    background-color: $color-action-background;
-    position: relative;
-  }
-
-  // The icon is not animated, because in the popover, switching between a
-  // managed and a legacy QR code would reset the animation.
-  .icon-mobile {
-    color: $color-action-overlay;
-    font-size: 98px;
-    position: absolute;
-    right: 18px;
-    top: -32px;
-    transform: rotate(15deg);
-
-    &::after {
-      background-color: #fff;
-      content: '';
-      height: 65px;
-      left: 5px;
-      position: absolute;
-      top: 18px;
-      width: 32px;
-      z-index: -1;
-    }
-  }
-
-  .collect-qr {
-    float: left;
-    margin-right: 15px;
-  }
-
-  p {
-    &:first-child { margin-top: 5px; }
-    &:last-child { margin-bottom: 5px; }
-  }
-
   &.legacy {
     .panel-heading { background-color: #777; }
     .icon-mobile { color: #555; }

--- a/src/components/field-key/row.vue
+++ b/src/components/field-key/row.vue
@@ -21,7 +21,7 @@ except according to the terms contained in the LICENSE file.
     <td>
       <a v-if="fieldKey.token != null" ref="popoverLink" href="#"
         class="field-key-row-popover-link" role="button"
-        @click.prevent="showCode">
+        @click.prevent="toggleQr">
         <span class="icon-qrcode"></span>{{ $t('seeCode') }}
       </a>
       <template v-else>
@@ -62,15 +62,15 @@ export default {
     },
     highlighted: Number
   },
-  emits: ['show-code', 'revoke'],
+  emits: ['toggle-qr', 'revoke'],
   computed: {
     actionsId() {
       return `field-key-row-actions${this.fieldKey.id}`;
     }
   },
   methods: {
-    showCode() {
-      this.$emit('show-code', this.fieldKey, this.$refs.popoverLink);
+    toggleQr() {
+      this.$emit('toggle-qr', this.fieldKey, this.$refs.popoverLink);
     }
   }
 };

--- a/src/components/form-draft/qr-panel.vue
+++ b/src/components/form-draft/qr-panel.vue
@@ -10,10 +10,27 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="form-draft-qr-panel">
-    <collect-qr v-if="formDraft.dataExists" :settings="settings"
-      error-correction-level="Q" :cell-size="3" draft/>
-  </div>
+  <qr-panel class="form-draft-qr-panel">
+    <template #title>{{ $t('title') }}</template>
+    <template #body>
+      <collect-qr v-if="formDraft.dataExists" :settings="settings"
+        error-correction-level="Q" :cell-size="3" draft/>
+      <i18n-t keypath="intro.full" tag="p">
+        <template #temporaryCode>
+          <strong>{{ $t('intro.temporaryCode') }}</strong>
+        </template>
+      </i18n-t>
+      <p>{{ $t('stopsWorking') }}</p>
+      <p>{{ $t('instructions') }}</p>
+      <i18n-t keypath="codesForUsers.full" tag="p">
+        <template #appUsers>
+          <router-link :to="projectPath('app-users')">
+            {{ $t('codesForUsers.appUsers') }}
+          </router-link>
+        </template>
+      </i18n-t>
+    </template>
+  </qr-panel>
 </template>
 
 <script setup>
@@ -21,7 +38,9 @@ import { computed, inject } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import CollectQr from '../collect-qr.vue';
+import QrPanel from '../qr-panel.vue';
 
+import useRoutes from '../../composables/routes';
 import { apiPaths } from '../../util/request';
 import { useRequestData } from '../../request-data';
 
@@ -52,15 +71,34 @@ const settings = computed(() => {
     admin: {}
   };
 });
+
+const { projectPath } = useRoutes();
 </script>
 
 <i18n lang="json5">
 {
   "en": {
+    // This is the title at the top of a pop-up. "Code" refers to a QR code.
+    "title": "Testing Code",
     // @transifexKey component.FormDraftTesting.collectProjectName
     // This text will be shown in ODK Collect when testing a Draft Form. {name}
     // is the title of the Draft Form.
     "collectProjectName": "[Draft] {name}",
+    "intro": {
+      // This is shown next to a QR code.
+      "full": "This is a {temporaryCode}.",
+      // "Code" refers to a QR code.
+      "temporaryCode": "Temporary Testing Code"
+    },
+    // "It" refers to a temporary testing code.
+    "stopsWorking": "It will stop working when you publish this Draft.",
+    // The table is a table of test Submissions.
+    "instructions": "Scan this QR code to configure Collect on a device for testing and submitting data to this test table.",
+    "codesForUsers": {
+      // "Codes" refers to "QR codes".
+      "full": "To create codes to distribute to users, please see the {appUsers} page.",
+      "appUsers": "App Users"
+    }
   }
 }
 </i18n>

--- a/src/components/form-draft/qr-panel.vue
+++ b/src/components/form-draft/qr-panel.vue
@@ -15,9 +15,9 @@ except according to the terms contained in the LICENSE file.
     <template #body>
       <collect-qr v-if="formDraft.dataExists" :settings="settings"
         error-correction-level="Q" :cell-size="3" draft/>
-      <i18n-t keypath="intro.full" tag="p">
+      <i18n-t keypath="introduction.full" tag="p">
         <template #temporaryCode>
-          <strong>{{ $t('intro.temporaryCode') }}</strong>
+          <strong>{{ $t('introduction.temporaryCode') }}</strong>
         </template>
       </i18n-t>
       <p>{{ $t('stopsWorking') }}</p>
@@ -84,7 +84,7 @@ const { projectPath } = useRoutes();
     // This text will be shown in ODK Collect when testing a Draft Form. {name}
     // is the title of the Draft Form.
     "collectProjectName": "[Draft] {name}",
-    "intro": {
+    "introduction": {
       // This is shown next to a QR code.
       "full": "This is a {temporaryCode}.",
       // "Code" refers to a QR code.

--- a/src/components/form-draft/qr-panel.vue
+++ b/src/components/form-draft/qr-panel.vue
@@ -1,0 +1,66 @@
+<!--
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div class="form-draft-qr-panel">
+    <collect-qr v-if="formDraft.dataExists" :settings="settings"
+      error-correction-level="Q" :cell-size="3" draft/>
+  </div>
+</template>
+
+<script setup>
+import { computed, inject } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import CollectQr from '../collect-qr.vue';
+
+import { apiPaths } from '../../util/request';
+import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'FormDraftQrPanel'
+});
+
+const { resourceView } = useRequestData();
+const formDraft = resourceView('formDraft', (data) => data.get());
+
+const { t } = useI18n();
+const projectId = inject('projectId');
+const xmlFormId = inject('xmlFormId');
+const settings = computed(() => {
+  const { draftToken } = formDraft;
+  const url = apiPaths.serverUrlForFormDraft(draftToken, projectId, xmlFormId);
+  return {
+    general: {
+      server_url: `${window.location.origin}${url}`,
+      form_update_mode: 'match_exactly',
+      autosend: 'wifi_and_cellular'
+    },
+    project: {
+      name: t('collectProjectName', { name: formDraft.nameOrId }),
+      icon: '📝'
+    },
+    // Collect requires the settings to have an `admin` property.
+    admin: {}
+  };
+});
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.FormDraftTesting.collectProjectName
+    // This text will be shown in ODK Collect when testing a Draft Form. {name}
+    // is the title of the Draft Form.
+    "collectProjectName": "[Draft] {name}",
+  }
+}
+</i18n>

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div>
-    <page-section>
+    <page-section id="form-draft-testing-info">
       <template #heading>
         <span>{{ $t('title') }}</span>
       </template>
@@ -32,9 +32,8 @@ except according to the terms contained in the LICENSE file.
             </p>
           </div>
         </div>
-        <p>{{ $t('body[0]') }}</p>
         <p>
-          <span>{{ $t('body[1]') }}</span>
+          <span>{{ $t('introduction') }}</span>
           <sentence-separator/>
           <i18n-t keypath="moreInfo.helpArticle.full">
             <template #helpArticle>
@@ -101,22 +100,24 @@ const fetchKeys = () => {
 };
 fetchKeys();
 
-const popoverData = shallowReactive({ trigger: null });
+const popoverData = shallowReactive({ target: null });
 const togglePopover = (button) => {
   popoverData.target = popoverData.target == null ? button : null;
 };
 const hidePopover = () => { popoverData.target = null; };
 </script>
 
+<style lang="scss">
+#form-draft-testing-info { margin-bottom: 25px; }
+</style>
+
 <i18n lang="json5">
 {
   "en": {
     // This is a title shown above a section of the page.
     "title": "Draft Testing",
-    "body": [
-      "You can use the configuration code to the right to set up a mobile device to download this Draft. You can also click the New button above to create a new Submission from your web browser.",
-      "Draft Submissions go into the test table below, where you can preview and download them. When you publish this Draft Form, its test Submissions will be permanently removed."
-    ],
+    // @transifexKey component.FormDraftTesting.body.1
+    "introduction": "Draft Submissions go into the test table below, where you can preview and download them. When you publish this Draft Form, its test Submissions will be permanently removed.",
     // @transifexKey component.FormDraftTesting.datasetsPreview
     "entitiesTesting": {
       "title": "This Form can update Entities",

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -50,11 +50,11 @@ except according to the terms contained in the LICENSE file.
 
     <loading :state="keys.initiallyLoading"/>
     <submission-list v-show="keys.dataExists" :project-id="projectId"
-      :xml-form-id="xmlFormId" draft @fetch-keys="fetchData"/>
+      :xml-form-id="xmlFormId" draft @fetch-keys="fetchKeys"/>
   </div>
 </template>
 
-<script>
+<script setup>
 import DocLink from '../doc-link.vue';
 import EnketoFill from '../enketo/fill.vue';
 import Loading from '../loading.vue';
@@ -67,49 +67,33 @@ import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
 
-export default {
-  name: 'FormDraftTesting',
-  components: {
-    PageSection,
-    FloatRow,
-    CollectQr,
-    DocLink,
-    EnketoFill,
-    Loading,
-    SentenceSeparator,
-    SubmissionList
+defineOptions({
+  name: 'FormDraftTesting'
+});
+const props = defineProps({
+  projectId: {
+    type: String,
+    required: true
   },
-  props: {
-    projectId: {
-      type: String,
-      required: true
-    },
-    xmlFormId: {
-      type: String,
-      required: true
-    }
-  },
-  setup() {
-    const { resourceView, createResource } = useRequestData();
-
-    // SubmissionList expects submission stores to be created!
-    useSubmissions();
-    const formDraft = resourceView('formDraft', (data) => data.get());
-    const keys = createResource('keys');
-    return { formDraft, keys };
-  },
-  created() {
-    this.fetchData();
-  },
-  methods: {
-    fetchData() {
-      // We do not reconcile this.keys and this.formDraft.keyId.
-      this.keys.request({
-        url: apiPaths.submissionKeys(this.projectId, this.xmlFormId, true)
-      }).catch(noop);
-    }
+  xmlFormId: {
+    type: String,
+    required: true
   }
+});
+
+const { resourceView, createResource } = useRequestData();
+const formDraft = resourceView('formDraft', (data) => data.get());
+// SubmissionList expects submission stores to be created!
+useSubmissions();
+
+const keys = createResource('keys');
+const fetchKeys = () => {
+  // We do not reconcile `keys` and formDraft.keyId.
+  keys.request({
+    url: apiPaths.submissionKeys(props.projectId, props.xmlFormId, true)
+  }).catch(noop);
 };
+fetchKeys();
 </script>
 
 <i18n lang="json5">

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -11,52 +11,42 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div>
-    <div id="form-draft-testing-info" class="row">
-      <div class="col-xs-8">
-        <page-section>
-          <template #heading>
-            <span>{{ $t('title') }}</span>
-            <enketo-fill v-if="formDraft.dataExists" :form-version="formDraft">
-              <span class="icon-plus-circle"></span>{{ $t('action.createSubmission') }}
-            </enketo-fill>
-          </template>
-          <template #body>
-            <div v-if="formDraft.entityRelated" class="panel-dialog">
-              <div class="panel-heading">
-                <span class="panel-title">
-                  <span class="icon-database"></span>
-                  {{ $t('entitiesTesting.title') }}
-                </span>
-              </div>
-              <div class="panel-body">
-                <p>
-                  {{ $t('entitiesTesting.body[0]') }}
-                </p>
-                <p>
-                  {{ $t('entitiesTesting.body[1]') }}
-                </p>
-              </div>
-            </div>
-            <p>{{ $t('body[0]') }}</p>
+    <page-section>
+      <template #heading>
+        <span>{{ $t('title') }}</span>
+        <enketo-fill v-if="formDraft.dataExists" :form-version="formDraft">
+          <span class="icon-plus-circle"></span>{{ $t('action.createSubmission') }}
+        </enketo-fill>
+      </template>
+      <template #body>
+        <div v-if="formDraft.entityRelated" class="panel-dialog">
+          <div class="panel-heading">
+            <span class="panel-title">
+              <span class="icon-database"></span>
+              {{ $t('entitiesTesting.title') }}
+            </span>
+          </div>
+          <div class="panel-body">
             <p>
-              <span>{{ $t('body[1]') }}</span>
-              <sentence-separator/>
-              <i18n-t keypath="moreInfo.helpArticle.full">
-                <template #helpArticle>
-                  <doc-link to="central-forms/#working-with-form-drafts">{{ $t('moreInfo.helpArticle.helpArticle') }}</doc-link>
-                </template>
-              </i18n-t>
+              {{ $t('entitiesTesting.body[0]') }}
             </p>
-          </template>
-        </page-section>
-      </div>
-      <div class="col-xs-4">
-        <float-row>
-          <collect-qr v-if="formDraft.dataExists" :settings="qrSettings"
-            error-correction-level="Q" :cell-size="3" draft/>
-        </float-row>
-      </div>
-    </div>
+            <p>
+              {{ $t('entitiesTesting.body[1]') }}
+            </p>
+          </div>
+        </div>
+        <p>{{ $t('body[0]') }}</p>
+        <p>
+          <span>{{ $t('body[1]') }}</span>
+          <sentence-separator/>
+          <i18n-t keypath="moreInfo.helpArticle.full">
+            <template #helpArticle>
+              <doc-link to="central-forms/#working-with-form-drafts">{{ $t('moreInfo.helpArticle.helpArticle') }}</doc-link>
+            </template>
+          </i18n-t>
+        </p>
+      </template>
+    </page-section>
 
     <loading :state="keys.initiallyLoading"/>
     <submission-list v-show="keys.dataExists" :project-id="projectId"
@@ -65,18 +55,14 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
-// Import PageSection before FloatRow in order to have the same import order as
-// FormSubmissions: see https://github.com/vuejs/vue-cli/issues/3771
-import PageSection from '../page/section.vue';
-import FloatRow from '../float-row.vue';
-import CollectQr from '../collect-qr.vue';
 import DocLink from '../doc-link.vue';
 import EnketoFill from '../enketo/fill.vue';
 import Loading from '../loading.vue';
+import PageSection from '../page/section.vue';
 import SentenceSeparator from '../sentence-separator.vue';
 import SubmissionList from '../submission/list.vue';
-import useSubmissions from '../../request-data/submissions';
 
+import useSubmissions from '../../request-data/submissions';
 import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
@@ -112,28 +98,6 @@ export default {
     const keys = createResource('keys');
     return { formDraft, keys };
   },
-  computed: {
-    qrSettings() {
-      const url = apiPaths.serverUrlForFormDraft(
-        this.formDraft.draftToken,
-        this.projectId,
-        this.xmlFormId
-      );
-      return {
-        general: {
-          server_url: `${window.location.origin}${url}`,
-          form_update_mode: 'match_exactly',
-          autosend: 'wifi_and_cellular'
-        },
-        project: {
-          name: this.$t('collectProjectName', { name: this.formDraft.nameOrId }),
-          icon: '📝'
-        },
-        // Collect requires the settings to have an `admin` property.
-        admin: {}
-      };
-    }
-  },
   created() {
     this.fetchData();
   },
@@ -148,14 +112,6 @@ export default {
 };
 </script>
 
-<style lang="scss">
-#form-draft-testing-info {
-  .page-section, .float-row {
-    margin-bottom: 25px;
-  }
-}
-</style>
-
 <i18n lang="json5">
 {
   "en": {
@@ -165,9 +121,6 @@ export default {
       "You can use the configuration code to the right to set up a mobile device to download this Draft. You can also click the New button above to create a new Submission from your web browser.",
       "Draft Submissions go into the test table below, where you can preview and download them. When you publish this Draft Form, its test Submissions will be permanently removed."
     ],
-    // This text will be shown in ODK Collect when testing a Draft Form. {name}
-    // is the title of the Draft Form.
-    "collectProjectName": "[Draft] {name}",
     // @transifexKey component.FormDraftTesting.datasetsPreview
     "entitiesTesting": {
       "title": "This Form can update Entities",

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -14,9 +14,6 @@ except according to the terms contained in the LICENSE file.
     <page-section>
       <template #heading>
         <span>{{ $t('title') }}</span>
-        <enketo-fill v-if="formDraft.dataExists" :form-version="formDraft">
-          <span class="icon-plus-circle"></span>{{ $t('action.createSubmission') }}
-        </enketo-fill>
       </template>
       <template #body>
         <div v-if="formDraft.entityRelated" class="panel-dialog">
@@ -62,7 +59,6 @@ except according to the terms contained in the LICENSE file.
 import { provide, shallowReactive } from 'vue';
 
 import DocLink from '../doc-link.vue';
-import EnketoFill from '../enketo/fill.vue';
 import FormDraftQrPanel from './qr-panel.vue';
 import Loading from '../loading.vue';
 import PageSection from '../page/section.vue';

--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -47,18 +47,26 @@ except according to the terms contained in the LICENSE file.
         </p>
       </template>
     </page-section>
-
     <loading :state="keys.initiallyLoading"/>
     <submission-list v-show="keys.dataExists" :project-id="projectId"
-      :xml-form-id="xmlFormId" draft @fetch-keys="fetchKeys"/>
+      :xml-form-id="xmlFormId" draft @fetch-keys="fetchKeys"
+      @toggle-qr="togglePopover"/>
+
+    <popover :target="popoverData.target" placement="right" @hide="hidePopover">
+      <form-draft-qr-panel/>
+    </popover>
   </div>
 </template>
 
 <script setup>
+import { provide, shallowReactive } from 'vue';
+
 import DocLink from '../doc-link.vue';
 import EnketoFill from '../enketo/fill.vue';
+import FormDraftQrPanel from './qr-panel.vue';
 import Loading from '../loading.vue';
 import PageSection from '../page/section.vue';
+import Popover from '../popover.vue';
 import SentenceSeparator from '../sentence-separator.vue';
 import SubmissionList from '../submission/list.vue';
 
@@ -80,6 +88,8 @@ const props = defineProps({
     required: true
   }
 });
+provide('projectId', props.projectId);
+provide('xmlFormId', props.xmlFormId);
 
 const { resourceView, createResource } = useRequestData();
 const formDraft = resourceView('formDraft', (data) => data.get());
@@ -94,6 +104,12 @@ const fetchKeys = () => {
   }).catch(noop);
 };
 fetchKeys();
+
+const popoverData = shallowReactive({ trigger: null });
+const togglePopover = (button) => {
+  popoverData.target = popoverData.target == null ? button : null;
+};
+const hidePopover = () => { popoverData.target = null; };
 </script>
 
 <i18n lang="json5">

--- a/src/components/qr-panel.vue
+++ b/src/components/qr-panel.vue
@@ -1,0 +1,72 @@
+<!--
+Copyright 2024 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div class="qr-panel panel panel-default">
+    <div class="panel-heading">
+      <h1 class="panel-title"><slot name="title"></slot></h1>
+      <span class="icon-mobile"></span>
+    </div>
+    <div class="panel-body"><slot name="body"></slot></div>
+  </div>
+</template>
+
+<script setup>
+defineOptions({
+  name: 'QrPanel'
+});
+</script>
+
+<style lang="scss">
+@import '../assets/scss/variables';
+
+.qr-panel {
+  margin-bottom: 0;
+  width: 505px;
+
+  .panel-heading {
+    background-color: $color-action-background;
+    position: relative;
+  }
+
+  // The icon is not animated, because in FieldKeyQrPanel, switching between a
+  // managed and a legacy QR code would reset the animation.
+  .icon-mobile {
+    color: $color-action-overlay;
+    font-size: 98px;
+    position: absolute;
+    right: 18px;
+    top: -32px;
+    transform: rotate(15deg);
+
+    &::after {
+      background-color: #fff;
+      content: '';
+      height: 65px;
+      left: 5px;
+      position: absolute;
+      top: 18px;
+      width: 32px;
+      z-index: -1;
+    }
+  }
+
+  .collect-qr {
+    float: left;
+    margin-right: 15px;
+  }
+
+  p {
+    &:first-child { margin-top: 5px; }
+    &:last-child { margin-bottom: 5px; }
+  }
+}
+</style>

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -19,8 +19,9 @@ except according to the terms contained in the LICENSE file.
             class="btn btn-default" @click="$emit('toggle-qr', $event.target)">
             <span class="icon-qrcode"></span>{{ $t('action.testOnDevice') }}
           </button>
-          <enketo-fill id="submission-list-test-in-browser"
-            :form-version="formVersion">
+          <enketo-fill v-if="formVersion.dataExists"
+            id="submission-list-test-in-browser" :form-version="formVersion"
+            btn="default">
             <span class="icon-plus-circle"></span>{{ $t('action.testInBrowser') }}
           </enketo-fill>
         </template>

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -14,6 +14,12 @@ except according to the terms contained in the LICENSE file.
     <loading :state="fields.initiallyLoading"/>
     <div v-show="selectedFields != null">
       <div id="submission-list-actions">
+        <template v-if="draft">
+          <button id="submission-list-test-on-device" type="button"
+            class="btn btn-default" @click="$emit('toggle-qr', $event.target)">
+            <span class="icon-qrcode"></span>{{ $t('action.testOnDevice') }}
+          </button>
+        </template>
         <form class="form-inline" @submit.prevent>
           <submission-filters v-if="!draft" v-model:submitterId="submitterIds"
             v-model:submissionDate="submissionDateRange"
@@ -134,7 +140,7 @@ export default {
       default: (loaded) => (loaded < 1000 ? 250 : 1000)
     }
   },
-  emits: ['fetch-keys', 'fetch-deleted-count'],
+  emits: ['fetch-keys', 'fetch-deleted-count', 'toggle-qr'],
   setup(props) {
     const { form, keys, resourceView, odata, submitters, deletedSubmissionCount } = useRequestData();
     const formVersion = props.draft
@@ -475,11 +481,6 @@ export default {
   align-items: baseline;
   display: flex;
   flex-wrap: wrap-reverse;
-
-  // If there are filters, then there is already no left margin. But if there
-  // aren't filters (in the case of a form draft), then we need to remove the
-  // left margin.
-  form > :first-child { margin-left: 0; }
 }
 #submission-field-dropdown {
   margin-left: 15px;
@@ -500,6 +501,9 @@ export default {
 <i18n lang="json5">
 {
   "en": {
+    "action": {
+      "testOnDevice": "Test on device",
+    },
     "noMatching": "There are no matching Submissions.",
     "downloadDisabled": "Download is unavailable for deleted Submissions",
     "filterDisabledMessage": "Filtering is unavailable for deleted Submissions",

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -19,6 +19,10 @@ except according to the terms contained in the LICENSE file.
             class="btn btn-default" @click="$emit('toggle-qr', $event.target)">
             <span class="icon-qrcode"></span>{{ $t('action.testOnDevice') }}
           </button>
+          <enketo-fill id="submission-list-test-in-browser"
+            :form-version="formVersion">
+            <span class="icon-plus-circle"></span>{{ $t('action.testInBrowser') }}
+          </enketo-fill>
         </template>
         <form class="form-inline" @submit.prevent>
           <submission-filters v-if="!draft" v-model:submitterId="submitterIds"
@@ -81,6 +85,7 @@ except according to the terms contained in the LICENSE file.
 import { DateTime } from 'luxon';
 import { shallowRef, watch, watchEffect, reactive } from 'vue';
 
+import EnketoFill from '../enketo/fill.vue';
 import Loading from '../loading.vue';
 import Spinner from '../spinner.vue';
 import OdataLoadingMessage from '../odata-loading-message.vue';
@@ -107,6 +112,7 @@ import { useRequestData } from '../../request-data';
 export default {
   name: 'SubmissionList',
   components: {
+    EnketoFill,
     Loading,
     Spinner,
     SubmissionDelete,
@@ -202,9 +208,9 @@ export default {
     const { request } = useRequest();
 
     return {
-      form, keys, fields, formVersion, odata, submitters,
+      form, keys, fields, formVersion, odata, submitters, deletedSubmissionCount,
       submitterIds, submissionDateRange, reviewStates, allReviewStates,
-      request, deletedSubmissionCount
+      request
     };
   },
   data() {
@@ -496,6 +502,10 @@ export default {
   margin-bottom: 10px;
   margin-left: auto;
 }
+
+#submission-list-test-in-browser {
+  margin-left: 10px;
+}
 </style>
 
 <i18n lang="json5">
@@ -503,6 +513,7 @@ export default {
   "en": {
     "action": {
       "testOnDevice": "Test on device",
+      "testInBrowser": "Test in browser"
     },
     "noMatching": "There are no matching Submissions.",
     "downloadDisabled": "Download is unavailable for deleted Submissions",

--- a/test/components/field-key/row.spec.js
+++ b/test/components/field-key/row.spec.js
@@ -49,11 +49,12 @@ describe('FieldKeyRow', () => {
         .createPast(1, { displayName: 'App User 2' });
     });
 
-    it('shows the popover', async () => {
+    it('toggles the popover', async () => {
       const app = await load('/projects/1/app-users', { attachTo: document.body });
-      document.querySelectorAll('.popover').length.should.equal(0);
       await app.get('.field-key-row-popover-link').trigger('click');
-      document.querySelectorAll('.popover').length.should.equal(1);
+      should.exist(document.querySelector('.popover .field-key-qr-panel'));
+      await app.get('.field-key-row-popover-link').trigger('click');
+      should.not.exist(document.querySelector('.popover'));
     });
 
     it("shows the app user's display name", async () => {

--- a/test/components/form-draft/qr-panel.spec.js
+++ b/test/components/form-draft/qr-panel.spec.js
@@ -19,7 +19,7 @@ const mountComponent = () => {
 };
 
 describe('FormDraftQrPanel', () => {
-  it('shows a QR code that encodes the correct settings', async () => {
+  it('shows a QR code that encodes the correct settings', () => {
     testData.extendedForms.createPast(1, { name: 'My Form', draft: true });
     const component = mountComponent();
     const { draftToken } = testData.extendedFormDrafts.last();

--- a/test/components/form-draft/qr-panel.spec.js
+++ b/test/components/form-draft/qr-panel.spec.js
@@ -1,0 +1,36 @@
+import CollectQr from '../../../src/components/collect-qr.vue';
+import FormDraftQrPanel from '../../../src/components/form-draft/qr-panel.vue';
+
+import testData from '../../data';
+import { mockRouter } from '../../util/router';
+import { mount } from '../../util/lifecycle';
+
+const mountComponent = () => {
+  const formDraft = testData.extendedFormDrafts.last();
+  return mount(FormDraftQrPanel, {
+    global: {
+      provide: { projectId: 1, xmlFormId: 'f' }
+    },
+    container: {
+      router: mockRouter('/projects/1/forms/f/draft/testing'),
+      requestData: { formDraft }
+    }
+  });
+};
+
+describe('FormDraftQrPanel', () => {
+  it('shows a QR code that encodes the correct settings', async () => {
+    testData.extendedForms.createPast(1, { name: 'My Form', draft: true });
+    const component = mountComponent();
+    const { draftToken } = testData.extendedFormDrafts.last();
+    component.getComponent(CollectQr).props().settings.should.eql({
+      general: {
+        server_url: `http://localhost:9876/v1/test/${draftToken}/projects/1/forms/f/draft`,
+        form_update_mode: 'match_exactly',
+        autosend: 'wifi_and_cellular'
+      },
+      project: { name: '[Draft] My Form', icon: '📝' },
+      admin: {}
+    });
+  });
+});

--- a/test/components/form-draft/testing.spec.js
+++ b/test/components/form-draft/testing.spec.js
@@ -16,9 +16,8 @@ describe('FormDraftTesting', () => {
     });
     await component.get('#submission-list-test-on-device').trigger('click');
     should.exist(document.querySelector('.popover .form-draft-qr-panel'));
-    // Click elsewhere to hide the popover.
-    await component.get('#submission-list .empty-table-message').trigger('click');
-    should.not.exist(document.querySelector('.popover .form-draft-qr-panel'));
+    await component.get('#submission-list-test-on-device').trigger('click');
+    should.not.exist(document.querySelector('.popover'));
   });
 
   describe('submission count', () => {

--- a/test/components/form-draft/testing.spec.js
+++ b/test/components/form-draft/testing.spec.js
@@ -16,6 +16,20 @@ describe('FormDraftTesting', () => {
     component.getComponent(EnketoFill).should.be.visible();
   });
 
+  it('toggles the QR code for testing', async () => {
+    mockLogin();
+    testData.extendedForms.createPast(1, { draft: true });
+    const component = await load('/projects/1/forms/f/draft/testing', {
+      root: false,
+      attachTo: document.body
+    });
+    await component.get('#submission-list-test-on-device').trigger('click');
+    should.exist(document.querySelector('.popover .form-draft-qr-panel'));
+    // Click elsewhere to hide the popover.
+    await component.get('#submission-list .empty-table-message').trigger('click');
+    should.not.exist(document.querySelector('.popover .form-draft-qr-panel'));
+  });
+
   describe('submission count', () => {
     beforeEach(mockLogin);
 

--- a/test/components/form-draft/testing.spec.js
+++ b/test/components/form-draft/testing.spec.js
@@ -1,5 +1,4 @@
 import ChecklistStep from '../../../src/components/checklist-step.vue';
-import CollectQr from '../../../src/components/collect-qr.vue';
 import EnketoFill from '../../../src/components/enketo/fill.vue';
 import FormDraftStatus from '../../../src/components/form-draft/status.vue';
 import SubmissionDownloadButton from '../../../src/components/submission/download-button.vue';
@@ -15,24 +14,6 @@ describe('FormDraftTesting', () => {
     const path = '/projects/1/forms/f/draft/testing';
     const component = await load(path, { root: false });
     component.getComponent(EnketoFill).should.be.visible();
-  });
-
-  it('shows a QR code that encodes the correct settings', async () => {
-    mockLogin();
-    testData.extendedForms.createPast(1, { name: 'My Form', draft: true });
-    const component = await load('/projects/1/forms/f/draft/testing', {
-      root: false
-    });
-    const { draftToken } = testData.extendedFormDrafts.last();
-    component.getComponent(CollectQr).props().settings.should.eql({
-      general: {
-        server_url: `http://localhost:9876/v1/test/${draftToken}/projects/1/forms/f/draft`,
-        form_update_mode: 'match_exactly',
-        autosend: 'wifi_and_cellular'
-      },
-      project: { name: '[Draft] My Form', icon: '📝' },
-      admin: {}
-    });
   });
 
   describe('submission count', () => {

--- a/test/components/form-draft/testing.spec.js
+++ b/test/components/form-draft/testing.spec.js
@@ -1,5 +1,4 @@
 import ChecklistStep from '../../../src/components/checklist-step.vue';
-import EnketoFill from '../../../src/components/enketo/fill.vue';
 import FormDraftStatus from '../../../src/components/form-draft/status.vue';
 import SubmissionDownloadButton from '../../../src/components/submission/download-button.vue';
 
@@ -8,14 +7,6 @@ import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 
 describe('FormDraftTesting', () => {
-  it('shows the New button', async () => {
-    mockLogin();
-    testData.extendedForms.createPast(1, { draft: true });
-    const path = '/projects/1/forms/f/draft/testing';
-    const component = await load(path, { root: false });
-    component.getComponent(EnketoFill).should.be.visible();
-  });
-
   it('toggles the QR code for testing', async () => {
     mockLogin();
     testData.extendedForms.createPast(1, { draft: true });

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -79,7 +79,7 @@ describe('SubmissionList', () => {
     });
   });
 
-  it('shows the "Test in browser" button', async () => {
+  it('shows the "Test in browser" button for a form draft', async () => {
     testData.extendedForms.createPast(1, { draft: true });
     const component = await loadSubmissionList();
     const actions = component.get('#submission-list-actions');

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -1,3 +1,4 @@
+import EnketoFill from '../../../src/components/enketo/fill.vue';
 import Spinner from '../../../src/components/spinner.vue';
 import SubmissionDataRow from '../../../src/components/submission/data-row.vue';
 import SubmissionDownload from '../../../src/components/submission/download.vue';
@@ -76,6 +77,13 @@ describe('SubmissionList', () => {
           count.should.equal(2);
         });
     });
+  });
+
+  it('shows the "Test in browser" button', async () => {
+    testData.extendedForms.createPast(1, { draft: true });
+    const component = await loadSubmissionList();
+    const actions = component.get('#submission-list-actions');
+    actions.findComponent(EnketoFill).exists().should.be.true;
   });
 
   it('shows a message if there are no submissions', () => {

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -78,134 +78,260 @@ describe('SubmissionList', () => {
     });
   });
 
-  describe('after login', () => {
-    it('shows a message if there are no submissions', () => {
-      testData.extendedForms.createPast(1);
-      return loadSubmissionList().then(component => {
-        component.get('.empty-table-message').should.be.visible();
-      });
+  it('shows a message if there are no submissions', () => {
+    testData.extendedForms.createPast(1);
+    return loadSubmissionList().then(component => {
+      component.get('.empty-table-message').should.be.visible();
     });
+  });
 
-    describe('after the refresh button is clicked', () => {
-      it('completes a background refresh', () => {
-        testData.extendedSubmissions.createPast(1);
-        const assertRowCount = (count, responseIndex = 0) => (component, _, i) => {
-          if (i === responseIndex) {
-            component.findAllComponents(SubmissionMetadataRow).length.should.equal(count);
-            component.findAllComponents(SubmissionDataRow).length.should.equal(count);
-          }
-        };
-        return load('/projects/1/forms/f/submissions', { root: false })
-          .afterResponses(assertRowCount(1))
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeEachResponse(assertRowCount(1))
-          .respondWithData(() => {
-            testData.extendedSubmissions.createNew();
-            return testData.submissionOData();
-          })
-          .respondWithData(() => testData.submissionDeletedOData())
-          .afterResponse(assertRowCount(2));
-      });
-
-      it('does not show a loading message', () => {
-        testData.extendedSubmissions.createPast(1);
-        return loadSubmissionList()
-          .complete()
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeEachResponse(component => {
-            component.get('#odata-loading-message').should.be.hidden();
-          })
-          .respondWithData(testData.submissionOData);
-      });
-
-      it('should show correct row number after refresh', () => {
-        testData.extendedSubmissions.createPast(1);
-        return loadSubmissionList()
-          .complete()
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeEachResponse(component => {
-            testData.extendedSubmissions.createPast(1);
-            component.get('#odata-loading-message').should.be.hidden();
-          })
-          .respondWithData(testData.submissionOData)
-          .afterResponse(component => {
-            component.findAllComponents(SubmissionMetadataRow).forEach((r, i) => {
-              r.props().rowNumber.should.be.equal(2 - i);
-            });
-          });
-      });
-    });
-
-    describe('load by chunk', () => {
-      const checkTop = ({ url }, top) => {
-        url.should.match(new RegExp(`[?&]%24top=${top}(&|$)`));
-      };
-      const checkIds = (component, count, offset = 0) => {
-        const rows = component.findAllComponents(SubmissionDataRow);
-        rows.length.should.equal(count);
-        const submissions = testData.extendedSubmissions.sorted();
-        submissions.length.should.be.at.least(count + offset);
-        for (let i = 0; i < rows.length; i += 1) {
-          const text = rows[i].get('td:last-child').text();
-          text.should.equal(submissions[i + offset].instanceId);
+  describe('after the refresh button is clicked', () => {
+    it('completes a background refresh', () => {
+      testData.extendedSubmissions.createPast(1);
+      const assertRowCount = (count, responseIndex = 0) => (component, _, i) => {
+        if (i === responseIndex) {
+          component.findAllComponents(SubmissionMetadataRow).length.should.equal(count);
+          component.findAllComponents(SubmissionDataRow).length.should.equal(count);
         }
       };
-      const checkMessage = (component, text) => {
-        const message = component.get('#odata-loading-message');
-        if (text == null) {
-          message.should.be.hidden();
-        } else {
-          message.should.not.be.hidden();
-          message.get('#odata-loading-message-text').text().should.equal(text);
-
-          const spinner = component.findAllComponents(Spinner).find(wrapper =>
-            message.element.contains(wrapper.element));
-          spinner.props().state.should.be.true;
-        }
-      };
-
-      it('loads a single submission', () => {
-        createSubmissions(1);
-        return loadSubmissionList()
-          .beforeEachResponse((component, { url }) => {
-            if (url.includes('.svc/Submissions'))
-              checkMessage(component, 'Loading 1 Submission…');
-          });
-      });
-
-      it('loads all submissions if there are few of them', () => {
-        createSubmissions(2);
-        return loadSubmissionList()
-          .beforeEachResponse((component, { url }) => {
-            if (url.includes('.svc/Submissions'))
-              checkMessage(component, 'Loading 2 Submissions…');
-          });
-      });
-
-      it('initially loads only the first chunk if there are many submissions', () => {
-        createSubmissions(3);
-        return loadSubmissionList({
-          props: { top: () => 2 }
+      return load('/projects/1/forms/f/submissions', { root: false })
+        .afterResponses(assertRowCount(1))
+        .request(component =>
+          component.get('#submission-list-refresh-button').trigger('click'))
+        .beforeEachResponse(assertRowCount(1))
+        .respondWithData(() => {
+          testData.extendedSubmissions.createNew();
+          return testData.submissionOData();
         })
-          .beforeEachResponse((component, config) => {
-            if (config.url.includes('.svc/Submissions')) {
-              checkMessage(component, 'Loading the first 2 of 3 Submissions…');
-              checkTop(config, 2);
-            }
+        .respondWithData(() => testData.submissionDeletedOData())
+        .afterResponse(assertRowCount(2));
+    });
+
+    it('does not show a loading message', () => {
+      testData.extendedSubmissions.createPast(1);
+      return loadSubmissionList()
+        .complete()
+        .request(component =>
+          component.get('#submission-list-refresh-button').trigger('click'))
+        .beforeEachResponse(component => {
+          component.get('#odata-loading-message').should.be.hidden();
+        })
+        .respondWithData(testData.submissionOData);
+    });
+
+    it('should show correct row number after refresh', () => {
+      testData.extendedSubmissions.createPast(1);
+      return loadSubmissionList()
+        .complete()
+        .request(component =>
+          component.get('#submission-list-refresh-button').trigger('click'))
+        .beforeEachResponse(component => {
+          testData.extendedSubmissions.createPast(1);
+          component.get('#odata-loading-message').should.be.hidden();
+        })
+        .respondWithData(testData.submissionOData)
+        .afterResponse(component => {
+          component.findAllComponents(SubmissionMetadataRow).forEach((r, i) => {
+            r.props().rowNumber.should.be.equal(2 - i);
+          });
+        });
+    });
+  });
+
+  describe('load by chunk', () => {
+    const checkTop = ({ url }, top) => {
+      url.should.match(new RegExp(`[?&]%24top=${top}(&|$)`));
+    };
+    const checkIds = (component, count, offset = 0) => {
+      const rows = component.findAllComponents(SubmissionDataRow);
+      rows.length.should.equal(count);
+      const submissions = testData.extendedSubmissions.sorted();
+      submissions.length.should.be.at.least(count + offset);
+      for (let i = 0; i < rows.length; i += 1) {
+        const text = rows[i].get('td:last-child').text();
+        text.should.equal(submissions[i + offset].instanceId);
+      }
+    };
+    const checkMessage = (component, text) => {
+      const message = component.get('#odata-loading-message');
+      if (text == null) {
+        message.should.be.hidden();
+      } else {
+        message.should.not.be.hidden();
+        message.get('#odata-loading-message-text').text().should.equal(text);
+
+        const spinner = component.findAllComponents(Spinner).find(wrapper =>
+          message.element.contains(wrapper.element));
+        spinner.props().state.should.be.true;
+      }
+    };
+
+    it('loads a single submission', () => {
+      createSubmissions(1);
+      return loadSubmissionList()
+        .beforeEachResponse((component, { url }) => {
+          if (url.includes('.svc/Submissions'))
+            checkMessage(component, 'Loading 1 Submission…');
+        });
+    });
+
+    it('loads all submissions if there are few of them', () => {
+      createSubmissions(2);
+      return loadSubmissionList()
+        .beforeEachResponse((component, { url }) => {
+          if (url.includes('.svc/Submissions'))
+            checkMessage(component, 'Loading 2 Submissions…');
+        });
+    });
+
+    it('initially loads only the first chunk if there are many submissions', () => {
+      createSubmissions(3);
+      return loadSubmissionList({
+        props: { top: () => 2 }
+      })
+        .beforeEachResponse((component, config) => {
+          if (config.url.includes('.svc/Submissions')) {
+            checkMessage(component, 'Loading the first 2 of 3 Submissions…');
+            checkTop(config, 2);
+          }
+        })
+        .afterResponses(component => {
+          checkIds(component, 2);
+        });
+    });
+
+    it('clicking refresh button loads only first chunk of submissions', () => {
+      createSubmissions(3);
+      return loadSubmissionList({
+        props: { top: () => 2 }
+      })
+        .complete()
+        .request(component =>
+          component.get('#submission-list-refresh-button').trigger('click'))
+        .beforeEachResponse((_, config) => {
+          checkTop(config, 2, 0);
+        })
+        .respondWithData(() => testData.submissionOData(2, 0))
+        .afterResponse(component => {
+          checkIds(component, 2);
+        });
+    });
+
+    describe('scrolling', () => {
+      it('scrolling to the bottom loads the next chunk of submissions', () => {
+        createSubmissions(12);
+        // Chunk 1
+        return loadSubmissionList({
+          props: { top: (loaded) => (loaded < 8 ? 2 : 3) }
+        })
+          .beforeEachResponse((component, { url }) => {
+            if (url.includes('.svc/Submissions'))
+              checkMessage(component, 'Loading the first 2 of 12 Submissions…');
           })
           .afterResponses(component => {
-            checkIds(component, 2);
+            checkMessage(component, null);
+          })
+          // Chunk 2
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 2);
+            checkMessage(component, 'Loading 2 more of 10 remaining Submissions…');
+          })
+          .respondWithData(() => testData.submissionOData(2, 2))
+          .afterResponse(component => {
+            checkIds(component, 4);
+            checkMessage(component, null);
+          })
+          // Chunk 3
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 2, 4);
+            checkMessage(component, 'Loading 2 more of 8 remaining Submissions…');
+          })
+          .respondWithData(() => testData.submissionOData(2, 4))
+          .afterResponse(component => {
+            checkIds(component, 6);
+            checkMessage(component, null);
+          })
+          // Chunk 4 (last small chunk)
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 2, 6);
+            checkMessage(component, 'Loading 2 more of 6 remaining Submissions…');
+          })
+          .respondWithData(() => testData.submissionOData(2, 6))
+          .afterResponse(component => {
+            checkIds(component, 8);
+            checkMessage(component, null);
+          })
+          // Chunk 5
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 3, 8);
+            checkMessage(component, 'Loading 3 more of 4 remaining Submissions…');
+          })
+          .respondWithData(() => testData.submissionOData(3, 8))
+          .afterResponse(component => {
+            checkIds(component, 11);
+            checkMessage(component, null);
+          })
+          // Chunk 6
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 3, 11);
+            checkMessage(component, 'Loading the last Submission…');
+          })
+          .respondWithData(() => testData.submissionOData(3, 11))
+          .afterResponse(component => {
+            checkIds(component, 12);
+            checkMessage(component, null);
           });
       });
 
-      it('clicking refresh button loads only first chunk of submissions', () => {
-        createSubmissions(3);
+      it('does nothing upon scroll if keys request results in error', () => {
+        createSubmissions(251);
+        return load('/projects/1/forms/f/submissions', { root: false }, {
+          keys: mockResponse.problem
+        })
+          .complete()
+          .testNoRequest(scroll);
+      });
+
+      it('does nothing upon scroll if fields request results in error', () => {
+        createSubmissions(251);
+        return load('/projects/1/forms/f/submissions', { root: false }, {
+          fields: mockResponse.problem
+        })
+          .complete()
+          .testNoRequest(scroll);
+      });
+
+      it('does nothing upon scroll if submissions request results in error', () => {
+        createSubmissions(251);
+        return load('/projects/1/forms/f/submissions', { root: false }, {
+          odata: mockResponse.problem
+        })
+          .complete()
+          .testNoRequest(scroll);
+      });
+
+      it('does nothing after user scrolls somewhere other than bottom of page', () => {
+        createSubmissions(5);
         return loadSubmissionList({
           props: { top: () => 2 }
         })
+          .complete()
+          .testNoRequest(scroll(false));
+      });
+
+      it('clicking refresh button loads first chunk, even after scrolling', () => {
+        createSubmissions(5);
+        return loadSubmissionList({
+          props: { top: () => 2 }
+        })
+          .complete()
+          .request(scroll)
+          .respondWithData(() => testData.submissionOData(2, 2))
           .complete()
           .request(component =>
             component.get('#submission-list-refresh-button').trigger('click'))
@@ -215,329 +341,201 @@ describe('SubmissionList', () => {
           .respondWithData(() => testData.submissionOData(2, 0))
           .afterResponse(component => {
             checkIds(component, 2);
+          })
+          .request(scroll)
+          .beforeEachResponse((_, config) => {
+            checkTop(config, 2, 2);
+          })
+          .respondWithData(() => testData.submissionOData(2, 2));
+      });
+
+      it('scrolling to the bottom has no effect if awaiting response', () => {
+        createSubmissions(5);
+        return loadSubmissionList({
+          props: { top: () => 2 }
+        })
+          .complete()
+          // Sends a request.
+          .request(scroll)
+          // This should not send a request. If it does, then the number of
+          // requests will exceed the number of responses, and the mockHttp()
+          // object will throw an error.
+          .beforeAnyResponse(scroll)
+          .respondWithData(() => testData.submissionOData(2, 2))
+          .complete()
+          .request(component =>
+            component.get('#submission-list-refresh-button').trigger('click'))
+          // Should not send a request.
+          .beforeAnyResponse(scroll)
+          .respondWithData(() => testData.submissionOData(2, 0));
+      });
+
+      it('scrolling has no effect after all submissions have been loaded', () => {
+        createSubmissions(2);
+        return loadSubmissionList({
+          props: { top: () => 2 }
+        })
+          .complete()
+          .testNoRequest(scroll);
+      });
+    });
+
+    describe('refreshing keys', () => {
+      it('opens modal with encrpytion password after refreshing keys', () => {
+        // create project with managed encryption, form, and 0 submissions to start
+        testData.extendedProjects.createPast(1, {
+          key: testData.standardKeys.createPast(1, { managed: true }).last()
+        });
+        testData.extendedForms.createPast(1);
+        return load('/projects/1/forms/f/submissions', { root: false }, {
+          keys: () => [] // if there are 0 submissions, backend returns empty key array
+        })
+          .complete()
+          .request(async (app) => {
+            await app.get('#submission-download-button').trigger('click');
+            const modal = app.getComponent(SubmissionDownload);
+            await modal.find('input[type="password"]').exists().should.be.false;
+            return app.get('#submission-list-refresh-button').trigger('click');
+          })
+          .beforeAnyResponse(() => {
+            testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
+          })
+          .respondWithData(() => testData.submissionOData(1, 0))
+          .respondWithData(() => testData.submissionDeletedOData())
+          .respondWithData(() => testData.standardKeys.sorted())
+          .complete()
+          .request(async (app) => {
+            await app.get('#submission-download-button').trigger('click');
+            const modal = app.getComponent(SubmissionDownload);
+            await modal.find('input[type="password"]').exists().should.be.true;
           });
       });
 
-      describe('scrolling', () => {
-        it('scrolling to the bottom loads the next chunk of submissions', () => {
-          createSubmissions(12);
-          // Chunk 1
-          return loadSubmissionList({
-            props: { top: (loaded) => (loaded < 8 ? 2 : 3) }
-          })
-            .beforeEachResponse((component, { url }) => {
-              if (url.includes('.svc/Submissions'))
-                checkMessage(component, 'Loading the first 2 of 12 Submissions…');
-            })
-            .afterResponses(component => {
-              checkMessage(component, null);
-            })
-            // Chunk 2
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 2);
-              checkMessage(component, 'Loading 2 more of 10 remaining Submissions…');
-            })
-            .respondWithData(() => testData.submissionOData(2, 2))
-            .afterResponse(component => {
-              checkIds(component, 4);
-              checkMessage(component, null);
-            })
-            // Chunk 3
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 2, 4);
-              checkMessage(component, 'Loading 2 more of 8 remaining Submissions…');
-            })
-            .respondWithData(() => testData.submissionOData(2, 4))
-            .afterResponse(component => {
-              checkIds(component, 6);
-              checkMessage(component, null);
-            })
-            // Chunk 4 (last small chunk)
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 2, 6);
-              checkMessage(component, 'Loading 2 more of 6 remaining Submissions…');
-            })
-            .respondWithData(() => testData.submissionOData(2, 6))
-            .afterResponse(component => {
-              checkIds(component, 8);
-              checkMessage(component, null);
-            })
-            // Chunk 5
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 3, 8);
-              checkMessage(component, 'Loading 3 more of 4 remaining Submissions…');
-            })
-            .respondWithData(() => testData.submissionOData(3, 8))
-            .afterResponse(component => {
-              checkIds(component, 11);
-              checkMessage(component, null);
-            })
-            // Chunk 6
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 3, 11);
-              checkMessage(component, 'Loading the last Submission…');
-            })
-            .respondWithData(() => testData.submissionOData(3, 11))
-            .afterResponse(component => {
-              checkIds(component, 12);
-              checkMessage(component, null);
-            });
+      it('sends request for encryption keys on draft/testing submission refresh', () => {
+        // create project with managed encryption, form, and 0 submissions to start
+        testData.extendedProjects.createPast(1, {
+          key: testData.standardKeys.createPast(1, { managed: true }).last()
         });
-
-        it('does nothing upon scroll if keys request results in error', () => {
-          createSubmissions(251);
-          return load('/projects/1/forms/f/submissions', { root: false }, {
-            keys: mockResponse.problem
+        testData.extendedForms.createPast(1, { xmlFormId: 'e', draft: true });
+        return load('/projects/1/forms/e/draft/testing', { root: false }, {
+          keys: () => [] // if there are 0 submissions, backend returns empty key array
+        })
+          .complete()
+          .request(component =>
+            component.get('#submission-list-refresh-button').trigger('click'))
+          .beforeAnyResponse(() => {
+            testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
           })
-            .complete()
-            .testNoRequest(scroll);
+          .respondWithData(() => testData.submissionOData(1, 0))
+          .respondWithData(() => testData.standardKeys.sorted())
+          .testRequests([
+            null,
+            { url: '/v1/projects/1/forms/e/draft/submissions/keys' }
+          ]);
+      });
+
+      it('sends request for encryption keys on published submission refresh', () => {
+        // create project with managed encryption, form, and 0 submissions to start
+        testData.extendedProjects.createPast(1, {
+          key: testData.standardKeys.createPast(1, { managed: true }).last()
         });
-
-        it('does nothing upon scroll if fields request results in error', () => {
-          createSubmissions(251);
-          return load('/projects/1/forms/f/submissions', { root: false }, {
-            fields: mockResponse.problem
+        testData.extendedForms.createPast(1);
+        return load('/projects/1/forms/f/submissions', { root: false }, {
+          keys: () => [] // if there are 0 submissions, backend returns empty key array
+        })
+          .complete()
+          .request(component =>
+            component.get('#submission-list-refresh-button').trigger('click'))
+          .beforeAnyResponse(() => {
+            testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
           })
-            .complete()
-            .testNoRequest(scroll);
-        });
+          .respondWithData(() => testData.submissionOData(1, 0))
+          .respondWithData(() => testData.submissionDeletedOData())
+          .respondWithData(() => testData.standardKeys.sorted())
+          .testRequests([
+            null,
+            null,
+            { url: '/v1/projects/1/forms/f/submissions/keys' }
+          ]);
+      });
+    });
 
-        it('does nothing upon scroll if submissions request results in error', () => {
-          createSubmissions(251);
-          return load('/projects/1/forms/f/submissions', { root: false }, {
-            odata: mockResponse.problem
-          })
-            .complete()
-            .testNoRequest(scroll);
-        });
-
-        it('does nothing after user scrolls somewhere other than bottom of page', () => {
-          createSubmissions(5);
-          return loadSubmissionList({
-            props: { top: () => 2 }
-          })
-            .complete()
-            .testNoRequest(scroll(false));
-        });
-
-        it('clicking refresh button loads first chunk, even after scrolling', () => {
-          createSubmissions(5);
-          return loadSubmissionList({
-            props: { top: () => 2 }
-          })
-            .complete()
-            .request(scroll)
-            .respondWithData(() => testData.submissionOData(2, 2))
-            .complete()
-            .request(component =>
-              component.get('#submission-list-refresh-button').trigger('click'))
-            .beforeEachResponse((_, config) => {
+    describe('count update', () => {
+      it.skip('scrolling to the bottom continues to fetch the next chunk', () => {
+        createSubmissions(4);
+        // 4 submissions exist. About to request $top=2, $skip=0.
+        return loadSubmissionList({
+          props: { top: () => 2 }
+        })
+          .beforeEachResponse((component, config) => {
+            if (config.url.includes('.svc/Submissions')) {
               checkTop(config, 2, 0);
-            })
-            .respondWithData(() => testData.submissionOData(2, 0))
-            .afterResponse(component => {
-              checkIds(component, 2);
-            })
-            .request(scroll)
-            .beforeEachResponse((_, config) => {
-              checkTop(config, 2, 2);
-            })
-            .respondWithData(() => testData.submissionOData(2, 2));
-        });
-
-        it('scrolling to the bottom has no effect if awaiting response', () => {
-          createSubmissions(5);
-          return loadSubmissionList({
-            props: { top: () => 2 }
+              checkMessage(component, 'Loading the first 2 of 4 Submissions…');
+            }
           })
-            .complete()
-            // Sends a request.
-            .request(scroll)
-            // This should not send a request. If it does, then the number of
-            // requests will exceed the number of responses, and the mockHttp()
-            // object will throw an error.
-            .beforeAnyResponse(scroll)
-            .respondWithData(() => testData.submissionOData(2, 2))
-            .complete()
-            .request(component =>
-              component.get('#submission-list-refresh-button').trigger('click'))
-            // Should not send a request.
-            .beforeAnyResponse(scroll)
-            .respondWithData(() => testData.submissionOData(2, 0));
-        });
-
-        it('scrolling has no effect after all submissions have been loaded', () => {
-          createSubmissions(2);
-          return loadSubmissionList({
-            props: { top: () => 2 }
+          .complete()
+          // 4 submissions exist, but 4 more are about to be created. About to
+          // request $top=2, $skip=2.
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 2, 2);
+            checkMessage(component, 'Loading the last 2 Submissions…');
           })
-            .complete()
-            .testNoRequest(scroll);
-        });
+          .respondWithData(() => {
+            testData.extendedSubmissions.createPast(4);
+            // This returns 2 of the 4 new submissions.
+            return testData.submissionOData(2, 2);
+          })
+          .afterResponse(component => {
+            checkIds(component, 2, 4);
+            checkMessage(component, null);
+          })
+          // 8 submissions exist. About to request $top=2, $skip=4.
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 2, 4);
+            checkMessage(component, 'Loading the last 2 Submissions…');
+          })
+          // Returns the 2 submissions that are already shown in the table.
+          .respondWithData(() => testData.submissionOData(2, 4))
+          .afterResponse(component => {
+            checkIds(component, 2, 4);
+            checkMessage(component, null);
+          })
+          // 8 submissions exist. About to request $top=2, $skip=6.
+          .request(scroll)
+          .beforeEachResponse((component, config) => {
+            checkTop(config, 2, 6);
+            checkMessage(component, 'Loading the last 2 Submissions…');
+          })
+          // Returns the last 2 submissions.
+          .respondWithData(() => testData.submissionOData(2, 6))
+          .afterResponse(component => {
+            checkIds(component, 4, 4);
+            checkMessage(component, null);
+          })
+          // 8 submissions exist. No request will be sent.
+          .testNoRequest(scroll);
       });
 
-      describe('refreshing keys', () => {
-        it('opens modal with encrpytion password after refreshing keys', () => {
-          // create project with managed encryption, form, and 0 submissions to start
-          testData.extendedProjects.createPast(1, {
-            key: testData.standardKeys.createPast(1, { managed: true }).last()
+      it('does not update requestData.odata.originalCount', () => {
+        createSubmissions(251);
+        return load('/projects/1/forms/f/submissions', { root: false })
+          .afterResponses(component => {
+            const { requestData } = component.vm.$container;
+            requestData.localResources.odata.originalCount.should.equal(251);
+            requestData.form.submissions.should.equal(251);
+          })
+          .request(scroll)
+          .respondWithData(() => {
+            testData.extendedSubmissions.createPast(1);
+            return testData.submissionOData(2, 250);
+          })
+          .afterResponse(component => {
+            const { requestData } = component.vm.$container;
+            requestData.localResources.odata.originalCount.should.equal(251);
+            requestData.form.submissions.should.equal(252);
           });
-          testData.extendedForms.createPast(1);
-          return load('/projects/1/forms/f/submissions', { root: false }, {
-            keys: () => [] // if there are 0 submissions, backend returns empty key array
-          })
-            .complete()
-            .request(async (app) => {
-              await app.get('#submission-download-button').trigger('click');
-              const modal = app.getComponent(SubmissionDownload);
-              await modal.find('input[type="password"]').exists().should.be.false;
-              return app.get('#submission-list-refresh-button').trigger('click');
-            })
-            .beforeAnyResponse(() => {
-              testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
-            })
-            .respondWithData(() => testData.submissionOData(1, 0))
-            .respondWithData(() => testData.submissionDeletedOData())
-            .respondWithData(() => testData.standardKeys.sorted())
-            .complete()
-            .request(async (app) => {
-              await app.get('#submission-download-button').trigger('click');
-              const modal = app.getComponent(SubmissionDownload);
-              await modal.find('input[type="password"]').exists().should.be.true;
-            });
-        });
-
-        it('sends request for encryption keys on draft/testing submission refresh', () => {
-          // create project with managed encryption, form, and 0 submissions to start
-          testData.extendedProjects.createPast(1, {
-            key: testData.standardKeys.createPast(1, { managed: true }).last()
-          });
-          testData.extendedForms.createPast(1, { xmlFormId: 'e', draft: true });
-          return load('/projects/1/forms/e/draft/testing', { root: false }, {
-            keys: () => [] // if there are 0 submissions, backend returns empty key array
-          })
-            .complete()
-            .request(component =>
-              component.get('#submission-list-refresh-button').trigger('click'))
-            .beforeAnyResponse(() => {
-              testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
-            })
-            .respondWithData(() => testData.submissionOData(1, 0))
-            .respondWithData(() => testData.standardKeys.sorted())
-            .testRequests([
-              null,
-              { url: '/v1/projects/1/forms/e/draft/submissions/keys' }
-            ]);
-        });
-
-        it('sends request for encryption keys on published submission refresh', () => {
-          // create project with managed encryption, form, and 0 submissions to start
-          testData.extendedProjects.createPast(1, {
-            key: testData.standardKeys.createPast(1, { managed: true }).last()
-          });
-          testData.extendedForms.createPast(1);
-          return load('/projects/1/forms/f/submissions', { root: false }, {
-            keys: () => [] // if there are 0 submissions, backend returns empty key array
-          })
-            .complete()
-            .request(component =>
-              component.get('#submission-list-refresh-button').trigger('click'))
-            .beforeAnyResponse(() => {
-              testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
-            })
-            .respondWithData(() => testData.submissionOData(1, 0))
-            .respondWithData(() => testData.submissionDeletedOData())
-            .respondWithData(() => testData.standardKeys.sorted())
-            .testRequests([
-              null,
-              null,
-              { url: '/v1/projects/1/forms/f/submissions/keys' }
-            ]);
-        });
-      });
-
-      describe('count update', () => {
-        it.skip('scrolling to the bottom continues to fetch the next chunk', () => {
-          createSubmissions(4);
-          // 4 submissions exist. About to request $top=2, $skip=0.
-          return loadSubmissionList({
-            props: { top: () => 2 }
-          })
-            .beforeEachResponse((component, config) => {
-              if (config.url.includes('.svc/Submissions')) {
-                checkTop(config, 2, 0);
-                checkMessage(component, 'Loading the first 2 of 4 Submissions…');
-              }
-            })
-            .complete()
-            // 4 submissions exist, but 4 more are about to be created. About to
-            // request $top=2, $skip=2.
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 2, 2);
-              checkMessage(component, 'Loading the last 2 Submissions…');
-            })
-            .respondWithData(() => {
-              testData.extendedSubmissions.createPast(4);
-              // This returns 2 of the 4 new submissions.
-              return testData.submissionOData(2, 2);
-            })
-            .afterResponse(component => {
-              checkIds(component, 2, 4);
-              checkMessage(component, null);
-            })
-            // 8 submissions exist. About to request $top=2, $skip=4.
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 2, 4);
-              checkMessage(component, 'Loading the last 2 Submissions…');
-            })
-            // Returns the 2 submissions that are already shown in the table.
-            .respondWithData(() => testData.submissionOData(2, 4))
-            .afterResponse(component => {
-              checkIds(component, 2, 4);
-              checkMessage(component, null);
-            })
-            // 8 submissions exist. About to request $top=2, $skip=6.
-            .request(scroll)
-            .beforeEachResponse((component, config) => {
-              checkTop(config, 2, 6);
-              checkMessage(component, 'Loading the last 2 Submissions…');
-            })
-            // Returns the last 2 submissions.
-            .respondWithData(() => testData.submissionOData(2, 6))
-            .afterResponse(component => {
-              checkIds(component, 4, 4);
-              checkMessage(component, null);
-            })
-            // 8 submissions exist. No request will be sent.
-            .testNoRequest(scroll);
-        });
-
-        it('does not update requestData.odata.originalCount', () => {
-          createSubmissions(251);
-          return load('/projects/1/forms/f/submissions', { root: false })
-            .afterResponses(component => {
-              const { requestData } = component.vm.$container;
-              requestData.localResources.odata.originalCount.should.equal(251);
-              requestData.form.submissions.should.equal(251);
-            })
-            .request(scroll)
-            .respondWithData(() => {
-              testData.extendedSubmissions.createPast(1);
-              return testData.submissionOData(2, 250);
-            })
-            .afterResponse(component => {
-              const { requestData } = component.vm.$container;
-              requestData.localResources.odata.originalCount.should.equal(251);
-              requestData.form.submissions.should.equal(252);
-            });
-        });
       });
     });
   });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -4681,6 +4681,10 @@
         "testOnDevice": {
           "string": "Test on device",
           "developer_comment": "This is the text for an action, for example, the text of a button."
+        },
+        "testInBrowser": {
+          "string": "Test in browser",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
         }
       },
       "noMatching": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -4643,6 +4643,12 @@
       }
     },
     "SubmissionList": {
+      "action": {
+        "testOnDevice": {
+          "string": "Test on device",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      },
       "noMatching": {
         "string": "There are no matching Submissions."
       },

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2914,6 +2914,40 @@
         }
       }
     },
+    "FormDraftQrPanel": {
+      "title": {
+        "string": "Testing Code",
+        "developer_comment": "This is the title at the top of a pop-up. \"Code\" refers to a QR code."
+      },
+      "intro": {
+        "full": {
+          "string": "This is a {temporaryCode}.",
+          "developer_comment": "This is shown next to a QR code.\n\n{temporaryCode} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nTemporary Testing Code"
+        },
+        "temporaryCode": {
+          "string": "Temporary Testing Code",
+          "developer_comment": "\"Code\" refers to a QR code.\n\nThis text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {temporaryCode} is in the following text:\n\nThis is a {temporaryCode}."
+        }
+      },
+      "stopsWorking": {
+        "string": "It will stop working when you publish this Draft.",
+        "developer_comment": "\"It\" refers to a temporary testing code."
+      },
+      "instructions": {
+        "string": "Scan this QR code to configure Collect on a device for testing and submitting data to this test table.",
+        "developer_comment": "The table is a table of test Submissions."
+      },
+      "codesForUsers": {
+        "full": {
+          "string": "To create codes to distribute to users, please see the {appUsers} page.",
+          "developer_comment": "\"Codes\" refers to \"QR codes\".\n\n{appUsers} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nApp Users"
+        },
+        "appUsers": {
+          "string": "App Users",
+          "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {appUsers} is in the following text:\n\nTo create codes to distribute to users, please see the {appUsers} page."
+        }
+      }
+    },
     "FormDraftStatus": {
       "draftChecklist": {
         "title": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2983,10 +2983,6 @@
           "string": "Draft Submissions go into the test table below, where you can preview and download them. When you publish this Draft Form, its test Submissions will be permanently removed."
         }
       },
-      "collectProjectName": {
-        "string": "[Draft] {name}",
-        "developer_comment": "This text will be shown in ODK Collect when testing a Draft Form. {name} is the title of the Draft Form."
-      },
       "datasetsPreview": {
         "title": {
           "string": "This Form can update Entities"
@@ -2999,6 +2995,10 @@
             "string": "For now, we recommend trying your Form definition in Draft state to verify its logic. Before publishing, you can verify that it updates all of the desired properties."
           }
         }
+      },
+      "collectProjectName": {
+        "string": "[Draft] {name}",
+        "developer_comment": "This text will be shown in ODK Collect when testing a Draft Form. {name} is the title of the Draft Form."
       }
     },
     "FormHead": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2919,7 +2919,7 @@
         "string": "Testing Code",
         "developer_comment": "This is the title at the top of a pop-up. \"Code\" refers to a QR code."
       },
-      "intro": {
+      "introduction": {
         "full": {
           "string": "This is a {temporaryCode}.",
           "developer_comment": "This is shown next to a QR code.\n\n{temporaryCode} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nTemporary Testing Code"
@@ -3010,9 +3010,6 @@
         "developer_comment": "This is a title shown above a section of the page."
       },
       "body": {
-        "0": {
-          "string": "You can use the configuration code to the right to set up a mobile device to download this Draft. You can also click the New button above to create a new Submission from your web browser."
-        },
         "1": {
           "string": "Draft Submissions go into the test table below, where you can preview and download them. When you publish this Draft Form, its test Submissions will be permanently removed."
         }


### PR DESCRIPTION
This PR makes progress on getodk/central#728, adding the "Test on device" and "Test in browser" buttons.

#### What has been done to verify that this works as intended?

I updated tests, and I also tried it out locally.

#### Why is this the best possible solution? Were any other approaches considered?

In general, I tried to follow existing patterns. To show the popover, I did something similar to what's done in `FieldKeyList`. For the content of the popover, I pulled out the generic parts of `FieldKeyQrPanel` into a new component, `QrPanel`.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced