### PR TITLE
Allow user to drop form attachments anywhere on Edit Form page

### DIFF
--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -142,6 +142,9 @@ export default {
       this[event.type]?.(event, ...args);
     };
   },
+  beforeUnmount() {
+    this.dragHandler = noop;
+  },
   methods: {
     ////////////////////////////////////////////////////////////////////////////
     // FILE INPUT

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -63,7 +63,7 @@ export default {
     FormAttachmentTable,
     FormAttachmentUploadFiles
   },
-  inject: ['alert', 'projectId', 'handleDrag', 'disableDrag'],
+  inject: ['alert', 'projectId', 'dragDisabled', 'dragHandler'],
   setup() {
     const { project, form, draftAttachments, datasets } = useRequestData();
     const { request } = useRequest();
@@ -132,13 +132,15 @@ export default {
       immediate: true
     },
     uploading(uploading) {
-      this.disableDrag(uploading);
+      this.dragDisabled = uploading;
     }
   },
   created() {
-    this.handleDrag((event, ...args) => {
+    this.dragHandler = (event, ...args) => {
+      // Delegate to one of the drag and drop methods below (e.g.,
+      // this.dragenter()).
       this[event.type]?.(event, ...args);
-    });
+    };
   },
   methods: {
     ////////////////////////////////////////////////////////////////////////////
@@ -162,7 +164,7 @@ export default {
       return count;
     },
     // this.dragenter(), this.dragleave(), and this.drop() are called via
-    // this.handleDrag().
+    // this.dragHandler.
     dragenter(event) {
       const { items } = event.dataTransfer;
       this.countOfFilesOverDropZone = this.fileItemCount(items);

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <file-drop-zone id="form-edit" :disabled="dragDisabled" :styled="false"
-    @dragenter="handleDrag" @dragleave="handleDrag" @drop="handleDrag">
+    @dragenter="dragHandler" @dragleave="dragHandler" @drop="dragHandler">
     <div class="row">
       <div class="col-xs-6">
         <form-edit-loading-draft v-if="!formDraft.dataExists"/>
@@ -115,11 +115,17 @@ watchEffect(() => {
   }
 });
 
-// Dragging and dropping form attachments
-const handleDrag = ref(noop);
-provide('handleDrag', (f) => { handleDrag.value = f; });
+/* We allow form attachments to be dragged and dropped anywhere in FormEdit.
+That's why FileDropZone is in this component. But it's FormAttachmentList that
+actually knows how to handle drag events. FormAttachmentList is a few layers
+away from FormEdit, so the two communicate using refs. FormEdit provides the
+refs, then FormAttachmentList sets their values. That approach allows the two
+components to interact directly without getting intermediate components
+involved. */
 const dragDisabled = ref(false);
-provide('disableDrag', (disabled) => { dragDisabled.value = disabled; });
+provide('dragDisabled', dragDisabled);
+const dragHandler = ref(noop);
+provide('dragHandler', dragHandler);
 
 const uploadModal = modalData();
 const { router, alert } = inject('container');

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -10,7 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div id="form-edit">
+  <file-drop-zone id="form-edit" :disabled="dragDisabled" :styled="false"
+    @dragenter="handleDrag" @dragleave="handleDrag" @drop="handleDrag">
     <div class="row">
       <div class="col-xs-6">
         <form-edit-loading-draft v-if="!formDraft.dataExists"/>
@@ -38,13 +39,14 @@ except according to the terms contained in the LICENSE file.
       @success="afterPublish"/>
     <form-draft-abandon v-bind="abandonModal" @hide="abandonModal.hide()"
       @success="afterAbandon"/>
-  </div>
+  </file-drop-zone>
 </template>
 
 <script setup>
-import { inject, provide, watchEffect } from 'vue';
+import { inject, provide, ref, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import FileDropZone from '../file-drop-zone.vue';
 import FormDraftAbandon from '../form-draft/abandon.vue';
 import FormDraftPublish from '../form-draft/publish.vue';
 import FormDraftTesting from '../form-draft/testing.vue';
@@ -112,6 +114,12 @@ watchEffect(() => {
     }).catch(noop);
   }
 });
+
+// Dragging and dropping form attachments
+const handleDrag = ref(noop);
+provide('handleDrag', (f) => { handleDrag.value = f; });
+const dragDisabled = ref(false);
+provide('disableDrag', (disabled) => { dragDisabled.value = disabled; });
 
 const uploadModal = modalData();
 const { router, alert } = inject('container');

--- a/test/components/form/edit.spec.js
+++ b/test/components/form/edit.spec.js
@@ -1,5 +1,6 @@
 import Property from '../../util/ds-property-enum';
 import testData from '../../data';
+import { dragAndDrop } from '../../util/trigger';
 import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 
@@ -43,5 +44,31 @@ describe('FormEdit', () => {
         url: '/v1/projects/1/forms/f/draft/dataset-diff'
       }]);
     });
+  });
+
+  it('does not error for file drop after attachments section is removed', () => {
+    testData.extendedForms.createPast(1, { draft: true });
+    testData.standardFormAttachments.createPast(1, { name: 'foo' });
+    return load('/projects/1/forms/f/draft')
+      .afterResponses(app => {
+        app.find('#form-edit-attachments').exists().should.be.true;
+      })
+      .request(async (app) => {
+        await app.get('#form-edit-publish-button').trigger('click');
+        return app.get('#form-draft-publish .btn-primary').trigger('click');
+      })
+      .respondWithData(() => {
+        testData.extendedFormDrafts.publish(-1);
+        return { success: true };
+      })
+      .respondWithData(() => testData.extendedProjects.last())
+      .respondWithData(() => testData.extendedForms.last())
+      .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
+      .respondWithData(() => testData.formDatasetDiffs.sorted())
+      .afterResponses(async (app) => {
+        app.find('#form-edit-attachments').exists().should.be.false;
+        // As long as this doesn't result in an error, we're in the clear.
+        await dragAndDrop(app.get('#form-edit'), [new File([''], 'foo')]);
+      });
   });
 });


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It makes it possible for the user to drag and drop attachments anywhere on the Edit Form page. Currently, drag and drop is limited to the `FormAttachmentList` component within the Attachments section of the page.

#### What has been done to verify that this works as intended?

Existing tests continue to pass. I also tried it out some locally.

#### Why is this the best possible solution? Were any other approaches considered?

There's a little bit of awkwardness in that the `FileDropZone` component is rendered in `FormEdit`, but all the drag and drop logic is in `FormAttachmentList`, which is a few layers away. Rather than trying to emit and re-emit up through those layers, I'm using provide/inject to pass setter functions from `FormEdit` to `FormAttachmentList`. That allows `FormAttachmentList` to interact with the `FileDropZone` without getting intermediate components involved.

I also wondered whether it was possible to keep the `FileDropZone` in `FormAttachmentList`, but teleport it to `FormEdit`. I don't think that really works though, because we also need to pass content in a slot to `FileDropZone`. Specifically, that content needs to be the contents of `FormEdit`.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced