### PR TITLE
Fixes #1047: preventDefault()

### DIFF
--- a/test/components/entity/upload/data-template.spec.js
+++ b/test/components/entity/upload/data-template.spec.js
@@ -27,6 +27,10 @@ describe('EntityUploadDataTemplate', () => {
     const clock = sinon.useFakeTimers(Date.parse('2024-12-31T01:23:45'));
     testData.extendedDatasets.createPast(1);
     const a = mountComponent().get('a');
+    // We don't want to actually download the file. See CF#1047.
+    // Additionally, since Chrome Headless 131.0.0.0, this test has started
+    // failing.
+    a.element.addEventListener('click', (e) => { e.preventDefault(); });
     await a.trigger('click');
     a.attributes().download.should.equal('trees 20241231012345.csv');
     clock.tick(1000);

--- a/test/components/entity/upload/data-template.spec.js
+++ b/test/components/entity/upload/data-template.spec.js
@@ -26,15 +26,16 @@ describe('EntityUploadDataTemplate', () => {
   it('has the correct filename', async () => {
     const clock = sinon.useFakeTimers(Date.parse('2024-12-31T01:23:45'));
     testData.extendedDatasets.createPast(1);
-    const a = mountComponent().get('a');
-    // We don't want to actually download the file. See CF#1047.
+    const component = mountComponent();
+    const a = component.get('a');
+    // Call setFilename method directly instead of trigger click event which
+    // creates the actual file in the file system; see CF#1047.
     // Additionally, since Chrome Headless 131.0.0.0, this test has started
-    // failing.
-    a.element.addEventListener('click', (e) => { e.preventDefault(); });
-    await a.trigger('click');
+    // failing
+    component.vm.setFilename({ target: a.element });
     a.attributes().download.should.equal('trees 20241231012345.csv');
     clock.tick(1000);
-    await a.trigger('click');
+    component.vm.setFilename({ target: a.element });
     a.attributes().download.should.equal('trees 20241231012346.csv');
   });
 });


### PR DESCRIPTION
Closes #1047 

Builds are failing on the master branch as well, this fix is necessary now.

#### What has been done to verify that this works as intended?

All tests are passing and no file is created on the file system.

#### Why is this the best possible solution? Were any other approaches considered?

This solves the problem, but I am open to hearing other options. @matthew-white mentioned something about `preventDefault` in tests in the [issue](https://github.com/getodk/central-frontend/issues/1047), I don't where to set that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced