### PR TITLE
Show tag for current published version of form

### DIFF
--- a/src/components/form-version/row.vue
+++ b/src/components/form-version/row.vue
@@ -12,7 +12,10 @@ except according to the terms contained in the LICENSE file.
 <template>
   <tr class="form-version-row">
     <td class="version">
-      <form-version-string :version="version.version"/>
+      <div>
+        <div><form-version-string :version="version.version"/></div>
+        <div v-if="current"><span class="chip">{{ $t('current') }}</span></div>
+      </div>
     </td>
     <td>
       <time-and-user :iso="version.publishedAt" :user="version.publishedBy"/>
@@ -24,22 +27,22 @@ except according to the terms contained in the LICENSE file.
   </tr>
 </template>
 
-<script>
+<script setup>
 import FormVersionDefDropdown from './def-dropdown.vue';
 import FormVersionString from './string.vue';
 import TimeAndUser from '../time-and-user.vue';
 
-export default {
-  name: 'FormVersionRow',
-  components: { FormVersionDefDropdown, FormVersionString, TimeAndUser },
-  props: {
-    version: {
-      type: Object,
-      required: true
-    }
+defineOptions({
+  name: 'FormVersionRow'
+});
+defineProps({
+  version: {
+    type: Object,
+    required: true
   },
-  emits: ['view-xml']
-};
+  current: Boolean
+});
+defineEmits(['view-xml']);
 </script>
 
 <style lang="scss">
@@ -47,6 +50,27 @@ export default {
 
 .form-version-row {
   .table tbody & td { vertical-align: middle; }
-  .version { @include text-overflow-ellipsis; }
+
+  .version > div {
+    column-gap: 15px;
+    display: flex;
+
+    > :first-child {
+      @include text-overflow-ellipsis;
+      // This is needed to prevent overflow when the flexbox only has one child.
+      max-width: 100%;
+    }
+
+    > :last-child { flex-shrink: 0; }
+  }
 }
 </style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // This is a label shown for the current version of a Form.
+    "current": "Current Published Version"
+  }
+}
+</i18n>

--- a/src/components/form-version/table.vue
+++ b/src/components/form-version/table.vue
@@ -19,8 +19,9 @@ except according to the terms contained in the LICENSE file.
       </tr>
     </thead>
     <tbody v-if="formVersions.dataExists">
-      <form-version-row v-for="version of formVersions" :key="version.version"
-        :version="version" @view-xml="$emit('view-xml')"/>
+      <form-version-row v-for="(version, index) in formVersions"
+        :key="version.version" :version="version" :current="index === 0"
+        @view-xml="$emit('view-xml')"/>
     </tbody>
   </table>
 </template>

--- a/test/components/form-version/row.spec.js
+++ b/test/components/form-version/row.spec.js
@@ -13,14 +13,41 @@ describe('FormVersionRow', () => {
     mockLogin({ displayName: 'Alice' });
   });
 
-  it('shows the version string', async () => {
-    testData.extendedForms.createPast(1);
-    const component = await load('/projects/1/forms/f/versions', { root: false });
-    const row = component.getComponent(FormVersionRow);
-    row.getComponent(FormVersionString).props().version.should.equal('v1');
+  describe('name column', () => {
+    it('shows the version string', async () => {
+      testData.extendedForms.createPast(1);
+      const component = await load('/projects/1/forms/f/versions', { root: false });
+      const row = component.getComponent(FormVersionRow);
+      row.getComponent(FormVersionString).props().version.should.equal('v1');
+    });
+
+    it('shows a tag for the current version', async () => {
+      testData.extendedForms.createPast(1);
+      testData.extendedFormVersions.createPast(1);
+      const component = await load('/projects/1/forms/f/versions', { root: false });
+      const rows = component.findAllComponents(FormVersionRow);
+      rows.length.should.equal(2);
+      const chip = rows[0].get('.chip');
+      chip.text().should.equal('Current Published Version');
+      rows[1].find('.chip').exists().should.be.false;
+    });
+
+    it('shows tooltips', async () => {
+      // The text truncation works slightly differently for the current version
+      // vs. other versions. With the current version, the flexbox has two
+      // children, whereas for other versions, it only has one. Here, we test
+      // the current version and another version.
+      testData.extendedForms.createPast(1, { version: 'x'.repeat(1000) });
+      testData.extendedFormVersions.createPast(1, { version: 'y'.repeat(1000) });
+      const component = await load('/projects/1/forms/f/versions', { root: false });
+      const versionStrings = component.findAllComponents(FormVersionString);
+      versionStrings.length.should.equal(2);
+      await versionStrings[0].should.have.textTooltip();
+      await versionStrings[1].should.have.textTooltip();
+    });
   });
 
-  describe('published', () => {
+  describe('published column', () => {
     it('shows publishedAt', () => {
       const form = testData.extendedForms.createPast(1).last();
       return load('/projects/1/forms/f/versions').then(app => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3382,6 +3382,12 @@
         }
       }
     },
+    "FormVersionRow": {
+      "current": {
+        "string": "Current Published Version",
+        "developer_comment": "This is a label shown for the current version of a Form."
+      }
+    },
     "FormVersionString": {
       "blank": {
         "string": "(blank)",


### PR DESCRIPTION
This PR updates the form versions page, showing a tag of "Current Published Version" next to the latest version. That's part of the release criteria for getodk/central#865. Here's a screenshot of what that looks like:

<img width="958" src="https://github.com/user-attachments/assets/1c97c35f-a9dc-4380-b4df-e938a7892a0a" />

#### What has been done to verify that this works as intended?

I wrote new tests and tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced