### PR TITLE
Adjust spacing between actions above submissions table

### DIFF
--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -33,13 +33,13 @@ except according to the terms contained in the LICENSE file.
           <submission-field-dropdown
             v-if="selectedFields != null && fields.selectable.length > 11"
             v-model="selectedFields"/>
-          <button id="submission-list-refresh-button" type="button"
-            class="btn btn-default" :aria-disabled="refreshing"
-            @click="fetchChunk(false, true)">
-            <span class="icon-refresh"></span>{{ $t('action.refresh') }}
-            <spinner :state="refreshing"/>
-          </button>
         </form>
+        <button id="submission-list-refresh-button" type="button"
+          class="btn btn-default" :aria-disabled="refreshing"
+          @click="fetchChunk(false, true)">
+          <span class="icon-refresh"></span>{{ $t('action.refresh') }}
+          <spinner :state="refreshing"/>
+        </button>
         <submission-download-button :form-version="formVersion"
           :aria-disabled="deleted" v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"
           :filtered="odataFilter != null && !deleted" @download="downloadModal.show()"/>
@@ -485,27 +485,44 @@ export default {
 }
 
 #submission-list-actions {
-  align-items: baseline;
+  align-items: center;
   display: flex;
   flex-wrap: wrap-reverse;
+  // This is 10px of space between actions on the row and also 10px between
+  // rows if the actions start wrapping.
+  gap: 10px;
+  margin-bottom: 25px;
+
+  .form-inline {
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
 }
 #submission-field-dropdown {
+  // This is the entire spacing between the dropdown and the filters to its
+  // left. Since they're both children of the form, the flexbox gap doesn't
+  // apply to them.
   margin-left: 15px;
-  margin-right: 5px;
-}
-#submission-list-refresh-button {
-  margin-left: 10px;
+  // Additional space between the dropdown and the refresh button
   margin-right: 5px;
 }
 #submission-download-button {
-  // The bottom margin is for if the download button wraps above the other
-  // actions.
-  margin-bottom: 10px;
   margin-left: auto;
 }
 
 #submission-list-test-in-browser {
-  margin-left: 10px;
+  ~ .form-inline {
+    margin-left: auto;
+
+    #submission-field-dropdown {
+      // There are no filters, so no need for margin-left.
+      margin-left: 0;
+      // Further increase the space between the dropdown and the refresh button.
+      margin-right: 10px;
+    }
+  }
+
+  ~ #submission-download-button { margin-left: 0; }
 }
 </style>
 

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -488,10 +488,12 @@ export default {
   align-items: center;
   display: flex;
   flex-wrap: wrap-reverse;
-  // This is 10px of space between actions on the row and also 10px between
-  // rows if the actions start wrapping.
+  // This results in 10px of space between elements on the row, as well as 10px
+  // between rows if elements start wrapping. The main example of that is that
+  // the download button can wrap above the other actions if the viewport is not
+  // wide enough.
   gap: 10px;
-  margin-bottom: 25px;
+  margin-bottom: 30px;
 
   .form-inline {
     margin-bottom: 0;
@@ -500,18 +502,20 @@ export default {
 }
 #submission-field-dropdown {
   // This is the entire spacing between the dropdown and the filters to its
-  // left. Since they're both children of the form, the flexbox gap doesn't
-  // apply to them.
+  // left. Since they're both child elements of the form, the flexbox gap does
+  // not apply to them.
   margin-left: 15px;
   // Additional space between the dropdown and the refresh button
   margin-right: 5px;
 }
-#submission-download-button {
-  margin-left: auto;
-}
+#submission-download-button { margin-left: auto; }
 
+// Adjust the spacing between actions on the draft testing page.
 #submission-list-test-in-browser {
   ~ .form-inline {
+    // It is possible for .form-inline to be :empty, but we still render it so
+    // that the buttons that follow it are shown on the righthand side of the
+    // page.
     margin-left: auto;
 
     #submission-field-dropdown {


### PR DESCRIPTION
This PR addresses the following to-do mentioned at https://github.com/getodk/central/issues/833#issuecomment-2529012617:

> Move the Refresh button next to the Download button

The refresh button will be moved for the draft testing page only. It will stay where it is on the regular submissions page.

This PR similarly groups the column selection dropdown with the refresh and download buttons on the right.

Additionally, I noticed issues with the vertical alignment of the actions above the table:

- The download button doesn't seem to be vertically aligned with the rest of the actions (at least on the submissions page and probably also the draft testing page). You can see that on staging if you decrease the width of the viewport enough such that the download button is positioned close to the rest of the actions.
- On the draft testing page, the test buttons are not vertically aligned with the refresh button.

This PR fixes these issues with vertical alignment.

#### What has been done to verify that this works as intended?

I iterated locally on the spacing/positioning of actions. I viewed the before/after side-by-side.

As part of the PR, I moved the refresh button outside the form. (See the comment below.) That shouldn't have any effect on behavior, but I did do a quick check that the refresh button still worked. That's also something that tests look at.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This PR should only affect the spacing/positioning of actions. It's mostly changes to styles.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced