### PR TITLE
Reorder form tabs

### DIFF
--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -27,13 +27,7 @@ except according to the terms contained in the LICENSE file.
           <div class="col-xs-6">
             <ul id="form-head-form-tabs" class="nav nav-tabs">
               <!-- No v-if, because anyone who can navigate to the form should
-              be able to navigate to .../versions and .../submissions. -->
-              <li :class="formTabClass('versions')" role="presentation">
-                <router-link :to="tabPath('versions')"
-                  v-tooltip.aria-describedby="formTabDescription">
-                  {{ $t('formHead.tab.versions') }}
-                </router-link>
-              </li>
+              be able to navigate to .../submissions and .../versions. -->
               <li :class="formTabClass('submissions')" role="presentation">
                 <router-link :to="tabPath('submissions')"
                   v-tooltip.aria-describedby="formTabDescription">
@@ -54,6 +48,12 @@ except according to the terms contained in the LICENSE file.
                   <span v-if="form.dataExists" class="badge">
                     {{ $n(form.publicLinks, 'default') }}
                   </span>
+                </router-link>
+              </li>
+              <li :class="formTabClass('versions')" role="presentation">
+                <router-link :to="tabPath('versions')"
+                  v-tooltip.aria-describedby="formTabDescription">
+                  {{ $t('formHead.tab.versions') }}
                 </router-link>
               </li>
               <li v-if="rendersFormTabs" :class="formTabClass('settings')"

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -1,7 +1,7 @@
 import Breadcrumbs from '../../../src/components/breadcrumbs.vue';
 
 import testData from '../../data';
-import { findTab } from '../../util/dom';
+import { findTab, textWithout } from '../../util/dom';
 import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 
@@ -65,13 +65,13 @@ describe('FormHead', () => {
       testData.standardFormAttachments.createPast(1, { blobExists: false });
       return load('/projects/1/forms/f/draft').then(app => {
         const tabs = app.findAll('#form-head-form-nav .nav-tabs a');
-        tabs.map(tab => tab.text()).should.eql([
+        tabs.map(tab => textWithout(tab, '.badge')).should.eql([
+          'Submissions',
+          'Public Access',
           'Versions',
-          'Submissions 0',
-          'Public Access 0',
-          'Settings Open',
+          'Settings',
           'Status',
-          'Form Attachments 1',
+          'Form Attachments',
           'Testing'
         ]);
       });
@@ -84,8 +84,8 @@ describe('FormHead', () => {
       testData.standardFormAttachments.createPast(1);
       return load('/projects/1/forms/f/draft/testing').then(app => {
         const tabs = app.findAll('#form-head-form-nav .nav-tabs a');
-        const text = tabs.map(tab => tab.text());
-        text.should.eql(['Versions', 'Submissions 0', 'Testing']);
+        const text = tabs.map(tab => textWithout(tab, '.badge'));
+        text.should.eql(['Submissions', 'Versions', 'Testing']);
       });
     });
 


### PR DESCRIPTION
This is a follow-up PR to #1132 and ties up a loose end for getodk/central#865. As of #1132, the submissions page is the primary page for a published form: if you click a link to a published form, it will go to the submissions page. However, the submissions tab currently isn't the first tab on the form page. The result is that when you navigate to a form, you see that you're not on the first tab. This PR reorders the form tabs to match the order in the release criteria, where the submissions tab comes first.

#### What has been done to verify that this works as intended?

Updated tests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced