### PR TITLE
Send requests needed for form infonav buttons

### DIFF
--- a/src/components/form-draft/status.vue
+++ b/src/components/form-draft/status.vue
@@ -122,10 +122,10 @@ export default {
   },
   emits: ['fetch-project', 'fetch-form', 'fetch-draft', 'fetch-linked-datasets'],
   setup() {
-    const { form, publishedAttachments, formVersions, formDraft, datasets, formDatasetDiff, formDraftDatasetDiff } = useRequestData();
+    const { form, formVersions, formDraft, datasets, formDraftDatasetDiff } = useRequestData();
     const { projectPath, publishedFormPath } = useRoutes();
     return {
-      form, publishedAttachments, formVersions, formDraft, datasets, formDatasetDiff, formDraftDatasetDiff,
+      form, formVersions, formDraft, datasets, formDraftDatasetDiff,
       projectPath, publishedFormPath
     };
   },

--- a/src/components/form-draft/status.vue
+++ b/src/components/form-draft/status.vue
@@ -120,7 +120,7 @@ export default {
       required: true
     }
   },
-  emits: ['fetch-project', 'fetch-form', 'fetch-draft'],
+  emits: ['fetch-project', 'fetch-form', 'fetch-draft', 'fetch-linked-datasets'],
   setup() {
     const { form, publishedAttachments, formVersions, formDraft, datasets, formDatasetDiff, formDraftDatasetDiff } = useRequestData();
     const { projectPath, publishedFormPath } = useRoutes();
@@ -163,9 +163,8 @@ export default {
       this.$emit('fetch-form');
 
       // Other resources that may have changed after publish
-      this.publishedAttachments.reset();
+      this.$emit('fetch-linked-datasets');
       this.datasets.reset();
-      this.formDatasetDiff.reset();
       this.formDraftDatasetDiff.reset();
 
       // We will update additional resources, but only after navigating to the

--- a/src/components/form/show.vue
+++ b/src/components/form/show.vue
@@ -109,6 +109,13 @@ const stopWaitingForProject = watchEffect(() => {
       url: apiPaths.formActors(props.projectId, props.xmlFormId, 'app-user')
     }).catch(noop);
   }
+  /* It doesn't work to call stopWaitingForProject() synchronously. You can see
+  that if you remove the nextTick() and try running tests. I think the reason
+  why is that if you navigate from another page that has fetched `project`
+  already (e.g., the form list), then project.dataExists will be `true`, so the
+  watch effect will complete synchronously during component setup. But in that
+  case, watchEffect() won't have had a chance to return a value:
+  stopWaitingForProject won't be assigned yet. */
   nextTick(() => stopWaitingForProject());
 });
 

--- a/src/components/form/show.vue
+++ b/src/components/form/show.vue
@@ -25,8 +25,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { useRouter } from 'vue-router';
 import { nextTick, watchEffect } from 'vue';
+import { useRouter } from 'vue-router';
 
 import FormHead from './head.vue';
 import Loading from '../loading.vue';

--- a/src/request-data/form.js
+++ b/src/request-data/form.js
@@ -34,6 +34,9 @@ export default () => {
       .filter(a => a.datasetExists)
       .map(a => a.name.replace(/\.csv$/i, '')))
   }));
+  const appUserCount = createResource('appUserCount', () => ({
+    transformResponse: ({ data }) => data.length
+  }));
 
   watchSyncEffect(() => {
     if (form.dataExists && publicLinks.dataExists &&
@@ -42,6 +45,6 @@ export default () => {
   });
 
   return {
-    form, formDraft, attachments, formVersions, formVersionXml, publicLinks, formDraftDatasetDiff, formDatasetDiff, publishedAttachments
+    form, formDraft, attachments, formVersions, formVersionXml, publicLinks, formDraftDatasetDiff, formDatasetDiff, publishedAttachments, appUserCount
   };
 };

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1143,7 +1143,7 @@ describe('FormAttachmentList', () => {
             return { success: true };
           })
           .respondWithData(() => testData.extendedForms.last())
-          .respondWithData(() => []) // publishedAttachments
+          .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
           .respondWithData(() => testData.formDatasetDiffs.sorted())
           .respondWithData(() => testData.extendedProjects.last())
           .respondForComponent('FormSubmissions')
@@ -1156,10 +1156,7 @@ describe('FormAttachmentList', () => {
           })
           .respondFor('/projects/1/forms/f/draft', {
             project: false,
-            form: false,
-            publishedAttachments: false,
-            formDatasetDiff: false,
-            appUserCount: false
+            form: false
           })
           .complete()
           .route('/projects/1/forms/f/draft/attachments')
@@ -1201,7 +1198,7 @@ describe('FormAttachmentList', () => {
             return { success: true };
           })
           .respondWithData(() => testData.extendedForms.last())
-          .respondWithData(() => []) // publishedAttachments
+          .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
           .respondWithData(() => testData.formDatasetDiffs.sorted())
           .respondWithData(() => testData.extendedProjects.last())
           .respondForComponent('FormSubmissions')
@@ -1214,10 +1211,7 @@ describe('FormAttachmentList', () => {
           })
           .respondFor('/projects/1/forms/f/draft', {
             project: false,
-            form: false,
-            publishedAttachments: false,
-            formDatasetDiff: false,
-            appUserCount: false
+            form: false
           })
           .complete()
           .route('/projects/1/forms/f/draft/attachments')

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1129,12 +1129,8 @@ describe('FormAttachmentList', () => {
         });
         return load('/projects/1/forms/f/draft/attachments')
           .complete()
-          .load('/projects/1/forms/f/draft', {
-            project: false,
-            form: false,
-            formDraft: false,
-            attachments: false
-          })
+          .route('/projects/1/forms/f/draft')
+          .respondWithData(() => testData.extendedFormVersions.published())
           .complete()
           .request(async (app) => {
             await app.get('#form-draft-status-publish-button').trigger('click');
@@ -1147,11 +1143,10 @@ describe('FormAttachmentList', () => {
             return { success: true };
           })
           .respondWithData(() => testData.extendedForms.last())
-          .respondFor('/projects/1/forms/f/submissions', {
-            form: false,
-            formDraft: false,
-            attachments: false
-          })
+          .respondWithData(() => []) // publishedAttachments
+          .respondWithData(() => testData.formDatasetDiffs.sorted())
+          .respondWithData(() => testData.extendedProjects.last())
+          .respondForComponent('FormSubmissions')
           .complete()
           .request(app =>
             app.get('#form-head-create-draft-button').trigger('click'))
@@ -1161,7 +1156,10 @@ describe('FormAttachmentList', () => {
           })
           .respondFor('/projects/1/forms/f/draft', {
             project: false,
-            form: false
+            form: false,
+            publishedAttachments: false,
+            formDatasetDiff: false,
+            appUserCount: false
           })
           .complete()
           .route('/projects/1/forms/f/draft/attachments')
@@ -1189,12 +1187,8 @@ describe('FormAttachmentList', () => {
         return load('/projects/1/forms/f/draft/attachments')
           .respondWithData(() => testData.extendedDatasets.sorted())
           .complete()
-          .load('/projects/1/forms/f/draft', {
-            project: false,
-            form: false,
-            formDraft: false,
-            attachments: false
-          })
+          .route('/projects/1/forms/f/draft')
+          .respondWithData(() => testData.extendedFormVersions.published())
           .complete()
           .request(async (app) => {
             await app.get('#form-draft-status-publish-button').trigger('click');
@@ -1207,11 +1201,10 @@ describe('FormAttachmentList', () => {
             return { success: true };
           })
           .respondWithData(() => testData.extendedForms.last())
-          .respondFor('/projects/1/forms/f/submissions', {
-            form: false,
-            formDraft: false,
-            attachments: false
-          })
+          .respondWithData(() => []) // publishedAttachments
+          .respondWithData(() => testData.formDatasetDiffs.sorted())
+          .respondWithData(() => testData.extendedProjects.last())
+          .respondForComponent('FormSubmissions')
           .complete()
           .request(app =>
             app.get('#form-head-create-draft-button').trigger('click'))
@@ -1221,7 +1214,10 @@ describe('FormAttachmentList', () => {
           })
           .respondFor('/projects/1/forms/f/draft', {
             project: false,
-            form: false
+            form: false,
+            publishedAttachments: false,
+            formDatasetDiff: false,
+            appUserCount: false
           })
           .complete()
           .route('/projects/1/forms/f/draft/attachments')

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -156,7 +156,7 @@ describe('FormDraftAbandon', () => {
         })
         .respondWithSuccess()
         .respondWithData(() => []) // forms
-        .respondWithData(() => []); // deleted forms
+        .respondWithData(() => []); // deletedForms
     };
 
     it('shows a success alert', () =>

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -126,12 +126,7 @@ describe('FormDraftAbandon', () => {
           return app.get('#form-draft-abandon .btn-danger').trigger('click');
         })
         .respondWithSuccess()
-        .respondFor('/projects/1/forms/f/submissions', {
-          project: false,
-          form: false,
-          formDraft: false,
-          attachments: false
-        });
+        .respondForComponent('FormSubmissions');
     };
 
     it('shows a success alert', () =>

--- a/test/components/form-draft/publish.spec.js
+++ b/test/components/form-draft/publish.spec.js
@@ -352,7 +352,7 @@ describe('FormDraftPublish', () => {
         return { success: true };
       })
       .respondWithData(() => testData.extendedForms.last())
-      .respondWithData(() => []) // publishedAttachments
+      .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
       .respondWithData(() => testData.formDatasetDiffs.sorted())
       .respondWithData(() => testData.extendedProjects.last())
       .respondForComponent('FormSubmissions');

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -233,8 +233,11 @@ describe('FormHead', () => {
           .respondFor('/projects/1/forms/f/draft', {
             project: false,
             form: false,
+            publishedAttachments: false,
+            formDatasetDiff: false,
             formDraft: () =>
-              testData.extendedFormDrafts.createNew({ draft: true })
+              testData.extendedFormDrafts.createNew({ draft: true }),
+            appUserCount: false
           })
           .afterResponses(app => {
             app.vm.$route.path.should.equal('/projects/1/forms/f/draft');

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -233,11 +233,8 @@ describe('FormHead', () => {
           .respondFor('/projects/1/forms/f/draft', {
             project: false,
             form: false,
-            publishedAttachments: false,
-            formDatasetDiff: false,
             formDraft: () =>
-              testData.extendedFormDrafts.createNew({ draft: true }),
-            appUserCount: false
+              testData.extendedFormDrafts.createNew({ draft: true })
           })
           .afterResponses(app => {
             app.vm.$route.path.should.equal('/projects/1/forms/f/draft');

--- a/test/components/form/show.spec.js
+++ b/test/components/form/show.spec.js
@@ -20,7 +20,10 @@ describe('FormShow', () => {
       { url: '/v1/projects/1', extended: true },
       { url: '/v1/projects/1/forms/a%20b', extended: true },
       { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
-      { url: '/v1/projects/1/forms/a%20b/draft/attachments' }
+      { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
+      { url: '/v1/projects/1/forms/a%20b/attachments' },
+      { url: '/v1/projects/1/forms/a%20b/dataset-diff' },
+      { url: '/v1/projects/1/forms/a%20b/assignments/app-user' }
     ]);
   });
 

--- a/test/components/form/show.spec.js
+++ b/test/components/form/show.spec.js
@@ -7,27 +7,45 @@ import { mockLogin } from '../../util/session';
 import { mockResponse } from '../../util/axios';
 
 describe('FormShow', () => {
-  beforeEach(mockLogin);
-
   it('requires the projectId route param to be integer', async () => {
+    mockLogin();
     const app = await load('/projects/p/forms/f/settings');
     app.findComponent(NotFound).exists().should.be.true;
   });
 
-  it('sends the correct initial requests', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a b' });
-    return load('/projects/1/forms/a%20b/settings').testRequests([
-      { url: '/v1/projects/1', extended: true },
-      { url: '/v1/projects/1/forms/a%20b', extended: true },
-      { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
-      { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
-      { url: '/v1/projects/1/forms/a%20b/attachments' },
-      { url: '/v1/projects/1/forms/a%20b/dataset-diff' },
-      { url: '/v1/projects/1/forms/a%20b/assignments/app-user' }
-    ]);
+  describe('initial requests', () => {
+    it('sends the correct requests for a sitewide administrator', () => {
+      mockLogin();
+      testData.extendedForms.createPast(1, { xmlFormId: 'a b' });
+      return load('/projects/1/forms/a%20b/versions').testRequests([
+        { url: '/v1/projects/1', extended: true },
+        { url: '/v1/projects/1/forms/a%20b', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
+        { url: '/v1/projects/1/forms/a%20b/versions', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/attachments' },
+        { url: '/v1/projects/1/forms/a%20b/dataset-diff' },
+        { url: '/v1/projects/1/forms/a%20b/assignments/app-user' }
+      ]);
+    });
+
+    it('sends the correct requests for a project viewer', () => {
+      mockLogin({ role: 'none' });
+      testData.extendedProjects.createPast(1, { role: 'viewer', forms: 1 });
+      testData.extendedForms.createPast(1, { xmlFormId: 'a b' });
+      return load('/projects/1/forms/a%20b/versions').testRequests([
+        { url: '/v1/projects/1', extended: true },
+        { url: '/v1/projects/1/forms/a%20b', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
+        { url: '/v1/projects/1/forms/a%20b/versions', extended: true }
+      ]);
+    });
   });
 
   describe('requestData reconciliation', () => {
+    beforeEach(mockLogin);
+
     it('updates attachments if it is defined but formDraft is not', async () => {
       testData.extendedForms.createPast(1);
       const attachments = testData.standardFormAttachments.createPast(1).sorted();
@@ -48,6 +66,7 @@ describe('FormShow', () => {
   });
 
   it('re-renders the router view after a route change', () => {
+    mockLogin();
     testData.extendedForms
       .createPast(1, { xmlFormId: 'f1' })
       .createPast(1, { xmlFormId: 'f2' });

--- a/test/components/form/submissions.spec.js
+++ b/test/components/form/submissions.spec.js
@@ -52,9 +52,8 @@ describe('FormSubmissions', () => {
         .afterResponses(app => {
           findTab(app, 'Submissions').get('.badge').text().should.equal('10');
         })
-        .load('/projects/1/forms/f/submissions', {
-          project: false, form: false, formDraft: false, attachments: false
-        })
+        .route('/projects/1/forms/f/submissions')
+        .respondForComponent('FormSubmissions')
         .complete()
         .route('/projects/1/forms/f/settings')
         .then(app => {

--- a/test/components/submission/filters.spec.js
+++ b/test/components/submission/filters.spec.js
@@ -480,11 +480,16 @@ describe('SubmissionFilters', () => {
   it('does not send an extra OData request after filtering, then navigating away', () => {
     testData.extendedForms.createPast(1);
     testData.extendedFormVersions.createPast(1, { draft: true });
+    let odataRequests = 0;
     return load('/projects/1/forms/f/submissions?reviewState=%27approved%27')
       .complete()
-      // If an extra request is sent, there will be no response specified for
-      // the request, causing the test to fail.
       .route('/projects/1/forms/f/draft/testing')
-      .respondForComponent('FormDraftTesting');
+      .respondForComponent('FormDraftTesting')
+      .beforeEachResponse((_, { url }) => {
+        if (url.includes('.svc')) odataRequests += 1;
+      })
+      .afterResponses(() => {
+        odataRequests.should.equal(1);
+      });
   });
 });

--- a/test/components/submission/filters.spec.js
+++ b/test/components/submission/filters.spec.js
@@ -482,9 +482,9 @@ describe('SubmissionFilters', () => {
     testData.extendedFormVersions.createPast(1, { draft: true });
     return load('/projects/1/forms/f/submissions?reviewState=%27approved%27')
       .complete()
-      // If an extra request is sent, then .load() will fail.
-      .load('/projects/1/forms/f/draft/testing', {
-        project: false, form: false, formDraft: false, attachments: false
-      });
+      // If an extra request is sent, there will be no response specified for
+      // the request, causing the test to fail.
+      .route('/projects/1/forms/f/draft/testing')
+      .respondForComponent('FormDraftTesting');
   });
 });

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -128,12 +128,7 @@ describe('createCentralRouter()', () => {
       return load('/projects/1/forms/f/settings')
         .complete()
         .route('/projects/1/forms/f')
-        .respondFor('/projects/1/forms/f/submissions', {
-          project: false,
-          form: false,
-          formDraft: false,
-          attachments: false
-        })
+        .respondForComponent('FormSubmissions')
         .afterResponses(app => {
           app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
         });
@@ -393,15 +388,19 @@ describe('createCentralRouter()', () => {
         it('preserves data that FormShow uses', () =>
           load('/projects/1/forms/f/settings')
             .complete()
-            .load('/projects/1/forms/f/public-links', {
-              project: false,
-              form: false,
-              formDraft: false,
-              attachments: false
-            })
+            .route('/projects/1/forms/f/public-links')
+            .respondForComponent('PublicLinkList')
             .complete()
             .route('/projects/1/forms/f/settings')
-            .then(dataExists(['project', 'form', 'formDraft', 'attachments'])));
+            .then(dataExists([
+              'project',
+              'form',
+              'formDraft',
+              'attachments',
+              'publishedAttachments',
+              'formDatasetDiff',
+              'appUserCount'
+            ])));
 
         it('preserves publicLinks', () =>
           load('/projects/1/forms/f/public-links')

--- a/test/util/http.js
+++ b/test/util/http.js
@@ -431,6 +431,7 @@ class MockHttp {
     return this.respond(() => mockResponse.problem(problemOrCode));
   }
 
+  // Specifies a response to return for a matching request.
   respondIf(f, responseCallback) {
     return this._with({
       respondIf: [...this._respondIf, [f, responseCallback]]
@@ -449,10 +450,10 @@ class MockHttp {
   }
 
   // respondForComponent() responds with all the responses expected for the
-  // specified component. This method is used in respondFor() and elsewhere, but
-  // it is rarely used directly in tests.
-  respondForComponent(name, options = undefined) {
-    return requestDataByComponent(name).responses.reduce(
+  // specified route component. Most tests should use respondFor() instead of
+  // this method.
+  respondForComponent(componentName, options = undefined) {
+    return requestDataByComponent(componentName).responses.reduce(
       (series, [resourceName, response]) => {
         const option = options != null ? options[resourceName] : null;
         if (option === false) return series;
@@ -464,7 +465,7 @@ class MockHttp {
             () => mockResponse.of((option ?? response[1])())
           );
         }
-        throw new Error('invalid response for component');
+        throw new Error(`invalid response for component ${componentName}`);
       },
       this
     );

--- a/test/util/http/data.js
+++ b/test/util/http/data.js
@@ -78,12 +78,14 @@ const responsesByComponent = {
     attachments: () => (testData.extendedFormVersions.last().publishedAt == null
       ? testData.standardFormAttachments.sorted()
       : mockResponse.problem(404.1)),
+
+    // Conditional responses (mockHttp().respondIf())
     publishedAttachments: [
       ({ url }) => /^\/v1\/projects\/\d+\/forms\/[^/]+\/attachments$/.test(url),
       () => []
     ],
     formDatasetDiff: [
-      ({ url }) => /^\/v1\/projects\/\d+\/forms\/[^/]+\/dataset-diff/.test(url),
+      ({ url }) => /^\/v1\/projects\/\d+\/forms\/[^/]+\/dataset-diff$/.test(url),
       () => testData.formDatasetDiffs.sorted()
     ],
     appUserCount: [

--- a/test/util/http/data.js
+++ b/test/util/http/data.js
@@ -36,12 +36,10 @@ for (const [resourceName, callback] of Object.entries(responseDefaults))
   responseDefaults[resourceName] = () => mockResponse.of(callback());
 
 const componentResponses = (map) => Object.entries(map)
-  .map(([resourceName, callbackOrTrue]) => {
-    const callback = callbackOrTrue === true
-      ? responseDefaults[resourceName]
-      : () => mockResponse.of(callbackOrTrue());
-    return [resourceName, callback];
-  });
+  .map(([resourceName, response]) => [
+    resourceName,
+    response === true ? responseDefaults[resourceName] : response
+  ]);
 
 const responsesByComponent = {
   ConfigError: [],
@@ -79,7 +77,19 @@ const responsesByComponent = {
       : mockResponse.problem(404.1)),
     attachments: () => (testData.extendedFormVersions.last().publishedAt == null
       ? testData.standardFormAttachments.sorted()
-      : mockResponse.problem(404.1))
+      : mockResponse.problem(404.1)),
+    publishedAttachments: [
+      ({ url }) => /^\/v1\/projects\/\d+\/forms\/[^/]+\/attachments$/.test(url),
+      () => []
+    ],
+    formDatasetDiff: [
+      ({ url }) => /^\/v1\/projects\/\d+\/forms\/[^/]+\/dataset-diff/.test(url),
+      () => testData.formDatasetDiffs.sorted()
+    ],
+    appUserCount: [
+      ({ url }) => /^\/v1\/projects\/\d+\/forms\/[^/]+\/assignments\/app-user$/.test(url),
+      () => []
+    ]
   }),
   FormPreview: componentResponses({
     form: () => testData.extendedForms.last(),


### PR DESCRIPTION
This PR sends three new requests from `FormShow` that will be needed for the form infonav buttons (getodk/central#827):

- `publishedAttachments`. This is the list of form attachments for the published version of the form. We will use it to retrieve the list of entity lists that the form uses (via `publishedAttachments.linkedDatasets`). We used to request this on the form overview before that page was removed in [#1132](https://github.com/getodk/central-frontend/pull/1132).
- `formDatasetDiff`. This gives us the list of entity lists that the form updates. Again, we used to request this on the form overview (in the `DatasetSummary` component).
- `appUserCount`. This is an entirely new resource. It is the count of app users assigned to the form.

The infonav buttons will be shown on every form page, which is why these requests are sent from `FormShow`.

#### What has been done to verify that this works as intended?

I updated existing tests and added a new one.

#### Why is this the best possible solution? Were any other approaches considered?

One change I wanted to make a note of is related to testing. Usually when a core route component like `FormShow` sends new requests, a bunch of tests start failing. That's because it's expected that a response will be specified for every request that's sent. If there's a request without a response, that's usually a sign that something has gone wrong or that a test isn't working as expected. But that means that before the new response is added to tests, the new request results in test failures.

Usually the fix is just a simple update of the list of automatic responses in test/http/data.js. However, with this PR, things are more complicated because the three new requests are sent conditionally. They're sent for sitewide administrators and project managers, but not project viewers. Historically, there hasn't been a good way to handle those sorts of conditional requests in testing: updating test/http/data.js wouldn't be enough. We could add the new requests to test/http/data.js, but any test that renders `FormShow` for a project viewer would still fail. For project viewers, we would be returning all the responses requested, but we also be returning responses that weren't requested. Too many responses are a problem in testing in the same way that too few responses are.

To address that, I've updated `mockHttp()` in a way that I've wanted to for a while. Previously, every response you specified to `mockHttp()` would always be returned. If it wasn't requested, then that'd be an error. However, with this PR, I've added a new method to `mockHttp()`: `respondIf()`. `respondIf()` allows you to return a specified response only if a matching request is sent. If no matching request is sent, then that's not an error.

`respondIf()` helps with requests that are sent conditionally, but it also has an additional benefit. Normally, responses specified to `mockHttp()` are returned in the same order as they were specified. If the request order changes, then the order of responses needs to change in testing. However, `respondIf()` doesn't care about request order. A request can come at any time / in any order, and if it matches, the corresponding response will be returned. That's important for the new requests in this PR, because they'll be sent only once the project response is received. The project response will be received only after all route components have been rendered and sent their initial requests, which means that going forward, the requests that `FormShow` sends will be interwoven with requests from the bottom-most route component. Previously, requests would always be grouped by route component. `mockHttp()` wouldn't have been able to handle that before, but now it can.

Beyond this PR, I'm starting to think about how we might be able to use `respondIf()` to make some of our testing more flexible in general around requests/responses.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced