### PR TITLE
Fixes: remove default chevron in Safari for Forms trash

### DIFF
--- a/src/components/form/trash-list.vue
+++ b/src/components/form/trash-list.vue
@@ -102,44 +102,54 @@ export default {
 
 <style lang="scss">
 @import '../../assets/scss/mixins';
+#form-trash-list {
+  #form-trash-list-header {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
 
-#form-trash-list-header {
-  display: flex;
-  align-items: baseline;
+    #form-trash-expander {
+      // Fixate the width as icon-chevron-down and icon-chevron-right have unequal width :-(
+      display: inline-block;
+      width: 1em;
+      margin-right: 15px;
+      font-size: 12px;
+    }
 
-  #form-trash-expander {
-    // Fixate the width as icon-chevron-down and icon-chevron-right have unequal width :-(
-    display: inline-block;
-    width: 1em;
+    .icon-trash {
+      padding-right: 8px;
+    }
+
+    .trash-count {
+      font-weight: normal;
+      color: black;
+    }
+
+    #form-trash-list-title {
+      font-size: 26px;
+      font-weight: 700;
+      color: $color-danger;
+      display: flex;
+      align-items: center;
+    }
+
+    #form-trash-list-count {
+      font-size: 20px;
+      color: #888;
+      padding-left: 4px;
+    }
+
+    #form-trash-list-note {
+      margin-left: auto;
+      color: #888
+    }
   }
 
-  .icon-trash {
-    padding-right: 8px;
-  }
-
-  .trash-count {
-    font-weight: normal;
-    color: black;
-  }
-
-  #form-trash-list-title {
-    font-size: 26px;
-    font-weight: 700;
-    color: $color-danger;
-  }
-
-  #form-trash-list-count {
-    font-size: 20px;
-    color: #888;
-    padding-left: 4px;
-  }
-
-  #form-trash-list-note {
-    margin-left: auto;
-    color: #888
+  // Hides default chevron in safari
+  summary::-webkit-details-marker {
+    display: none;
   }
 }
-
 </style>
 
 <i18n lang="json5">


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/690#issuecomment-2479976134

### Changes:

* remove default chevron in Safari for Forms trash
* Set cursor to pointer for the Form trash heading
* Align the heading items to middle
* Add space between chevron and trash icon
* Reduce the size of chevron

#### What has been done to verify that this works as intended?

Checked in all three browsers.

#### Why is this the best possible solution? Were any other approaches considered?

Implemented as suggested, `::-webkit-details-marker` appears to be only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced