### PR TITLE
Show warning if form attachment is missing

### DIFF
--- a/src/components/form/edit/attachments.vue
+++ b/src/components/form/edit/attachments.vue
@@ -10,7 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <form-edit-section id="form-edit-attachments" icon="paperclip" dotted>
+  <form-edit-section id="form-edit-attachments" icon="paperclip" dotted
+    :warning="draftAttachments.dataExists && draftAttachments.missingCount !== 0">
     <template #title>{{ $t('resource.attachments') }}</template>
     <template v-if="draftAttachments.dataExists" #subtitle>
       <template v-if="draftAttachments.size === 0">

--- a/src/components/form/edit/section.vue
+++ b/src/components/form/edit/section.vue
@@ -10,10 +10,11 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="form-edit-section">
+  <div class="form-edit-section" :class="{ warning }">
     <div>
       <div class="form-edit-section-icon-container">
         <span :class="`icon-${icon}`"></span>
+        <span v-if="warning" class="icon-warning"></span>
       </div>
       <div v-if="dotted" class="form-edit-section-dots"></div>
     </div>
@@ -34,11 +35,14 @@ defineProps({
     type: String,
     required: true
   },
-  dotted: Boolean
+  dotted: Boolean,
+  warning: Boolean
 });
 </script>
 
 <style lang="scss">
+@import '../../../assets/scss/variables';
+
 $dots-margin-block: 9px;
 
 .form-edit-section {
@@ -72,6 +76,7 @@ $dots-margin-block: 9px;
 
   flex-shrink: 0;
   font-size: 35px;
+  position: relative;
 }
 
 .form-edit-section-dots {
@@ -90,5 +95,17 @@ $dots-margin-block: 9px;
   margin-top: -10px;
 
   &:empty { display: none; }
+}
+
+.form-edit-section.warning {
+  .form-edit-section-icon-container { background-color: $color-warning; }
+  .form-edit-section-subtitle { color: $color-warning; }
+}
+.form-edit-section-icon-container .icon-warning:nth-child(2) {
+  position: absolute;
+  right: 2px;
+  bottom: 7px;
+
+  font-size: 18px;
 }
 </style>

--- a/src/components/form/edit/section.vue
+++ b/src/components/form/edit/section.vue
@@ -98,8 +98,8 @@ $dots-margin-block: 9px;
 }
 
 .form-edit-section.warning {
-  .form-edit-section-icon-container { background-color: $color-warning; }
-  .form-edit-section-subtitle { color: $color-warning; }
+  .form-edit-section-icon-container { background-color: $color-warning-light; }
+  .form-edit-section-subtitle { color: $color-warning-light; }
 }
 .form-edit-section-icon-container .icon-warning:nth-child(2) {
   position: absolute;

--- a/test/components/form/edit/attachments.spec.js
+++ b/test/components/form/edit/attachments.spec.js
@@ -1,3 +1,5 @@
+import FormEditSection from '../../../../src/components/form/edit/section.vue';
+
 import testData from '../../../data';
 import { load } from '../../../util/http';
 import { mockLogin } from '../../../util/session';
@@ -31,5 +33,13 @@ describe('FormDefAttachments', () => {
       const subtitle = app.get('#form-edit-attachments .form-edit-section-subtitle').text();
       subtitle.should.equal('2 attachments');
     });
+  });
+
+  it('shows a warning if there is a missing attachment', async () => {
+    testData.extendedForms.createPast(1, { draft: true });
+    testData.standardFormAttachments.createPast(1, { blobExists: false });
+    const app = await load('/projects/1/forms/f/draft');
+    const section = app.get('#form-edit-attachments').getComponent(FormEditSection);
+    section.props().warning.should.be.true;
   });
 });

--- a/test/components/form/edit/section.spec.js
+++ b/test/components/form/edit/section.spec.js
@@ -1,0 +1,19 @@
+import FormEditSection from '../../../../src/components/form/edit/section.vue';
+
+import { mergeMountOptions, mount } from '../../../util/lifecycle';
+
+const mountComponent = (options = undefined) =>
+  mount(FormEditSection, mergeMountOptions(options, {
+    props: { icon: 'star' },
+    slots: { title: 'Some title', subtitle: 'Some subtitle', body: 'Some body' }
+  }));
+
+describe('FormEditSection', () => {
+  it('renders correctly if the warning prop is true', () => {
+    const component = mountComponent({
+      props: { warning: true }
+    });
+    component.classes('warning').should.be.true;
+    component.find('.icon-warning').exists().should.be.true;
+  });
+});


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It shows a warning if a form attachment is missing.

#### What has been done to verify that this works as intended?

New tests. I also tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced