### PR TITLE
Make feedback button more visible

### DIFF
--- a/src/components/feedback-button.vue
+++ b/src/components/feedback-button.vue
@@ -46,10 +46,10 @@ const surveyLink = computed(() => {
   position: fixed;
   z-index: 99999;
   right: 0;
-  bottom: 100px;
+  bottom: 250px;
   height: 4em;
   border: 2px solid;
-  border-color: #e3e4e4;
+  border-color: $color-accent-primary;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
   text-align: center;


### PR DESCRIPTION
Closes #673

#### What has been done to verify that this works as intended?
Ran it locally.

#### Why is this the best possible solution? Were any other approaches considered?
I ended up with 250px from the bottom. That feels like a good balance of more eye catching but not too disruptive, especially in languages where the button text is longer.

@alyblenkin please take a quick look and if you're not loving it, let's adjust on a call next time we chat!

| 500px FR | 250px FR | 250px EN |
|-----------|----------|------------|
<img width="1510" alt="Screenshot 2024-11-25 at 4 25 37 PM" src="https://github.com/user-attachments/assets/299bde45-939b-4624-a47b-efb59893eaf6"> |  <img width="1508" alt="Screenshot 2024-11-25 at 4 26 08 PM" src="https://github.com/user-attachments/assets/0819163e-2e4c-4c3a-ad18-73dfa6cbb1fa"> |  <img width="1512" alt="Screenshot 2024-11-25 at 4 26 25 PM" src="https://github.com/user-attachments/assets/1a34e876-0037-4caa-b37b-2913b049f5fb">

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

CSS-only changes

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced