### PR TITLE
Fixes tests that send user preference request when changing project sort order

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -6,7 +6,7 @@ trap 'rm -- "$output"' EXIT
 NODE_ENV=test karma start | tee "$output"
 # Search for: warnings from console.warn(), including Vue warnings; Sass
 # warnings; and warnings from Karma.
-if grep -F -e 'WARN LOG:' -e 'Module Warning' -e 'WARN [web-server]:' -C5 "$output"; then
+if grep -F -e 'WARN LOG:' -e 'ERROR LOG:' -e 'Module Warning' -e 'WARN [web-server]:' -C5 "$output"; then
 	# Reset the text format in case the search results contained formatted text.
 	tput sgr0
 	echo


### PR DESCRIPTION

#### What has been done to verify that this works as intended?

All tests are passing, none of them are logging ERROR LOG

#### Why is this the best possible solution? Were any other approaches considered?

I have modified the tests to use mockHttp where user preferences were changed.

I was thinking to add exception for user-preference request in `logUnhandledRequest`, but went against it for the sake of consistency and to have visibility about this request while writing tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced