### PR TITLE
Increase timeout for tests of SubmissionList pagination

### DIFF
--- a/test/components/submission/list.spec.js
+++ b/test/components/submission/list.spec.js
@@ -807,7 +807,9 @@ describe('SubmissionList', () => {
     });
   });
 
-  describe('pagination', () => {
+  describe('pagination', function() { // eslint-disable-line func-names
+    this.timeout(4000);
+
     const checkIds = (component, count, offset = 0) => {
       const rows = component.findAllComponents(SubmissionDataRow);
       rows.length.should.equal(count);


### PR DESCRIPTION
I noticed this test failure in CircleCI ([here](https://app.circleci.com/pipelines/github/getodk/central-frontend/2316/workflows/359e1c75-7305-4230-af0b-d288ca231e5a/jobs/2629)):

```
1) should show correct row number
     SubmissionList pagination
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

Locally, I've seen:

```
1) should load previous page
     SubmissionList pagination
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

I think it's fine that those tests take a little longer, but we want to prevent intermittent test failures. This PR tries to do that by increasing the test timeout.

Both of the examples above come from the same `describe()` block, so I applied the timeout on the `describe()` level (Mocha docs [here](https://mochajs.org/#suite-level)). The default timeout is 2000ms, so I'm starting out by increasing the timeout to 4000. I wouldn't mind increasing it further.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced