### PR TITLE
Increase line-height in HoverCard to prevent text truncation

### DIFF
--- a/src/components/hover-card.vue
+++ b/src/components/hover-card.vue
@@ -109,6 +109,7 @@ $border-radius: 12px;
 .hover-card { width: 290px; }
 
 .hover-card-heading {
+  // Used to align the top of the icon with the top of the text.
   $icon-margin-top: 2px;
 
   background-color: #666;
@@ -119,7 +120,7 @@ $border-radius: 12px;
   color: #fff;
   display: flex;
   line-height: 1.2;
-  padding: #{$padding-panel-body - $icon-margin-top} $padding-panel-body 12px;
+  padding: #{$padding-panel-body - $icon-margin-top} $padding-panel-body 13px;
 
   > [class^="icon-"] {
     flex-shrink: 0;
@@ -139,10 +140,7 @@ $border-radius: 12px;
   margin-bottom: 1px;
 }
 
-.hover-card-subtitle {
-  font-size: 12px;
-  margin-bottom: 1px;
-}
+.hover-card-subtitle { font-size: 12px; }
 
 .hover-card-body {
   background-color: #fff;

--- a/src/components/hover-card.vue
+++ b/src/components/hover-card.vue
@@ -109,6 +109,8 @@ $border-radius: 12px;
 .hover-card { width: 290px; }
 
 .hover-card-heading {
+  $icon-margin-top: 2px;
+
   background-color: #666;
   border-inline: $border;
   border-top: $border;
@@ -116,15 +118,14 @@ $border-radius: 12px;
   border-top-right-radius: $border-radius;
   color: #fff;
   display: flex;
-  // Align the top of the text with the top of the icon.
-  line-height: 1;
-  padding: $padding-panel-body;
-  padding-bottom: 12px;
+  line-height: 1.2;
+  padding: #{$padding-panel-body - $icon-margin-top} $padding-panel-body 12px;
 
   > [class^="icon-"] {
     flex-shrink: 0;
     font-size: 26px;
     margin-right: 10px;
+    margin-top: $icon-margin-top;
   }
 
   // Needed for .hover-card-title to truncate.
@@ -135,15 +136,12 @@ $border-radius: 12px;
   @include text-overflow-ellipsis;
   font-size: 16px;
   font-weight: 500;
-  // This padding has two purposes. We need space between the title and the
-  // subtitle. Since the line-height is 1, we also need space for descenders in
-  // the text. It's for the latter reason that we use padding instead of margin.
-  padding-bottom: 3px;
+  margin-bottom: 1px;
 }
 
 .hover-card-subtitle {
   font-size: 12px;
-  padding-bottom: 2px;
+  margin-bottom: 1px;
 }
 
 .hover-card-body {


### PR DESCRIPTION
This PR attempts to address the issue described at https://github.com/getodk/central/issues/670#issuecomment-2527556597.

I actually had difficulty reproducing the issue locally. I can see that Szymon is seeing a different font than I am. However, after trying each of the fonts listed in the CSS, I don't see text truncation:

https://github.com/getodk/central-frontend/blob/f1949fff55e56447e809c5c7d51f7d7046bb4405/src/assets/css/bootstrap.css#L281

I tried in both Chrome and Firefox.

At some point, we should maybe look into what options we have around standardizing fonts in Central. For now, I'm hoping I can solve the issue by increasing the line height. I strongly suspect that the text truncation that Szymon is seeing is due to `line-height` being set to 1 in the `HoverCard` component.

#### What has been done to verify that this works as intended?

I wasn't able to reproduce the issue, so my main goal was to keep the look of the hover cards as consistent as possible while also increasing the line height. I compared hover cards side-by-side before/after making this change.

#### Why is this the best possible solution? Were any other approaches considered?

The main change I want to try is increasing the line height. After making that change, I also had to fiddle with margin/padding.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced