### PR TITLE
Feature #847: Add close button to QR popover

### DIFF
--- a/src/components/field-key/new.vue
+++ b/src/components/field-key/new.vue
@@ -41,7 +41,7 @@ except according to the terms contained in the LICENSE file.
               <span>{{ $t('success[0]', created) }}</span>
             </p>
           </div>
-          <field-key-qr-panel :field-key="created" :managed="managed"/>
+          <field-key-qr-panel :field-key="created" :managed="managed" :show-close="false"/>
           <p>{{ $t('success[1]', created) }}</p>
           <i18n-t tag="p" keypath="success[2].full">
             <template #formAccessSettings>

--- a/src/components/popover.vue
+++ b/src/components/popover.vue
@@ -74,11 +74,13 @@ export default {
     // not show, then hide), we use event capturing here.
     document.addEventListener('click', this.hideAfterClick, true);
     window.addEventListener('resize', this.hideAfterResize);
+    document.addEventListener('keydown', this.hideAfterEsc);
   },
   beforeUnmount() {
     if (this.target != null) this.hide();
     document.removeEventListener('click', this.hideAfterClick, true);
     window.removeEventListener('resize', this.hideAfterResize);
+    document.removeEventListener('keydown', this.hideAfterEsc);
   },
   methods: {
     show() {
@@ -108,12 +110,16 @@ export default {
       this.show();
     },
     hideAfterClick(event) {
-      if (this.target != null && event.target.closest('.popover') == null &&
-        !this.target.contains(event.target))
+      if (this.target != null &&
+          ((event.target.closest('.popover') == null && !this.target.contains(event.target)) ||
+            (event.target.hasAttribute('data-closes-popover'))))
         this.$emit('hide');
     },
     hideAfterResize() {
       if (this.target != null) this.$emit('hide');
+    },
+    hideAfterEsc({ key }) {
+      if (this.target != null && key === 'Escape') this.$emit('hide');
     }
   }
 };

--- a/src/components/qr-panel.vue
+++ b/src/components/qr-panel.vue
@@ -15,13 +15,24 @@ except according to the terms contained in the LICENSE file.
       <h1 class="panel-title"><slot name="title"></slot></h1>
       <span class="icon-mobile"></span>
     </div>
-    <div class="panel-body"><slot name="body"></slot></div>
+    <div class="panel-body">
+      <slot name="body"></slot>
+      <div v-if="showClose" class="panel-footer">
+        <button type="button" class="btn btn-primary" data-closes-popover>{{ $t('action.close') }}</button>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
 defineOptions({
   name: 'QrPanel'
+});
+defineProps({
+  showClose: {
+    type: Boolean,
+    default: true
+  }
 });
 </script>
 
@@ -35,6 +46,11 @@ defineOptions({
   .panel-heading {
     background-color: $color-action-background;
     position: relative;
+  }
+
+  .panel-footer {
+    margin-bottom: -15px;
+    border-radius: 0;
   }
 
   // The icon is not animated, because in FieldKeyQrPanel, switching between a

--- a/test/components/field-key/row.spec.js
+++ b/test/components/field-key/row.spec.js
@@ -57,6 +57,14 @@ describe('FieldKeyRow', () => {
       should.not.exist(document.querySelector('.popover'));
     });
 
+    it('hides the popover on close button', async () => {
+      const app = await load('/projects/1/app-users', { attachTo: document.body });
+      await app.get('.field-key-row-popover-link').trigger('click');
+      should.exist(document.querySelector('.popover .field-key-qr-panel'));
+      await document.querySelector('.popover button').click();
+      should.not.exist(document.querySelector('.popover'));
+    });
+
     it("shows the app user's display name", async () => {
       const app = await load('/projects/1/app-users', { attachTo: document.body });
       await app.get('.field-key-row-popover-link').trigger('click');

--- a/test/components/form-draft/testing.spec.js
+++ b/test/components/form-draft/testing.spec.js
@@ -20,6 +20,19 @@ describe('FormDraftTesting', () => {
     should.not.exist(document.querySelector('.popover'));
   });
 
+  it('hides QR code on close button', async () => {
+    mockLogin();
+    testData.extendedForms.createPast(1, { draft: true });
+    const component = await load('/projects/1/forms/f/draft/testing', {
+      root: false,
+      attachTo: document.body
+    });
+    await component.get('#submission-list-test-on-device').trigger('click');
+    should.exist(document.querySelector('.popover .form-draft-qr-panel'));
+    await document.querySelector('.popover button').click();
+    should.not.exist(document.querySelector('.popover'));
+  });
+
   describe('submission count', () => {
     beforeEach(mockLogin);
 

--- a/test/components/popover.spec.js
+++ b/test/components/popover.spec.js
@@ -27,6 +27,28 @@ describe('Popover', () => {
     document.querySelectorAll('.popover').length.should.equal(0);
   });
 
+  it('hides the popover after close button of popover is clicked', async () => {
+    const component = mount(TestUtilPopoverLinks, { attachTo: document.body });
+    document.querySelector('#show-foo').click();
+    await component.vm.$nextTick();
+    await component.vm.$nextTick();
+    document.querySelectorAll('.popover').length.should.equal(1);
+    document.querySelector('.popover button').click();
+    await component.vm.$nextTick();
+    document.querySelectorAll('.popover').length.should.equal(0);
+  });
+
+  it('hides on escape', async () => {
+    const component = mount(TestUtilPopoverLinks, { attachTo: document.body });
+    document.querySelector('#show-foo').click();
+    await component.vm.$nextTick();
+    await component.vm.$nextTick();
+    document.querySelectorAll('.popover').length.should.equal(1);
+    await component.trigger('keydown', { key: 'Escape' });
+    await component.vm.$nextTick();
+    document.querySelectorAll('.popover').length.should.equal(0);
+  });
+
   it('does not hide the popover after a click on the popover', async () => {
     const component = mount(TestUtilPopoverLinks, { attachTo: document.body });
     document.querySelector('#show-foo').click();

--- a/test/util/components/popover-links.vue
+++ b/test/util/components/popover-links.vue
@@ -6,6 +6,7 @@
 
     <popover :target="popover.target" placement="left" @hide="hide">
       <p>{{ popover.text }}</p>
+      <button type="button" data-closes-popover>close</button>
     </popover>
   </div>
 </template>


### PR DESCRIPTION


Closes getodk/central#847

### Changes:

* Hide popover on click of a button that has data-closes-popover attribute
* Hide popover on escape key as well
* Added button in QR panel to hide popover (self)

#### What has been done to verify that this works as intended?

Tried in chrome and added fews tests.

#### Why is this the best possible solution? Were any other approaches considered?

Because popover component adds click eventListener on the document that `useCapture`, I was not able to handle vue events directly on qr-panel component. Having another condition in `closeAfterClick` that checks if the event target is a close button, identified by `data-closes-popover` attribute, seems reasonable to me.

I have also added event listener for escape key, which is applicable on all popover. If we want we can add a prop to add it on selective popovers - like maybe we don't hide hover-cards on escape 🤷‍♂️.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't see any regression risks here.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced