### PR TITLE
Change .dl-horizontal to be a grid

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -53,6 +53,8 @@ dl > * {
   }
 }
 
+// Normal <dl> elements that are not .dl-horizontal are expected to have
+// children that are <div> elements. Each <div> must contain a <dt> and a <dd>.
 dl:not(.dl-horizontal) {
   > div {
     display: flex;
@@ -67,17 +69,28 @@ dl:not(.dl-horizontal) {
   dd { font-size: 16px; }
 }
 
+// <dl> elements that are .dl-horizontal are expected to have children that are
+// <dt> and <dd> elements. That's different from how other <dl> elements work,
+// as their children are expected to be <div> elements. The difference comes
+// down to the fact that .dl-horizontal uses a CSS grid, while other <dl>
+// elements use flexbox.
 .dl-horizontal {
+  $padding-between: 10px;
+  $dt-width: 160px + $padding-panel-body + $padding-between;
+
   display: grid;
-  grid-template-columns: fit-content(50%) 1fr;
+  // Components may override grid-template-columns in order to adjust the width
+  // of the <dt>.
+  grid-template-columns: $dt-width 1fr;
 
-  dt { padding-right: 12px; }
-  dd { padding-left: 12px; }
+  dt { padding-left: $padding-panel-body; }
+  dd { padding-right: $padding-panel-body; }
+
+  // Equally distribute the padding between the <dt> and the <dd> so that it is
+  // easy for components to give the two elements the same width.
+  dt { padding-right: $padding-between; }
+  dd { padding-left: $padding-between; }
 }
-
-// Prevents <dt> elements from truncating. Useful for <dt> elements that have a
-// known fixed width.
-.dl-horizontal-fixed { grid-template-columns: max-content 1fr; }
 
 .dfn { border-bottom: 2px dotted #999; }
 

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -40,21 +40,24 @@ h1, .h1 {
 
 p { @include text-block; }
 
-dl > div {
+dl > * {
   border-bottom: 1px solid #ddd;
-  display: flex;
   padding-bottom: 10px;
   padding-top: 10px;
 
-  &:first-child { padding-top: 0; }
+  &:first-of-type { padding-top: 0; }
 
-  &:last-child {
+  &:last-of-type {
     border-bottom: none;
     padding-bottom: 0;
   }
 }
+
 dl:not(.dl-horizontal) {
-  > div { flex-direction: column-reverse; }
+  > div {
+    display: flex;
+    flex-direction: column-reverse;
+  }
 
   dt {
     color: #666;
@@ -63,15 +66,18 @@ dl:not(.dl-horizontal) {
 
   dd { font-size: 16px; }
 }
-.dl-horizontal {
-  dt {
-    @include text-overflow-ellipsis;
-    flex-shrink: 0;
-    width: 160px;
-  }
 
-  dd { margin-left: 20px; }
+.dl-horizontal {
+  display: grid;
+  grid-template-columns: fit-content(50%) 1fr;
+
+  dt { padding-right: 12px; }
+  dd { padding-left: 12px; }
 }
+
+// Prevents <dt> elements from truncating. Useful for <dt> elements that have a
+// known fixed width.
+.dl-horizontal-fixed { grid-template-columns: max-content 1fr; }
 
 .dfn { border-bottom: 2px dotted #999; }
 

--- a/src/components/entity/upload/header-errors.vue
+++ b/src/components/entity/upload/header-errors.vue
@@ -11,38 +11,36 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <dl id="entity-upload-header-errors" class="dl-horizontal">
-    <div>
-      <dt>{{ $t('expectedHeader') }}</dt>
-      <dd :ref="setHeaderElement(0)" class="csv-header" @scroll="scrollHeader">
-        {{ expectedHeader }}
-      </dd>
-    </div>
-    <div>
-      <dt v-tooltip.text>{{ filename }}</dt>
-      <dd :ref="setHeaderElement(1)" class="csv-header" @scroll="scrollHeader">
-        {{ header }}
-      </dd>
-    </div>
-    <div v-if="hasSuggestion" id="entity-upload-header-errors-suggestions">
-      <dt>{{ $t('suggestions.title') }}</dt>
-      <dd>
-        <p v-if="invalidQuotes">{{ $t('suggestions.invalidQuotes') }}</p>
-        <i18n-t v-if="missingLabel" tag="p" keypath="suggestions.missingLabel">
-          <template #label>
-            <span class="text-monospace">label</span>
-          </template>
-        </i18n-t>
-        <p v-if="unknownProperty">{{ $t('suggestions.unknownProperty') }}</p>
-        <p v-if="duplicateColumn">{{ $t('suggestions.duplicateColumn') }}</p>
-        <p v-if="emptyColumn">{{ $t('suggestions.emptyColumn') }}</p>
-        <i18n-t v-if="delimiter !== ','" tag="p"
-          keypath="suggestions.delimiterNotComma">
-          <template #delimiter>
-            <code>{{ formattedDelimiter }}</code>
-          </template>
-        </i18n-t>
-      </dd>
-    </div>
+    <dt>{{ $t('expectedHeader') }}</dt>
+    <dd :ref="setHeaderElement(0)" class="csv-header" @scroll="scrollHeader">
+      {{ expectedHeader }}
+    </dd>
+
+    <dt id="entity-upload-header-filename" v-tooltip.text>{{ filename }}</dt>
+    <dd :ref="setHeaderElement(1)" class="csv-header" @scroll="scrollHeader">
+      {{ header }}
+    </dd>
+
+    <dt v-if="hasSuggestion" class="entity-upload-header-errors-suggestions">
+      {{ $t('suggestions.title') }}
+    </dt>
+    <dd v-if="hasSuggestion" class="entity-upload-header-errors-suggestions">
+      <p v-if="invalidQuotes">{{ $t('suggestions.invalidQuotes') }}</p>
+      <i18n-t v-if="missingLabel" tag="p" keypath="suggestions.missingLabel">
+        <template #label>
+          <span class="text-monospace">label</span>
+        </template>
+      </i18n-t>
+      <p v-if="unknownProperty">{{ $t('suggestions.unknownProperty') }}</p>
+      <p v-if="duplicateColumn">{{ $t('suggestions.duplicateColumn') }}</p>
+      <p v-if="emptyColumn">{{ $t('suggestions.emptyColumn') }}</p>
+      <i18n-t v-if="delimiter !== ','" tag="p"
+        keypath="suggestions.delimiterNotComma">
+        <template #delimiter>
+          <code>{{ formattedDelimiter }}</code>
+        </template>
+      </i18n-t>
+    </dd>
   </dl>
 </template>
 
@@ -107,11 +105,8 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
 
 #entity-upload-header-errors {
   margin-bottom: 0;
-
-  div {
-    padding-left: $padding-panel-body;
-    padding-right: $padding-panel-body;
-  }
+  padding-left: $padding-panel-body;
+  padding-right: $padding-panel-body;
 
   .csv-header {
     @include line-clamp(3);
@@ -121,7 +116,9 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
   }
 }
 
-#entity-upload-header-errors-suggestions {
+#entity-upload-header-filename { @include text-overflow-ellipsis; }
+
+.entity-upload-header-errors-suggestions {
   color: $color-danger;
 
   p:last-child { margin-bottom: 0; }

--- a/src/components/entity/upload/header-errors.vue
+++ b/src/components/entity/upload/header-errors.vue
@@ -12,13 +12,19 @@ except according to the terms contained in the LICENSE file.
 <template>
   <dl id="entity-upload-header-errors" class="dl-horizontal">
     <dt>{{ $t('expectedHeader') }}</dt>
-    <dd :ref="setHeaderElement(0)" class="csv-header" @scroll="scrollHeader">
-      {{ expectedHeader }}
+    <dd>
+      <div :ref="setHeaderElement(0)" class="csv-header" @scroll="scrollHeader">
+        {{ expectedHeader }}
+      </div>
     </dd>
 
-    <dt id="entity-upload-header-filename" v-tooltip.text>{{ filename }}</dt>
-    <dd :ref="setHeaderElement(1)" class="csv-header" @scroll="scrollHeader">
-      {{ header }}
+    <dt id="entity-upload-header-errors-filename" v-tooltip.text>
+      {{ filename }}
+    </dt>
+    <dd>
+      <div :ref="setHeaderElement(1)" class="csv-header" @scroll="scrollHeader">
+        {{ header }}
+      </div>
     </dd>
 
     <dt v-if="hasSuggestion" class="entity-upload-header-errors-suggestions">
@@ -105,8 +111,6 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
 
 #entity-upload-header-errors {
   margin-bottom: 0;
-  padding-left: $padding-panel-body;
-  padding-right: $padding-panel-body;
 
   .csv-header {
     @include line-clamp(3);
@@ -114,9 +118,10 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
     overflow-x: auto;
     white-space: break-spaces;
   }
+  dd:has(.csv-header) { overflow-x: hidden; }
 }
 
-#entity-upload-header-filename { @include text-overflow-ellipsis; }
+#entity-upload-header-errors-filename { @include text-overflow-ellipsis; }
 
 .entity-upload-header-errors-suggestions {
   color: $color-danger;

--- a/test/components/entity/upload/header-errors.spec.js
+++ b/test/components/entity/upload/header-errors.spec.js
@@ -36,7 +36,7 @@ describe('EntityUploadHeaderErrors', () => {
 
   describe('suggestions', () => {
     const getSuggestion = (component) => {
-      const p = component.findAll('#entity-upload-header-errors-suggestions p');
+      const p = component.findAll('.entity-upload-header-errors-suggestions p');
       p.length.should.equal(1);
       return p[0];
     };
@@ -48,7 +48,7 @@ describe('EntityUploadHeaderErrors', () => {
       const component = mountComponent({
         props: { header: 'label', missingProperty: true }
       });
-      component.find('#entity-upload-header-errors-suggestions').exists().should.be.false;
+      component.find('.entity-upload-header-errors-suggestions').exists().should.be.false;
     });
 
     describe('delimiter is not a comma', () => {


### PR DESCRIPTION
We have two types of `<dl>` elements in Frontend:

1. `<dl>` elements that appear in `SubmissionBasicDetails`, `EntityBasicDetails`, and `EntityData`. The `<dt>` comes before the `<dd>` in the DOM, but for display, the `<dt>` is shown below the `<dd>`. We use flexbox and `flex-direction: column-reverse` to achieve that.
2. The `<dl>` element in `EntityUploadHeaderErrors`. This uses the `dl-horizontal` class in order to display the `<dt>` elements and the `<dd>` elements as two columns.

In hover cards, we're going to be using `<dl class="dl-horizontal">`. However, there's an issue: right now, `<dt>` elements in `.dl-horizontal` have a fixed width of 160px. Working on hover cards, I've found that different hover cards need different widths for their `<dt>` elements. We want the `<dt>` elements to be as narrow as possible, since hover cards as a whole are pretty narrow. Yet in some cases, `<dt>` elements need to be fairly wide, e.g., "Last Submission" in the hover card for a form is pretty wide. I want to set it up so that `<dt>` elements are as wide as they need to be, but no wider. That'll leave the rest of the width of the hover card to the `<dd>`, whose text is more likely to be arbitrarily long. I also think that strategy will work great with i18n, since some translated text is likely to be longer than the English. We really want to avoid truncating `<dt>` elements in hover cards, because it's not possible to hover over a hover card in order to view a tooltip. There's more to say about the width of hover cards and the `<dt>` elements within them, but the general point is that we need the width of `<dt>` elements to be more dynamic than they are now.

#### What has been done to verify that this works as intended?

This PR only touches styles. I took a look locally at both types of `<dl>` elements.

#### Why is this the best possible solution? Were any other approaches considered?

Setting `max-width` on the `<dt>` elements is not enough, because each pair of `<dt>`/`<dd>` elements is independent of the others. We need the width of every `<dt>` element to be the same, since they're displayed like a column. To achieve that, I've changed `<dl class="dl-horizontal">` to use a CSS grid. That allows us to display the `<dt>` elements like a column while also giving us a lot of flexibility around the width of the elements.

One requirement of the CSS grid (I think) is that the children of `<dl class="dl-horizontal">` need to be `<dt>` and `<dd>` elements, not `<div>` elements. Those `<div>` elements are needed for the flexbox used in the first type of `<dl>` above, but they aren't needed for (and I think don't work with) a CSS grid. In this PR, I've removed `<div>` elements in `EntityUploadHeaderErrors`.

I didn't try to change the first type of `<dl>` to use a CSS grid instead of flexbox. I feel like that type of `<dl>` is served well by flexbox. I've added comments about the structure that each type of `<dl>` expects.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

In this PR, I've refactored `.dl-horizontal` to use a CSS grid, but I've tried to keep its current behavior the same: `EntityUploadHeaderErrors` should not have changed at all. The goal of this PR is to set the groundwork for the more dynamic behavior that we'll need in hover cards.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced