### PR TITLE
Add preventDefault + hack to avoid karma throwing some of your tests …

### DIFF
--- a/test/components/entity/upload/data-template.spec.js
+++ b/test/components/entity/upload/data-template.spec.js
@@ -12,6 +12,9 @@ const mountComponent = () => mount(EntityUploadDataTemplate, {
 });
 
 describe('EntityUploadDataTemplate', () => {
+  // hack: without this 'has the correct filename' fails. Possibly because of karma#3887
+  beforeEach(async () => {});
+
   it('has the correct data URL', () => {
     testData.extendedDatasets.createPast(1, {
       properties: [{ name: 'hauteur' }, { name: 'circonférence' }]
@@ -27,6 +30,7 @@ describe('EntityUploadDataTemplate', () => {
     const clock = sinon.useFakeTimers(Date.parse('2024-12-31T01:23:45'));
     testData.extendedDatasets.createPast(1);
     const a = mountComponent().get('a');
+    a.element.addEventListener('click', (e) => { e.preventDefault(); });
     await a.trigger('click');
     a.attributes().download.should.equal('trees 20241231012345.csv');
     clock.tick(1000);


### PR DESCRIPTION
Closes https://github.com/getodk/central-frontend/issues/1047 and makes all test pass which are currently failing.

#### What has been done to verify that this works as intended?

All tests are passing and no file is created on the file system.

#### Why is this the best possible solution? Were any other approaches considered?

`preventDefault` fixes #1047.

**Fix for failing test:**

This is mysterious fix, I don't exactly know the root cause. The issue seems related to https://github.com/karma-runner/karma/issues/3887 because when I ran only two tests in `data-template.spec.ts`, I saw this error "Some of your tests did a full page reload!".

One suggestion over there is to add following:

```
beforeEach(async () => {
    window.onbeforeunload = () => "Oh no!";
});
```

So I added that and it worked. It didn't make sense to me so I removed the `onbeforeunload`, just kept `beforeEach(async () => {};` and it worked as well. That's what this PR contains.

Alternative solution: https://github.com/getodk/central-frontend/pull/1122

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced