### PR TITLE
feature #789: Show delete and undelete events in Submission feed/deta…

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -20,6 +20,18 @@ except according to the terms contained in the LICENSE file.
           <template #name><actor-link :actor="entry.actor"/></template>
         </i18n-t>
       </template>
+      <template v-else-if="entry.action === 'submission.delete'">
+        <span class="icon-trash"></span>
+        <i18n-t keypath="title.delete">
+          <template #name><actor-link :actor="entry.actor"/></template>
+        </i18n-t>
+      </template>
+      <template v-else-if="entry.action === 'submission.restore'">
+        <span class="icon-recycle"></span>
+        <i18n-t keypath="title.undelete">
+          <template #name><actor-link :actor="entry.actor"/></template>
+        </i18n-t>
+      </template>
       <template v-else-if="updateOrEdit">
         <i18n-t :keypath="`title.updateReviewState.${reviewState}.full`">
           <template #reviewState>
@@ -189,7 +201,7 @@ export default {
     font-weight: normal;
   }
 
-  .icon-cloud-upload, .icon-comment { color: #bbb; }
+  .icon-cloud-upload, .icon-comment, .icon-trash, .icon-recycle { color: #bbb; }
   .entity-icon { color: $color-action-foreground; }
   .icon-warning { color: $color-danger; }
   .review-state {
@@ -326,7 +338,35 @@ export default {
 
       Comment • {name}
       */
-      "comment": "Comment by {name}"
+      "comment": "Comment by {name}",
+      /*
+      This text is shown in the list of actions performed on a Submission.
+      There is an icon before the text that corresponds to the word "Deleted",
+      so it is essential for "Deleted" to also come first in the translation. If
+      that is unnatural in your language, you can also split the text into two
+      parts. For example, instead of:
+
+      Deleted by {name}
+
+      you could split it into:
+
+      Deleted • {name}
+      */
+      "delete": "Deleted by {name}",
+      /*
+      This text is shown in the list of actions performed on a Submission.
+      There is an icon before the text that corresponds to the word "Undeleted",
+      so it is essential for "Undeleted" to also come first in the translation. If
+      that is unnatural in your language, you can also split the text into two
+      parts. For example, instead of:
+
+      Undeleted by {name}
+
+      you could split it into:
+
+      Undeleted • {name}
+      */
+      "undelete": "Undeleted by {name}"
     }
   }
 }

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -71,6 +71,20 @@ describe('SubmissionFeedEntry', () => {
       title.text().should.equal('Submitted by Alice');
     });
 
+    it('renders correctly for a submission.delete audit', () => {
+      testData.extendedAudits.createPast(1, { action: 'submission.delete' });
+      const title = mountComponent().get('.feed-entry-title');
+      title.find('.icon-trash').exists().should.be.true;
+      title.text().should.equal('Deleted by Alice');
+    });
+
+    it('renders correctly for a submission.restore audit', () => {
+      testData.extendedAudits.createPast(1, { action: 'submission.restore' });
+      const title = mountComponent().get('.feed-entry-title');
+      title.find('.icon-recycle').exists().should.be.true;
+      title.text().should.equal('Undeleted by Alice');
+    });
+
     describe('submission.update audit', () => {
       it('renders correctly for null', () => {
         testData.extendedAudits.createPast(1, {

--- a/test/data/audits.js
+++ b/test/data/audits.js
@@ -14,6 +14,8 @@ const actionsWithDefaultActor = new Set([
   'entity.update.version',
   'entity.update.resolve',
   'submission.create',
+  'submission.delete',
+  'submission.restore',
   'submission.update',
   'submission.update.version',
   'user.session.create'
@@ -26,6 +28,7 @@ const defaultActee = (action) => {
     action === 'entity.update.resolve')
     return extendedDatasets.last();
   if (action === 'submission.create' || action === 'submission.update' ||
+    action === 'submission.delete' || action === 'submission.restore' ||
     action === 'submission.update.version')
     return extendedForms.last();
   if (action === 'user.session.create')

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -4582,6 +4582,14 @@
         "comment": {
           "string": "Comment by {name}",
           "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Comment\", so it is essential for \"Comment\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nComment by {name}\n\nyou could split it into:\n\nComment • {name}"
+        },
+        "delete": {
+          "string": "Deleted by {name}",
+          "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Deleted\", so it is essential for \"Deleted\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nDeleted by {name}\n\nyou could split it into:\n\nDeleted • {name}"
+        },
+        "undelete": {
+          "string": "Undeleted by {name}",
+          "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Undeleted\", so it is essential for \"Undeleted\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nUndeleted by {name}\n\nyou could split it into:\n\nUndeleted • {name}"
         }
       }
     },


### PR DESCRIPTION
Closes getodk/central#789

#### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Consistent with existing approach

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

NA

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced