### PR TITLE
Redo breadcrumbs

### DIFF
--- a/src/components/breadcrumbs.vue
+++ b/src/components/breadcrumbs.vue
@@ -14,8 +14,8 @@ except according to the terms contained in the LICENSE file.
     <template v-for="(link, index) in links" :key="index">
       <div class="breadcrumb-item" v-tooltip.text>
         <router-link :to="link.path">
-          {{ link.text }}
           <span v-if="link.icon" :class="link.icon"></span>
+          {{ link.text }}
         </router-link>
       </div>
       <span class="separator">/</span>

--- a/src/components/dataset/show.vue
+++ b/src/components/dataset/show.vue
@@ -113,14 +113,14 @@ export default {
     const { tabPath, tabClass } = useTabs(datasetPath());
     return {
       project, dataset, ...resourceStates([project, dataset]),
-      projectPath, tabPath, tabClass, canRoute, publishedFormPath
+      datasetPath, projectPath, tabPath, tabClass, canRoute, publishedFormPath
     };
   },
   computed: {
     breadcrumbLinks() {
       return [
-        { text: this.project.nameWithArchived, path: this.projectPath() },
-        { text: this.$t('resource.entities'), path: this.projectPath('entity-lists'), icon: 'icon-database' }
+        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath('entity-lists'), icon: 'icon-archive' },
+        { text: this.datasetName, path: this.datasetPath(), icon: 'icon-database' }
       ];
     }
   },

--- a/src/components/dataset/show.vue
+++ b/src/components/dataset/show.vue
@@ -119,7 +119,7 @@ export default {
   computed: {
     breadcrumbLinks() {
       return [
-        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath('entity-lists'), icon: 'icon-archive' },
+        { text: this.project.nameWithArchived, path: this.projectPath('entity-lists'), icon: 'icon-archive' },
         { text: this.datasetName, path: this.datasetPath(), icon: 'icon-database' }
       ];
     }

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -159,9 +159,9 @@ const EntityBranchData = defineAsyncComponent(loadAsync('EntityBranchData'));
 const branchData = modalData('EntityBranchData');
 
 const breadcrumbLinks = computed(() => [
-  { text: project.nameWithArchived, path: projectPath() },
-  { text: t('resource.entities'), path: projectPath('entity-lists'), icon: 'icon-database' },
-  { text: props.datasetName, path: datasetPath('entities') },
+  { text: project.dataExists ? project.nameWithArchived : t('resource.project'), path: projectPath('entity-lists'), icon: 'icon-archive' },
+  { text: props.datasetName, path: datasetPath(), icon: 'icon-database' },
+  { text: entity.dataExists ? entity.currentVersion.label : t('resource.entity'), path: datasetPath('entities') }
 ]);
 
 </script>

--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -130,8 +130,8 @@ export default {
     },
     breadcrumbLinks() {
       return [
-        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath() },
-        { text: this.$t('resource.forms'), path: this.projectPath(), icon: 'icon-file' }
+        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath(), icon: 'icon-archive' },
+        { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.formPath(), icon: 'icon-file' }
       ];
     },
     uniqueDatasetCount() {

--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -131,7 +131,7 @@ export default {
     breadcrumbLinks() {
       return [
         { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath(), icon: 'icon-archive' },
-        { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.formPath(), icon: 'icon-file' }
+        { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.form.publishedAt != null ? this.formPath() : '', icon: 'icon-file' }
       ];
     },
     uniqueDatasetCount() {

--- a/src/components/project/show.vue
+++ b/src/components/project/show.vue
@@ -11,6 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div>
+    <breadcrumbs v-if="project.dataExists" :links="breadcrumbLinks"/>
     <page-head v-show="project.dataExists">
       <template v-if="project.dataExists" #title>
         {{ project.nameWithArchived }}
@@ -76,6 +77,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import Breadcrumbs from '../breadcrumbs.vue';
 import Loading from '../loading.vue';
 import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
@@ -90,7 +92,7 @@ import { noop } from '../../util/util';
 
 export default {
   name: 'ProjectShow',
-  components: { Loading, PageBody, PageHead, ProjectOverviewDescription },
+  components: { Breadcrumbs, Loading, PageBody, PageHead, ProjectOverviewDescription },
   props: {
     projectId: {
       type: String,
@@ -108,6 +110,11 @@ export default {
     };
   },
   computed: {
+    breadcrumbLinks() {
+      return [
+        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath(), icon: 'icon-archive' }
+      ];
+    },
     canUpdate() {
       return this.project.dataExists && this.project.permits('project.update');
     }

--- a/src/components/submission/show.vue
+++ b/src/components/submission/show.vue
@@ -108,9 +108,9 @@ export default {
   computed: {
     breadcrumbLinks() {
       return [
-        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath() },
-        { text: this.$t('resource.forms'), path: this.projectPath(), icon: 'icon-file' },
-        { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.formPath('submissions') }
+        { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath(), icon: 'icon-archive' },
+        { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.formPath(), icon: 'icon-file' },
+        { text: this.submission.dataExists ? this.submission.instanceNameOrId : this.$t('resource.submission'), path: this.formPath('submissions') }
       ];
     }
   },

--- a/test/components/dataset/show.spec.js
+++ b/test/components/dataset/show.spec.js
@@ -47,13 +47,15 @@ describe('DatasetShow', () => {
   });
 
   it('renders breadcrumbs', async () => {
+    testData.extendedProjects.createPast(1, { name: 'My Project' });
     testData.extendedDatasets.createPast(1);
     const component = await load('/projects/1/entity-lists/trees/properties');
     const { links } = component.getComponent(Breadcrumbs).props();
     links.length.should.equal(2);
-    links[0].path.should.equal('/projects/1');
-    links[1].text.should.equal('Entities');
-    links[1].path.should.equal('/projects/1/entity-lists');
+    links[0].text.should.equal('My Project');
+    links[0].path.should.equal('/projects/1/entity-lists');
+    links[1].text.should.equal('trees');
+    links[1].path.should.equal('/projects/1/entity-lists/trees');
   });
 
   it('show correct project name', async () => {

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -38,17 +38,20 @@ describe('EntityShow', () => {
       ]);
   });
 
-  it('renders a back link', async () => {
+  it('renders breadcrumbs', async () => {
+    testData.extendedProjects.createPast(1, { name: 'My Project' });
     testData.extendedDatasets.createPast(1, { name: 'á', entities: 1 });
-    testData.extendedEntities.createPast(1, { uuid: 'e' });
+    testData.extendedEntities.createPast(1, { uuid: 'e', label: 'My Entity' });
     const component = await load('/projects/1/entity-lists/%C3%A1/entities/e', {
       root: false
     });
     const { links } = component.getComponent(Breadcrumbs).props();
-    links[0].path.should.equal('/projects/1');
-    links[1].text.should.equal('Entities');
-    links[1].path.should.equal('/projects/1/entity-lists');
-    links[2].text.should.equal('á');
+    links.length.should.equal(3);
+    links[0].text.should.equal('My Project');
+    links[0].path.should.equal('/projects/1/entity-lists');
+    links[1].text.should.equal('á');
+    links[1].path.should.equal('/projects/1/entity-lists/%C3%A1');
+    links[2].text.should.equal('My Entity');
     links[2].path.should.equal('/projects/1/entity-lists/%C3%A1/entities');
   });
 

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -34,13 +34,13 @@ describe('FormHead', () => {
     });
 
     it("renders the project's name as a link in the breadcrumb", async () => {
-      testData.extendedForms.createPast(1);
+      testData.extendedForms.createPast(1, { name: 'My Form' });
       const component = await load('/projects/1/forms/f/settings');
       const { links } = component.getComponent(Breadcrumbs).props();
       links.length.should.equal(2);
       links[0].path.should.equal('/projects/1');
-      links[1].text.should.equal('Forms');
-      links[1].path.should.equal('/projects/1');
+      links[1].text.should.equal('My Form');
+      links[1].path.should.equal('/projects/1/forms/f');
     });
 
     it("shows the form's name", async () => {

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -43,6 +43,16 @@ describe('FormHead', () => {
       links[1].path.should.equal('/projects/1/forms/f');
     });
 
+    it('links to the draft form in the breadcrumb if unpublished', async () => {
+      testData.extendedForms.createPast(1, { name: 'My Form', draft: true });
+      const component = await load('/projects/1/forms/f/draft');
+      const { links } = component.getComponent(Breadcrumbs).props();
+      links.length.should.equal(2);
+      links[0].path.should.equal('/projects/1');
+      links[1].text.should.equal('My Form');
+      links[1].path.should.equal('');
+    });
+
     it("shows the form's name", async () => {
       testData.extendedForms.createPast(1, { name: 'My Form' });
       const app = await load('/projects/1/forms/f/settings');

--- a/test/components/page/breadcrumbs.spec.js
+++ b/test/components/page/breadcrumbs.spec.js
@@ -19,7 +19,7 @@ describe('Breadcrumbs', () => {
       }
     });
     const breadcrumbs = component.get('.breadcrumbs');
-    breadcrumbs.text().should.equal('Projects /Forms /');
+    breadcrumbs.text().should.equal('Projects/ Forms/');
   });
 
   it('renders a link', () => {

--- a/test/components/project/show.spec.js
+++ b/test/components/project/show.spec.js
@@ -1,4 +1,5 @@
 import ProjectOverviewDescription from '../../../src/components/project/overview/description.vue';
+import Breadcrumbs from '../../../src/components/breadcrumbs.vue';
 import Loading from '../../../src/components/loading.vue';
 import NotFound from '../../../src/components/not-found.vue';
 import ProjectOverview from '../../../src/components/project/overview.vue';
@@ -99,6 +100,18 @@ describe('ProjectShow', () => {
       .afterResponses(app => {
         expect(app.getComponent(ProjectOverview).vm).to.not.equal(vm);
       });
+  });
+
+
+  it('renders breadcrumbs', async () => {
+    mockLogin();
+    testData.extendedProjects.createPast(1, { name: 'My Project' });
+    testData.extendedDatasets.createPast(1);
+    const component = await load('/projects/1');
+    const { links } = component.getComponent(Breadcrumbs).props();
+    links.length.should.equal(1);
+    links[0].text.should.equal('My Project');
+    links[0].path.should.equal('/projects/1');
   });
 
   describe('title', () => {

--- a/test/components/submission/show.spec.js
+++ b/test/components/submission/show.spec.js
@@ -17,30 +17,34 @@ describe('SubmissionShow', () => {
   });
 
   it('renders breadcrumbs with links', async () => {
+    testData.extendedProjects.createPast(1, { name: 'My Project' });
     testData.extendedForms.createPast(1, { name: 'My Form', xmlFormId: 'a b', submissions: 1 });
     testData.extendedSubmissions.createPast(1, { instanceId: 's' });
     const component = await load('/projects/1/forms/a%20b/submissions/s', {
       root: false
     });
     const { links } = component.getComponent(Breadcrumbs).props();
+    links[0].text.should.equal('My Project');
     links[0].path.should.equal('/projects/1');
-    links[1].text.should.equal('Forms');
-    links[1].path.should.equal('/projects/1');
-    links[2].text.should.equal('My Form');
+    links[1].text.should.equal('My Form');
+    links[1].path.should.equal('/projects/1/forms/a%20b');
+    links[2].text.should.equal('s');
     links[2].path.should.equal('/projects/1/forms/a%20b/submissions');
   });
 
   it('renders the xmlformid of the form in the breadcrumb if it has no name', async () => {
+    testData.extendedProjects.createPast(1, { name: 'My Project' });
     testData.extendedForms.createPast(1, { name: null, xmlFormId: 'a b', submissions: 1 });
     testData.extendedSubmissions.createPast(1, { instanceId: 's' });
     const component = await load('/projects/1/forms/a%20b/submissions/s', {
       root: false
     });
     const { links } = component.getComponent(Breadcrumbs).props();
+    links[0].text.should.equal('My Project');
     links[0].path.should.equal('/projects/1');
-    links[1].text.should.equal('Forms');
-    links[1].path.should.equal('/projects/1');
-    links[2].text.should.equal('a b');
+    links[1].text.should.equal('a b');
+    links[1].path.should.equal('/projects/1/forms/a%20b');
+    links[2].text.should.equal('s');
     links[2].path.should.equal('/projects/1/forms/a%20b/submissions');
   });
 


### PR DESCRIPTION
Part of https://github.com/getodk/central/issues/924

This redoes the breadcrumbs to have icons, have the names of the objects, and to feel more hierarchical. 

Project name --> form list or entity lists list (basically 2 views of the project home)
Form name --> form home
Entity list name --> entity list home
Submission ID --> uhh I had it link to the form home which is also the submission list but it could link to itself or something?
Entity ID --> also links to entities on entity list page, essentially the entity list home

<img width="506" alt="Screenshot 2025-03-21 at 3 55 02 PM" src="https://github.com/user-attachments/assets/20b1c2de-bd65-4cac-ac7e-682bd3a26fde" />

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Testing it and trying it out.

#### Why is this the best possible solution? Were any other approaches considered?

The code feels easier to think about because there is a much clearer hierarchy/repetition!
It seems nice that the name of the thing goes to the page about the thing and there aren't extraneous links.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced