### PR TITLE
fixes: use safer method of getting filename from URL

### DIFF
--- a/src/components/form/preview.vue
+++ b/src/components/form/preview.vue
@@ -99,7 +99,7 @@ const getAttachment = (url) => request({
     props.projectId,
     props.xmlFormId,
     props.draft,
-    url.pathname.substring(1)
+    url.pathname.split('/').pop()
   ),
   alert: false
 }).then(axiosResponse => {


### PR DESCRIPTION
Hélène mentioned that she was getting 404 for the Web Forms with the attachments in an older version of Firefox. 

The format of URL received from the Web Form is `jr://<format>/<filename>`; examples: `jr://file/colors.xml` and `jr://file-csv/patients.csv` . I think that particular version of Firefox must be returning `/<format>/<filename>` for `pathname`, other browsers return `/<filename>` and treats `<format>` as `host`. 

The requests sent by the browser yesterday were: `https://dev.getodk.cloud/v1/projects/3/forms/nigeria_wards_external/attachments/%2Ffile%2Flgas.xml` and `https://dev.getodk.cloud/v1/projects/3/forms/nigeria_wards_external/attachments/%2Ffile%2Fwards.xml`

They include extra `/file` in the URL.

With the change made in this PR, it should resolve the issue for the browsers that return everything after jr protocal in pathname.

#### What has been done to verify that this works as intended?

I have tested in all three browsers.

#### Why is this the best possible solution? Were any other approaches considered?

It makes the filename retrieval from URL a bit safer. See details above.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced