### PR TITLE
Show offline entity backlog events and unknown events

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <feed-entry :iso="entry.loggedAt ?? entry.createdAt"
-    :wrap-title="entry.action === 'entity.create' || entry.action === 'entity.update.version'"
+    :wrap-title="entry.action === 'entity.create' || entry.action === 'entity.update.version' || entry.action?.startsWith('submission.backlog')"
     class="submission-feed-entry">
     <template #title>
       <template v-if="entry.action === 'submission.create'">
@@ -84,6 +84,10 @@ except according to the terms contained in the LICENSE file.
         <span class="submission-feed-entry-entity-error">{{ $t('title.entity.error') }}</span>
         <span class="entity-error-message" v-tooltip.text>{{ entry.details.problem?.problemDetails?.reason ?? entry.details.errorMessage ?? '' }}</span>
       </template>
+      <template v-else-if="entry.action?.startsWith('submission.backlog')">
+        <span class="icon-clock-o"></span>
+        <span>{{ $t(`title.submissionBacklog.${entry.action.replace('submission.backlog.', '')}`) }}</span>
+      </template>
       <template v-else-if="comment">
         <span class="icon-comment"></span>
         <i18n-t keypath="title.comment">
@@ -91,7 +95,7 @@ except according to the terms contained in the LICENSE file.
         </i18n-t>
       </template>
       <template v-else>
-        <span class="icon-clock-o"></span>
+        <span class="icon-question-circle-o"></span>
         {{ entry.action }}
       </template>
     </template>
@@ -370,7 +374,15 @@ export default {
 
       Undeleted • {name}
       */
-      "undelete": "Undeleted by {name}"
+      "undelete": "Undeleted by {name}",
+      /*
+      This text is shown in the list of actions performed on a Submission.
+      */
+      "submissionBacklog": {
+        "hold": "Waiting for previous Submission in offline update chain before updating Entity",
+        "force": "Processed Submission from backlog without previous Submission in offline update chain",
+        "reprocess": "Previous Submission in offline update chain was received"
+      }
     }
   }
 }

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -84,11 +84,15 @@ except according to the terms contained in the LICENSE file.
         <span class="submission-feed-entry-entity-error">{{ $t('title.entity.error') }}</span>
         <span class="entity-error-message" v-tooltip.text>{{ entry.details.problem?.problemDetails?.reason ?? entry.details.errorMessage ?? '' }}</span>
       </template>
-      <template v-else>
+      <template v-else-if="comment">
         <span class="icon-comment"></span>
         <i18n-t keypath="title.comment">
           <template #name><actor-link :actor="entry.actor"/></template>
         </i18n-t>
+      </template>
+      <template v-else>
+        <span class="icon-clock-o"></span>
+        {{ entry.action }}
       </template>
     </template>
     <template #body>

--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -209,7 +209,9 @@ export default {
     font-weight: normal;
   }
 
-  .icon-cloud-upload, .icon-comment, .icon-trash, .icon-recycle { color: #bbb; }
+  .icon-cloud-upload, .icon-comment, .icon-trash, .icon-recycle, .icon-clock-o {
+    color: #bbb;
+  }
   .entity-icon { color: $color-action-foreground; }
   .icon-warning { color: $color-danger; }
   .review-state {

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -171,10 +171,33 @@ describe('SubmissionFeedEntry', () => {
       title.text().should.equal('Comment by Alice');
     });
 
+    describe('submission.backlog.* audits', () => {
+      it('renders correctly for hold', () => {
+        testData.extendedAudits.createPast(1, { action: 'submission.backlog.hold' });
+        const title = mountComponent().get('.feed-entry-title');
+        title.find('.icon-clock-o').exists().should.be.true;
+        title.text().should.equal('Waiting for previous Submission in offline update chain before updating Entity');
+      });
+
+      it('renders correctly for reprocess', () => {
+        testData.extendedAudits.createPast(1, { action: 'submission.backlog.reprocess' });
+        const title = mountComponent().get('.feed-entry-title');
+        title.find('.icon-clock-o').exists().should.be.true;
+        title.text().should.equal('Previous Submission in offline update chain was received');
+      });
+
+      it('renders correctly for force', () => {
+        testData.extendedAudits.createPast(1, { action: 'submission.backlog.force' });
+        const title = mountComponent().get('.feed-entry-title');
+        title.find('.icon-clock-o').exists().should.be.true;
+        title.text().should.equal('Processed Submission from backlog without previous Submission in offline update chain');
+      });
+    });
+
     it('renders an unknown action by displaying it', () => {
       testData.extendedAudits.createPast(1, { action: 'unknown.action' });
       const title = mountComponent().get('.feed-entry-title');
-      title.find('.icon-clock-o').exists().should.be.true;
+      title.find('.icon-question-circle-o').exists().should.be.true;
       title.text().should.equal('unknown.action');
     });
 

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -171,6 +171,13 @@ describe('SubmissionFeedEntry', () => {
       title.text().should.equal('Comment by Alice');
     });
 
+    it('renders an unknown action by displaying it', () => {
+      testData.extendedAudits.createPast(1, { action: 'unknown.action' });
+      const title = mountComponent().get('.feed-entry-title');
+      title.find('.icon-clock-o').exists().should.be.true;
+      title.text().should.equal('unknown.action');
+    });
+
     describe('entity.create audit', () => {
       it('renders correctly for newly created entity with ideally formatted details', () => {
         testData.extendedAudits.createPast(1, {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -4590,6 +4590,20 @@
         "undelete": {
           "string": "Undeleted by {name}",
           "developer_comment": "This text is shown in the list of actions performed on a Submission. There is an icon before the text that corresponds to the word \"Undeleted\", so it is essential for \"Undeleted\" to also come first in the translation. If that is unnatural in your language, you can also split the text into two parts. For example, instead of:\n\nUndeleted by {name}\n\nyou could split it into:\n\nUndeleted • {name}"
+        },
+        "submissionBacklog": {
+          "hold": {
+            "string": "Waiting for previous Submission in offline update chain before updating Entity",
+            "developer_comment": "This text is shown in the list of actions performed on a Submission."
+          },
+          "force": {
+            "string": "Processed Submission from backlog without previous Submission in offline update chain",
+            "developer_comment": "This text is shown in the list of actions performed on a Submission."
+          },
+          "reprocess": {
+            "string": "Previous Submission in offline update chain was received",
+            "developer_comment": "This text is shown in the list of actions performed on a Submission."
+          }
         }
       }
     },


### PR DESCRIPTION
Related to backend PR https://github.com/getodk/central-backend/pull/1332

It used to be that any unknown action defaulted to showing up as a comment. I've changed it to make it show the text of the action... and also a clock icon. It should probably be a more generic icon, but the clock goes with the specific "unknown" audit actions I'm targeting but don't feel like making special cases of yet.

<img width="896" alt="Screenshot 2024-12-06 at 6 48 50 PM" src="https://github.com/user-attachments/assets/ab910a05-c2f4-44c1-9a29-f9b2653da1d3">


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced