### PR TITLE
fixes: disable download attachment button for deleted Submissions

### DIFF
--- a/src/components/submission/data-row.vue
+++ b/src/components/submission/data-row.vue
@@ -16,7 +16,9 @@ except according to the terms contained in the LICENSE file.
         <template v-if="field.binary === true">
           <a v-if="rawValue(submission, field) != null" class="binary-link"
             :href="formattedValue(submission, field)" target="_blank"
-            :aria-label="$t('submission.binaryLinkTitle')" v-tooltip.aria-label>
+            :aria-disabled="deleted"
+            :aria-label="deleted ? $t('submission.fileDownloadUnavailable') : $t('submission.binaryLinkTitle')"
+            v-tooltip.aria-label>
             <span class="icon-check"></span> <span class="icon-download"></span>
           </a>
         </template>
@@ -76,7 +78,11 @@ export default {
     fields: {
       type: Array,
       required: true
-    }
+    },
+    deleted: {
+      type: Boolean,
+      default: false
+    },
   },
   computed: {
     htmlClass() {

--- a/src/components/submission/table.vue
+++ b/src/components/submission/table.vue
@@ -36,7 +36,7 @@ except according to the terms contained in the LICENSE file.
     </template>
     <template #data-scrolling="{ data }">
       <submission-data-row :project-id="projectId" :xml-form-id="xmlFormId"
-        :draft="draft" :submission="data" :fields="fields"/>
+        :draft="draft" :submission="data" :fields="fields" :deleted="deleted"/>
     </template>
   </table-freeze>
 </template>

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -361,7 +361,8 @@
     // This text is shown under the "Latest Submission" column of the tables
     // for Projects and Forms. It is shown for a Project or Form with no Submissions.
     "noSubmission": "(none)",
-    "emptyTable": "There are no Submissions yet."
+    "emptyTable": "There are no Submissions yet.",
+    "fileDownloadUnavailable": "File download is not available for deleted Submissions."
   },
   "entity": {
     // This is the label of an Entity.

--- a/test/components/submission/data-row.spec.js
+++ b/test/components/submission/data-row.spec.js
@@ -324,6 +324,24 @@ describe('SubmissionDataRow', () => {
       td.find('a').exists().should.be.false;
       td.text().should.equal('');
     });
+
+    it('disables the link if the Submission is deleted', async () => {
+      testData.extendedForms.createPast(1, {
+        fields: [testData.fields.binary('/b')],
+        submissions: 1
+      });
+      testData.extendedSubmissions.createPast(1, {
+        instanceId: 'a b',
+        b: 'c d.jpg'
+      });
+      const td = mountComponent({ deleted: true }).get('td');
+      td.classes('binary-field').should.be.true;
+      const a = td.get('a');
+      a.attributes()['aria-disabled'].should.equal('true');
+      await a.should.have.tooltip('File download is not available for deleted Submissions.');
+      a.find('.icon-check').exists().should.be.true;
+      a.find('.icon-download').exists().should.be.true;
+    });
   });
 
   it('shows the instance ID', () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -790,6 +790,9 @@
     },
     "emptyTable": {
       "string": "There are no Submissions yet."
+    },
+    "fileDownloadUnavailable": {
+      "string": "File download is not available for deleted Submissions."
     }
   },
   "entity": {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/709#issuecomment-2516784226

#### What has been done to verify that this works as intended?

Added a test.

#### Why is this the best possible solution? Were any other approaches considered?

We can hide the button altogether but that would be confusing to the users. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None


#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced