### PR TITLE
Finish first row of FormEdit

### DIFF
--- a/src/components/form-draft/abandon.vue
+++ b/src/components/form-draft/abandon.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
     <template #title>{{ title }}</template>
     <template #body>
       <div class="modal-introduction">
-        <template v-if="form.publishedAt != null">
+        <template v-if="form.dataExists && form.publishedAt != null">
           <p>{{ $t('introduction.abandon[0]') }}</p>
           <p>{{ $t('introduction.abandon[1]') }}</p>
         </template>
@@ -64,7 +64,7 @@ export default {
   },
   computed: {
     title() {
-      return this.form.publishedAt != null
+      return this.form.dataExists && this.form.publishedAt != null
         ? this.$t('title.abandon')
         : this.$t('title.deleteForm');
     }

--- a/src/components/form-draft/publish.vue
+++ b/src/components/form-draft/publish.vue
@@ -125,7 +125,7 @@ export default {
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.
-    const { formVersions, draftAttachments, resourceView, formDraftDatasetDiff } = useRequestData();
+    const { formVersions, draftAttachments, formDraftDatasetDiff, resourceView } = useRequestData();
     const formDraft = resourceView('formDraft', (data) => data.get());
 
     const { request, awaitingResponse } = useRequest();

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -19,6 +19,9 @@ except according to the terms contained in the LICENSE file.
         <form-edit-draft-controls v-else @publish="publishModal.show()"
           @abandon="abandonModal.show()"/>
       </div>
+      <div class="col-xs-6">
+        <form-edit-published-version v-if="form.dataExists"/>
+      </div>
     </div>
     <template v-if="formDraft.dataExists && formDraft.isDefined()">
       <form-draft-status @fetch-draft="fetchDraft(true)"/>
@@ -46,6 +49,7 @@ import FormDraftTesting from '../form-draft/testing.vue';
 import FormEditCreateDraft from './edit/create-draft.vue';
 import FormEditDraftControls from './edit/draft-controls.vue';
 import FormEditLoadingDraft from './edit/loading-draft.vue';
+import FormEditPublishedVersion from './edit/published-version.vue';
 
 import useRoutes from '../../composables/routes';
 import { apiPaths } from '../../util/request';

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div>
+  <div id="form-edit">
     <div class="row">
       <div class="col-xs-6">
         <form-edit-loading-draft v-if="!formDraft.dataExists"/>
@@ -141,6 +141,14 @@ const afterAbandon = () => {
 const rendersAttachments = computed(() =>
   draftAttachments.dataExists && draftAttachments.size !== 0);
 </script>
+
+<style lang="scss">
+#form-edit {
+  padding-inline: 10px;
+}
+
+body:has(#form-edit) { background-color: #fff; }
+</style>
 
 <i18n lang="json5">
 {

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -13,7 +13,8 @@ except according to the terms contained in the LICENSE file.
   <div>
     <div class="row">
       <div class="col-xs-6">
-        <form-edit-create-draft v-if="formDraft.dataExists && formDraft.isEmpty()"
+        <form-edit-loading-draft v-if="!formDraft.dataExists"/>
+        <form-edit-create-draft v-else-if="formDraft.isEmpty()"
           @success="fetchDraft(true)"/>
       </div>
     </div>
@@ -34,6 +35,7 @@ import FormAttachmentList from '../form-attachment/list.vue';
 import FormDraftStatus from '../form-draft/status.vue';
 import FormDraftTesting from '../form-draft/testing.vue';
 import FormEditCreateDraft from './edit/create-draft.vue';
+import FormEditLoadingDraft from './edit/loading-draft.vue';
 
 import { apiPaths } from '../../util/request';
 import { noop } from '../../util/util';

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -16,28 +16,41 @@ except according to the terms contained in the LICENSE file.
         <form-edit-loading-draft v-if="!formDraft.dataExists"/>
         <form-edit-create-draft v-else-if="formDraft.isEmpty()"
           @success="fetchDraft(true)"/>
+        <form-edit-draft-controls v-else @publish="publishModal.show()"
+          @abandon="abandonModal.show()"/>
       </div>
     </div>
     <template v-if="formDraft.dataExists && formDraft.isDefined()">
-      <form-draft-status @fetch-project="$emit('fetch-project', $event)"
-        @fetch-form="$emit('fetch-form')" @fetch-draft="fetchDraft(true)"
-        @fetch-linked-datasets="$emit('fetch-linked-datasets')"/>
+      <form-draft-status @fetch-draft="fetchDraft(true)"/>
       <form-attachment-list v-if="rendersAttachments"/>
       <form-draft-testing/>
     </template>
+
+    <form-draft-publish v-if="formDraft.dataExists && formDraft.isDefined()"
+      v-bind="publishModal" @hide="publishModal.hide()"
+      @success="afterPublish"/>
+    <form-draft-abandon v-bind="abandonModal" @hide="abandonModal.hide()"
+      @success="afterAbandon"/>
   </div>
 </template>
 
 <script setup>
-import { computed, provide, watchEffect } from 'vue';
+import { computed, inject, provide, watchEffect } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import FormAttachmentList from '../form-attachment/list.vue';
+import FormDraftAbandon from '../form-draft/abandon.vue';
+import FormDraftPublish from '../form-draft/publish.vue';
 import FormDraftStatus from '../form-draft/status.vue';
 import FormDraftTesting from '../form-draft/testing.vue';
 import FormEditCreateDraft from './edit/create-draft.vue';
+import FormEditDraftControls from './edit/draft-controls.vue';
 import FormEditLoadingDraft from './edit/loading-draft.vue';
 
+import useRoutes from '../../composables/routes';
+import { afterNextNavigation } from '../../util/router';
 import { apiPaths } from '../../util/request';
+import { modalData } from '../../util/reactivity';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
 
@@ -54,11 +67,11 @@ const props = defineProps({
     required: true
   }
 });
-defineEmits(['fetch-project', 'fetch-form', 'fetch-linked-datasets']);
+const emit = defineEmits(['fetch-project', 'fetch-form', 'fetch-linked-datasets']);
 provide('projectId', props.projectId);
 provide('xmlFormId', props.xmlFormId);
 
-const { formVersions, formDraft, draftAttachments } = useRequestData();
+const { form, formVersions, formDraft, draftAttachments, datasets, formDraftDatasetDiff } = useRequestData();
 
 const fetchDraft = (resend) => {
   formDraft.request({
@@ -87,6 +100,70 @@ watchEffect(() => {
   ]);
 });
 
+const publishModal = modalData();
+const { router, alert } = inject('container');
+const { t } = useI18n();
+const { projectPath, publishedFormPath } = useRoutes();
+const afterPublish = () => {
+  // We need to clear the form before navigating to the submissions page: if the
+  // form didn't already have a published version, then there would be a
+  // validateData violation if we didn't clear it.
+  emit('fetch-form');
+
+  // Other resources that may have changed after publish
+  emit('fetch-linked-datasets');
+  datasets.reset();
+  formDraftDatasetDiff.reset();
+
+  // We will update additional resources, but only after navigating to the
+  // submissions page. We need to wait to update these resources because they
+  // are used on the current page.
+  afterNextNavigation(router, () => {
+    // Re-request the project in case its `datasets` property has changed.
+    emit('fetch-project', true);
+    formVersions.data = null;
+    formDraft.setToNone();
+    draftAttachments.reset();
+
+    alert.success(t('alert.publish'));
+  });
+  router.push(publishedFormPath());
+};
+
+const abandonModal = modalData();
+const afterAbandon = () => {
+  formDraftDatasetDiff.reset();
+  if (form.publishedAt != null) {
+    afterNextNavigation(router, () => {
+      formDraft.setToNone();
+      draftAttachments.reset();
+      alert.success(t('alert.abandon'));
+    });
+    router.push(publishedFormPath());
+  } else {
+    const { nameOrId } = form;
+    afterNextNavigation(router, () => {
+      alert.success(t('alert.delete', { name: nameOrId }));
+    });
+    router.push(projectPath());
+  }
+};
+
 const rendersAttachments = computed(() =>
   draftAttachments.dataExists && draftAttachments.size !== 0);
 </script>
+
+<i18n lang="json5">
+{
+  "en": {
+    "alert": {
+      // @transifexKey component.FormDraftStatus.alert.publish
+      "publish": "Your Draft is now published. Any devices retrieving Forms for this Project will now receive the new Form definition and Form Attachments.",
+      // @transifexKey component.FormDraftStatus.alert.abandon
+      "abandon": "The Draft version of this Form has been successfully deleted.",
+      // @transifexKey component.FormDraftStatus.alert.delete
+      "delete": "The Form “{name}” was deleted."
+    }
+  }
+}
+</i18n>

--- a/src/components/form/edit/create-draft.vue
+++ b/src/components/form/edit/create-draft.vue
@@ -17,7 +17,7 @@ except according to the terms contained in the LICENSE file.
       <button id="form-edit-create-draft-button" type="button"
         class="btn btn-primary" :aria-disabled="awaitingResponse"
         @click="create">
-        <span class="icon-plus-circle"></span>{{ $t('action.create') }}
+        <span class="icon-pencil"></span>{{ $t('action.create') }}
         <spinner :state="awaitingResponse"/>
       </button>
       <p>{{ $t('toMakeChanges') }}</p>
@@ -55,7 +55,12 @@ const create = () => {
 </script>
 
 <style lang="scss">
-#form-edit-create-draft-button + p { margin-bottom: 0; }
+#form-edit-create-draft-button {
+  font-size: 14px;
+
+  ~ p { color: #666; }
+  + p { margin-block: 3px 0; }
+}
 </style>
 
 <i18n lang="json5">

--- a/src/components/form/edit/draft-controls.vue
+++ b/src/components/form/edit/draft-controls.vue
@@ -1,0 +1,70 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <form-edit-section id="form-edit-draft-controls" icon="pencil" dotted>
+    <template #title>{{ $t('title') }}</template>
+    <template #subtitle>{{ $t('subtitle') }}</template>
+    <template #body>
+      <button id="form-edit-abandon-button" type="button" class="btn btn-danger"
+        @click="$emit('abandon')">
+        <span class="icon-trash"></span>{{ abandonText }}
+      </button>
+      <button id="form-edit-publish-button" type="button"
+        class="btn btn-primary" @click="$emit('publish')">
+        <span class="icon-star"></span>{{ $t('action.publish') }}
+      </button>
+    </template>
+  </form-edit-section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import FormEditSection from './section.vue';
+
+import { useRequestData } from '../../../request-data';
+
+defineOptions({
+  name: 'FormEditDraftControls'
+});
+defineEmits(['abandon', 'publish']);
+
+const { form } = useRequestData();
+
+const { t } = useI18n();
+const abandonText = computed(() => (!form.dataExists
+  ? ''
+  : (form.publishedAt == null ? t('action.delete') : t('action.abandon'))));
+</script>
+
+<style lang="scss">
+#form-edit-publish-button { margin-left: 10px; }
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.FormEditCreateDraft.title
+    "title": "Draft version",
+    // This refers to the draft version of a Form.
+    "subtitle": "Ready to publish",
+    "action": {
+      "delete": "Delete Form",
+      // @transifexKey component.FormDraftStatus.actions.action.abandon
+      "abandon": "Abandon Draft",
+      // @transifexKey component.FormDraftStatus.actions.action.publish
+      "publish": "Publish Draft"
+    }
+  }
+}
+</i18n>

--- a/src/components/form/edit/loading-draft.vue
+++ b/src/components/form/edit/loading-draft.vue
@@ -1,0 +1,41 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <form-edit-section icon="pencil">
+    <template #title>{{ $t('title') }}</template>
+    <template #body>
+      <loading :state="formDraft.initiallyLoading"/>
+    </template>
+  </form-edit-section>
+</template>
+
+<script setup>
+import FormEditSection from './section.vue';
+import Loading from '../../loading.vue';
+
+import { useRequestData } from '../../../request-data';
+
+defineOptions({
+  name: 'FormEditLoadingDraft'
+});
+
+const { formDraft } = useRequestData();
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.FormEditCreateDraft.title
+    "title": "Draft version"
+  }
+}
+</i18n>

--- a/src/components/form/edit/published-version.vue
+++ b/src/components/form/edit/published-version.vue
@@ -1,0 +1,79 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <form-edit-section id="form-edit-published-version" icon="star"
+    :class="{ draft: form.publishedAt == null }">
+    <template #title>{{ $t('title') }}</template>
+    <template #subtitle>
+      <template v-if="form.publishedAt == null">{{ $t('subtitle.draft') }}</template>
+      <i18n-t v-else keypath="subtitle.published">
+        <template #dateTime>
+          <date-time :iso="form.publishedAt"/>
+        </template>
+      </i18n-t>
+    </template>
+    <template #body>
+      <div v-if="form.publishedAt != null" id="form-edit-published-version-string">
+        <form-version-string :version="form.version"/>
+      </div>
+    </template>
+  </form-edit-section>
+</template>
+
+<script setup>
+import DateTime from '../../date-time.vue';
+import FormEditSection from './section.vue';
+import FormVersionString from '../../form-version/string.vue';
+
+import { useRequestData } from '../../../request-data';
+
+defineOptions({
+  name: 'FormEditPublishedVersion'
+});
+
+// The component assumes that this data will exist when the component is
+// created.
+const { form } = useRequestData();
+</script>
+
+<style lang="scss">
+@import '../../../assets/scss/mixins';
+
+#form-edit-published-version {
+  &.draft { opacity: 0.2; }
+}
+
+#form-edit-published-version-string {
+  @include text-overflow-ellipsis;
+  font-size: 17px;
+  font-weight: bold;
+  line-height: 1.2;
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // This refers to the published version of a Form.
+    "title": "Published version",
+    "subtitle": {
+      // This refers to the Form.
+      "draft": "Not yet published",
+      // This shows the date and time at which the current version of the Form
+      // was published, for example: "Published 2020/01/01 01:23". {dateTime}
+      // may show a formatted date like "2020/01/01", or it may use a word like
+      // "today", "yesterday", or "Sunday".
+      "published": "Published {dateTime}"
+    }
+  }
+}
+</i18n>

--- a/src/components/form/edit/section.vue
+++ b/src/components/form/edit/section.vue
@@ -31,6 +31,7 @@ defineProps({
   icon: {
     type: String,
     required: true
-  }
+  },
+  dotted: Boolean
 });
 </script>

--- a/src/components/form/edit/section.vue
+++ b/src/components/form/edit/section.vue
@@ -10,20 +10,22 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <page-section>
-    <template #heading>
-      <span><slot name="title"></slot></span>
-    </template>
-    <template #body>
-      <p><slot name="subtitle"></slot></p>
-      <slot name="body"></slot>
-    </template>
-  </page-section>
+  <div class="form-edit-section">
+    <div>
+      <div class="form-edit-section-icon-container">
+        <span :class="`icon-${icon}`"></span>
+      </div>
+      <div v-if="dotted" class="form-edit-section-dots"></div>
+    </div>
+    <div>
+      <p class="form-edit-section-title"><slot name="title"></slot></p>
+      <p class="form-edit-section-subtitle"><slot name="subtitle"></slot></p>
+      <div><slot name="body"></slot></div>
+    </div>
+  </div>
 </template>
 
 <script setup>
-import PageSection from '../../page/section.vue';
-
 defineOptions({
   name: 'FormEditSection'
 });
@@ -35,3 +37,49 @@ defineProps({
   dotted: Boolean
 });
 </script>
+
+<style lang="scss">
+.form-edit-section {
+  column-gap: 15px;
+  display: flex;
+
+  > :first-child {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  > :nth-child(2) {
+    padding-block: 16px 35px;
+  }
+}
+
+.form-edit-section-icon-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  $radius: 36px;
+  width: #{2 * $radius};
+  height: #{2 * $radius};
+  border-radius: $radius;
+  background-color: #eee;
+
+  flex-shrink: 0;
+  font-size: 35px;
+}
+
+.form-edit-section-dots {
+  border-left: 2px dotted #999;
+  height: 100%;
+  margin-top: 9px;
+}
+
+.form-edit-section-title {
+  font-size: 17px;
+  font-weight: bold;
+  line-height: 1.2;
+  margin-bottom: 0;
+}
+</style>

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1136,13 +1136,11 @@ describe('FormAttachmentList', () => {
             testData.extendedProjects.update(-1, { datasets: 1, updatedAt: null });
             return { success: true };
           })
+          .respondWithData(() => testData.extendedProjects.last())
           .respondWithData(() => testData.extendedForms.last())
           .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
           .respondWithData(() => testData.formDatasetDiffs.sorted())
-          .respondWithData(() => testData.extendedProjects.last())
-          .respondForComponent('FormSubmissions')
           .complete()
-          .route('/projects/1/forms/f/draft')
           .request(app =>
             app.get('#form-edit-create-draft-button').trigger('click'))
           .respondWithData(() => {
@@ -1182,13 +1180,11 @@ describe('FormAttachmentList', () => {
             testData.extendedProjects.update(-1, { datasets: 2, updatedAt: null });
             return { success: true };
           })
+          .respondWithData(() => testData.extendedProjects.last())
           .respondWithData(() => testData.extendedForms.last())
           .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
           .respondWithData(() => testData.formDatasetDiffs.sorted())
-          .respondWithData(() => testData.extendedProjects.last())
-          .respondForComponent('FormSubmissions')
           .complete()
-          .route('/projects/1/forms/f/draft')
           .request(app =>
             app.get('#form-edit-create-draft-button').trigger('click'))
           .respondWithData(() => {

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -1127,7 +1127,7 @@ describe('FormAttachmentList', () => {
         return load('/projects/1/forms/f/draft')
           .complete()
           .request(async (app) => {
-            await app.get('#form-draft-status-publish-button').trigger('click');
+            await app.get('#form-edit-publish-button').trigger('click');
             return app.get('#form-draft-publish .btn-primary').trigger('click');
           })
           .respondWithData(() => {
@@ -1173,7 +1173,7 @@ describe('FormAttachmentList', () => {
         return load('/projects/1/forms/f/draft')
           .complete()
           .request(async (app) => {
-            await app.get('#form-draft-status-publish-button').trigger('click');
+            await app.get('#form-edit-publish-button').trigger('click');
             return app.get('#form-draft-publish .btn-primary').trigger('click');
           })
           .respondWithData(() => {

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -125,27 +125,23 @@ describe('FormDraftAbandon', () => {
           await app.get('#form-edit-abandon-button').trigger('click');
           return app.get('#form-draft-abandon .btn-danger').trigger('click');
         })
-        .respondWithSuccess()
-        .respondForComponent('FormSubmissions');
+        .respondWithSuccess();
     };
 
-    it('shows a success alert', () =>
-      abandon().then(app => {
-        app.should.alert('success', 'The Draft version of this Form has been successfully deleted.');
-      }));
+    it('hides the modal', async () => {
+      const app = await abandon();
+      app.getComponent(FormDraftAbandon).props().state.should.be.false;
+    });
 
-    it('redirects to the submissions page', () =>
-      abandon().then(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
-      }));
+    it('shows a success alert', async () => {
+      const app = await abandon();
+      app.should.alert('success', 'The Draft version of this Form has been successfully deleted.');
+    });
 
-    it('shows the create draft button', () =>
-      abandon()
-        .complete()
-        .route('/projects/1/forms/f/draft')
-        .afterResponses(app => {
-          app.get('#form-edit-create-draft-button').should.be.visible();
-        }));
+    it('shows the create draft button', async () => {
+      const app = await abandon();
+      app.get('#form-edit-create-draft-button').should.be.visible();
+    });
   });
 
   describe('after abandoning draft for a form without a published version', () => {

--- a/test/components/form-draft/abandon.spec.js
+++ b/test/components/form-draft/abandon.spec.js
@@ -19,7 +19,7 @@ describe('FormDraftAbandon', () => {
     testData.extendedForms.createPast(1, { draft: true });
     return load('/projects/1/forms/f/draft', { root: false }).testModalToggles({
       modal: FormDraftAbandon,
-      show: '#form-draft-status-abandon-button',
+      show: '#form-edit-abandon-button',
       hide: '.btn-link'
     });
   });
@@ -122,7 +122,7 @@ describe('FormDraftAbandon', () => {
       return load('/projects/1/forms/f/draft')
         .complete()
         .request(async (app) => {
-          await app.get('#form-draft-status-abandon-button').trigger('click');
+          await app.get('#form-edit-abandon-button').trigger('click');
           return app.get('#form-draft-abandon .btn-danger').trigger('click');
         })
         .respondWithSuccess()
@@ -154,7 +154,7 @@ describe('FormDraftAbandon', () => {
       return load('/projects/1/forms/f/draft')
         .complete()
         .request(async (app) => {
-          await app.get('#form-draft-status-abandon-button').trigger('click');
+          await app.get('#form-edit-abandon-button').trigger('click');
           return app.get('#form-draft-abandon .btn-danger').trigger('click');
         })
         .respondWithSuccess()

--- a/test/components/form-draft/publish.spec.js
+++ b/test/components/form-draft/publish.spec.js
@@ -34,7 +34,7 @@ describe('FormDraftPublish', () => {
       return load('/projects/1/forms/f/draft', { root: false })
         .testModalToggles({
           modal: FormDraftPublish,
-          show: '#form-draft-status-publish-button',
+          show: '#form-edit-publish-button',
           hide: '.btn-link'
         });
     });
@@ -356,7 +356,7 @@ describe('FormDraftPublish', () => {
       return load('/projects/1/forms/f/draft')
         .complete()
         .request(async (app) => {
-          await app.get('#form-draft-status-publish-button').trigger('click');
+          await app.get('#form-edit-publish-button').trigger('click');
           return app.get('#form-draft-publish .btn-primary').trigger('click');
         })
         .modify(respondToPublish);
@@ -423,7 +423,7 @@ describe('FormDraftPublish', () => {
         .respondForComponent('FormEdit', { formVersions: false })
         .complete()
         .request(async (app) => {
-          await app.get('#form-draft-status-publish-button').trigger('click');
+          await app.get('#form-edit-publish-button').trigger('click');
           return app.get('#form-draft-publish .btn-primary').trigger('click');
         })
         .modify(respondToPublish)

--- a/test/components/form/edit/draft-controls.spec.js
+++ b/test/components/form/edit/draft-controls.spec.js
@@ -1,0 +1,24 @@
+import FormEditDraftControls from '../../../../src/components/form/edit/draft-controls.vue';
+
+import testData from '../../../data';
+import { mount } from '../../../util/lifecycle';
+
+const mountComponent = () => mount(FormEditDraftControls, {
+  container: {
+    requestData: { form: testData.extendedForms.last() }
+  }
+});
+
+describe('FormEditDraftControls', () => {
+  it('shows a "Delete Form" button if the form is a draft', () => {
+    testData.extendedForms.createPast(1, { draft: true });
+    const text = mountComponent().get('#form-edit-abandon-button').text();
+    text.should.equal('Delete Form');
+  });
+
+  it('shows an "Abandon Form" button if the form is published', () => {
+    testData.extendedForms.createPast(1);
+    const text = mountComponent().get('#form-edit-abandon-button').text();
+    text.should.equal('Abandon Draft');
+  });
+});

--- a/test/components/form/edit/draft-controls.spec.js
+++ b/test/components/form/edit/draft-controls.spec.js
@@ -16,7 +16,7 @@ describe('FormEditDraftControls', () => {
     text.should.equal('Delete Form');
   });
 
-  it('shows an "Abandon Form" button if the form is published', () => {
+  it('shows an "Abandon Draft" button if the form is published', () => {
     testData.extendedForms.createPast(1);
     const text = mountComponent().get('#form-edit-abandon-button').text();
     text.should.equal('Abandon Draft');

--- a/test/components/form/edit/published-version.spec.js
+++ b/test/components/form/edit/published-version.spec.js
@@ -1,0 +1,33 @@
+import FormEditPublishedVersion from '../../../../src/components/form/edit/published-version.vue';
+import FormVersionString from '../../../../src/components/form-version/string.vue';
+
+import testData from '../../../data';
+import { mount } from '../../../util/lifecycle';
+
+const mountComponent = () => mount(FormEditPublishedVersion, {
+  container: {
+    requestData: { form: testData.extendedForms.last() }
+  }
+});
+
+describe('FormEditPublishedVersion', () => {
+  it('renders correctly if the form is published', async () => {
+    testData.extendedForms.createPast(1, { version: 'foobar' });
+    const component = mountComponent();
+    component.classes('draft').should.be.false;
+    const subtitle = component.get('.form-edit-section-subtitle').text();
+    subtitle.should.startWith('Published 20');
+    const versionString = component.getComponent(FormVersionString);
+    versionString.text().should.equal('foobar');
+    await versionString.should.have.textTooltip();
+  });
+
+  it('renders correctly if the form is a draft', () => {
+    testData.extendedForms.createPast(1, { draft: true });
+    const component = mountComponent();
+    component.classes('draft').should.be.true;
+    const subtitle = component.get('.form-edit-section-subtitle').text();
+    subtitle.should.equal('Not yet published');
+    component.findComponent(FormVersionString).exists().should.be.false;
+  });
+});

--- a/test/components/form/edit/published-version.spec.js
+++ b/test/components/form/edit/published-version.spec.js
@@ -3,6 +3,7 @@ import FormVersionString from '../../../../src/components/form-version/string.vu
 
 import testData from '../../../data';
 import { mount } from '../../../util/lifecycle';
+import { setLuxon } from '../../../util/date-time';
 
 const mountComponent = () => mount(FormEditPublishedVersion, {
   container: {
@@ -12,11 +13,15 @@ const mountComponent = () => mount(FormEditPublishedVersion, {
 
 describe('FormEditPublishedVersion', () => {
   it('renders correctly if the form is published', async () => {
-    testData.extendedForms.createPast(1, { version: 'foobar' });
+    setLuxon({ defaultZoneName: 'UTC' });
+    testData.extendedForms.createPast(1, {
+      version: 'foobar',
+      publishedAt: '2025-01-02T12:34:56.789Z'
+    });
     const component = mountComponent();
     component.classes('draft').should.be.false;
     const subtitle = component.get('.form-edit-section-subtitle').text();
-    subtitle.should.startWith('Published 20');
+    subtitle.should.equal('Published 2025/01/02 12:34');
     const versionString = component.getComponent(FormVersionString);
     versionString.text().should.equal('foobar');
     await versionString.should.have.textTooltip();

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3077,6 +3077,22 @@
         }
       }
     },
+    "FormEditPublishedVersion": {
+      "title": {
+        "string": "Published version",
+        "developer_comment": "This refers to the published version of a Form."
+      },
+      "subtitle": {
+        "draft": {
+          "string": "Not yet published",
+          "developer_comment": "This refers to the Form."
+        },
+        "published": {
+          "string": "Published {dateTime}",
+          "developer_comment": "This shows the date and time at which the current version of the Form was published, for example: \"Published 2020/01/01 01:23\". {dateTime} may show a formatted date like \"2020/01/01\", or it may use a word like \"today\", \"yesterday\", or \"Sunday\"."
+        }
+      }
+    },
     "FormHead": {
       "projectNav": {
         "action": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2994,22 +2994,6 @@
           }
         }
       },
-      "actions": {
-        "title": {
-          "string": "Actions",
-          "developer_comment": "This is a title shown above a section of the page."
-        },
-        "action": {
-          "publish": {
-            "string": "Publish Draft",
-            "developer_comment": "This is the text for an action, for example, the text of a button."
-          },
-          "abandon": {
-            "string": "Abandon Draft",
-            "developer_comment": "This is the text for an action, for example, the text of a button."
-          }
-        }
-      },
       "alert": {
         "upload": {
           "string": "Success! The new Form definition has been saved as your Draft."
@@ -3022,6 +3006,18 @@
         },
         "delete": {
           "string": "The Form “{name}” was deleted."
+        }
+      },
+      "actions": {
+        "action": {
+          "abandon": {
+            "string": "Abandon Draft",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          },
+          "publish": {
+            "string": "Publish Draft",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
         }
       }
     },
@@ -3067,6 +3063,18 @@
       },
       "noEffectUntilPublish": {
         "string": "The published version will not be affected until you publish your Draft."
+      }
+    },
+    "FormEditDraftControls": {
+      "subtitle": {
+        "string": "Ready to publish",
+        "developer_comment": "This refers to the draft version of a Form."
+      },
+      "action": {
+        "delete": {
+          "string": "Delete Form",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
       }
     },
     "FormHead": {


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It finishes the first row of the page:

- Lefthand side of the row
  - Show a loading message while the form draft is requested.
  - Show buttons to abandon or publish the draft.
  - Update the behavior of abandoning or publishing the draft. The user will no longer be redirected to the submissions page after completing the action.
- Righthand side of the row
  - Add a section for the published version of the form.
- This PR also styles the first row.

#### What has been done to verify that this works as intended?

New and updated tests. I also tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced