### PR TITLE
Redirect from hash-based URL with query param

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -83,7 +83,9 @@ router.afterEach(unlessFailure(to => {
   // navigation. To support, bookmarked links, we are redirecting old URL to the new one.
   // Using to.fullPath instead of to.hash because to.hash has URL decoded value whereas to.fullPath
   // gives percentage encoded value - central#919.
-  router.beforeEach(to => (to.path === '/' && to.fullPath.startsWith('/#/') ? to.fullPath.substring(2) : true));
+  // Note: to.path is '/#/some/path' when the route has query parameter after '#'
+  // e.g. /#/some/path?next=/ - central#939
+  router.beforeEach(to => (to.fullPath.startsWith('/#/') ? to.fullPath.substring(2) : true));
 
 
   //////////////////////////////////////////////////////////////////////////////

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -164,6 +164,16 @@ describe('createCentralRouter()', () => {
           app.vm.$route.path.should.equal("/projects/1/forms/'%3D%2B%2F*-451%25%2F%25/submissions");
         });
     });
+
+    it('redirects if URL starts with hash and contains query parameter', () => {
+      testData.extendedForms.createPast(1);
+      return load('/#/projects/1/forms/f/submissions?reviewState=%27hasIssues%27', {}, false)
+        .respondFor('/projects/1/forms/f/submissions?reviewState=%27hasIssues%27')
+        .afterResponses(app => {
+          app.vm.$route.path.should.be.equal('/projects/1/forms/f/submissions');
+          app.vm.$route.query.should.be.deep.equal({ reviewState: "'hasIssues'" });
+        });
+    });
   });
 
   describe('requireLogin', () => {


### PR DESCRIPTION
Fixes getodk/central#939

#### What has been done to verify that this works as intended?

Added a test. Manual verification

#### Why is this the best possible solution? Were any other approaches considered?

I was thinking to add a condition to check if `to.path.startsWith('/#/')` but couldn't see any advantage. When URL is hash-bash with query parameters, the value of `to.path` is not `/` instead it is full hash value with query parameters.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced