### PR TITLE
Wrap form attachments table in scrollable container

### DIFF
--- a/src/components/entity/table.vue
+++ b/src/components/entity/table.vue
@@ -47,7 +47,7 @@ import { ref } from 'vue';
 
 import EntityDataRow from './data-row.vue';
 import EntityMetadataRow from './metadata-row.vue';
-import TableFreeze from '../table-freeze.vue';
+import TableFreeze from '../table/freeze.vue';
 
 import { markRowsChanged, markRowsDeleted } from '../../util/dom';
 import { useRequestData } from '../../request-data';

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -321,13 +321,6 @@ export default {
 </script>
 
 <style lang="scss">
-#form-attachment-list {
-  .panel-dialog {
-    margin-top: -5px;
-    margin-bottom: 25px;
-  }
-}
-
 #form-attachment-list-upload-button {
   margin-right: 5px;
 

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -12,26 +12,12 @@ except according to the terms contained in the LICENSE file.
 <template>
   <file-drop-zone id="form-attachment-list" :disabled="uploading"
     :styled="false" @dragenter="dragenter" @dragleave="dragleave" @drop="drop">
-    <table id="form-attachment-list-table" class="table">
-      <thead>
-        <tr>
-          <th class="form-attachment-list-type">{{ $t('header.type') }}</th>
-          <th class="form-attachment-list-name">{{ $t('header.name') }}</th>
-          <th class="form-attachment-list-uploaded">{{ $t('header.uploaded') }}</th>
-          <th class="form-attachment-list-action"></th>
-        </tr>
-      </thead>
-      <tbody v-if="form.dataExists && draftAttachments.dataExists">
-        <form-attachment-row v-for="attachment of draftAttachments.values()"
-          :key="attachment.name" :attachment="attachment"
-          :file-is-over-drop-zone="countOfFilesOverDropZone !== 0 && !uploading"
-          :dragover-attachment="dragoverAttachment"
-          :planned-uploads="plannedUploads"
-          :updated-attachments="updatedAttachments" :data-name="attachment.name"
-          :linkable="attachment.type === 'file' && !!dsHashset && dsHashset.has(attachment.name.replace(/\.[^.]+$/i, ''))"
-          @link="linkDatasetModal.show({ attachment: $event })"/>
-      </tbody>
-    </table>
+    <form-attachment-table
+      :file-is-over-drop-zone="countOfFilesOverDropZone !== 0 && !uploading"
+      :dragover-attachment="dragoverAttachment"
+      :planned-uploads="plannedUploads"
+      :updated-attachments="updatedAttachments"
+      @link="linkDatasetModal.show({ attachment: $event })"/>
     <p>
       <button id="form-attachment-list-upload-button" type="button"
         class="btn btn-primary" @click="uploadFilesModal.show()">
@@ -61,7 +47,7 @@ import FileDropZone from '../file-drop-zone.vue';
 import FormAttachmentLinkDataset from './link-dataset.vue';
 import FormAttachmentNameMismatch from './name-mismatch.vue';
 import FormAttachmentPopups from './popups.vue';
-import FormAttachmentRow from './row.vue';
+import FormAttachmentTable from './table.vue';
 import FormAttachmentUploadFiles from './upload-files.vue';
 
 import useRequest from '../../composables/request';
@@ -77,7 +63,7 @@ export default {
     FormAttachmentLinkDataset,
     FormAttachmentNameMismatch,
     FormAttachmentPopups,
-    FormAttachmentRow,
+    FormAttachmentTable,
     FormAttachmentUploadFiles
   },
   inject: ['alert', 'projectId'],
@@ -139,9 +125,6 @@ export default {
   computed: {
     uploading() {
       return this.uploadStatus.total !== 0;
-    },
-    dsHashset() {
-      return this.datasets.dataExists ? new Set(this.datasets.map(d => `${d.name}`)) : null;
     }
   },
   watch: {
@@ -345,34 +328,6 @@ export default {
   }
 }
 
-#form-attachment-list-table {
-  margin-bottom: 5px;
-
-  .form-attachment-list-type {
-    // Fix the widths of the Type and Name columns so that the width of the
-    // Uploaded column is also fixed. We do not want the width of the Uploaded
-    // column to change when a Replace label is added to a row.
-    max-width: 125px;
-    min-width: 125px;
-    width: 125px;
-  }
-
-  .form-attachment-list-name {
-    max-width: 250px;
-    min-width: 250px;
-    width: 250px;
-  }
-
-  .form-attachment-list-uploaded {
-    // Set the column to a minimum width such that when a Replace label is
-    // added to a row, it does not cause additional wrapping.
-    min-width: 300px;
-
-    // So that column doesn't grow infinitely
-    width: 1px;
-  }
-}
-
 #form-attachment-list-upload-button {
   margin-right: 5px;
 
@@ -388,11 +343,6 @@ export default {
     },
     // This text is shown next to a button with the text "Choose files".
     "orDrag": "or drag files onto this page to upload",
-    "header": {
-      // This is the text of a table column header. The column shows when each
-      // Media File was uploaded.
-      "uploaded": "Uploaded"
-    },
     "problem": {
       // {message} is an error message from the server.
       "noneUploaded": "{message} No files were successfully uploaded.",

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -185,7 +185,6 @@ export default {
     .form-attachment-list-action {
       div {
         text-align: right;
-        width: 200px;
 
         button {
           // adjusting for td padding

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -153,10 +153,12 @@ export default {
     box-shadow: inset 0 1px $color-info, inset 0 -1px $color-info;
 
     &:first-child {
+      border-left: none;
       box-shadow: inset 1px 1px $color-info, inset 0 -1px $color-info;
     }
 
     &:last-child {
+      border-right: none;
       box-shadow: inset 0 1px $color-info, inset -1px -1px $color-info;
     }
   }

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -148,49 +148,45 @@ export default {
 <style lang="scss">
 @import '../../assets/scss/mixins';
 
-#form-attachment-table {
-  > tbody > tr {
-    &.targeted {
-      > td {
-        box-shadow: inset 0 1px $color-info, inset 0 -1px $color-info;
+.form-attachment-row {
+  &.targeted td {
+    box-shadow: inset 0 1px $color-info, inset 0 -1px $color-info;
 
-        &:first-child {
-          box-shadow: inset 1px 1px $color-info, inset 0 -1px $color-info;
-        }
-
-        &:last-child {
-          box-shadow: inset 0 1px $color-info, inset -1px -1px $color-info;
-        }
-      }
+    &:first-child {
+      box-shadow: inset 1px 1px $color-info, inset 0 -1px $color-info;
     }
 
-    .form-attachment-list-name { @include text-overflow-ellipsis; }
-
-    .label {
-      margin-left: 5px;
+    &:last-child {
+      box-shadow: inset 0 1px $color-info, inset -1px -1px $color-info;
     }
+  }
 
-    .icon-exclamation-triangle {
-      color: #e1bf50;
+  .form-attachment-list-name { @include text-overflow-ellipsis; }
+
+  .label {
+    margin-left: 5px;
+  }
+
+  .icon-exclamation-triangle {
+    color: #e1bf50;
+    margin-right: $margin-right-icon;
+  }
+
+  .form-attachment-list-uploaded {
+    .icon-link {
       margin-right: $margin-right-icon;
+      color: $color-action-foreground;
     }
+  }
 
-    .form-attachment-list-uploaded {
-      .icon-link {
-        margin-right: $margin-right-icon;
-        color: $color-action-foreground;
-      }
-    }
+  .form-attachment-list-action {
+    div {
+      text-align: right;
 
-    .form-attachment-list-action {
-      div {
-        text-align: right;
-
-        button {
-          // adjusting for td padding
-          margin-top: -8px;
-          margin-bottom: -4px;
-        }
+      button {
+        // adjusting for td padding
+        margin-top: -8px;
+        margin-bottom: -4px;
       }
     }
   }

--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <tr :class="htmlClass">
+  <tr :class="htmlClass" :data-name="attachment.name">
     <td class="form-attachment-list-type">{{ type }}</td>
     <td class="form-attachment-list-name">
       <a v-if="attachment.blobExists" :href="href" target="_blank"
@@ -82,7 +82,7 @@ export default {
       type: Boolean,
       default: false
     },
-    dragoverAttachment: Object, // eslint-disable-line vue/require-default-prop
+    dragoverAttachment: Object,
     plannedUploads: {
       type: Array,
       required: true
@@ -148,7 +148,7 @@ export default {
 <style lang="scss">
 @import '../../assets/scss/mixins';
 
-#form-attachment-list-table {
+#form-attachment-table {
   > tbody > tr {
     &.targeted {
       > td {

--- a/src/components/form-attachment/table.vue
+++ b/src/components/form-attachment/table.vue
@@ -64,7 +64,7 @@ const dsHashset = computed(() =>
 
 <style lang="scss">
 #form-attachment-table {
-  margin-bottom: 5px;
+  margin-bottom: 10px;
 
   .form-attachment-list-type {
     // Fix the widths of the Type and Name columns so that the width of the

--- a/src/components/form-attachment/table.vue
+++ b/src/components/form-attachment/table.vue
@@ -13,10 +13,10 @@ except according to the terms contained in the LICENSE file.
   <table id="form-attachment-table" class="table">
     <thead>
       <tr>
-        <th class="form-attachment-list-type">{{ $t('header.type') }}</th>
-        <th class="form-attachment-list-name">{{ $t('header.name') }}</th>
-        <th class="form-attachment-list-uploaded">{{ $t('header.uploaded') }}</th>
-        <th class="form-attachment-list-action"></th>
+        <th>{{ $t('header.type') }}</th>
+        <th>{{ $t('header.name') }}</th>
+        <th>{{ $t('header.uploaded') }}</th>
+        <th></th>
       </tr>
     </thead>
     <tbody v-if="form.dataExists && draftAttachments.dataExists">
@@ -63,32 +63,15 @@ const dsHashset = computed(() =>
 </script>
 
 <style lang="scss">
+@import '../../assets/scss/variables';
+
 #form-attachment-table {
   margin-bottom: 10px;
 
-  .form-attachment-list-type {
-    // Fix the widths of the Type and Name columns so that the width of the
-    // Uploaded column is also fixed. We do not want the width of the Uploaded
-    // column to change when a Replace label is added to a row.
-    max-width: 125px;
-    min-width: 125px;
-    width: 125px;
-  }
-
-  .form-attachment-list-name {
-    max-width: 250px;
-    min-width: 250px;
-    width: 250px;
-  }
-
-  .form-attachment-list-uploaded {
-    // Set the column to a minimum width such that when a Replace label is
-    // added to a row, it does not cause additional wrapping.
-    min-width: 300px;
-
-    // So that column doesn't grow infinitely
-    width: 1px;
-  }
+  table-layout: fixed;
+  th:first-child { width: 125px; }
+  th:nth-child(2) { width: 250px; }
+  th:last-child { width: #{200px + $padding-left-table-data + $padding-right-table-data}; }
 }
 </style>
 

--- a/src/components/form-attachment/table.vue
+++ b/src/components/form-attachment/table.vue
@@ -1,0 +1,106 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <table id="form-attachment-table" class="table">
+    <thead>
+      <tr>
+        <th class="form-attachment-list-type">{{ $t('header.type') }}</th>
+        <th class="form-attachment-list-name">{{ $t('header.name') }}</th>
+        <th class="form-attachment-list-uploaded">{{ $t('header.uploaded') }}</th>
+        <th class="form-attachment-list-action"></th>
+      </tr>
+    </thead>
+    <tbody v-if="form.dataExists && draftAttachments.dataExists">
+      <form-attachment-row v-for="attachment of draftAttachments.values()"
+        :key="attachment.name" :attachment="attachment"
+        :file-is-over-drop-zone="fileIsOverDropZone"
+        :dragover-attachment="dragoverAttachment"
+        :planned-uploads="plannedUploads"
+        :updated-attachments="updatedAttachments"
+        :linkable="attachment.type === 'file' && dsHashset.has(attachment.name.replace(/\.[^.]+$/i, ''))"
+        @link="$emit('link', $event)"/>
+    </tbody>
+  </table>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import FormAttachmentRow from './row.vue';
+
+import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'FormAttachmentTable'
+});
+defineProps({
+  fileIsOverDropZone: Boolean,
+  dragoverAttachment: Object,
+  plannedUploads: {
+    type: Array,
+    required: true
+  },
+  updatedAttachments: {
+    type: Set,
+    required: true
+  }
+});
+defineEmits(['link']);
+
+const { form, draftAttachments, datasets } = useRequestData();
+
+const dsHashset = computed(() =>
+  (datasets.dataExists ? new Set(datasets.map(d => `${d.name}`)) : new Set()));
+</script>
+
+<style lang="scss">
+#form-attachment-table {
+  margin-bottom: 5px;
+
+  .form-attachment-list-type {
+    // Fix the widths of the Type and Name columns so that the width of the
+    // Uploaded column is also fixed. We do not want the width of the Uploaded
+    // column to change when a Replace label is added to a row.
+    max-width: 125px;
+    min-width: 125px;
+    width: 125px;
+  }
+
+  .form-attachment-list-name {
+    max-width: 250px;
+    min-width: 250px;
+    width: 250px;
+  }
+
+  .form-attachment-list-uploaded {
+    // Set the column to a minimum width such that when a Replace label is
+    // added to a row, it does not cause additional wrapping.
+    min-width: 300px;
+
+    // So that column doesn't grow infinitely
+    width: 1px;
+  }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.FormAttachmentList.header
+    "header": {
+      // This is the text of a table column header. The column shows when each
+      // Media File was uploaded.
+      "uploaded": "Uploaded"
+    }
+  }
+}
+</i18n>

--- a/src/components/form-attachment/table.vue
+++ b/src/components/form-attachment/table.vue
@@ -10,32 +10,35 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <table id="form-attachment-table" class="table">
-    <thead>
-      <tr>
-        <th>{{ $t('header.type') }}</th>
-        <th>{{ $t('header.name') }}</th>
-        <th>{{ $t('header.uploaded') }}</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody v-if="form.dataExists && draftAttachments.dataExists">
-      <form-attachment-row v-for="attachment of draftAttachments.values()"
-        :key="attachment.name" :attachment="attachment"
-        :file-is-over-drop-zone="fileIsOverDropZone"
-        :dragover-attachment="dragoverAttachment"
-        :planned-uploads="plannedUploads"
-        :updated-attachments="updatedAttachments"
-        :linkable="attachment.type === 'file' && dsHashset.has(attachment.name.replace(/\.[^.]+$/i, ''))"
-        @link="$emit('link', $event)"/>
-    </tbody>
-  </table>
+  <table-scroll id="form-attachment-table">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>{{ $t('header.type') }}</th>
+          <th>{{ $t('header.name') }}</th>
+          <th>{{ $t('header.uploaded') }}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody v-if="form.dataExists && draftAttachments.dataExists">
+        <form-attachment-row v-for="attachment of draftAttachments.values()"
+          :key="attachment.name" :attachment="attachment"
+          :file-is-over-drop-zone="fileIsOverDropZone"
+          :dragover-attachment="dragoverAttachment"
+          :planned-uploads="plannedUploads"
+          :updated-attachments="updatedAttachments"
+          :linkable="attachment.type === 'file' && dsHashset.has(attachment.name.replace(/\.[^.]+$/i, ''))"
+          @link="$emit('link', $event)"/>
+      </tbody>
+    </table>
+  </table-scroll>
 </template>
 
 <script setup>
 import { computed } from 'vue';
 
 import FormAttachmentRow from './row.vue';
+import TableScroll from '../table/scroll.vue';
 
 import { useRequestData } from '../../request-data';
 
@@ -67,8 +70,10 @@ const dsHashset = computed(() =>
 
 #form-attachment-table {
   margin-bottom: 10px;
+  max-height: 70vh;
 
-  table-layout: fixed;
+  table { table-layout: fixed; }
+
   th:first-child { width: 125px; }
   th:nth-child(2) { width: 250px; }
   th:last-child { width: #{200px + $padding-left-table-data + $padding-right-table-data}; }

--- a/src/components/project/form-access/table.vue
+++ b/src/components/project/form-access/table.vue
@@ -46,7 +46,7 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 import ProjectFormAccessRow from './row.vue';
-import TableFreeze from '../../table-freeze.vue';
+import TableFreeze from '../../table/freeze.vue';
 
 import { useRequestData } from '../../../request-data';
 

--- a/src/components/submission/table.vue
+++ b/src/components/submission/table.vue
@@ -46,7 +46,7 @@ import { computed, ref } from 'vue';
 
 import SubmissionDataRow from './data-row.vue';
 import SubmissionMetadataRow from './metadata-row.vue';
-import TableFreeze from '../table-freeze.vue';
+import TableFreeze from '../table/freeze.vue';
 
 import useChunkyArray from '../../composables/chunky-array';
 import { markRowsChanged, markRowsDeleted } from '../../util/dom';

--- a/src/components/table/freeze.vue
+++ b/src/components/table/freeze.vue
@@ -131,7 +131,7 @@ defineExpose({ getRowPair });
 </script>
 
 <style lang="scss">
-@import '../assets/scss/mixins';
+@import '../../assets/scss/mixins';
 
 .table-freeze { @include clearfix; }
 

--- a/src/components/table/scroll.vue
+++ b/src/components/table/scroll.vue
@@ -1,0 +1,45 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div class="table-scroll">
+    <slot></slot>
+  </div>
+</template>
+
+<script setup>
+defineOptions({
+  name: 'TableScroll'
+});
+</script>
+
+<style lang="scss">
+@import '../../assets/scss/variables';
+
+.table-scroll {
+  border-bottom: $border-top-table-data;
+  margin-bottom: $margin-bottom-table;
+  overflow: hidden auto;
+  position: relative;
+
+  table { margin-bottom: 0; }
+
+  thead {
+    position: sticky;
+    top: 0;
+  }
+
+  th:first-child { border-left: 1px solid $color-table-heading-background; }
+  th:last-child { border-right: 1px solid $color-table-heading-background; }
+  td:first-child { border-left: $border-top-table-data; }
+  td:last-child { border-right: $border-top-table-data; }
+}
+</style>

--- a/test/components/table/freeze.spec.js
+++ b/test/components/table/freeze.spec.js
@@ -1,6 +1,6 @@
-import TableFreeze from '../../src/components/table-freeze.vue';
+import TableFreeze from '../../../src/components/table/freeze.vue';
 
-import { mergeMountOptions, mount } from '../util/lifecycle';
+import { mergeMountOptions, mount } from '../../util/lifecycle';
 
 const mountComponent = (options) =>
   mount(TableFreeze, mergeMountOptions(options, {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2629,12 +2629,6 @@
         "string": "or drag files onto this page to upload",
         "developer_comment": "This text is shown next to a button with the text \"Choose files\"."
       },
-      "header": {
-        "uploaded": {
-          "string": "Uploaded",
-          "developer_comment": "This is the text of a table column header. The column shows when each Media File was uploaded."
-        }
-      },
       "problem": {
         "noneUploaded": {
           "string": "{message} No files were successfully uploaded.",
@@ -2651,6 +2645,12 @@
         },
         "link": {
           "string": "Entity List linked successfully."
+        }
+      },
+      "header": {
+        "uploaded": {
+          "string": "Uploaded",
+          "developer_comment": "This is the text of a table column header. The column shows when each Media File was uploaded."
         }
       }
     },


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It implements the following part of the release criteria:

<blockquote>

- If the table is taller than 80vh, I should see just the table area limit to 80vh and scroll vertically.
  - Ideally I should not see the header portion scroll, I should always see it
</blockquote>

I went with 70vh instead of 80vh for reasons that I mentioned in a [comment](https://docs.google.com/document/d/1fD60li-PNTjE19g8_aN-aLuZfbO_eUKy3MeJXDoqkCU/edit?disco=AAABhXB1rx8) on the release criteria.

I also added a border around the table after discussion with Nicole.

#### What has been done to verify that this works as intended?

I tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced