### PR TITLE
Upgraded web-forms to 0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
-        "@getodk/web-forms": "^0.5.0",
+        "@getodk/web-forms": "^0.6.0",
         "axios": "^1.6.2",
         "bootstrap": "~3",
         "dompurify": "~2",
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@getodk/web-forms": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.5.0.tgz",
-      "integrity": "sha512-JKG+PJ+aWKK53mwr74aOPJRue6BPUm3p5IvuwwUrs84x4kXqbj6DZeWWtL0XyQi08rj82N/leoGsExMWzyXaFA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.6.0.tgz",
+      "integrity": "sha512-Ua64MTTpVftMUfPWdvWyQSn4FApZYNbrUEVVKJuGG8opo5CLJmbQziOE5uUZvUCZ8WhbijkeEEI9Srag0zRxaw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.20.4 || ^20.17.0 || ^22.9.0",
@@ -13352,9 +13352,9 @@
       }
     },
     "@getodk/web-forms": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.5.0.tgz",
-      "integrity": "sha512-JKG+PJ+aWKK53mwr74aOPJRue6BPUm3p5IvuwwUrs84x4kXqbj6DZeWWtL0XyQi08rj82N/leoGsExMWzyXaFA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.6.0.tgz",
+      "integrity": "sha512-Ua64MTTpVftMUfPWdvWyQSn4FApZYNbrUEVVKJuGG8opo5CLJmbQziOE5uUZvUCZ8WhbijkeEEI9Srag0zRxaw==",
       "requires": {}
     },
     "@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",
-    "@getodk/web-forms": "^0.5.0",
+    "@getodk/web-forms": "^0.6.0",
     "axios": "^1.6.2",
     "bootstrap": "~3",
     "dompurify": "~2",

--- a/src/components/form-attachment/link-dataset.vue
+++ b/src/components/form-attachment/link-dataset.vue
@@ -67,7 +67,7 @@ export default {
     link() {
       this.request({
         method: 'PATCH',
-        url: apiPaths.formDraftAttachment(this.form.projectId, this.form.xmlFormId, this.attachment.name),
+        url: apiPaths.formDraftAttachment(this.form.projectId, this.form.xmlFormId, true, this.attachment.name),
         data: { dataset: true }
       })
         .then(() => {

--- a/src/components/form-attachment/link-dataset.vue
+++ b/src/components/form-attachment/link-dataset.vue
@@ -67,7 +67,7 @@ export default {
     link() {
       this.request({
         method: 'PATCH',
-        url: apiPaths.formDraftAttachment(this.form.projectId, this.form.xmlFormId, true, this.attachment.name),
+        url: apiPaths.formAttachment(this.form.projectId, this.form.xmlFormId, true, this.attachment.name),
         data: { dataset: true }
       })
         .then(() => {

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -285,6 +285,7 @@ export default {
         url: apiPaths.formDraftAttachment(
           this.form.projectId,
           this.form.xmlFormId,
+          true,
           attachment.name
         ),
         headers: {

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -282,7 +282,7 @@ export default {
 
       return this.request({
         method: 'POST',
-        url: apiPaths.formDraftAttachment(
+        url: apiPaths.formAttachment(
           this.form.projectId,
           this.form.xmlFormId,
           true,

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -133,6 +133,7 @@ export default {
       return apiPaths.formDraftAttachment(
         this.form.projectId,
         this.form.xmlFormId,
+        true,
         this.attachment.name
       );
     },

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -130,7 +130,7 @@ export default {
       return this.$te(path, this.$i18n.fallbackLocale) ? this.$t(path) : type;
     },
     href() {
-      return apiPaths.formDraftAttachment(
+      return apiPaths.formAttachment(
         this.form.projectId,
         this.form.xmlFormId,
         true,

--- a/src/composables/request.js
+++ b/src/composables/request.js
@@ -90,9 +90,7 @@ const _request = (container, awaitingResponse) => (config) => {
   const { data } = axiosConfig;
   // This limit is set in the nginx config. The alert also mentions this number.
   if (data != null && data instanceof File && data.size > 100000000) {
-    if (alertOption) {
-      alert.danger(i18n.t('mixin.request.alert.fileSize', { name: data.name }));
-    }
+    alert.danger(i18n.t('mixin.request.alert.fileSize', { name: data.name }));
     return Promise.reject(new Error('file size exceeds limit'));
   }
 
@@ -113,8 +111,8 @@ const _request = (container, awaitingResponse) => (config) => {
       // eslint-disable-next-line no-param-reassign
       awaitingResponse.value = false;
 
-      logAxiosError(logger, error);
       if (alertOption) {
+        logAxiosError(logger, error);
         alert.danger(requestAlertMessage(i18n, error, problemToAlert));
       }
       throw error;

--- a/src/composables/request.js
+++ b/src/composables/request.js
@@ -83,13 +83,16 @@ const _request = (container, awaitingResponse) => (config) => {
   const {
     fulfillProblem = undefined,
     problemToAlert = undefined,
+    alert: alertOption = true,
     ...axiosConfig
   } = config;
 
   const { data } = axiosConfig;
   // This limit is set in the nginx config. The alert also mentions this number.
   if (data != null && data instanceof File && data.size > 100000000) {
-    alert.danger(i18n.t('mixin.request.alert.fileSize', { name: data.name }));
+    if (alertOption) {
+      alert.danger(i18n.t('mixin.request.alert.fileSize', { name: data.name }));
+    }
     return Promise.reject(new Error('file size exceeds limit'));
   }
 
@@ -111,7 +114,9 @@ const _request = (container, awaitingResponse) => (config) => {
       awaitingResponse.value = false;
 
       logAxiosError(logger, error);
-      alert.danger(requestAlertMessage(i18n, error, problemToAlert));
+      if (alertOption) {
+        alert.danger(requestAlertMessage(i18n, error, problemToAlert));
+      }
       throw error;
     })
     .then(response => {

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -113,7 +113,7 @@ export const apiPaths = {
   publishFormDraft: formPath('/draft/publish'),
   publishedAttachments: formPath('/attachments'),
   formDraftAttachments: formPath('/draft/attachments'),
-  formDraftAttachment: (projectId, xmlFormId, draft, attachmentName) => {
+  formAttachment: (projectId, xmlFormId, draft, attachmentName) => {
     const encodedFormId = encodeURIComponent(xmlFormId);
     const encodedName = encodeURIComponent(attachmentName);
     const draftPath = draft ? '/draft' : '';

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -113,10 +113,11 @@ export const apiPaths = {
   publishFormDraft: formPath('/draft/publish'),
   publishedAttachments: formPath('/attachments'),
   formDraftAttachments: formPath('/draft/attachments'),
-  formDraftAttachment: (projectId, xmlFormId, attachmentName) => {
+  formDraftAttachment: (projectId, xmlFormId, draft, attachmentName) => {
     const encodedFormId = encodeURIComponent(xmlFormId);
     const encodedName = encodeURIComponent(attachmentName);
-    return `/v1/projects/${projectId}/forms/${encodedFormId}/draft/attachments/${encodedName}`;
+    const draftPath = draft ? '/draft' : '';
+    return `/v1/projects/${projectId}/forms/${encodedFormId}${draftPath}/attachments/${encodedName}`;
   },
   submissions: (projectId, xmlFormId, draft, extension, query = undefined) => {
     const encodedFormId = encodeURIComponent(xmlFormId);

--- a/test/composables/request.spec.js
+++ b/test/composables/request.spec.js
@@ -87,6 +87,17 @@ describe('useRequest()', () => {
         .afterResponse(component => {
           component.should.alert('danger', 'Message from problemToAlert');
         }));
+
+    it('does not show alert when it is set to false', () =>
+      mockHttp()
+        .mount(TestUtilRequest)
+        .request(component =>
+          component.vm.request({ method: 'DELETE', url: '/v1/projects/1', alert: false })
+            .catch(noop))
+        .respondWithProblem({ code: 403.1, message: 'Insufficient rights' })
+        .afterResponse(component => {
+          component.should.not.alert();
+        }));
   });
 
   describe('fulfillProblem', () => {

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -165,12 +165,12 @@ describe('util/request', () => {
     });
 
     it('formAttachment - draft', () => {
-      const path = apiPaths.formDraftAttachment(1, 'a b', true, 'c d');
+      const path = apiPaths.formAttachment(1, 'a b', true, 'c d');
       path.should.equal('/v1/projects/1/forms/a%20b/draft/attachments/c%20d');
     });
 
     it('formAttachment - published', () => {
-      const path = apiPaths.formDraftAttachment(1, 'a b', false, 'c d');
+      const path = apiPaths.formAttachment(1, 'a b', false, 'c d');
       path.should.equal('/v1/projects/1/forms/a%20b/attachments/c%20d');
     });
 

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -164,9 +164,14 @@ describe('util/request', () => {
       path.should.equal('/v1/projects/1/forms/a%20b/draft/attachments');
     });
 
-    it('formDraftAttachment', () => {
-      const path = apiPaths.formDraftAttachment(1, 'a b', 'c d');
+    it('formAttachment - draft', () => {
+      const path = apiPaths.formDraftAttachment(1, 'a b', true, 'c d');
       path.should.equal('/v1/projects/1/forms/a%20b/draft/attachments/c%20d');
+    });
+
+    it('formAttachment - published', () => {
+      const path = apiPaths.formDraftAttachment(1, 'a b', false, 'c d');
+      path.should.equal('/v1/projects/1/forms/a%20b/attachments/c%20d');
     });
 
     it('publishedAttachments', () => {


### PR DESCRIPTION

#### What has been done to verify that this works as intended?

Manual verification, deployed at Dev environment. Sample Form: https://dev.getodk.cloud/#/projects/2/forms/ExternalInstance

#### Why is this the best possible solution? Were any other approaches considered?

Using the existing `request` object to handle attachment fetching seemed like a logical option to me. The other options were to create a new function from scratch using `fetch` or import `XFormResource` from `@getodk/common`, both options would have required separate authentication and error handling mechanism.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced