### PR TITLE
Only log QR code settings if config.devTools is true

### DIFF
--- a/src/components/collect-qr.vue
+++ b/src/components/collect-qr.vue
@@ -21,9 +21,9 @@ except according to the terms contained in the LICENSE file.
 let id = 0;
 </script>
 <script setup>
-import { onMounted, ref } from 'vue';
 import qrcode from 'qrcode-generator';
 import pako from 'pako/lib/deflate';
+import { inject, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import useEventListener from '../composables/event-listener';
@@ -130,8 +130,9 @@ id += 1;
 // be rendered in two places in the DOM. Also due to the popover, we can't use
 // Vue event handlers. See the Popover component for details.
 const idClass = `collect-qr${id}`;
+const config = inject('config');
 useEventListener(document.body, 'click', (event) => {
-  if (event.target.parentNode.classList.contains(idClass))
+  if (config.devTools && event.target.parentNode.classList.contains(idClass))
     console.log(props.settings); // eslint-disable-line no-console
 });
 </script>


### PR DESCRIPTION
This is a follow-up PR after #1100. Now that the Frontend config includes the `devTools` flag, we can use it to decide whether to log the QR code settings. That's behavior that we only intend to use in development/test environments.

#### What has been done to verify that this works as intended?

Now by default, clicking a QR code will not log anything. I can see that behavior locally. I also see that when I change `config.devTools` to `true`, clicking a QR code logs its settings.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced