### PR TITLE
fixes #721: Add BOM to entities upload template

### DIFF
--- a/src/components/entity/upload/data-template.vue
+++ b/src/components/entity/upload/data-template.vue
@@ -41,7 +41,8 @@ const href = computed(() => {
   const headers = dataset.properties.map(({ name }) => name);
   headers.unshift('label');
   const csv = headers.join(',');
-  return `data:text/csv;charset=UTF-8,${encodeURIComponent(csv)}`;
+  // \uFEFF is byte-order-mark - fixes getodk/central#721
+  return `data:text/csv;charset=UTF-8,\uFEFF${encodeURIComponent(csv)}`;
 });
 const setFilename = (event) => {
   const now = DateTime.local().toFormat('yyyyMMddHHmmss');

--- a/test/components/entity/upload/data-template.spec.js
+++ b/test/components/entity/upload/data-template.spec.js
@@ -17,7 +17,7 @@ describe('EntityUploadDataTemplate', () => {
       properties: [{ name: 'hauteur' }, { name: 'circonférence' }]
     });
     const { href } = mountComponent().get('a').attributes();
-    const expectedStart = 'data:text/csv;charset=UTF-8,';
+    const expectedStart = 'data:text/csv;charset=UTF-8,\ufeff';
     href.should.startWith(expectedStart);
     const content = decodeURIComponent(href.replace(expectedStart, ''));
     content.should.equal('label,hauteur,circonférence');


### PR DESCRIPTION
Closes getodk/central#721

#### What has been done to verify that this works as intended?

Manually tested it.

#### Why is this the best possible solution? Were any other approaches considered?

This solves the problem in a user friendly way. Other approach is to train users via documentation to use import CSV option Excel rather.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None, but template might have different behaviour in other spreadsheet programs. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

NA

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced