### PR TITLE
Changing text for convert pending submission modal

### DIFF
--- a/src/components/dataset/pending-submissions.vue
+++ b/src/components/dataset/pending-submissions.vue
@@ -30,7 +30,7 @@ except according to the terms contained in the LICENSE file.
               <strong>{{ $t('dontConvert.label') }}</strong>
             </label>
             <p id="dataset-auto-convert-false" class="help-block">
-              {{ $tcn('dontConvert.description', pendingSubmissions) }}
+              {{ $t('dontConvert.description', pendingSubmissions) }}
             </p>
           </div>
           <div class="radio">
@@ -40,7 +40,7 @@ except according to the terms contained in the LICENSE file.
               <strong>{{ $t('convert.label') }}</strong>
             </label>
             <p id="dataset-auto-convert-true" class="help-block">
-              {{ $tcn('convert.description', pendingSubmissions) }}
+              {{ $t('convert.description', pendingSubmissions) }}
             </p>
           </div>
         </form>
@@ -91,17 +91,17 @@ const convert = ref(null);
     "explanation": {
       "userAction": "You are setting Entity creation to occur when Submissions are first received by Central.",
       "implication": {
-        "full": "Once this takes effect, Entities will no longer be generated when Submissions are marked Approved, including {records} we found that has neither been marked Approved nor Rejected. | Once this takes effect, Entities will no longer be generated when Submissions are marked Approved, including {records} we found that have neither been marked Approved nor Rejected.",
-        "records": "{count} record | {count} records"
+        "full": "You currently have {records} not marked Approved nor Rejected.",
+        "records": "{count} pending record | {count} pending records"
       }
     },
     "dontConvert": {
       "label": "I understand and this is not a problem for me.",
-      "description": "Change the setting and do nothing with the pending Submission. | Change the setting and do nothing with the pending Submissions."
+      "description": "Change the setting and do nothing with the pending Submission."
     },
     "convert": {
-      "label": "Convert all pending Submissions to Entities now.",
-      "description": "Change the setting and create Entity out of {count} Submission not yet Approved or Rejected. The Review States will not be affected. | Change the setting and create Entities out of all {count} Submissions not yet Approved or Rejected. The Review States will not be affected."
+      "label": "Convert all pending Submissions that create Entities.",
+      "description": "Change the setting and create Entities from any Submissions that indicate Entity creation and have not been Approved or Rejected."
     }
   }
 }

--- a/test/components/dataset/settings.spec.js
+++ b/test/components/dataset/settings.spec.js
@@ -104,7 +104,7 @@ describe('DatasetSettings', () => {
       .complete()
       .request(async (component) => {
         const modal = component.getComponent(DatasetPendingSubmissions);
-        modal.text().should.match(/10 records/);
+        modal.text().should.match(/10 pending records/);
         await modal.get('input[value="true"]').setValue(true);
         return modal.get('.btn-danger').trigger('click');
       })

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1654,12 +1654,12 @@
         },
         "implication": {
           "full": {
-            "string": "{count, plural, one {Once this takes effect, Entities will no longer be generated when Submissions are marked Approved, including {records} we found that has neither been marked Approved nor Rejected.} other {Once this takes effect, Entities will no longer be generated when Submissions are marked Approved, including {records} we found that have neither been marked Approved nor Rejected.}}",
-            "developer_comment": "{records} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} records"
+            "string": "You currently have {records} not marked Approved nor Rejected.",
+            "developer_comment": "{records} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} pending records"
           },
           "records": {
-            "string": "{count, plural, one {{count} record} other {{count} records}}",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {records} is in the following text. (The plural form of the text is shown.)\n\nOnce this takes effect, Entities will no longer be generated when Submissions are marked Approved, including {records} we found that have neither been marked Approved nor Rejected."
+            "string": "{count, plural, one {{count} pending record} other {{count} pending records}}",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {records} is in the following text:\n\nYou currently have {records} not marked Approved nor Rejected."
           }
         }
       },
@@ -1668,15 +1668,15 @@
           "string": "I understand and this is not a problem for me."
         },
         "description": {
-          "string": "{count, plural, one {Change the setting and do nothing with the pending Submission.} other {Change the setting and do nothing with the pending Submissions.}}"
+          "string": "Change the setting and do nothing with the pending Submission."
         }
       },
       "convert": {
         "label": {
-          "string": "Convert all pending Submissions to Entities now."
+          "string": "Convert all pending Submissions that create Entities."
         },
         "description": {
-          "string": "{count, plural, one {Change the setting and create Entity out of {count} Submission not yet Approved or Rejected. The Review States will not be affected.} other {Change the setting and create Entities out of all {count} Submissions not yet Approved or Rejected. The Review States will not be affected.}}"
+          "string": "Change the setting and create Entities from any Submissions that indicate Entity creation and have not been Approved or Rejected."
         }
       }
     },


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/837

I found the second sentence in the original modal too long/hard to reason about with the future/past negatives so I made it simpler.

> Once this takes effect, Entities will no longer be generated when Submissions are marked Approved, including {records} we found that has neither been marked Approved nor Rejected.

<img width="649" alt="Screenshot 2025-03-21 at 2 03 17 PM" src="https://github.com/user-attachments/assets/b205baf3-72d6-4f0d-bcfc-a2180e04e699" />


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced