### PR TITLE
Don't request resources for published form if form is draft

### DIFF
--- a/test/components/form/show.spec.js
+++ b/test/components/form/show.spec.js
@@ -23,9 +23,9 @@ describe('FormShow', () => {
         { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
         { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
         { url: '/v1/projects/1/forms/a%20b/versions', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/assignments/app-user' },
         { url: '/v1/projects/1/forms/a%20b/attachments' },
-        { url: '/v1/projects/1/forms/a%20b/dataset-diff' },
-        { url: '/v1/projects/1/forms/a%20b/assignments/app-user' }
+        { url: '/v1/projects/1/forms/a%20b/dataset-diff' }
       ]);
     });
 
@@ -39,6 +39,19 @@ describe('FormShow', () => {
         { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
         { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
         { url: '/v1/projects/1/forms/a%20b/versions', extended: true }
+      ]);
+    });
+
+    it('does not send requests for entity lists if form is a draft', () => {
+      mockLogin();
+      testData.extendedForms.createPast(1, { xmlFormId: 'a b', draft: true });
+      return load('/projects/1/forms/a%20b/draft').testRequests([
+        { url: '/v1/projects/1', extended: true },
+        { url: '/v1/projects/1/forms/a%20b', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/draft', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/draft/attachments' },
+        { url: '/v1/projects/1/forms/a%20b/versions', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/assignments/app-user' }
       ]);
     });
   });


### PR DESCRIPTION
This is a follow-up PR to #1134 and fixes an issue introduced from that PR. Currently, if you navigate to a form without a published version, you'll see an error message. That's because the request for the dataset diff returns an error response if the form isn't published. We don't need to call `fetchLinkedDatasets()` in `FormShow` if the form isn't published, and this PR makes a change along those lines. Making that change prevents the error message.

If/when a draft form is published, `fetchLinkedDatasets()` will be called. That hasn't changed.

#### What has been done to verify that this works as intended?

New test.

#### Why is this the best possible solution? Were any other approaches considered?

We could send the request and just suppress the error, but I think it's nicer not to send the request in the first place.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced