### PR TITLE
Fixes getodk/central#919: use fullPath instead of hash for redirecting

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -81,7 +81,9 @@ router.afterEach(unlessFailure(to => {
 
   // We used to have hash-based navigation, we have now switched to web-history-based
   // navigation. To support, bookmarked links, we are redirecting old URL to the new one.
-  router.beforeEach(to => (to.path === '/' && to.hash.startsWith('#/') ? to.hash.substring(1) : true));
+  // Using to.fullPath instead of to.hash because to.hash has URL decoded value whereas to.fullPath
+  // gives percentage encoded value - central#919.
+  router.beforeEach(to => (to.path === '/' && to.fullPath.startsWith('/#/') ? to.fullPath.substring(2) : true));
 
 
   //////////////////////////////////////////////////////////////////////////////

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -155,6 +155,15 @@ describe('createCentralRouter()', () => {
         .afterResponses(app => {
           app.vm.$route.path.should.equal('/account/edit');
         }));
+
+    it('redirects if the hash is a path and it contains non-ascii characters', () => {
+      testData.extendedForms.createPast(1);
+      return load("/#/projects/1/forms/'%3D%2B%2F*-451%25%2F%25/submissions", {}, false)
+        .respondFor("/projects/1/forms/'%3D%2B%2F*-451%25%2F%25/submissions")
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal("/projects/1/forms/'%3D%2B%2F*-451%25%2F%25/submissions");
+        });
+    });
   });
 
   describe('requireLogin', () => {


### PR DESCRIPTION
Closes getodk/central#919

#### What has been done to verify that this works as intended?

Added a test. Also manually verified it.

#### Why is this the best possible solution? Were any other approaches considered?

I view the value of `to` object in beforeEach and `fullPath` seamed to have exactly same value that user enters in the address bar. Vue router [docs](https://router.vuejs.org/api/interfaces/RouteLocationNormalizedGeneric.html#fullPath) also suggest that fullPath will have percentage encoded value.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced