### PR TITLE
Use FormLink in DatasetOverview

### DIFF
--- a/src/components/dataset/overview.vue
+++ b/src/components/dataset/overview.vue
@@ -19,10 +19,10 @@ except according to the terms contained in the LICENSE file.
       <template #body>
         <div class="row">
           <div class="col-md-6 creation-forms">
-            <connection-to-forms :properties="dataset.properties" :source-forms="dataset.sourceForms" :project-id="projectId"/>
+            <connection-to-forms/>
           </div>
           <div class="col-md-6 linked-forms">
-            <linked-forms :linked-forms="dataset.linkedForms" :project-id="projectId"/>
+            <linked-forms/>
           </div>
         </div>
       </template>
@@ -37,7 +37,7 @@ except according to the terms contained in the LICENSE file.
         </button>
       </template>
       <template #body>
-        <dataset-properties :properties="dataset.properties" :project-id="projectId"/>
+        <dataset-properties/>
       </template>
     </page-section>
     <dataset-property-new v-bind="newDatasetPropertyModal"

--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -21,7 +21,9 @@ except according to the terms contained in the LICENSE file.
         <expandable-row v-for="(form) in propertiesByForm" :key="form.xmlFormId">
           <template #title>
             <div class="form-name">
-              <router-link :to="publishedFormPath(projectId, form.xmlFormId)" v-tooltip.text>{{ form.name }}</router-link>
+              <form-link :form="form"
+                :to="publishedFormPath(form.projectId, form.xmlFormId)"
+                v-tooltip.text/>
             </div>
           </template>
           <template #caption>
@@ -39,44 +41,35 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 import ExpandableRow from '../../expandable-row.vue';
+import FormLink from '../../form/link.vue';
 import I18nList from '../../i18n/list.vue';
 import SummaryItem from '../../summary-item.vue';
 
 import useRoutes from '../../../composables/routes';
+import { useRequestData } from '../../../request-data';
 
 export default {
   name: 'ConnectionToForms',
   components: {
     ExpandableRow,
+    FormLink,
     I18nList,
     SummaryItem
   },
-  props: {
-    properties: {
-      type: Array,
-      required: true
-    },
-    sourceForms: {
-      type: Array,
-      required: true
-    },
-    projectId: {
-      type: String,
-      required: true
-    }
-  },
   setup() {
+    const { dataset } = useRequestData();
     const { publishedFormPath } = useRoutes();
-    return { publishedFormPath };
+    return { dataset, publishedFormPath };
   },
   computed: {
     totalProperties() {
-      return this.properties.length;
+      return this.dataset.properties.length;
     },
     propertiesByForm() {
-      const formMap = new Map(this.sourceForms.map(f => ([f.xmlFormId, { ...f, projectId: this.projectId, properties: [] }])));
+      const formMap = new Map(this.dataset.sourceForms.map(f =>
+        [f.xmlFormId, { ...f, properties: [] }]));
 
-      for (const p of this.properties) {
+      for (const p of this.dataset.properties) {
         for (const f of p.forms) {
           const form = formMap.get(f.xmlFormId);
           form.properties.push(p.name);

--- a/src/components/dataset/overview/dataset-properties.vue
+++ b/src/components/dataset/overview/dataset-properties.vue
@@ -26,16 +26,19 @@ except according to the terms contained in the LICENSE file.
             {{ property.name }}
           </td>
           <td>
-            <router-link v-if="property.forms.length > 0" :to="publishedFormPath(projectId, property.forms[0].xmlFormId)" v-tooltip.text>
-              {{ property.forms[0].name }}
-            </router-link>
+            <form-link v-if="property.forms.length > 0"
+              :form="property.forms[0]"
+              :to="publishedFormPath(property.forms[0].projectId, property.forms[0].xmlFormId)"
+              v-tooltip.text/>
             <div v-else class="empty-update-form">{{ $t('none') }}</div>
           </td>
         </tr>
         <template v-for="(form, index) in property.forms" :key="form.xmlFormId">
           <tr v-if="index > 0">
             <td>
-              <router-link :to="publishedFormPath(projectId, form.xmlFormId)" v-tooltip.text>{{ form.name }}</router-link>
+              <form-link :form="form"
+                :to="publishedFormPath(form.projectId, form.xmlFormId)"
+                v-tooltip.text/>
             </td>
           </tr>
         </template>
@@ -49,21 +52,19 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
+import FormLink from '../../form/link.vue';
+
 import useRoutes from '../../../composables/routes';
+import { useRequestData } from '../../../request-data';
 
 defineOptions({
   name: 'DatasetProperties'
 });
-defineProps({
-  properties: {
-    type: Array,
-    required: true
-  },
-  projectId: {
-    type: String,
-    required: true
-  }
-});
+
+const { dataset } = useRequestData();
+const properties = computed(() => dataset.properties);
 
 const { publishedFormPath } = useRoutes();
 </script>

--- a/src/components/dataset/overview/linked-forms.vue
+++ b/src/components/dataset/overview/linked-forms.vue
@@ -21,7 +21,9 @@ except according to the terms contained in the LICENSE file.
         <tbody>
           <tr v-for="(form) in linkedForms" :key="form.xmlFormId">
             <td>
-              <router-link :to="publishedFormPath(projectId, form.xmlFormId)" v-tooltip.text>{{ form.name }}</router-link>
+              <form-link :form="form"
+                :to="publishedFormPath(form.projectId, form.xmlFormId)"
+                v-tooltip.text/>
             </td>
           </tr>
         </tbody>
@@ -31,23 +33,20 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
+import FormLink from '../../form/link.vue';
 import SummaryItem from '../../summary-item.vue';
 
 import useRoutes from '../../../composables/routes';
+import { useRequestData } from '../../../request-data';
 
 defineOptions({
   name: 'LinkedForms'
 });
-defineProps({
-  linkedForms: {
-    type: Array,
-    required: true
-  },
-  projectId: {
-    type: String,
-    required: true
-  }
-});
+
+const { dataset } = useRequestData();
+const linkedForms = computed(() => dataset.linkedForms);
 
 const { publishedFormPath } = useRoutes();
 </script>

--- a/src/request-data/resources.js
+++ b/src/request-data/resources.js
@@ -78,7 +78,18 @@ export default (container, createResource) => {
   }));
 
   createResource('dataset', () => ({
-    transformResponse: ({ data }) => shallowReactive(data)
+    transformResponse: ({ data }) => {
+      // Add projectId to forms. FormLink expects this property to exist on form
+      // objects.
+      const { projectId } = data;
+      for (const form of data.sourceForms) form.projectId = projectId;
+      for (const form of data.linkedForms) form.projectId = projectId;
+      for (const property of data.properties) {
+        for (const form of property.forms) form.projectId = projectId;
+      }
+
+      return shallowReactive(data);
+    }
   }));
 
   const formDraft = createResource('formDraft', () =>

--- a/test/components/dataset/overview/connection-to-forms.spec.js
+++ b/test/components/dataset/overview/connection-to-forms.spec.js
@@ -1,25 +1,21 @@
-import { RouterLinkStub } from '@vue/test-utils';
 import { nextTick } from 'vue';
 
-import ConnectionToForm from '../../../../src/components/dataset/overview/connection-to-forms.vue';
+import ConnectionToForms from '../../../../src/components/dataset/overview/connection-to-forms.vue';
 import ExpandableRow from '../../../../src/components/expandable-row.vue';
+import FormLink from '../../../../src/components/form/link.vue';
 
 import testData from '../../../data';
 import { mockRouter } from '../../../util/router';
 import { mount } from '../../../util/lifecycle';
 
-const mountComponent = () => mount(ConnectionToForm, {
-  props: {
-    properties: testData.extendedDatasets.last().properties,
-    sourceForms: testData.extendedDatasets.last().sourceForms,
-    projectId: testData.extendedProjects.first().id.toString()
-  },
+const mountComponent = () => mount(ConnectionToForms, {
   container: {
-    router: mockRouter('/')
+    router: mockRouter('/'),
+    requestData: { dataset: testData.extendedDatasets.last() }
   }
 });
 
-describe('Connection to Forms', () => {
+describe('ConnectionToForms', () => {
   it('shows the creation forms with associated properties', async () => {
     testData.extendedDatasets.createPast(1, {
       name: 'trees',
@@ -62,17 +58,17 @@ describe('Connection to Forms', () => {
     rows[0].get('.title-cell').text().should.be.eql('Tree Registration');
     rows[0].get('.caption-cell').text().should.be.eql('2 of 3 properties');
     rows[0].get('.expanded-row').text().should.be.eql('height, type');
-    rows[0].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration');
+    rows[0].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration');
 
     rows[1].get('.title-cell').text().should.be.eql('Tree Registration Adv');
     rows[1].get('.caption-cell').text().should.be.eql('3 of 3 properties');
     rows[1].get('.expanded-row').text().should.be.eql('height, circumference, type');
-    rows[1].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
+    rows[1].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
 
     rows[2].get('.title-cell').text().should.be.eql('Form with no properties');
     rows[2].get('.caption-cell').text().should.be.eql('0 of 3 properties');
     rows[2].get('.expanded-row').text().should.be.eql('This Form only sets the “label”.');
-    rows[2].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/form_with_no_prop');
+    rows[2].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/form_with_no_prop');
   });
 
   it('does not break if there is no forms', () => {

--- a/test/components/dataset/overview/dataset-properties.spec.js
+++ b/test/components/dataset/overview/dataset-properties.spec.js
@@ -1,33 +1,18 @@
-/*
-Copyright 2023 ODK Central Developers
-See the NOTICE file at the top-level directory of this distribution and at
-https://github.com/getodk/central-frontend/blob/master/NOTICE.
+import DatasetProperties from '../../../../src/components/dataset/overview/dataset-properties.vue';
+import FormLink from '../../../../src/components/form/link.vue';
 
-This file is part of ODK Central. It is subject to the license terms in
-the LICENSE file found in the top-level directory of this distribution and at
-https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
-including this file, may be copied, modified, propagated, or distributed
-except according to the terms contained in the LICENSE file.
-*/
-
-import { RouterLinkStub } from '@vue/test-utils';
+import testData from '../../../data';
 import { mockRouter } from '../../../util/router';
 import { mount } from '../../../util/lifecycle';
 
-import DatasetProperties from '../../../../src/components/dataset/overview/dataset-properties.vue';
-import testData from '../../../data';
-
 const mountComponent = () => mount(DatasetProperties, {
-  props: {
-    properties: testData.extendedDatasets.last().properties,
-    projectId: testData.extendedProjects.first().id.toString()
-  },
   container: {
-    router: mockRouter('/')
+    router: mockRouter('/'),
+    requestData: { dataset: testData.extendedDatasets.last() }
   }
 });
 
-describe('Dataset Properties', () => {
+describe('DatasetProperties', () => {
   it('shows the properties with their forms', () => {
     testData.extendedDatasets.createPast(1, {
       name: 'trees',
@@ -61,19 +46,19 @@ describe('Dataset Properties', () => {
 
     rows[0].findAll('td')[0].text().should.be.eql('height');
     rows[0].findAll('td')[1].text().should.be.eql('Tree Registration');
-    rows[0].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration');
+    rows[0].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration');
     rows[1].findAll('td')[0].text().should.be.eql('Tree Registration Adv');
-    rows[1].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
+    rows[1].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
 
     rows[2].findAll('td')[0].text().should.be.eql('circumference');
     rows[2].findAll('td')[1].text().should.be.eql('Tree Registration Adv');
-    rows[2].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
+    rows[2].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
 
     rows[3].findAll('td')[0].text().should.be.eql('type');
     rows[3].findAll('td')[1].text().should.be.eql('Tree Registration');
-    rows[3].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration');
+    rows[3].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration');
     rows[4].findAll('td')[0].text().should.be.eql('Tree Registration Adv');
-    rows[4].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
+    rows[4].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/tree_registration_adv');
   });
 
   it('shows the property even if there is no associated form', () => {

--- a/test/components/dataset/overview/linked-forms.spec.js
+++ b/test/components/dataset/overview/linked-forms.spec.js
@@ -1,33 +1,18 @@
-/*
-Copyright 2023 ODK Central Developers
-See the NOTICE file at the top-level directory of this distribution and at
-https://github.com/getodk/central-frontend/blob/master/NOTICE.
+import FormLink from '../../../../src/components/form/link.vue';
+import LinkedForms from '../../../../src/components/dataset/overview/linked-forms.vue';
 
-This file is part of ODK Central. It is subject to the license terms in
-the LICENSE file found in the top-level directory of this distribution and at
-https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
-including this file, may be copied, modified, propagated, or distributed
-except according to the terms contained in the LICENSE file.
-*/
-
-import { RouterLinkStub } from '@vue/test-utils';
+import testData from '../../../data';
 import { mockRouter } from '../../../util/router';
 import { mount } from '../../../util/lifecycle';
 
-import LinkedForms from '../../../../src/components/dataset/overview/linked-forms.vue';
-import testData from '../../../data';
-
 const mountComponent = () => mount(LinkedForms, {
-  props: {
-    linkedForms: testData.extendedDatasets.last().linkedForms,
-    projectId: testData.extendedProjects.first().id.toString()
-  },
   container: {
-    router: mockRouter('/')
+    router: mockRouter('/'),
+    requestData: { dataset: testData.extendedDatasets.last() }
   }
 });
 
-describe('Linked Form Table', () => {
+describe('LinkedForms', () => {
   it('shows the linked forms', () => {
     testData.extendedDatasets.createPast(1, {
       name: 'trees', linkedForms: [
@@ -41,9 +26,10 @@ describe('Linked Form Table', () => {
     const rows = component.findAll('tr');
 
     rows[0].text().should.be.eql('Diagnosis');
-    rows[0].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/monthly_diagnosis');
+    rows[0].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/monthly_diagnosis');
+
     rows[1].text().should.be.eql('National Parks Survey');
-    rows[1].getComponent(RouterLinkStub).props().to.should.be.equal('/projects/1/forms/national_parks_survey');
+    rows[1].getComponent(FormLink).props().to.should.be.equal('/projects/1/forms/national_parks_survey');
   });
 
   it('does not break if there is no form', () => {

--- a/test/components/dataset/overview/property-new.spec.js
+++ b/test/components/dataset/overview/property-new.spec.js
@@ -1,6 +1,6 @@
 import DatasetPropertyNew from '../../../../src/components/dataset/overview/new-property.vue';
 import DatasetProperties from '../../../../src/components/dataset/overview/dataset-properties.vue';
-import ConnectionToForm from '../../../../src/components/dataset/overview/connection-to-forms.vue';
+import ConnectionToForms from '../../../../src/components/dataset/overview/connection-to-forms.vue';
 
 import testData from '../../../data';
 import { load, mockHttp } from '../../../util/http';
@@ -101,7 +101,7 @@ describe('DatasetPropertyNew', () => {
 
     it('updates property count in form summary', async () => {
       const app = await submit('width_cm');
-      const connections = app.findComponent(ConnectionToForm);
+      const connections = app.findComponent(ConnectionToForms);
       connections.find('.caption-cell').text().should.equal('1 of 2 properties');
     });
   });

--- a/test/request-data/resources.spec.js
+++ b/test/request-data/resources.spec.js
@@ -77,4 +77,43 @@ describe('createResources()', () => {
       });
     });
   });
+
+  describe('dataset', () => {
+    const createResource = () => {
+      const { requestData } = createTestContainer({
+        requestData: { dataset: testData.extendedDatasets.last() }
+      });
+      return requestData.dataset;
+    };
+
+    it('adds projectId to forms', () => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [
+          {
+            name: 'height',
+            forms: [
+              { name: 'Tree Registration', xmlFormId: 'tree_registration' },
+              { name: 'Tree Registration Adv', xmlFormId: 'tree_registration_adv' }
+            ]
+          }
+        ],
+        sourceForms: [
+          { name: 'Tree Registration', xmlFormId: 'tree_registration' },
+          { name: 'Tree Registration Adv', xmlFormId: 'tree_registration_adv' }
+        ],
+        linkedForms: [
+          { name: 'Diagnosis', xmlFormId: 'monthly_diagnosis' },
+          { name: 'National Parks Survey', xmlFormId: 'national_parks_survey' }
+        ]
+      });
+      const dataset = createResource();
+      const forms = [
+        ...dataset.sourceForms,
+        ...dataset.linkedForms,
+        ...dataset.properties[0].forms
+      ];
+      forms.length.should.equal(6);
+      for (const form of forms) form.projectId.should.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
This PR is in response to https://github.com/getodk/central/issues/670#issuecomment-2535848397. It adds hover cards for the forms shown on the entity list overview.

#### What has been done to verify that this works as intended?

I tried it out locally. I also updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

`FormLink` expects the form passed to it to have a `projectId` property. However, the forms listed in the entity list don't have a `projectId`. I think they just have an `xmlFormId` and `name`. I ended up thinking that the easiest thing was to add a `projectId` to these forms when the response for the entity list is received. That way, components don't have to do extra legwork and can just pass each form to `FormLink` as-is.

I've also added some explanatory comments below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced