### PR TITLE
Fix how hover card is hidden

### DIFF
--- a/src/components/hover-cards.vue
+++ b/src/components/hover-cards.vue
@@ -139,14 +139,12 @@ const hide = () => {
   component.value = null;
   placement.value = undefined;
 };
-watch(() => hoverCard.anchor, (anchor) => {
-  /* If hoverCard.state is `true`, then there are two possibilities. It could be
-  that hoverCard.state has changed from `false` to `true`. Or it could be that
-  it was `true` already, but hoverCard.anchor has changed. (That would be pretty
-  unusual, but it could happen if preventHide is set to `true` in
-  useHoverCard().) But most importantly, if hoverCard.state is `true`, then we
-  need to hide the current hover card before we show a new one. */
-  if (hoverCard.state) hide();
-  if (anchor != null) show();
+watch(() => hoverCard.anchor, (newAnchor, oldAnchor) => {
+  // Note the possibility that oldAnchor != null && newAnchor != null. That
+  // would be pretty unusual, but it could happen if preventHide is set to
+  // `true` in useHoverCard(). In that case, we need to hide the current hover
+  // card before we show the new one.
+  if (oldAnchor != null) hide();
+  if (newAnchor != null) show();
 });
 </script>

--- a/test/components/hover-cards.spec.js
+++ b/test/components/hover-cards.spec.js
@@ -159,12 +159,30 @@ describe('HoverCards', () => {
       ))
       .request(hover(clock))
       .respondWithData(() => testData.extendedDatasets.last())
-      .respondWithProblem(() => entity)
+      .respondWithProblem()
       .afterResponses(async (component) => {
         should.not.exist(document.querySelector('.popover'));
         component.should.not.alert();
         // Make sure that this does not result in a Vue warning.
         await getAnchor(component).trigger('mouseleave');
+      });
+  });
+
+  it('does not log an error if mouseleave is triggered during request', () => {
+    const clock = sinon.useFakeTimers();
+    const entity = testData.standardEntities.createPast(1).last();
+    return mockHttp()
+      .mount(TestUtilHoverCards, mountOptions(
+        EntityLink,
+        { projectId: 1, dataset: 'trees', entity }
+      ))
+      .request(hover(clock))
+      .beforeAnyResponse(component =>
+        getAnchor(component).trigger('mouseleave'))
+      .respondWithData(() => testData.extendedDatasets.last())
+      .respondWithData(() => entity)
+      .afterResponses(async () => {
+        should.not.exist(document.querySelector('.popover'));
       });
   });
 });


### PR DESCRIPTION
@lognaturel noticed that there are cases where mousing away from a link that shows a hover card causes an error to be logged in the browser console. She noticed this pattern:

> Maybe if I hover over a form title and remove my cursor before the card shows?

Looking into it, I think the specific problem was if the user mouses away while the hover card requests are in progress. Doing so is supposed to cancel the requests, but it wasn't doing so. That led to the following sequence:

- Requests are sent.
- `mouseleave` leads to `hoverCard.hide()` being called, which sets `hoverCard.anchor` to `null`.
- Requests succeed.
- `component.value` is set in the `HoverCards` component.
- `computePlacement()` is called. But `computePlacement()` needs to know the position of `hoverCard.anchor`. When it tries to figure that out and sees that `hoverCard.anchor` is `null`, it throws.
- The fact that `computePlacement()` throws triggers the `catch()` in the promise chain, which calls `resetResources()`. That clears the response data, but it doesn't reset `component.value` or `placement.value`. It shouldn't have to reset those things, because the only thing that's supposed to trigger the `catch()` is a request failure. But the fact that `component.value` is set while the response data is not means that the component attempts to render without any of the data it requires. That leads to an error, and it's that (pretty ugly) error that @lognaturel was seeing in the console.

The more general problem here is that `hoverCard.hide()` is not triggering the `hide()` function in the `HoverCards` component. The `hoverCard` object is just responsible for managing simple state about the hover card, not sending requests. It's the `hide()` function that's supposed to cancel requests and reset `component.value` and `placement.value`. The fact that it wasn't called was the root cause of the issue.

#### What has been done to verify that this works as intended?

I wrote a test that succeeds now but failed without the code change. I also tried out the fix locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced