### PR TITLE
Show tag when form definition or entity list has changed

### DIFF
--- a/src/components/form/edit/def.vue
+++ b/src/components/form/edit/def.vue
@@ -13,6 +13,7 @@ except according to the terms contained in the LICENSE file.
   <form-edit-section id="form-edit-def" icon="code">
     <template #title>{{ $t('resource.formDef') }}</template>
     <template #subtitle>{{ $t('subtitle') }}</template>
+    <template v-if="changed" #tag>{{ $t('changed') }}</template>
     <template #body>
       <div id="form-edit-def-container">
         <div>
@@ -39,7 +40,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { defineAsyncComponent } from 'vue';
+import { computed, defineAsyncComponent } from 'vue';
 
 import FormEditAttachments from './attachments.vue';
 import FormEditEntities from './entities.vue';
@@ -56,8 +57,11 @@ defineOptions({
 });
 defineEmits(['upload']);
 
-const { resourceView } = useRequestData();
+const { form, resourceView } = useRequestData();
 const formDraft = resourceView('formDraft', (data) => data.get());
+
+const changed = computed(() =>
+  form.dataExists && form.publishedAt != null && formDraft.hash !== form.hash);
 
 const FormVersionViewXml = defineAsyncComponent(loadAsync('FormVersionViewXml'));
 const viewXml = modalData('FormVersionViewXml');
@@ -119,6 +123,8 @@ const viewXml = modalData('FormVersionViewXml');
   "en": {
     // This refers to a Form Definition.
     "subtitle": "Uploaded",
+    // This refers to a Form Definition.
+    "changed": "Changed from published version",
     "action": {
       "upload": "Upload new Form Definition"
     },

--- a/src/components/form/edit/def.vue
+++ b/src/components/form/edit/def.vue
@@ -121,9 +121,9 @@ const viewXml = modalData('FormVersionViewXml');
 <i18n lang="json5">
 {
   "en": {
-    // This refers to a Form Definition.
+    // This refers to the draft version of a Form.
     "subtitle": "Uploaded",
-    // This refers to a Form Definition.
+    // This refers to the draft version of a Form.
     "changed": "Changed from published version",
     "action": {
       "upload": "Upload new Form Definition"

--- a/src/components/form/edit/entities.vue
+++ b/src/components/form/edit/entities.vue
@@ -13,8 +13,8 @@ except according to the terms contained in the LICENSE file.
   <form-edit-section id="form-edit-entities" icon="database">
     <template #title>{{ $t('resource.entities') }}</template>
     <template #subtitle>
-      <template v-if="formDraftDatasetDiff.dataExists">
-        {{ $tcn('datasetCount', formDraftDatasetDiff.length) }}
+      <template v-if="datasetDiff.dataExists">
+        {{ $tcn('datasetCount', datasetDiff.length) }}
       </template>
       <p v-else-if="!formDraft.entityRelated">
         <span>{{ $t('notEntityRelated') }}</span>
@@ -22,9 +22,10 @@ except according to the terms contained in the LICENSE file.
         <doc-link to="central-entities/">{{ $t('whatAreEntities') }}</doc-link>
       </p>
     </template>
+    <template v-if="diffHasNew" #tag>{{ $t('diffHasNew') }}</template>
     <template #body>
       <template v-if="formDraft.entityRelated">
-        <loading :state="formDraftDatasetDiff.initiallyLoading"/>
+        <loading :state="datasetDiff.initiallyLoading"/>
         <dataset-summary is-draft/>
       </template>
     </template>
@@ -32,6 +33,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
 import DatasetSummary from '../../dataset/summary.vue';
 import DocLink from '../../doc-link.vue';
 import FormEditSection from './section.vue';
@@ -44,8 +47,12 @@ defineOptions({
   name: 'FormEditEntities'
 });
 
-const { formDraftDatasetDiff, resourceView } = useRequestData();
+const { formDraftDatasetDiff: datasetDiff, resourceView } = useRequestData();
 const formDraft = resourceView('formDraft', (data) => data.get());
+
+const diffHasNew = computed(() =>
+  datasetDiff.dataExists && datasetDiff.some(dataset => dataset.isNew ||
+    dataset.properties.some(property => property.isNew)));
 </script>
 
 <style lang="scss">
@@ -62,7 +69,10 @@ const formDraft = resourceView('formDraft', (data) => data.get());
     "datasetCount": "Publishing this draft will update {count} Entity List | Publishing this draft will update {count} Entity Lists",
     // "Definition" refers to a Form Definition.
     "notEntityRelated": "This definition does not update any Entities.",
-    "whatAreEntities": "What are Entities?"
+    "whatAreEntities": "What are Entities?",
+    // This text is shown if publishing a Form Definition will create one or
+    // more Entity Lists or one or more Entity properties.
+    "diffHasNew": "New Entity Lists and/or properties will be created"
   }
 }
 </i18n>

--- a/src/components/form/edit/entities.vue
+++ b/src/components/form/edit/entities.vue
@@ -67,12 +67,12 @@ const diffHasNew = computed(() =>
 {
   "en": {
     "datasetCount": "Publishing this draft will update {count} Entity List | Publishing this draft will update {count} Entity Lists",
+    // This text is shown if publishing a Draft Form will create one or more
+    // Entity Lists or one or more Entity properties.
+    "diffHasNew": "New Entity Lists and/or properties will be created",
     // "Definition" refers to a Form Definition.
     "notEntityRelated": "This definition does not update any Entities.",
-    "whatAreEntities": "What are Entities?",
-    // This text is shown if publishing a Form Definition will create one or
-    // more Entity Lists or one or more Entity properties.
-    "diffHasNew": "New Entity Lists and/or properties will be created"
+    "whatAreEntities": "What are Entities?"
   }
 }
 </i18n>

--- a/src/components/form/edit/section.vue
+++ b/src/components/form/edit/section.vue
@@ -19,8 +19,16 @@ except according to the terms contained in the LICENSE file.
       <div v-if="dotted" class="form-edit-section-dots"></div>
     </div>
     <div>
-      <p class="form-edit-section-title"><slot name="title"></slot></p>
-      <p class="form-edit-section-subtitle"><slot name="subtitle"></slot></p>
+      <div class="form-edit-section-heading">
+        <div>
+          <p class="form-edit-section-title"><slot name="title"></slot></p>
+          <p class="form-edit-section-subtitle"><slot name="subtitle"></slot></p>
+        </div>
+        <div class="form-edit-section-tag">
+          <span class="icon-circle"></span>
+          <span><slot name="tag"></slot></span>
+        </div>
+      </div>
       <div class="form-edit-section-body"><slot name="body"></slot></div>
     </div>
   </div>
@@ -85,16 +93,41 @@ $dots-margin-block: 9px;
   margin-top: $dots-margin-block;
 }
 
+.form-edit-section-heading {
+  align-items: center;
+  column-gap: 15px;
+  display: flex;
+  margin-bottom: 10px;
+}
+
 .form-edit-section-title {
   font-size: 17px;
   font-weight: bold;
   line-height: 1.2;
+  margin-bottom: 0;
 }
 
 .form-edit-section-subtitle {
-  margin-top: -10px;
+  margin-bottom: 0;
 
   &:empty { display: none; }
+}
+
+.form-edit-section-tag {
+  display: flex;
+  align-items: center;
+  column-gap: $margin-right-icon;
+
+  background-color: rgba($color-accent-primary, 0.04);
+  border-radius: 6px;
+  color: $color-accent-primary;
+  padding: 5px 10px;
+
+  // Hide the entire element if no tag slot is provided. We don't want the icon
+  // to be shown in that case.
+  &:has(> :nth-child(2):empty) { display: none; }
+
+  .icon-circle { font-size: 12px; }
 }
 
 .form-edit-section.warning {

--- a/src/components/form/edit/section.vue
+++ b/src/components/form/edit/section.vue
@@ -121,7 +121,7 @@ $dots-margin-block: 9px;
   background-color: rgba($color-accent-primary, 0.04);
   border-radius: 6px;
   color: $color-accent-primary;
-  padding: 5px 10px;
+  padding: 5px 9px;
 
   // Hide the entire element if no tag slot is provided. We don't want the icon
   // to be shown in that case.

--- a/test/components/form/edit/def.spec.js
+++ b/test/components/form/edit/def.spec.js
@@ -19,6 +19,31 @@ describe('FormEditDef', () => {
     version.should.equal('v2');
   });
 
+  describe('tag', () => {
+    it('shows tag if form draft differs from published definition', async () => {
+      testData.extendedForms.createPast(1, { hash: 'foo' });
+      testData.extendedFormVersions.createPast(1, { hash: 'bar', draft: true });
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-def .form-edit-section-tag').text();
+      tag.should.equal('Changed from published version');
+    });
+
+    it('does not show the tag if the form is not published', async () => {
+      testData.extendedForms.createPast(1, { draft: true });
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-def .form-edit-section-tag').text();
+      tag.should.equal('');
+    });
+
+    it('does not show the tag if the form draft does not differ', async () => {
+      testData.extendedForms.createPast(1, { hash: 'foo' });
+      testData.extendedFormVersions.createPast(1, { hash: 'foo', draft: true });
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-def .form-edit-section-tag').text();
+      tag.should.equal('');
+    });
+  });
+
   it('toggles the "View XML" modal', () => {
     testData.extendedForms.createPast(1, { draft: true });
     return load('/projects/1/forms/f/draft', { root: false }).testModalToggles({

--- a/test/components/form/edit/entities.spec.js
+++ b/test/components/form/edit/entities.spec.js
@@ -23,6 +23,40 @@ describe('FormDefEntities', () => {
     const app = await load('/projects/1/forms/f/draft');
     const subtitle = app.get('#form-edit-entities .form-edit-section-subtitle').text();
     subtitle.should.startWith('This definition does not update any Entities.');
+    app.get('#form-edit-entities .form-edit-section-tag').text().should.equal('');
     app.find('#form-edit-entities .dataset-summary-row').exists().should.be.false;
+  });
+
+  describe('tag', () => {
+    beforeEach(() => {
+      testData.extendedForms.createPast(1, { draft: true, entityRelated: true });
+    });
+
+    it('is shown if the form draft creates a new entity list', async () => {
+      testData.formDraftDatasetDiffs.createPast(1, { isNew: true });
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-entities .form-edit-section-tag').text();
+      tag.should.startWith('New');
+    });
+
+    it('is shown if the form draft creates a new property', async () => {
+      testData.formDraftDatasetDiffs.createPast(1, {
+        isNew: false,
+        properties: [Property.NewProperty]
+      });
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-entities .form-edit-section-tag').text();
+      tag.should.startWith('New');
+    });
+
+    it('is not shown if the form draft does not create anything', async () => {
+      testData.formDraftDatasetDiffs.createPast(1, {
+        isNew: false,
+        properties: [Property.InFormProperty]
+      });
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-entities .form-edit-section-tag').text();
+      tag.should.equal('');
+    });
   });
 });

--- a/test/data/form-draft-dataset-diff.js
+++ b/test/data/form-draft-dataset-diff.js
@@ -9,7 +9,7 @@ import Property from '../util/ds-property-enum';
 export const formDraftDatasetDiffs = dataStore({
   factory: ({
     isNew,
-    properties
+    properties = []
   }) => ({
     name: faker.random.alphaNumeric(10),
     isNew,
@@ -26,6 +26,3 @@ export const formDraftDatasetDiffs = dataStore({
   }),
   sort: comparator((diff1, diff2) => diff1.name < diff2.name)
 });
-
-
-

--- a/test/data/form-draft-dataset-diff.js
+++ b/test/data/form-draft-dataset-diff.js
@@ -1,9 +1,8 @@
 import faker from 'faker';
 import { comparator } from 'ramda';
 
-import { dataStore } from './data-store';
 import Property from '../util/ds-property-enum';
-
+import { dataStore } from './data-store';
 
 // eslint-disable-next-line import/prefer-default-export
 export const formDraftDatasetDiffs = dataStore({

--- a/test/data/forms.js
+++ b/test/data/forms.js
@@ -139,6 +139,7 @@ formVersions = dataStore({
     version = 'v1',
     draft = false,
     key = null,
+    hash = 'a'.repeat(32),
     sha256 = 'a'.repeat(64),
     enketoId,
     publishedAt = undefined,
@@ -154,6 +155,7 @@ formVersions = dataStore({
       formId: form.id,
       version,
       keyId: key != null ? key.id : null,
+      hash,
       sha256,
       excelContentType
     };
@@ -203,7 +205,14 @@ const basicFormProps = [
 ];
 // Properties from formVersions above that will be added to all forms and form
 // versions in the views below
-const basicVersionProps = ['version', 'keyId', 'publishedAt', 'draftToken'];
+const basicVersionProps = [
+  'version',
+  'keyId',
+  'hash',
+  'sha256',
+  'publishedAt',
+  'draftToken'
+];
 
 const findVersionForForm = (form) => {
   let draft;

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3060,6 +3060,10 @@
         "string": "Uploaded",
         "developer_comment": "This refers to a Form Definition."
       },
+      "changed": {
+        "string": "Changed from published version",
+        "developer_comment": "This refers to a Form Definition."
+      },
       "action": {
         "upload": {
           "string": "Upload new Form Definition",
@@ -3093,6 +3097,10 @@
       },
       "whatAreEntities": {
         "string": "What are Entities?"
+      },
+      "diffHasNew": {
+        "string": "New Entity Lists and/or properties will be created",
+        "developer_comment": "This text is shown if publishing a Form Definition will create one or more Entity Lists or one or more Entity properties."
       }
     },
     "FormEditPublishedVersion": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3058,11 +3058,11 @@
     "FormEditDef": {
       "subtitle": {
         "string": "Uploaded",
-        "developer_comment": "This refers to a Form Definition."
+        "developer_comment": "This refers to the draft version of a Form."
       },
       "changed": {
         "string": "Changed from published version",
-        "developer_comment": "This refers to a Form Definition."
+        "developer_comment": "This refers to the draft version of a Form."
       },
       "action": {
         "upload": {
@@ -3091,16 +3091,16 @@
       "datasetCount": {
         "string": "{count, plural, one {Publishing this draft will update {count} Entity List} other {Publishing this draft will update {count} Entity Lists}}"
       },
+      "diffHasNew": {
+        "string": "New Entity Lists and/or properties will be created",
+        "developer_comment": "This text is shown if publishing a Draft Form will create one or more Entity Lists or one or more Entity properties."
+      },
       "notEntityRelated": {
         "string": "This definition does not update any Entities.",
         "developer_comment": "\"Definition\" refers to a Form Definition."
       },
       "whatAreEntities": {
         "string": "What are Entities?"
-      },
-      "diffHasNew": {
-        "string": "New Entity Lists and/or properties will be created",
-        "developer_comment": "This text is shown if publishing a Form Definition will create one or more Entity Lists or one or more Entity properties."
       }
     },
     "FormEditPublishedVersion": {


### PR DESCRIPTION
This PR makes progress on getodk/central#728. Some sections of the Edit Form page show a tag to the right of the title and subtitle when something has changed. This PR adds a `tag` slot to the `FormEditSection` component and adds tags in two specific places:

- `FormEditDef`: When the form definition has changed (based on the MD5 hash of the XForm).
- `FormEditEntities`: When the draft dataset diff indicates that an entity list or property is new.

#### What has been done to verify that this works as intended?

New tests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced