### PR TITLE
let's gzip JS

### DIFF
--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -60,7 +60,7 @@ http {
     gzip_vary on;
     gzip_min_length 1280;
     gzip_http_version 1.1;
-    gzip_types text/plain text/css application/json application/x-javascript text/xml text/csv;
+    gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml text/csv;
 
     location /- {
       proxy_pass http://localhost:8005/-;


### PR DESCRIPTION
Closes getodk/central#819

Please see getodk/central#819 for background info
Please see getodk/central#820 for the companion PR for the production setup, which explains why I didn't remove `application/x-javascript`.