### PR TITLE
Reorder form tabs, swapping Versions and Edit Form

### DIFF
--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -65,17 +65,17 @@ except according to the terms contained in the LICENSE file.
             </span>
           </router-link>
         </li>
-        <li :class="formTabClass('versions')" role="presentation">
-          <router-link :to="tabPath('versions')"
-            v-tooltip.aria-describedby="formTabDescription">
-            {{ $t('formHead.tab.versions') }}
-          </router-link>
-        </li>
         <li v-if="canRoute(tabPath('draft'))" :class="tabClass('draft')"
           role="presentation">
           <router-link :to="tabPath('draft')">
             {{ $t('formHead.tab.editForm') }}
             <span class="icon-pencil-square"></span>
+          </router-link>
+        </li>
+        <li :class="formTabClass('versions')" role="presentation">
+          <router-link :to="tabPath('versions')"
+            v-tooltip.aria-describedby="formTabDescription">
+            {{ $t('formHead.tab.versions') }}
           </router-link>
         </li>
         <li v-if="rendersFormTabs" :class="formTabClass('settings')"

--- a/test/components/form/head.spec.js
+++ b/test/components/form/head.spec.js
@@ -150,8 +150,8 @@ describe('FormHead', () => {
         tabs.map(tab => textWithout(tab, '.badge')).should.eql([
           'Submissions',
           'Public Access',
-          'Versions',
           'Edit Form',
+          'Versions',
           'Settings'
         ]);
       });


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It reorders the Versions and Edit Form tabs that are shown on form pages.

#### What has been done to verify that this works as intended?

Updated test.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced