### PR TITLE
Remove unused composable in ProjectFormAccessRow

### DIFF
--- a/src/components/project/form-access/row.vue
+++ b/src/components/project/form-access/row.vue
@@ -52,7 +52,6 @@ except according to the terms contained in the LICENSE file.
 <script>
 import FormLink from '../../form/link.vue';
 
-import useRoutes from '../../../composables/routes';
 import { useRequestData } from '../../../request-data';
 
 export default {
@@ -75,8 +74,7 @@ export default {
   emits: ['update:state', 'update:fieldKeyAccess'],
   setup() {
     const { fieldKeys } = useRequestData();
-    const { primaryFormPath } = useRoutes();
-    return { fieldKeys, primaryFormPath };
+    return { fieldKeys };
   },
   computed: {
     htmlClass() {


### PR DESCRIPTION
While looking into https://github.com/getodk/central/issues/670#issuecomment-2535848397, I looked to see which components still use `formPath()` or `*FormPath()` functions instead of `FormLink`. I noticed that `ProjectFormAccessRow` still references `primaryFormPath()` even though it now uses `FormLink`. We can just remove the reference, since the component doesn't use the function anymore.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced