### PR TITLE
Let project viewers request dataset-diffs for infonav button

### DIFF
--- a/src/components/form/show.vue
+++ b/src/components/form/show.vue
@@ -99,8 +99,8 @@ const stopAppUsersEffect = watchEffect(() => {
   nextTick(() => stopAppUsersEffect());
 });
 const stopDatasetsEffect = watchEffect(() => {
-  if (!(project.dataExists && form.dataExists)) return;
-  if (project.permits(['form.update', 'dataset.list']) && form.publishedAt != null)
+  if (!(form.dataExists)) return;
+  if (form.publishedAt != null)
     fetchLinkedDatasets();
   stopDatasetsEffect();
 });

--- a/test/components/form/show.spec.js
+++ b/test/components/form/show.spec.js
@@ -33,7 +33,9 @@ describe('FormShow', () => {
       return load('/projects/1/forms/a%20b/versions').testRequests([
         { url: '/v1/projects/1', extended: true },
         { url: '/v1/projects/1/forms/a%20b', extended: true },
-        { url: '/v1/projects/1/forms/a%20b/versions', extended: true }
+        { url: '/v1/projects/1/forms/a%20b/versions', extended: true },
+        { url: '/v1/projects/1/forms/a%20b/attachments' },
+        { url: '/v1/projects/1/forms/a%20b/dataset-diff' }
       ]);
     });
 


### PR DESCRIPTION
Frontend part of issue https://github.com/getodk/central/issues/897
Backend: https://github.com/getodk/central-backend/pull/1456

I was reading through the text on the issue, but thinking how these requests aren't really relevant for unpublished forms, so we still need to check the form settings.

> Once we change Backend, we should change Frontend so that it always sends those requests.


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Trying it out, tests.

#### Why is this the best possible solution? Were any other approaches considered?

See reasoning in issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Project viewers will get infonav buttons for related entity lists only (not app users).

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

no

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced