### PR TITLE
Features C#906: Use web history instead of hash for routing

### DIFF
--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -102,6 +102,7 @@ http {
 
     location / {
       root ./dist;
+      try_files $uri $uri/ /index.html;
 
       include ./common-headers.nginx.conf;
       # We return this header for more files in development than we do in

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,13 @@ except according to the terms contained in the LICENSE file.
       <p>Please enable JavaScript to continue.</p>
       <p>Powered by <a href="https://getodk.org">ODK</a>.</p>
     </noscript>
+    <script>
+      // We used to have hash-based navigation, we have now switched to web-history-based
+      // navigation. To support, bookmarked links, we are redirecting old URL to the new one.
+      if (window.location.href.startsWith(window.location.origin + "/#")) {
+          window.location.replace(window.location.origin + window.location.hash.substring(1));
+      }
+    </script>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -22,13 +22,6 @@ except according to the terms contained in the LICENSE file.
       <p>Please enable JavaScript to continue.</p>
       <p>Powered by <a href="https://getodk.org">ODK</a>.</p>
     </noscript>
-    <script>
-      // We used to have hash-based navigation, we have now switched to web-history-based
-      // navigation. To support, bookmarked links, we are redirecting old URL to the new one.
-      if (window.location.href.startsWith(window.location.origin + "/#")) {
-          window.location.replace(window.location.origin + window.location.hash.substring(1));
-      }
-    </script>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,7 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-import { START_LOCATION, createRouter, createWebHashHistory } from 'vue-router';
+import { START_LOCATION, createRouter, createWebHistory } from 'vue-router';
 import { last } from 'ramda';
 import { watchEffect } from 'vue';
 
@@ -24,7 +24,7 @@ import { noop } from './util/util';
 import { setDocumentTitle } from './util/reactivity';
 
 export default (container, {
-  history = createWebHashHistory(),
+  history = createWebHistory(),
   scrollBehavior = createScrollBehavior()
 } = {}) => {
   const routes = createRoutes(container);

--- a/src/router.js
+++ b/src/router.js
@@ -135,6 +135,9 @@ router.afterEach(unlessFailure(to => {
     };
   });
 
+  // We used to have hash-based navigation, we have now switched to web-history-based
+  // navigation. To support, bookmarked links, we are redirecting old URL to the new one.
+  router.beforeEach(to => (to.path === '/' && to.hash.startsWith('#/') ? to.hash.substring(1) : true));
 
 
   //////////////////////////////////////////////////////////////////////////////

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -148,6 +148,13 @@ describe('createCentralRouter()', () => {
           path.should.equal('/projects/1/entity-lists/trees/entities');
         });
     });
+
+    it('redirects if the hash is a path', () =>
+      load('/#/account/edit', {}, false)
+        .respondFor('/account/edit')
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/account/edit');
+        }));
   });
 
   describe('requireLogin', () => {


### PR DESCRIPTION
Closes getodk/central#906

#### What has been done to verify that this works as intended?

Manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

This change is prompted by the need to have cleaner and shorter public access link as part of web-forms integration. Since we control the server that serves frontend application we can easily use webhistory mode for routes. Even vue-router [recommends](https://router.vuejs.org/guide/essentials/history-mode.html#HTML5-Mode) web history mode. 

I have also added a small script in the index.html to redirect old hash based URLs to the newer ones, this will keep old bookmarked links (if any) still functional for the users.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have 
accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced