### PR TITLE
Features/822 pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@vue/cli-service": "^5.0.8",
         "@vue/compiler-sfc": "~3",
         "@vue/eslint-config-airbnb": "^7.0.0",
-        "@vue/test-utils": "^2.4.1",
+        "@vue/test-utils": "^2.4.6",
         "chai": "^5.1.1",
         "chai-as-promised": "^8.0.0",
         "comment-json": "~4",
@@ -1748,22 +1748,14 @@
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
     },
     "node_modules/@vue/test-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.1.tgz",
-      "integrity": "sha512-VO8nragneNzUZUah6kOjiFmD/gwRjUauG9DROh6oaOeFwX1cZRUNHhdeogE8635cISigXFTtGLUQWx5KCb0xeg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "js-beautify": "1.14.9",
-        "vue-component-type-helpers": "1.8.4"
-      },
-      "peerDependencies": {
-        "@vue/server-renderer": "^3.0.1",
-        "vue": "^3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@vue/server-renderer": {
-          "optional": true
-        }
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
       }
     },
     "node_modules/@vue/vue-loader-v15": {
@@ -11663,10 +11655,11 @@
       "dev": true
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.4.tgz",
-      "integrity": "sha512-6bnLkn8O0JJyiFSIF0EfCogzeqNXpnjJ0vW/SZzNHfe6sPx30lTtTXlE5TFs2qhJlAtDFybStVNpL73cPe3OMQ==",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.0.tgz",
+      "integrity": "sha512-cYrAnv2me7bPDcg9kIcGwjJiSB6Qyi08+jLDo9yuvoFQjzHiPTzML7RnkJB1+3P6KMsX/KbCD4QE3Tv/knEllw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.3.1",
@@ -14326,13 +14319,13 @@
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
     },
     "@vue/test-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.1.tgz",
-      "integrity": "sha512-VO8nragneNzUZUah6kOjiFmD/gwRjUauG9DROh6oaOeFwX1cZRUNHhdeogE8635cISigXFTtGLUQWx5KCb0xeg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
       "dev": true,
       "requires": {
-        "js-beautify": "1.14.9",
-        "vue-component-type-helpers": "1.8.4"
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
       }
     },
     "@vue/vue-loader-v15": {
@@ -21653,9 +21646,9 @@
       }
     },
     "vue-component-type-helpers": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.4.tgz",
-      "integrity": "sha512-6bnLkn8O0JJyiFSIF0EfCogzeqNXpnjJ0vW/SZzNHfe6sPx30lTtTXlE5TFs2qhJlAtDFybStVNpL73cPe3OMQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.0.tgz",
+      "integrity": "sha512-cYrAnv2me7bPDcg9kIcGwjJiSB6Qyi08+jLDo9yuvoFQjzHiPTzML7RnkJB1+3P6KMsX/KbCD4QE3Tv/knEllw==",
       "dev": true
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@vue/cli-service": "^5.0.8",
     "@vue/compiler-sfc": "~3",
     "@vue/eslint-config-airbnb": "^7.0.0",
-    "@vue/test-utils": "^2.4.1",
+    "@vue/test-utils": "^2.4.6",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "comment-json": "~4",

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -911,7 +911,7 @@ becomes more complicated.
 // markRowsChanged(), markRowsDeleted()
 
 [data-mark-rows-changed="true"] { background-color: $color-highlight; }
-[data-mark-rows-changed="false"] { transition: background-color 0.6s 6s; }
+[data-mark-rows-changed="false"] { transition: background-color 0.6s; }
 
 [data-mark-rows-deleted="true"] {
   opacity: 0;

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -26,7 +26,7 @@ except according to the terms contained in the LICENSE file.
       :aria-disabled="deleted"
       v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"/>
     </div>
-    <entity-table v-show="showsTable" ref="table"
+    <entity-table v-show="odataEntities.dataExists" ref="table"
       :properties="dataset.properties"
       :deleted="deleted" :awaiting-deleted-responses="awaitingResponses"
       @update="showUpdate"
@@ -168,9 +168,6 @@ export default {
       return this.conflict.length === 2
         ? null
         : (this.conflict[0] ? '__system/conflict ne null' : '__system/conflict eq null');
-    },
-    showsTable() {
-      return this.odataEntities.dataExists;
     },
     emptyTableMessage() {
       if (!this.odataEntities.dataExists) return '';
@@ -473,6 +470,10 @@ export default {
 #entity-list table:has(tbody:empty) {
     display: none;
   }
+
+#entity-table:has(tbody tr) + .empty-table-message {
+  display: none;
+}
 </style>
 
 <i18n lang="json5">

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -31,15 +31,23 @@ except according to the terms contained in the LICENSE file.
       :deleted="deleted" :awaiting-deleted-responses="awaitingResponses"
       @update="showUpdate"
       @resolve="showResolve" @delete="showDelete" @restore="showRestore"/>
-    <p v-show="showsEmptyMessage" class="empty-table-message">
-      {{ odataFilter == null ? $t('noEntities') : $t('noMatching') }}
+
+    <p v-show="emptyTableMessage" class="empty-table-message">
+      {{ emptyTableMessage }}
     </p>
     <odata-loading-message type="entity"
-      :top="top(odataEntities.dataExists ? odataEntities.value.length : 0)"
+      :top="pagination.size"
       :odata="odataEntities"
       :filter="odataFilter != null"
       :refreshing="refreshing"
       :total-count="dataset.dataExists ? dataset.entities : 0"/>
+
+    <!-- @update:page is emitted on size change as well -->
+    <pagination v-if="pagination.count > 0"
+            v-model:page="pagination.page" v-model:size="pagination.size"
+            :count="pagination.count" :size-options="pageSizeOptions"
+            :spinner="odataEntities.awaitingResponse"
+            @update:page="handlePageChange()"/>
 
     <entity-update v-bind="update" @hide="hideUpdate" @success="afterUpdate"/>
     <entity-resolve v-bind="resolve" @hide="hideResolve" @success="afterResolve"/>
@@ -53,7 +61,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
-import { watchEffect, reactive } from 'vue';
+import { reactive } from 'vue';
 
 import EntityDelete from './delete.vue';
 import EntityRestore from './restore.vue';
@@ -64,6 +72,7 @@ import EntityUpdate from './update.vue';
 import EntityResolve from './resolve.vue';
 import OdataLoadingMessage from '../odata-loading-message.vue';
 import Spinner from '../spinner.vue';
+import Pagination from '../pagination.vue';
 
 import useQueryRef from '../../composables/query-ref';
 import useRequest from '../../composables/request';
@@ -80,11 +89,12 @@ export default {
     EntityRestore,
     EntityDownloadButton,
     EntityFilters,
+    EntityResolve,
     EntityTable,
     EntityUpdate,
     OdataLoadingMessage,
+    Pagination,
     Spinner,
-    EntityResolve
   },
   inject: ['alert'],
   provide() {
@@ -102,11 +112,6 @@ export default {
     deleted: {
       type: Boolean,
       required: false
-    },
-    // Returns the value of the $top query parameter.
-    top: {
-      type: Function,
-      default: (loaded) => (loaded < 1000 ? 250 : 1000)
     }
   },
   emits: ['fetch-deleted-count'],
@@ -114,13 +119,6 @@ export default {
     // The dataset request object is how we get access to the
     // dataset properties for the columns.
     const { dataset, deletedEntityCount, odataEntities } = useRequestData();
-    // We do not reconcile `odataEntities` with either dataset.lastEntity or
-    // project.lastEntity.
-    watchEffect(() => {
-      if (dataset.dataExists && odataEntities.dataExists &&
-        !odataEntities.filtered)
-        dataset.entities = odataEntities.count;
-    });
 
     // Array of conflict statuses, where a conflict status is represented as a
     // boolean
@@ -135,7 +133,9 @@ export default {
 
     const { request } = useRequest();
 
-    return { dataset, odataEntities, conflict, request, deletedEntityCount };
+    const pageSizeOptions = [250, 500, 1000];
+
+    return { dataset, odataEntities, conflict, request, deletedEntityCount, pageSizeOptions };
   },
   data() {
     return {
@@ -157,44 +157,58 @@ export default {
       confirmRestore: true,
       restoreModal: modalData(),
 
-      awaitingResponses: new Set()
+      awaitingResponses: new Set(),
+
+      pagination: { page: 0, size: this.pageSizeOptions[0], count: 0 },
+      now: new Date().toISOString()
     };
   },
   computed: {
     odataFilter() {
-      if (this.deleted) return '__system/deletedAt ne null';
-
       return this.conflict.length === 2
         ? null
         : (this.conflict[0] ? '__system/conflict ne null' : '__system/conflict eq null');
     },
     showsTable() {
-      if (!this.odataEntities.dataExists) return false;
-      const { length } = this.odataEntities.value;
-      return length !== 0 && length !== this.odataEntities.removedCount;
+      return this.odataEntities.dataExists;
     },
-    showsEmptyMessage() {
-      // If there are more entities to fetch, then we don't show the message
-      // even if all entities on the page are deleted. That case is pretty
-      // unlikely though, because the user would have had to delete 250+
-      // entities.
-      return this.odataEntities.dataExists && !this.showsTable &&
-        this.odataEntities.nextLink == null;
+    emptyTableMessage() {
+      if (!this.odataEntities.dataExists) return '';
+      if (this.odataEntities.value.length > 0) return '';
+
+      if (this.odataEntities.removedEntities.size === this.odataEntities.count && this.odataEntities.count > 0) {
+        return this.deleted ? this.$t('deletedEntity.allRestored') : this.$t('allDeleted');
+      }
+      if (this.odataEntities.removedEntities.size > 0 && this.odataEntities.value.length === 0) {
+        return this.deleted ? this.$t('deletedEntity.allRestoredOnPage') : this.$t('allDeletedOnPage');
+      }
+      return this.deleted ? this.$t('deletedEntity.emptyTable')
+        : (this.odataFilter ? this.$t('noMatching') : this.$t('noEntities'));
     }
   },
   watch: {
     odataFilter() {
       this.fetchChunk(true);
+    },
+    deleted() {
+      this.fetchChunk(true);
+    },
+    'odataEntities.count': {
+      handler() {
+        if (this.dataset.dataExists && this.odataEntities.dataExists && !this.odataFilter && !this.deleted)
+          this.dataset.entities = this.odataEntities.count;
+      }
+    },
+    'odataEntities.removedEntities.size': {
+      handler(size) {
+        if (this.dataset.dataExists && this.odataEntities.dataExists && !this.odataFilter && !this.deleted) {
+          this.dataset.entities = this.odataEntities.count - size;
+        }
+      }
     }
   },
   created() {
     this.fetchChunk(true);
-  },
-  mounted() {
-    document.addEventListener('scroll', this.afterScroll);
-  },
-  beforeUnmount() {
-    document.removeEventListener('scroll', this.afterScroll);
   },
   methods: {
     // `clear` indicates whether this.odataEntities should be cleared before
@@ -204,35 +218,53 @@ export default {
       this.refreshing = refresh;
       // Are we fetching the first chunk of entities or the next chunk?
       const first = clear || refresh;
+
+      if (first) {
+        this.now = new Date().toISOString();
+        this.pagination.page = 0;
+      }
+
+      // Add snapshot filters
+      let $filter = this.odataFilter ? `${this.odataFilter} and ` : '';
+      if (this.deleted) {
+        $filter += `__system/deletedAt le ${this.now}`;
+      } else {
+        $filter += `__system/createdAt le ${this.now} and `;
+        $filter += `(__system/deletedAt eq null or __system/deletedAt gt ${this.now})`;
+      }
+
       this.odataEntities.request({
         url: apiPaths.odataEntities(
           this.projectId,
           this.datasetName,
           {
-            $top: this.top(first ? 0 : this.odataEntities.value.length),
+            $top: this.pagination.size,
+            $skip: this.pagination.page * this.pagination.size,
             $count: true,
-            $filter: this.odataFilter,
-            $skiptoken: !first ? new URL(this.odataEntities.nextLink).searchParams.get('$skiptoken') : null
+            $filter,
+            $orderby: '__system/createdAt desc'
           }
         ),
         clear,
         patch: !first
-          ? (response) => this.odataEntities.addChunk(response.data)
+          ? (response) => this.odataEntities.replaceData(response.data, response.config)
           : null
       })
         .then(() => {
+          this.pagination.count = this.odataEntities.count;
+
           if (this.deleted) {
             this.deletedEntityCount.cancelRequest();
             if (!this.deletedEntityCount.dataExists) {
               this.deletedEntityCount.data = reactive({});
             }
-            this.deletedEntityCount.value = this.odataEntities.originalCount;
+            this.deletedEntityCount.value = this.odataEntities.count;
           }
         })
         .finally(() => { this.refreshing = false; })
         .catch(noop);
 
-      // emit event to parent component to re-fetch deleted Submissions count
+      // emit event to parent component to re-fetch deleted Entity count
       if (refresh && !this.deleted) {
         this.$emit('fetch-deleted-count');
       }
@@ -338,6 +370,8 @@ export default {
           this.alert.success(this.$t('alert.entityDeleted', { label }));
           if (confirm != null) this.confirmDelete = confirm;
 
+          this.odataEntities.removedEntities.add(uuid);
+
           /* Before doing a couple more things, we first determine whether
           this.odataEntities.value still includes the entity and if so, what the
           current index of the entity is. If a request to refresh
@@ -351,8 +385,8 @@ export default {
             ? this.odataEntities.value.findIndex(entity => entity.__id === uuid)
             : -1;
           if (index !== -1) {
-            this.odataEntities.countRemoved();
             this.$refs.table.afterDelete(index);
+            this.odataEntities.value.splice(index, 1);
           }
         })
         .catch(noop)
@@ -385,13 +419,15 @@ export default {
           this.alert.success(this.$t('alert.entityRestored', { label }));
           if (confirm != null) this.confirmRestore = confirm;
 
+          this.odataEntities.removedEntities.add(uuid);
+
           // See the comments in requestDelete().
           const index = this.odataEntities.dataExists
             ? this.odataEntities.value.findIndex(entity => entity.__id === uuid)
             : -1;
           if (index !== -1) {
-            this.odataEntities.countRemoved();
             this.$refs.table.afterDelete(index);
+            this.odataEntities.value.splice(index, 1);
           }
         })
         .catch(noop)
@@ -399,16 +435,11 @@ export default {
           this.awaitingResponses.delete(uuid);
         });
     },
-    scrolledToBottom() {
-      // Using pageYOffset rather than scrollY in order to support IE.
-      return window.pageYOffset + window.innerHeight >=
-        document.body.offsetHeight - 5;
-    },
-    afterScroll() {
-      if (this.dataset.dataExists && this.odataEntities.dataExists &&
-        this.odataEntities.nextLink &&
-        !this.odataEntities.awaitingResponse && this.scrolledToBottom())
-        this.fetchChunk(false);
+    handlePageChange() {
+      // This function is called for size change as well. So when the total number of entities are
+      // less than the lowest size option, hence we don't need to make a request.
+      if (this.odataEntities.count < this.pageSizeOptions[0]) return;
+      this.fetchChunk(false);
     }
   }
 };
@@ -438,6 +469,10 @@ export default {
   margin-bottom: 10px;
   margin-left: auto;
 }
+
+#entity-list table:has(tbody:empty) {
+    display: none;
+  }
 </style>
 
 <i18n lang="json5">
@@ -446,11 +481,18 @@ export default {
     // This text is shown when there are no Entities to show in a table.
     "noEntities": "There are no Entities to show.",
     "noMatching": "There are no matching Entities.",
+    "allDeleted": "All Entities are deleted.",
+    "allDeletedOnPage": "All Entities on the page have been deleted.",
     "alert": {
       "delete": "Entity “{label}” has been deleted."
     },
     "filterDisabledMessage": "Filtering is unavailable for deleted Entities",
     "downloadDisabled": "Download is unavailable for deleted Entities",
+    "deletedEntity": {
+      "emptyTable": "There are no deleted Entities.",
+      "allRestored": "All deleted Entities are undeleted.",
+      "allRestoredOnPage": "All Entities on the page have been undeleted."
+    }
   }
 }
 </i18n>

--- a/src/components/entity/table.vue
+++ b/src/components/entity/table.vue
@@ -30,9 +30,9 @@ except according to the terms contained in the LICENSE file.
       <th>{{ $t('entity.entityId') }}</th>
     </template>
 
-    <template #data-frozen="{ data, index }">
+    <template #data-frozen="{ data }">
       <entity-metadata-row :entity="data"
-        :row-number="odataEntities.originalCount - index"
+        :row-number="data.__system.rowNumber"
         :verbs="project.verbs" :deleted="deleted"
         :awaiting-response="awaitingDeletedResponses.has(data.__id)"/>
     </template>

--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -78,19 +78,7 @@ const message = computed(() => {
       top: props.top
     });
   }
-
-  const pathPrefix = props.filter
-    ? `${props.type}.filtered`
-    : `${props.type}`;
-  const remaining = props.odata.originalCount - props.odata.value.length;
-  if (remaining > props.top) {
-    return tn(`${pathPrefix}.middle`, remaining, {
-      top: props.top
-    });
-  }
-  return remaining > 1
-    ? tn(`${pathPrefix}.last.multiple`, remaining)
-    : t(`${pathPrefix}.last.one`);
+  return null;
 });
 
 </script>

--- a/src/components/pagination.vue
+++ b/src/components/pagination.vue
@@ -54,8 +54,8 @@ except according to the terms contained in the LICENSE file.
         </select>
         <span>{{ $t('field.size') }}</span>
       </label>
+      <spinner :state="spinner" inline/>
     </form>
-    <spinner :state="spinner" inline/>
   </div>
 </template>
 
@@ -169,6 +169,7 @@ const sizeModel = computed({
 
   .form-inline {
     @include form-control-background;
+    width: 100%;
     align-items: center;
     display: flex;
     border-radius: 5px;

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -564,6 +564,10 @@ export default {
 #submission-list table:has(tbody:empty) {
   display: none;
 }
+
+#submission-table:has(tbody tr) + .empty-table-message {
+  display: none;
+}
 </style>
 
 <i18n lang="json5">

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -43,28 +43,29 @@ except according to the terms contained in the LICENSE file.
           :aria-disabled="deleted" v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"
           :filtered="odataFilter != null && !deleted" @download="downloadModal.show()"/>
       </div>
-      <submission-table v-show="odata.dataExists && odata.value.length !== 0 && odata.removedCount < odata.value.length"
+      <submission-table v-show="odata.dataExists"
         ref="table" :project-id="projectId" :xml-form-id="xmlFormId"
         :draft="draft" :fields="selectedFields"
         :deleted="deleted" :awaiting-deleted-responses="awaitingResponses"
         @review="reviewModal.show({ submission: $event })"
         @delete="showDelete"
         @restore="showRestore"/>
-      <p v-show="odata.dataExists && (odata.value.length === 0 || odata.removedCount === odata.value.length)"
-        class="empty-table-message">
-        <template v-if="deleted">
-          {{ $t('deletedSubmission.emptyTable') }}
-        </template>
-        <template v-else>
-          {{ odataFilter == null ? $t('submission.emptyTable') : $t('noMatching') }}
-        </template>
+      <p v-show="emptyTableMessage" class="empty-table-message">
+        {{ emptyTableMessage }}
       </p>
       <odata-loading-message type="submission"
-        :top="top(odata.dataExists ? odata.value.length : 0)"
+        :top="pagination.size"
         :odata="odata"
         :filter="!!odataFilter"
         :refreshing="refreshing"
         :total-count="formVersion.dataExists ? formVersion.submissions : 0"/>
+
+        <!-- @update:page is emitted on size change as well -->
+        <pagination v-if="pagination.count > 0"
+              v-model:page="pagination.page" v-model:size="pagination.size"
+              :count="pagination.count" :size-options="pageSizeOptions"
+              :spinner="odata.awaitingResponse"
+              @update:page="handlePageChange()"/>
     </div>
 
     <submission-download v-bind="downloadModal" :form-version="formVersion"
@@ -83,7 +84,7 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 import { DateTime } from 'luxon';
-import { shallowRef, watch, watchEffect, reactive } from 'vue';
+import { shallowRef, watch, reactive } from 'vue';
 
 import EnketoFill from '../enketo/fill.vue';
 import Loading from '../loading.vue';
@@ -97,6 +98,7 @@ import SubmissionTable from './table.vue';
 import SubmissionUpdateReviewState from './update-review-state.vue';
 import SubmissionDelete from './delete.vue';
 import SubmissionRestore from './restore.vue';
+import Pagination from '../pagination.vue';
 
 import useFields from '../../request-data/fields';
 import useQueryRef from '../../composables/query-ref';
@@ -114,6 +116,8 @@ export default {
   components: {
     EnketoFill,
     Loading,
+    OdataLoadingMessage,
+    Pagination,
     Spinner,
     SubmissionDelete,
     SubmissionDownload,
@@ -123,7 +127,6 @@ export default {
     SubmissionRestore,
     SubmissionTable,
     SubmissionUpdateReviewState,
-    OdataLoadingMessage
   },
   inject: ['alert'],
   props: {
@@ -139,11 +142,6 @@ export default {
     deleted: {
       type: Boolean,
       required: false
-    },
-    // Returns the value of the $top query parameter.
-    top: {
-      type: Function,
-      default: (loaded) => (loaded < 1000 ? 250 : 1000)
     }
   },
   emits: ['fetch-keys', 'fetch-deleted-count', 'toggle-qr'],
@@ -153,13 +151,6 @@ export default {
       ? resourceView('formDraft', (data) => data.get())
       : form;
     const fields = useFields();
-
-    // We do not reconcile `odata` with either form.lastSubmission or
-    // project.lastSubmission.
-    watchEffect(() => {
-      if (formVersion.dataExists && odata.dataExists && !odata.filtered)
-        formVersion.submissions = odata.count;
-    });
 
     const submitterIds = useQueryRef({
       fromQuery: (query) => {
@@ -207,10 +198,12 @@ export default {
     });
     const { request } = useRequest();
 
+    const pageSizeOptions = [250, 500, 1000];
+
     return {
       form, keys, fields, formVersion, odata, submitters, deletedSubmissionCount,
       submitterIds, submissionDateRange, reviewStates, allReviewStates,
-      request
+      request, pageSizeOptions
     };
   },
   data() {
@@ -233,7 +226,10 @@ export default {
       // state that indicates whether we need to show restore confirmation dialog
       confirmRestore: true,
 
-      awaitingResponses: new Set()
+      awaitingResponses: new Set(),
+
+      pagination: { page: 0, size: this.pageSizeOptions[0], count: 0 },
+      now: new Date().toISOString(),
     };
   },
   computed: {
@@ -246,7 +242,6 @@ export default {
     },
     odataFilter() {
       if (this.draft) return null;
-      if (this.deleted) return '__system/deletedAt ne null';
 
       const conditions = [];
       if (this.filtersOnSubmitterId) {
@@ -275,6 +270,19 @@ export default {
       paths.unshift('__id', '__system');
       return paths.join(',');
     },
+    emptyTableMessage() {
+      if (!this.odata.dataExists) return '';
+      if (this.odata.value.length > 0) return '';
+
+      if (this.odata.removedSubmissions.size === this.odata.count && this.odata.count > 0) {
+        return this.deleted ? this.$t('deletedSubmission.allRestored') : this.$t('allDeleted');
+      }
+      if (this.odata.removedSubmissions.size > 0 && this.odata.value.length === 0) {
+        return this.deleted ? this.$t('deletedSubmission.allRestoredOnPage') : this.$t('allDeletedOnPage');
+      }
+      return this.deleted ? this.$t('deletedSubmission.emptyTable')
+        : (this.odataFilter ? this.$t('noMatching') : this.$t('submission.emptyTable'));
+    }
   },
   watch: {
     odataFilter() {
@@ -282,16 +290,26 @@ export default {
     },
     selectedFields(_, oldFields) {
       if (oldFields != null) this.fetchChunk(true);
+    },
+    deleted() {
+      this.fetchChunk(true);
+    },
+    'odata.count': {
+      handler() {
+        if (this.formVersion.dataExists && this.odata.dataExists && !this.odataFilter)
+          this.formVersion.submissions = this.odata.count;
+      }
+    },
+    'odata.removedSubmissions.size': {
+      handler(size) {
+        if (this.formVersion.dataExists && this.odata.dataExists) {
+          this.formVersion.submissions += this.deleted ? size : -size;
+        }
+      }
     }
   },
   created() {
     this.fetchData();
-  },
-  mounted() {
-    document.addEventListener('scroll', this.afterScroll);
-  },
-  beforeUnmount() {
-    document.removeEventListener('scroll', this.afterScroll);
   },
   methods: {
     // `clear` indicates whether this.odata should be cleared before sending the
@@ -300,32 +318,51 @@ export default {
       this.refreshing = refresh;
       // Are we fetching the first chunk of submissions or the next chunk?
       const first = clear || refresh;
+
+      if (first) {
+        this.now = new Date().toISOString();
+        this.pagination.page = 0;
+      }
+
+      // Add snapshot filters
+      let $filter = this.odataFilter ? `${this.odataFilter} and ` : '';
+      if (this.deleted) {
+        // This is not foolproof. Missing clause: __system/deletedAt became null after `now`.
+        // We don't keep restore date, that would have helped here.
+        $filter += `__system/deletedAt le ${this.now}`;
+      } else {
+        $filter += `__system/submissionDate le ${this.now} and `;
+        $filter += `(__system/deletedAt eq null or __system/deletedAt gt ${this.now})`;
+      }
       this.odata.request({
         url: apiPaths.odataSubmissions(
           this.projectId,
           this.xmlFormId,
           this.draft,
           {
-            $top: this.top(first ? 0 : this.odata.value.length),
+            $top: this.pagination.size,
+            $skip: this.pagination.page * this.pagination.size,
             $count: true,
             $wkt: true,
-            $filter: this.odataFilter,
+            $filter,
             $select: this.odataSelect,
-            $skiptoken: !first ? new URL(this.odata.nextLink).searchParams.get('$skiptoken') : null
+            $orderby: '__system/submissionDate desc'
           }
         ),
         clear,
         patch: !first
-          ? (response) => this.odata.addChunk(response.data)
+          ? (response) => this.odata.replaceData(response.data, response.config)
           : null
       })
         .then(() => {
+          this.pagination.count = this.odata.count;
+
           if (this.deleted) {
             this.deletedSubmissionCount.cancelRequest();
             if (!this.deletedSubmissionCount.dataExists) {
               this.deletedSubmissionCount.data = reactive({});
             }
-            this.deletedSubmissionCount.value = this.odata.originalCount;
+            this.deletedSubmissionCount.value = this.odata.count;
           }
         })
         .finally(() => { this.refreshing = false; })
@@ -359,19 +396,6 @@ export default {
           url: apiPaths.submitters(this.projectId, this.xmlFormId, this.draft)
         }).catch(noop);
       }
-    },
-    scrolledToBottom() {
-      // Using pageYOffset rather than scrollY in order to support IE.
-      return window.pageYOffset + window.innerHeight >=
-        document.body.offsetHeight - 5;
-    },
-    // This method may need to change once we support submission deletion.
-    afterScroll() {
-      if (this.formVersion.dataExists && this.keys.dataExists &&
-        this.fields.dataExists && this.odata.dataExists &&
-        this.odata.nextLink &&
-        !this.odata.awaitingResponse && this.scrolledToBottom())
-        this.fetchChunk(false);
     },
     // This method accounts for the unlikely case that the user clicked the
     // refresh button before reviewing the submission. In that case, the
@@ -416,6 +440,7 @@ export default {
           this.alert.success(this.$t('alert.submissionDeleted'));
           if (confirm != null) this.confirmDelete = confirm;
 
+          this.odata.removedSubmissions.add(instanceId);
           /* Before doing a couple more things, we first determine whether
           this.odata.value still includes the Submission and if so, what the
           current index of the Submission is. If a request to refresh
@@ -429,8 +454,8 @@ export default {
             ? this.odata.value.findIndex(submission => submission.__id === instanceId)
             : -1;
           if (index !== -1) {
-            this.odata.countRemoved();
             this.$refs.table.afterDelete(index);
+            this.odata.value.splice(index, 1);
           }
         })
         .catch(noop)
@@ -456,19 +481,27 @@ export default {
           this.alert.success(this.$t('alert.submissionRestored'));
           if (confirm != null) this.confirmRestore = confirm;
 
+          this.odata.removedSubmissions.add(instanceId);
+
           // See the comments in requestDelete().
           const index = this.odata.dataExists
             ? this.odata.value.findIndex(submission => submission.__id === instanceId)
             : -1;
           if (index !== -1) {
-            this.odata.countRemoved();
             this.$refs.table.afterDelete(index);
+            this.odata.value.splice(index, 1);
           }
         })
         .catch(noop)
         .finally(() => {
           this.awaitingResponses.delete(instanceId);
         });
+    },
+    handlePageChange() {
+      // This function is called for size change as well. So the total number of submissions are
+      // less than the lowest size option, hence we don't need to make a request.
+      if (this.odata.count < this.pageSizeOptions[0]) return;
+      this.fetchChunk(false);
     }
   }
 };
@@ -527,6 +560,10 @@ export default {
 
   ~ #submission-download-button { margin-left: 0; }
 }
+
+#submission-list table:has(tbody:empty) {
+  display: none;
+}
 </style>
 
 <i18n lang="json5">
@@ -537,10 +574,14 @@ export default {
       "testInBrowser": "Test in browser"
     },
     "noMatching": "There are no matching Submissions.",
+    "allDeleted": "All Submissions are deleted.",
+    "allDeletedOnPage": "All Submissions on the page have been deleted.",
     "downloadDisabled": "Download is unavailable for deleted Submissions",
     "filterDisabledMessage": "Filtering is unavailable for deleted Submissions",
     "deletedSubmission": {
-      "emptyTable": "There are no deleted Submissions."
+      "emptyTable": "There are no deleted Submissions.",
+      "allRestored": "All deleted Submissions are undeleted.",
+      "allRestoredOnPage": "All Submissions on the page have been undeleted."
     }
   }
 }

--- a/src/components/submission/table.vue
+++ b/src/components/submission/table.vue
@@ -29,10 +29,10 @@ except according to the terms contained in the LICENSE file.
       <th>{{ $t('header.instanceId') }}</th>
     </template>
 
-    <template #data-frozen="{ data, index }">
+    <template #data-frozen="{ data }">
       <submission-metadata-row :project-id="projectId" :xml-form-id="xmlFormId"
         :draft="draft" :submission="data" :deleted="deleted" :awaiting-response="awaitingDeletedResponses.has(data.__id)"
-        :row-number="odata.originalCount - index" :verbs="project.verbs"/>
+        :row-number="data.__system.rowNumber" :verbs="project.verbs"/>
     </template>
     <template #data-scrolling="{ data }">
       <submission-data-row :project-id="projectId" :xml-form-id="xmlFormId"

--- a/src/components/table-freeze.vue
+++ b/src/components/table-freeze.vue
@@ -22,9 +22,11 @@ except according to the terms contained in the LICENSE file.
         :class="`actions-trigger-${actionsTrigger}`"
         @mousemove="setActionsTrigger('hover')"
         @focusin="setActionsTrigger('focus')" @click="actionClick">
-        <slot v-for="(element, index) in data" :key="element[keyProp]"
-          name="data-frozen" :data="element" :index="index">
-        </slot>
+        <transition-group name="table-freeze-row">
+          <slot v-for="(element, index) in data" :key="element[keyProp]"
+            name="data-frozen" :data="element" :index="index">
+          </slot>
+        </transition-group>
       </tbody>
     </table>
     <div v-if="!frozenOnly" class="table-freeze-scrolling-container">
@@ -38,9 +40,11 @@ except according to the terms contained in the LICENSE file.
         <tbody v-if="data != null" ref="scrollingBody"
           @mousemove="setActionsTrigger('hover')" @mouseover="toggleHoverClass"
           @mouseleave="removeHoverClass">
-          <slot v-for="(element, index) in data" :key="element[keyProp]"
-            name="data-scrolling" :data="element" :index="index">
-          </slot>
+          <transition-group name="table-freeze-row">
+            <slot v-for="(element, index) in data" :key="element[keyProp]"
+              name="data-scrolling" :data="element" :index="index">
+            </slot>
+          </transition-group>
         </tbody>
       </table>
     </div>
@@ -111,6 +115,8 @@ following cases in mind:
 */
 watch(() => props.data, removeHoverClass);
 
+
+
 const actionClick = (event) => {
   const action = event.target.closest('.btn-group .btn');
   if (action != null) {
@@ -123,6 +129,7 @@ const scrollingBody = ref(null);
 const getRowPair = (index) =>
   [frozenBody.value.rows[index], scrollingBody.value.rows[index]];
 defineExpose({ getRowPair });
+
 </script>
 
 <style lang="scss">
@@ -196,4 +203,5 @@ defineExpose({ getRowPair });
     }
   }
 }
+
 </style>

--- a/src/components/table-freeze.vue
+++ b/src/components/table-freeze.vue
@@ -115,8 +115,6 @@ following cases in mind:
 */
 watch(() => props.data, removeHoverClass);
 
-
-
 const actionClick = (event) => {
   const action = event.target.closest('.btn-group .btn');
   if (action != null) {

--- a/src/request-data/entities.js
+++ b/src/request-data/entities.js
@@ -13,36 +13,34 @@ import { shallowReactive, reactive } from 'vue';
 
 import { useRequestData } from './index';
 
+const transformValue = (data, config) => {
+  const { searchParams } = new URL(config.url, window.location.origin);
+
+  const skip = searchParams.get('$skip') ?? 0;
+  const count = data['@odata.count'];
+  return data.value.map((entity, index) => ({
+    ...entity,
+    __system: {
+      ...entity.__system,
+      rowNumber: count - skip - index
+    }
+  }));
+};
+
 export default () => {
   const { createResource } = useRequestData();
   const entityOData = createResource('odataEntities', () => ({
     transformResponse: ({ data, config }) => shallowReactive({
-      value: shallowReactive(data.value),
-      originalCount: data['@odata.count'],
+      value: reactive(transformValue(data, config)),
       count: data['@odata.count'],
-      removedCount: 0,
-      filtered: new URL(config.url, window.location.origin).searchParams.has('$filter'),
-      nextLink: data['@odata.nextLink']
+      removedEntities: reactive(new Set())
     }),
-    addChunk: (chunk) => {
-      for (const e of chunk.value) {
-        entityOData.value.push(e);
-      }
-      entityOData.count = chunk['@odata.count'];
-      entityOData.nextLink = chunk['@odata.nextLink'];
-    },
-    // countRemoved() updates the counts after an entity is deleted. We do not
-    // modify entityOData.value when an entity is deleted: doing so is possible,
-    // but it would cause EntityTable to re-render and overall doesn't seem
-    // simpler.
-    countRemoved: () => {
-      // This change to entityOData.count will be overwritten if/when the next
-      // chunk is received with the latest count. However, the change to
-      // entityOData.removedCount will persist as long as entityOData is not
-      // cleared (e.g., when the refresh button is clicked or a filter is
-      // changed).
-      entityOData.count -= 1;
-      entityOData.removedCount += 1;
+    replaceData(data, config) {
+      entityOData.count = data['@odata.count'];
+      entityOData.value = reactive(transformValue({
+        ...data,
+        value: data.value.filter(e => !entityOData.removedEntities.has(e.__id))
+      }, config));
     }
   }));
   const deletedEntityCount = createResource('deletedEntityCount', () => ({

--- a/src/request-data/submissions.js
+++ b/src/request-data/submissions.js
@@ -14,44 +14,34 @@ import { reactive, shallowReactive } from 'vue';
 import { computeIfExists } from './util';
 import { useRequestData } from './index';
 
+const transformValue = (data, config) => {
+  const { searchParams } = new URL(config.url, window.location.origin);
+
+  const skip = searchParams.get('$skip') ?? 0;
+  const count = data['@odata.count'];
+  return data.value.map((submission, index) => ({
+    ...submission,
+    __system: reactive({
+      ...submission.__system,
+      rowNumber: count - skip - index
+    })
+  }));
+};
+
 export default () => {
   const { createResource } = useRequestData();
   const odata = createResource('odata', () => ({
-    transformResponse: ({ data, config }) => {
-      for (const submission of data.value) {
-        submission.__system = reactive(submission.__system);
-      }
-      const { searchParams } = new URL(config.url, window.location.origin);
-      return shallowReactive({
-        value: shallowReactive(data.value),
-        count: data['@odata.count'],
-        // The count of submissions at the time of the initial fetch or last
-        // refresh
-        originalCount: data['@odata.count'],
-        // The count of submissions that are removed from the UI table but they
-        // are still there in `value`
-        removedCount: 0,
-        filtered: searchParams.has('$filter'),
-        nextLink: data['@odata.nextLink']
-      });
-    },
-    addChunk(chunk) {
-      for (const submission of chunk.value) {
-        odata.value.push(submission);
-      }
-
-      odata.count = chunk['@odata.count'];
-      odata.skip += chunk.value.length;
-      odata.nextLink = chunk['@odata.nextLink'];
-    },
-    countRemoved: () => {
-      // This change to odata.count will be overwritten if/when the next
-      // chunk is received with the latest count. However, the change to
-      // odata.removedCount will persist as long as odata is not
-      // cleared (e.g., when the refresh button is clicked or a filter is
-      // changed).
-      odata.count -= 1;
-      odata.removedCount += 1;
+    transformResponse: ({ data, config }) => shallowReactive({
+      value: shallowReactive(transformValue(data, config)),
+      count: data['@odata.count'],
+      removedSubmissions: reactive(new Set())
+    }),
+    replaceData(data, config) {
+      odata.count = data['@odata.count'];
+      odata.value = shallowReactive(transformValue({
+        ...data,
+        value: data.value.filter(s => !odata.removedSubmissions.has(s.__id))
+      }, config));
     }
   }));
   const submitters = createResource('submitters', () => ({

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -69,7 +69,7 @@ export const markRowsChanged = (trs) => {
   // transition: see app.scss. The CSS specifies the duration of the transition.
   setTimeout(() => {
     for (const tr of trs) tr.dataset.markRowsChanged = 'false';
-  });
+  }, 6000);
 };
 export const markRowChanged = (tr) => { markRowsChanged([tr]); };
 

--- a/test/components/entity/filters.spec.js
+++ b/test/components/entity/filters.spec.js
@@ -16,11 +16,12 @@ describe('EntityFilters', () => {
     });
 
     describe('initial request', () => {
-      it('does not filter by default', () =>
+      it('does not filter by conflict by default', () =>
         load('/projects/1/entity-lists/trees/entities', { root: false })
           .beforeEachResponse((_, { url }, index) => {
             if (index !== 1) return;
-            relativeUrl(url).searchParams.has('$filter').should.be.false;
+            const filter = relativeUrl(url).searchParams.get('$filter');
+            filter.should.not.match(/__system\/conflict ne null/);
           }));
 
       it('sends the correct request for ?conflict=true', () =>
@@ -28,7 +29,7 @@ describe('EntityFilters', () => {
           .beforeEachResponse((_, { url }, index) => {
             if (index !== 1) return;
             const filter = relativeUrl(url).searchParams.get('$filter');
-            filter.should.equal('__system/conflict ne null');
+            filter.should.match(/__system\/conflict ne null/);
           }));
 
       it('sends the correct request for ?conflict=false', () =>
@@ -36,7 +37,7 @@ describe('EntityFilters', () => {
           .beforeEachResponse((_, { url }, index) => {
             if (index !== 1) return;
             const filter = relativeUrl(url).searchParams.get('$filter');
-            filter.should.equal('__system/conflict eq null');
+            filter.should.match(/__system\/conflict eq null/);
           }));
     });
 
@@ -78,7 +79,7 @@ describe('EntityFilters', () => {
           load(`/projects/1/entity-lists/trees/entities?${query}`, { root: false })
             .beforeEachResponse((_, { url }, index) => {
               if (index !== 1) return;
-              relativeUrl(url).searchParams.has('$filter').should.be.false;
+              relativeUrl(url).searchParams.get('$filter').should.not.match(/conflict/);
             }));
       }
     });
@@ -92,7 +93,7 @@ describe('EntityFilters', () => {
           .request(changeMultiselect('#entity-filters-conflict', [0]))
           .beforeEachResponse((_, { url }) => {
             const filter = relativeUrl(url).searchParams.get('$filter');
-            filter.should.equal('__system/conflict ne null');
+            filter.should.match(/__system\/conflict ne null/);
           })
           .respondWithData(testData.entityOData));
 
@@ -145,7 +146,7 @@ describe('EntityFilters', () => {
           .route('/projects/1/entity-lists/trees/entities?conflict=true')
           .beforeEachResponse((_, { url }) => {
             const filter = relativeUrl(url).searchParams.get('$filter');
-            filter.should.equal('__system/conflict ne null');
+            filter.should.match(/__system\/conflict ne null/);
           })
           .respondWithData(testData.entityOData));
 

--- a/test/components/entity/upload/data-template.spec.js
+++ b/test/components/entity/upload/data-template.spec.js
@@ -26,7 +26,7 @@ describe('EntityUploadDataTemplate', () => {
     content.should.equal('label,hauteur,circonférence');
   });
 
-  it.skip('has the correct filename', async () => {
+  it('has the correct filename', async () => {
     const clock = sinon.useFakeTimers(Date.parse('2024-12-31T01:23:45'));
     testData.extendedDatasets.createPast(1);
     const a = mountComponent().get('a');

--- a/test/components/odata-loading-message.spec.js
+++ b/test/components/odata-loading-message.spec.js
@@ -10,12 +10,12 @@ describe('OdataLoadingMessage', () => {
     ['Loading Submissions…',                                  { dataExists: false, awaitingResponse: true, top: 0, refreshing: false, filter: false, totalCount: 0 }],
     ['Loading 10 Submissions…',                               { dataExists: false, awaitingResponse: true, top: 250, refreshing: false, filter: false, totalCount: 10 }],
     ['Loading the first 10 of 100 Submissions…',              { dataExists: false, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 100 }],
-    ['Loading 10 more of 90 remaining Submissions…',          { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 100, originalCount: 100, dataLength: 10 }],
-    ['Loading the last 5 Submissions…',                       { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 15, originalCount: 15, dataLength: 10 }],
-    ['Loading the last Submission…',                          { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 11, originalCount: 11, dataLength: 10 }],
-    ['Loading 10 more of 90 remaining matching Submissions…', { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 100, originalCount: 100, dataLength: 10 }],
-    ['Loading the last 5 matching Submissions…',              { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 15, originalCount: 15, dataLength: 10 }],
-    ['Loading the last matching Submission…',                 { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 11, originalCount: 11, dataLength: 10 }],
+    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 100, originalCount: 100, dataLength: 10 }],
+    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 15, originalCount: 15, dataLength: 10 }],
+    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 11, originalCount: 11, dataLength: 10 }],
+    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 100, originalCount: 100, dataLength: 10 }],
+    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 15, originalCount: 15, dataLength: 10 }],
+    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 11, originalCount: 11, dataLength: 10 }],
 
     ['Loading Entities…',                                     { dataExists: false, awaitingResponse: true, type: 'entity', top: 0, refreshing: false, filter: false, totalCount: 0 }],
     ['Loading matching Entities…',                            { dataExists: false, awaitingResponse: true, type: 'entity', top: 0, refreshing: false, filter: true, totalCount: 0 }]

--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -1,8 +1,8 @@
+import sinon from 'sinon';
+import { nextTick } from 'vue';
 import EnketoFill from '../../../src/components/enketo/fill.vue';
-import Spinner from '../../../src/components/spinner.vue';
 import SubmissionDataRow from '../../../src/components/submission/data-row.vue';
 import SubmissionDownload from '../../../src/components/submission/download.vue';
-import SubmissionList from '../../../src/components/submission/list.vue';
 import SubmissionMetadataRow from '../../../src/components/submission/metadata-row.vue';
 import SubmissionDelete from '../../../src/components/submission/delete.vue';
 import SubmissionRestore from '../../../src/components/submission/restore.vue';
@@ -12,7 +12,6 @@ import { changeMultiselect } from '../../util/trigger';
 import { load } from '../../util/http';
 import { loadSubmissionList } from '../../util/submission';
 import { mockLogin } from '../../util/session';
-import { mockResponse } from '../../util/axios';
 import { relativeUrl } from '../../util/request';
 import { testRouter } from '../../util/router';
 
@@ -20,24 +19,6 @@ import { testRouter } from '../../util/router';
 const createSubmissions = (count, factoryOptions = {}) => {
   testData.extendedForms.createPast(1, { submissions: count });
   testData.extendedSubmissions.createPast(count, factoryOptions);
-};
-const _scroll = (component, scrolledToBottom) => {
-  const method = component.vm.scrolledToBottom;
-  if (method == null) {
-    _scroll(component.getComponent(SubmissionList), scrolledToBottom);
-    return;
-  }
-  // eslint-disable-next-line no-param-reassign
-  component.vm.scrolledToBottom = () => scrolledToBottom;
-  document.dispatchEvent(new Event('scroll'));
-  // eslint-disable-next-line no-param-reassign
-  component.vm.scrolledToBottom = method;
-};
-// eslint-disable-next-line consistent-return
-const scroll = (componentOrBoolean) => {
-  if (componentOrBoolean === true || componentOrBoolean === false)
-    return (component) => _scroll(component, componentOrBoolean);
-  _scroll(componentOrBoolean, true);
 };
 
 describe('SubmissionList', () => {
@@ -146,405 +127,83 @@ describe('SubmissionList', () => {
     });
   });
 
-  describe('load by chunk', () => {
-    const checkTop = ({ url }, top) => {
-      url.should.match(new RegExp(`[?&]%24top=${top}(&|$)`));
-    };
-    const checkIds = (component, count, offset = 0) => {
-      const rows = component.findAllComponents(SubmissionDataRow);
-      rows.length.should.equal(count);
-      const submissions = testData.extendedSubmissions.sorted();
-      submissions.length.should.be.at.least(count + offset);
-      for (let i = 0; i < rows.length; i += 1) {
-        const text = rows[i].get('td:last-child').text();
-        text.should.equal(submissions[i + offset].instanceId);
-      }
-    };
-    const checkMessage = (component, text) => {
-      const message = component.get('#odata-loading-message');
-      if (text == null) {
-        message.should.be.hidden();
-      } else {
-        message.should.not.be.hidden();
-        message.get('#odata-loading-message-text').text().should.equal(text);
-
-        const spinner = component.findAllComponents(Spinner).find(wrapper =>
-          message.element.contains(wrapper.element));
-        spinner.props().state.should.be.true;
-      }
-    };
-
-    it('loads a single submission', () => {
-      createSubmissions(1);
-      return loadSubmissionList()
-        .beforeEachResponse((component, { url }) => {
-          if (url.includes('.svc/Submissions'))
-            checkMessage(component, 'Loading 1 Submission…');
-        });
-    });
-
-    it('loads all submissions if there are few of them', () => {
-      createSubmissions(2);
-      return loadSubmissionList()
-        .beforeEachResponse((component, { url }) => {
-          if (url.includes('.svc/Submissions'))
-            checkMessage(component, 'Loading 2 Submissions…');
-        });
-    });
-
-    it('initially loads only the first chunk if there are many submissions', () => {
-      createSubmissions(3);
-      return loadSubmissionList({
-        props: { top: () => 2 }
+  describe('refreshing keys', () => {
+    it('opens modal with encrpytion password after refreshing keys', () => {
+      // create project with managed encryption, form, and 0 submissions to start
+      testData.extendedProjects.createPast(1, {
+        key: testData.standardKeys.createPast(1, { managed: true }).last()
+      });
+      testData.extendedForms.createPast(1);
+      return load('/projects/1/forms/f/submissions', { root: false }, {
+        keys: () => [] // if there are 0 submissions, backend returns empty key array
       })
-        .beforeEachResponse((component, config) => {
-          if (config.url.includes('.svc/Submissions')) {
-            checkMessage(component, 'Loading the first 2 of 3 Submissions…');
-            checkTop(config, 2);
-          }
+        .complete()
+        .request(async (app) => {
+          await app.get('#submission-download-button').trigger('click');
+          const modal = app.getComponent(SubmissionDownload);
+          await modal.find('input[type="password"]').exists().should.be.false;
+          return app.get('#submission-list-refresh-button').trigger('click');
         })
-        .afterResponses(component => {
-          checkIds(component, 2);
+        .beforeAnyResponse(() => {
+          testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
+        })
+        .respondWithData(() => testData.submissionOData(1, 0))
+        .respondWithData(() => testData.submissionDeletedOData())
+        .respondWithData(() => testData.standardKeys.sorted())
+        .complete()
+        .request(async (app) => {
+          await app.get('#submission-download-button').trigger('click');
+          const modal = app.getComponent(SubmissionDownload);
+          await modal.find('input[type="password"]').exists().should.be.true;
         });
     });
 
-    it('clicking refresh button loads only first chunk of submissions', () => {
-      createSubmissions(3);
-      return loadSubmissionList({
-        props: { top: () => 2 }
+    it('sends request for encryption keys on draft/testing submission refresh', () => {
+      // create project with managed encryption, form, and 0 submissions to start
+      testData.extendedProjects.createPast(1, {
+        key: testData.standardKeys.createPast(1, { managed: true }).last()
+      });
+      testData.extendedForms.createPast(1, { xmlFormId: 'e', draft: true });
+      return load('/projects/1/forms/e/draft/testing', { root: false }, {
+        keys: () => [] // if there are 0 submissions, backend returns empty key array
       })
         .complete()
         .request(component =>
           component.get('#submission-list-refresh-button').trigger('click'))
-        .beforeEachResponse((_, config) => {
-          checkTop(config, 2, 0);
+        .beforeAnyResponse(() => {
+          testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
         })
-        .respondWithData(() => testData.submissionOData(2, 0))
-        .afterResponse(component => {
-          checkIds(component, 2);
-        });
+        .respondWithData(() => testData.submissionOData(1, 0))
+        .respondWithData(() => testData.standardKeys.sorted())
+        .testRequests([
+          null,
+          { url: '/v1/projects/1/forms/e/draft/submissions/keys' }
+        ]);
     });
 
-    describe('scrolling', () => {
-      it('scrolling to the bottom loads the next chunk of submissions', () => {
-        createSubmissions(12);
-        // Chunk 1
-        return loadSubmissionList({
-          props: { top: (loaded) => (loaded < 8 ? 2 : 3) }
+    it('sends request for encryption keys on published submission refresh', () => {
+      // create project with managed encryption, form, and 0 submissions to start
+      testData.extendedProjects.createPast(1, {
+        key: testData.standardKeys.createPast(1, { managed: true }).last()
+      });
+      testData.extendedForms.createPast(1);
+      return load('/projects/1/forms/f/submissions', { root: false }, {
+        keys: () => [] // if there are 0 submissions, backend returns empty key array
+      })
+        .complete()
+        .request(component =>
+          component.get('#submission-list-refresh-button').trigger('click'))
+        .beforeAnyResponse(() => {
+          testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
         })
-          .beforeEachResponse((component, { url }) => {
-            if (url.includes('.svc/Submissions'))
-              checkMessage(component, 'Loading the first 2 of 12 Submissions…');
-          })
-          .afterResponses(component => {
-            checkMessage(component, null);
-          })
-          // Chunk 2
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 2);
-            checkMessage(component, 'Loading 2 more of 10 remaining Submissions…');
-          })
-          .respondWithData(() => testData.submissionOData(2, 2))
-          .afterResponse(component => {
-            checkIds(component, 4);
-            checkMessage(component, null);
-          })
-          // Chunk 3
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 2, 4);
-            checkMessage(component, 'Loading 2 more of 8 remaining Submissions…');
-          })
-          .respondWithData(() => testData.submissionOData(2, 4))
-          .afterResponse(component => {
-            checkIds(component, 6);
-            checkMessage(component, null);
-          })
-          // Chunk 4 (last small chunk)
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 2, 6);
-            checkMessage(component, 'Loading 2 more of 6 remaining Submissions…');
-          })
-          .respondWithData(() => testData.submissionOData(2, 6))
-          .afterResponse(component => {
-            checkIds(component, 8);
-            checkMessage(component, null);
-          })
-          // Chunk 5
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 3, 8);
-            checkMessage(component, 'Loading 3 more of 4 remaining Submissions…');
-          })
-          .respondWithData(() => testData.submissionOData(3, 8))
-          .afterResponse(component => {
-            checkIds(component, 11);
-            checkMessage(component, null);
-          })
-          // Chunk 6
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 3, 11);
-            checkMessage(component, 'Loading the last Submission…');
-          })
-          .respondWithData(() => testData.submissionOData(3, 11))
-          .afterResponse(component => {
-            checkIds(component, 12);
-            checkMessage(component, null);
-          });
-      });
-
-      it('does nothing upon scroll if keys request results in error', () => {
-        createSubmissions(251);
-        return load('/projects/1/forms/f/submissions', { root: false }, {
-          keys: mockResponse.problem
-        })
-          .complete()
-          .testNoRequest(scroll);
-      });
-
-      it('does nothing upon scroll if fields request results in error', () => {
-        createSubmissions(251);
-        return load('/projects/1/forms/f/submissions', { root: false }, {
-          fields: mockResponse.problem
-        })
-          .complete()
-          .testNoRequest(scroll);
-      });
-
-      it('does nothing upon scroll if submissions request results in error', () => {
-        createSubmissions(251);
-        return load('/projects/1/forms/f/submissions', { root: false }, {
-          odata: mockResponse.problem
-        })
-          .complete()
-          .testNoRequest(scroll);
-      });
-
-      it('does nothing after user scrolls somewhere other than bottom of page', () => {
-        createSubmissions(5);
-        return loadSubmissionList({
-          props: { top: () => 2 }
-        })
-          .complete()
-          .testNoRequest(scroll(false));
-      });
-
-      it('clicking refresh button loads first chunk, even after scrolling', () => {
-        createSubmissions(5);
-        return loadSubmissionList({
-          props: { top: () => 2 }
-        })
-          .complete()
-          .request(scroll)
-          .respondWithData(() => testData.submissionOData(2, 2))
-          .complete()
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeEachResponse((_, config) => {
-            checkTop(config, 2, 0);
-          })
-          .respondWithData(() => testData.submissionOData(2, 0))
-          .afterResponse(component => {
-            checkIds(component, 2);
-          })
-          .request(scroll)
-          .beforeEachResponse((_, config) => {
-            checkTop(config, 2, 2);
-          })
-          .respondWithData(() => testData.submissionOData(2, 2));
-      });
-
-      it('scrolling to the bottom has no effect if awaiting response', () => {
-        createSubmissions(5);
-        return loadSubmissionList({
-          props: { top: () => 2 }
-        })
-          .complete()
-          // Sends a request.
-          .request(scroll)
-          // This should not send a request. If it does, then the number of
-          // requests will exceed the number of responses, and the mockHttp()
-          // object will throw an error.
-          .beforeAnyResponse(scroll)
-          .respondWithData(() => testData.submissionOData(2, 2))
-          .complete()
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          // Should not send a request.
-          .beforeAnyResponse(scroll)
-          .respondWithData(() => testData.submissionOData(2, 0));
-      });
-
-      it('scrolling has no effect after all submissions have been loaded', () => {
-        createSubmissions(2);
-        return loadSubmissionList({
-          props: { top: () => 2 }
-        })
-          .complete()
-          .testNoRequest(scroll);
-      });
-    });
-
-    describe('refreshing keys', () => {
-      it('opens modal with encrpytion password after refreshing keys', () => {
-        // create project with managed encryption, form, and 0 submissions to start
-        testData.extendedProjects.createPast(1, {
-          key: testData.standardKeys.createPast(1, { managed: true }).last()
-        });
-        testData.extendedForms.createPast(1);
-        return load('/projects/1/forms/f/submissions', { root: false }, {
-          keys: () => [] // if there are 0 submissions, backend returns empty key array
-        })
-          .complete()
-          .request(async (app) => {
-            await app.get('#submission-download-button').trigger('click');
-            const modal = app.getComponent(SubmissionDownload);
-            await modal.find('input[type="password"]').exists().should.be.false;
-            return app.get('#submission-list-refresh-button').trigger('click');
-          })
-          .beforeAnyResponse(() => {
-            testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
-          })
-          .respondWithData(() => testData.submissionOData(1, 0))
-          .respondWithData(() => testData.submissionDeletedOData())
-          .respondWithData(() => testData.standardKeys.sorted())
-          .complete()
-          .request(async (app) => {
-            await app.get('#submission-download-button').trigger('click');
-            const modal = app.getComponent(SubmissionDownload);
-            await modal.find('input[type="password"]').exists().should.be.true;
-          });
-      });
-
-      it('sends request for encryption keys on draft/testing submission refresh', () => {
-        // create project with managed encryption, form, and 0 submissions to start
-        testData.extendedProjects.createPast(1, {
-          key: testData.standardKeys.createPast(1, { managed: true }).last()
-        });
-        testData.extendedForms.createPast(1, { xmlFormId: 'e', draft: true });
-        return load('/projects/1/forms/e/draft/testing', { root: false }, {
-          keys: () => [] // if there are 0 submissions, backend returns empty key array
-        })
-          .complete()
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeAnyResponse(() => {
-            testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
-          })
-          .respondWithData(() => testData.submissionOData(1, 0))
-          .respondWithData(() => testData.standardKeys.sorted())
-          .testRequests([
-            null,
-            { url: '/v1/projects/1/forms/e/draft/submissions/keys' }
-          ]);
-      });
-
-      it('sends request for encryption keys on published submission refresh', () => {
-        // create project with managed encryption, form, and 0 submissions to start
-        testData.extendedProjects.createPast(1, {
-          key: testData.standardKeys.createPast(1, { managed: true }).last()
-        });
-        testData.extendedForms.createPast(1);
-        return load('/projects/1/forms/f/submissions', { root: false }, {
-          keys: () => [] // if there are 0 submissions, backend returns empty key array
-        })
-          .complete()
-          .request(component =>
-            component.get('#submission-list-refresh-button').trigger('click'))
-          .beforeAnyResponse(() => {
-            testData.extendedSubmissions.createPast(1, { status: 'notDecrypted' });
-          })
-          .respondWithData(() => testData.submissionOData(1, 0))
-          .respondWithData(() => testData.submissionDeletedOData())
-          .respondWithData(() => testData.standardKeys.sorted())
-          .testRequests([
-            null,
-            null,
-            { url: '/v1/projects/1/forms/f/submissions/keys' }
-          ]);
-      });
-    });
-
-    describe('count update', () => {
-      it.skip('scrolling to the bottom continues to fetch the next chunk', () => {
-        createSubmissions(4);
-        // 4 submissions exist. About to request $top=2, $skip=0.
-        return loadSubmissionList({
-          props: { top: () => 2 }
-        })
-          .beforeEachResponse((component, config) => {
-            if (config.url.includes('.svc/Submissions')) {
-              checkTop(config, 2, 0);
-              checkMessage(component, 'Loading the first 2 of 4 Submissions…');
-            }
-          })
-          .complete()
-          // 4 submissions exist, but 4 more are about to be created. About to
-          // request $top=2, $skip=2.
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 2, 2);
-            checkMessage(component, 'Loading the last 2 Submissions…');
-          })
-          .respondWithData(() => {
-            testData.extendedSubmissions.createPast(4);
-            // This returns 2 of the 4 new submissions.
-            return testData.submissionOData(2, 2);
-          })
-          .afterResponse(component => {
-            checkIds(component, 2, 4);
-            checkMessage(component, null);
-          })
-          // 8 submissions exist. About to request $top=2, $skip=4.
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 2, 4);
-            checkMessage(component, 'Loading the last 2 Submissions…');
-          })
-          // Returns the 2 submissions that are already shown in the table.
-          .respondWithData(() => testData.submissionOData(2, 4))
-          .afterResponse(component => {
-            checkIds(component, 2, 4);
-            checkMessage(component, null);
-          })
-          // 8 submissions exist. About to request $top=2, $skip=6.
-          .request(scroll)
-          .beforeEachResponse((component, config) => {
-            checkTop(config, 2, 6);
-            checkMessage(component, 'Loading the last 2 Submissions…');
-          })
-          // Returns the last 2 submissions.
-          .respondWithData(() => testData.submissionOData(2, 6))
-          .afterResponse(component => {
-            checkIds(component, 4, 4);
-            checkMessage(component, null);
-          })
-          // 8 submissions exist. No request will be sent.
-          .testNoRequest(scroll);
-      });
-
-      it('does not update requestData.odata.originalCount', () => {
-        createSubmissions(251);
-        return load('/projects/1/forms/f/submissions', { root: false })
-          .afterResponses(component => {
-            const { requestData } = component.vm.$container;
-            requestData.localResources.odata.originalCount.should.equal(251);
-            requestData.form.submissions.should.equal(251);
-          })
-          .request(scroll)
-          .respondWithData(() => {
-            testData.extendedSubmissions.createPast(1);
-            return testData.submissionOData(2, 250);
-          })
-          .afterResponse(component => {
-            const { requestData } = component.vm.$container;
-            requestData.localResources.odata.originalCount.should.equal(251);
-            requestData.form.submissions.should.equal(252);
-          });
-      });
+        .respondWithData(() => testData.submissionOData(1, 0))
+        .respondWithData(() => testData.submissionDeletedOData())
+        .respondWithData(() => testData.standardKeys.sorted())
+        .testRequests([
+          null,
+          null,
+          { url: '/v1/projects/1/forms/f/submissions/keys' }
+        ]);
     });
   });
 
@@ -565,17 +224,17 @@ describe('SubmissionList', () => {
         if (url.includes('.svc/Submissions')) should.not.exist($select(url));
       }));
 
-    it('specifies $select for the second chunk', () => {
-      testData.extendedSubmissions.createPast(2);
-      return loadSubmissionList({
-        props: { top: () => 1 }
-      })
+    it('specifies $select if the next button is clicked', () => {
+      testData.extendedSubmissions.createPast(251);
+      return loadSubmissionList()
         .complete()
-        .request(scroll)
+        .request(component => {
+          component.get('button[aria-label="Next page"]').trigger('click');
+        })
         .beforeEachResponse((_, { url }) => {
           $select(url).should.equal('__id,__system,g/s1,s2,s3,s4,s5,s6,s7,s8,s9,s10');
         })
-        .respondWithData(() => testData.submissionOData(1, 1));
+        .respondWithData(() => testData.submissionOData(1, 0));
     });
 
     it('specifies $select if the refresh button is clicked', () =>
@@ -738,10 +397,10 @@ describe('SubmissionList', () => {
         component.should.alert('success', 'The Submission has been deleted.');
       });
 
-      it('hides the row', async () => {
+      it('removes the row', async () => {
         const component = await del();
-        const row = component.getComponent(SubmissionMetadataRow);
-        row.element.dataset.markRowsDeleted.should.equal('true');
+        const row = component.findComponent(SubmissionMetadataRow);
+        row.exists().should.be.false;
       });
 
       it('updates the submission count', async () => {
@@ -768,21 +427,21 @@ describe('SubmissionList', () => {
       };
 
       it('hides the table', () =>
-        load('/projects/1/forms/f/submissions', { root: false })
+        load('/projects/1/forms/f/submissions', { root: false, attachTo: document.body })
           .complete()
           .request(del(1))
           .respondWithSuccess()
-          .afterResponse(component => {
-            component.get('#submission-table').should.be.visible();
+          .afterResponse(async component => {
+            component.get('#submission-table table').should.be.visible(true);
           })
           .request(del(0))
           .respondWithSuccess()
-          .afterResponse(component => {
-            component.get('#submission-table').should.be.hidden();
+          .afterResponse(async component => {
+            component.get('#submission-table table').should.be.hidden(true);
           }));
 
       it('shows a message', () =>
-        load('/projects/1/forms/f/submissions', { root: false })
+        load('/projects/1/forms/f/submissions', { root: false, attachTo: document.body })
           .complete()
           .request(del(1))
           .respondWithSuccess()
@@ -859,7 +518,7 @@ describe('SubmissionList', () => {
           })
           .respondWithSuccess()
           .afterResponse(component => {
-            component.find('.delete-button .spinner').classes().should.not.contain('active');
+            component.find('tbody tr').exists().should.be.false;
           }));
 
       it('shows the correct alert', () =>
@@ -970,8 +629,8 @@ describe('SubmissionList', () => {
 
       it('hides the row', async () => {
         const component = await restore();
-        const row = component.getComponent(SubmissionMetadataRow);
-        row.element.dataset.markRowsDeleted.should.equal('true');
+        const row = component.findComponent(SubmissionMetadataRow);
+        row.exists().should.be.false;
       });
 
       it('updates the submission count', async () => {
@@ -993,7 +652,7 @@ describe('SubmissionList', () => {
       };
 
       it('hides the table', () =>
-        load('/projects/1/forms/f/submissions?deleted=true', { root: false }, {
+        load('/projects/1/forms/f/submissions?deleted=true', { root: false, attachTo: document.body }, {
           deletedSubmissionCount: false,
           odata: testData.submissionDeletedOData
         })
@@ -1001,12 +660,12 @@ describe('SubmissionList', () => {
           .request(restore(1))
           .respondWithSuccess()
           .afterResponse(component => {
-            component.get('#submission-table').should.be.visible();
+            component.get('#submission-table table').should.be.visible(true);
           })
           .request(restore(0))
           .respondWithSuccess()
           .afterResponse(component => {
-            component.get('#submission-table').should.be.hidden();
+            component.get('#submission-table table').should.be.hidden(true);
           }));
 
       it('shows a message', () =>
@@ -1024,7 +683,7 @@ describe('SubmissionList', () => {
           .respondWithSuccess()
           .afterResponse(component => {
             component.get('.empty-table-message').should.be.visible();
-            component.get('.empty-table-message').text().should.be.equal('There are no deleted Submissions.');
+            component.get('.empty-table-message').text().should.be.equal('All deleted Submissions are undeleted.');
           }));
     });
 
@@ -1097,7 +756,7 @@ describe('SubmissionList', () => {
           })
           .respondWithSuccess()
           .afterResponse(component => {
-            component.find('.restore-button .spinner').classes().should.not.contain('active');
+            component.find('tbody tr').exists().should.be.false;
           }));
 
       it('shows the correct alert', () =>
@@ -1145,6 +804,132 @@ describe('SubmissionList', () => {
             happen. */
             component.get('#submission-table').should.be.visible();
           }));
+    });
+  });
+
+  describe('pagination', () => {
+    const checkIds = (component, count, offset = 0) => {
+      const rows = component.findAllComponents(SubmissionDataRow);
+      rows.length.should.equal(count);
+      const submissions = testData.extendedSubmissions.sorted();
+      submissions.length.should.be.at.least(count + offset);
+      for (let i = 0; i < rows.length; i += 1) {
+        const text = rows[i].get('td:last-child').text();
+        text.should.equal(submissions[i + offset].instanceId);
+      }
+    };
+
+    it('should load all submission if there are less than page size', async () => {
+      createSubmissions(3);
+      const component = await loadSubmissionList();
+      checkIds(component, 3);
+    });
+
+    it('should load next page', async () => {
+      createSubmissions(251);
+      return loadSubmissionList()
+        .complete()
+        .request(component =>
+          component.find('button[aria-label="Next page"]').trigger('click'))
+        .respondWithData(() => testData.submissionOData(250, 250))
+        .afterResponse(component => {
+          checkIds(component, 1, 250);
+        });
+    });
+
+    it('should load previous page', async () => {
+      createSubmissions(251);
+      const clock = sinon.useFakeTimers();
+      return loadSubmissionList()
+        .complete()
+        .request(component =>
+          component.find('button[aria-label="Next page"]').trigger('click'))
+        .respondWithData(() => testData.submissionOData(250, 250))
+        .complete()
+        .request(component =>
+          component.find('button[aria-label="Previous page"]').trigger('click'))
+        .respondWithData(() => testData.submissionOData(250))
+        .afterResponse(async component => {
+          // we still use chunky array which load 25 rows at a time
+          clock.tick(1000);
+          await nextTick();
+          checkIds(component, 250);
+        });
+    });
+
+    it('should change the page size', async () => {
+      createSubmissions(251);
+      const clock = sinon.useFakeTimers();
+      return loadSubmissionList()
+        .complete()
+        .request(component => {
+          const sizeDropdown = component.find('.pagination select:has(option[value="500"])');
+          return sizeDropdown.setValue(500);
+        })
+        .respondWithData(() => testData.submissionOData(500))
+        .afterResponse(async component => {
+          clock.tick(1000);
+          await nextTick();
+          checkIds(component, 251);
+        });
+    });
+
+    it('should load first page on refresh', async () => {
+      createSubmissions(251);
+      const clock = sinon.useFakeTimers();
+      return loadSubmissionList()
+        .complete()
+        .request(component =>
+          component.find('button[aria-label="Next page"]').trigger('click'))
+        .respondWithData(() => testData.submissionOData(250, 250))
+        .complete()
+        .request(component =>
+          component.get('#submission-list-refresh-button').trigger('click'))
+        .respondWithData(() => testData.submissionOData(250))
+        .afterResponse(async component => {
+          // we still use chunky array which load 25 rows at a time
+          clock.tick(1000);
+          await nextTick();
+          checkIds(component, 250);
+        });
+    });
+
+    it('should show correct row number', () => {
+      createSubmissions(251);
+      const clock = sinon.useFakeTimers();
+      return loadSubmissionList()
+        .afterResponse(async component => {
+          clock.tick(1000);
+          await nextTick();
+          const rows = component.findAllComponents(SubmissionMetadataRow);
+          rows[0].find('.row-number').text().should.be.eql('251');
+          rows[249].find('.row-number').text().should.be.eql('2');
+          rows.length.should.be.eql(250);
+        })
+        .request(component =>
+          component.find('button[aria-label="Next page"]').trigger('click'))
+        .respondWithData(() => testData.submissionOData(250, 250))
+        .afterResponse(component => {
+          const rows = component.findAllComponents(SubmissionMetadataRow);
+          rows[0].find('.row-number').text().should.be.eql('1');
+        });
+    });
+
+    it('should load correct page on clicking next twice', () => {
+      createSubmissions(501);
+      return loadSubmissionList()
+        .complete()
+        .request(async component => {
+          await component.find('button[aria-label="Next page"]').trigger('click');
+          component.find('button[aria-label="Next page"]').trigger('click');
+        })
+        .respondWithData(() => testData.submissionOData(250, 250))
+        .respondWithData(() => testData.submissionOData(250, 500))
+        .afterResponses(async component => {
+          await nextTick();
+          checkIds(component, 1, 500);
+          component.find('.pagination select').element.value.should.be.eql('2');
+        });
     });
   });
 });

--- a/test/data/entities.js
+++ b/test/data/entities.js
@@ -275,7 +275,6 @@ const restToOData = (filterExpression) => (top = 250, skip = 0, asc = false) => 
   const { properties } = extendedDatasets.last();
   return {
     '@odata.count': sorted.length,
-    '@odata.nextLink': top > 0 && (top + skip < sorted.length) ? `https://test/Entities?$top=${top}&$skipToken=thetoken` : undefined,
     value: sorted.slice(skip, skip + top).map(entity => {
       const result = {
         label: entity.currentVersion.label,

--- a/test/data/submissions.js
+++ b/test/data/submissions.js
@@ -181,8 +181,7 @@ const restToOData = (filterExpression) => (top = 250, skip = 0) => {
   return {
     '@odata.count': data.length,
     value: data.slice(skip, skip + top)
-      .map(submission => submission._odata),
-    '@odata.nextLink': top > 0 && (top + skip < data.length) ? `https://test/Submissions?$top=${top}&$skipToken=thetoken` : undefined
+      .map(submission => submission._odata)
   };
 };
 

--- a/test/unit/dom.spec.js
+++ b/test/unit/dom.spec.js
@@ -1,7 +1,7 @@
+import sinon from 'sinon';
 import { markRowChanged, markRowsChanged, px, requiredLabel, styleBox } from '../../src/util/dom';
 
 import { mount } from '../util/lifecycle';
-import { wait } from '../util/util';
 
 describe('util/dom', () => {
   describe('px()', () => {
@@ -39,6 +39,7 @@ describe('util/dom', () => {
 
   describe('markRowChanged(), markRowsChanged()', () => {
     it('toggles data-mark-rows-changed for a single row', async () => {
+      const clock = sinon.useFakeTimers();
       const table = mount({
         template: `<table>
           <tbody>
@@ -49,11 +50,12 @@ describe('util/dom', () => {
       const row = table.get('tr').element;
       markRowChanged(row);
       row.dataset.markRowsChanged.should.equal('true');
-      await wait();
+      clock.tick(6000);
       row.dataset.markRowsChanged.should.equal('false');
     });
 
     it('toggles data-mark-rows-changed for multiple rows', async () => {
+      const clock = sinon.useFakeTimers();
       const table = mount({
         template: `<table>
           <tbody>
@@ -66,7 +68,7 @@ describe('util/dom', () => {
       markRowsChanged(rows);
       rows[0].dataset.markRowsChanged.should.equal('true');
       rows[1].dataset.markRowsChanged.should.equal('true');
-      await wait();
+      clock.tick(6000);
       rows[0].dataset.markRowsChanged.should.equal('false');
       rows[1].dataset.markRowsChanged.should.equal('false');
     });

--- a/test/util/entity.js
+++ b/test/util/entity.js
@@ -14,8 +14,7 @@ export const loadEntityList = (mountOptions = {}) => {
   const mergedOptions = mergeMountOptions(mountOptions, {
     props: {
       projectId: project.id.toString(),
-      datasetName: dataset.name,
-      top: EntityList.props.top.default
+      datasetName: dataset.name
     },
     container: {
       requestData: testRequestData([useEntities], {
@@ -25,8 +24,8 @@ export const loadEntityList = (mountOptions = {}) => {
       router: mockRouter('')
     }
   });
-  const { top, deleted } = mergedOptions.props;
+  const { deleted } = mergedOptions.props;
   return mockHttp()
     .mount(EntityList, mergedOptions)
-    .respondWithData(() => (deleted ? testData.entityDeletedOData(top(0)) : testData.entityOData(top(0))));
+    .respondWithData(() => (deleted ? testData.entityDeletedOData() : testData.entityOData()));
 };

--- a/test/util/lifecycle.js
+++ b/test/util/lifecycle.js
@@ -48,6 +48,7 @@ export const mount = (component, options = {}) => {
   g.mocks = { $container: container, ...g.mocks };
   if (g.mixins != null) throw new Error('unexpected mixin');
   g.mixins = [shadowRouterProps];
+  g.stubs = { ...g.stubs, 'transition-group': { inheritAttrs: false, template: '<slot />' } };
   return vtuMount(component, { ...mountOptions, global: g });
 };
 

--- a/test/util/submission.js
+++ b/test/util/submission.js
@@ -17,7 +17,6 @@ export const loadSubmissionList = (mountOptions = {}) => {
       projectId: project.id.toString(),
       xmlFormId: form.xmlFormId,
       draft: form.publishedAt == null,
-      top: SubmissionList.props.top.default,
       deleted: false
     },
     container: {
@@ -34,11 +33,11 @@ export const loadSubmissionList = (mountOptions = {}) => {
         : `/projects/${project.id}/forms/${encodeURIComponent(form.xmlFormId)}/draft/testing`)
     }
   });
-  const { top, deleted } = mergedOptions.props;
+  const { deleted } = mergedOptions.props;
   return mockHttp()
     .mount(SubmissionList, mergedOptions)
     .respondWithData(() => form._fields)
-    .respondWithData(() => (deleted ? testData.submissionDeletedOData(top(0)) : testData.submissionOData(top(0))))
+    .respondWithData(() => (deleted ? testData.submissionDeletedOData() : testData.submissionOData()))
     .modify(series => {
       if (form.publishedAt == null) return series;
       return series.respondWithData(() => testData.extendedFieldKeys

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2079,6 +2079,12 @@
       "noMatching": {
         "string": "There are no matching Entities."
       },
+      "allDeleted": {
+        "string": "All Entities are deleted."
+      },
+      "allDeletedOnPage": {
+        "string": "All Entities on the page have been deleted."
+      },
       "alert": {
         "delete": {
           "string": "Entity “{label}” has been deleted."
@@ -2089,6 +2095,17 @@
       },
       "downloadDisabled": {
         "string": "Download is unavailable for deleted Entities"
+      },
+      "deletedEntity": {
+        "emptyTable": {
+          "string": "There are no deleted Entities."
+        },
+        "allRestored": {
+          "string": "All deleted Entities are undeleted."
+        },
+        "allRestoredOnPage": {
+          "string": "All Entities on the page have been undeleted."
+        }
       },
       "action": {
         "download": {
@@ -4842,6 +4859,12 @@
       "noMatching": {
         "string": "There are no matching Submissions."
       },
+      "allDeleted": {
+        "string": "All Submissions are deleted."
+      },
+      "allDeletedOnPage": {
+        "string": "All Submissions on the page have been deleted."
+      },
       "downloadDisabled": {
         "string": "Download is unavailable for deleted Submissions"
       },
@@ -4851,6 +4874,12 @@
       "deletedSubmission": {
         "emptyTable": {
           "string": "There are no deleted Submissions."
+        },
+        "allRestored": {
+          "string": "All deleted Submissions are undeleted."
+        },
+        "allRestoredOnPage": {
+          "string": "All Submissions on the page have been undeleted."
         }
       },
       "loading": {


### PR DESCRIPTION
Closes getodk/central#822

#### What has been done to verify that this works as intended?

Wrote some component tests and manually verified it. I am thinking to pass this to QA team even before we review/merge this PR.

#### Why is this the best possible solution? Were any other approaches considered?

We talked about what to do when a row is deleted, should we just remove the row from the UI or we fetch the next available row and update the count/page size. We decided that it is better to just remove the row.

**Transition Group**

I have used Vue's Transition Group (TG) component in our table-freeze component. I think this has simplified our code because model and view are alway in sync; and we no longer keep deleted row in the DOM hidden. 

I am not using css class provided by TG component and kept our transition logic in markRowChanged and markRowDeleted. Because TG doesn't help with row modified, so thought might as well keep both change/delete consistent. The only magic of TG is that it waits for `transitionend` event before removing row from the table, that event is raised when `transition` started by css property is completed.

**Snapshot Filters**

I am passing filters to odata endpoint to fetch the data for a single point in time so that submission/entity created or deleted after fetching first page don't effect our total count and number of pages. 

For alive records, those filters are records created before `now` and not deleted or deleted after `now`.
For deleted records, the filter is to fetch records that are deleted before `now`.

I am keeping a set of removed rows (instanceId or UUID), so I don't add those rows in resource store when page is changed.

Only weird case is where a user is looking at alive records and some other user undeletes a record, then next odata request will have different `count` and number of pages can change. But I think it's not super problematic.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced