### PR TITLE
Style info box about testing entities

### DIFF
--- a/src/components/form-draft/testing.vue
+++ b/src/components/form-draft/testing.vue
@@ -21,13 +21,16 @@ except according to the terms contained in the LICENSE file.
     </template>
     <template #body>
       <div v-if="formDraft.entityRelated" id="form-draft-testing-entities">
-        <span>{{ $t('entitiesTesting') }}</span>
-        <sentence-separator/>
-        <i18n-t keypath="moreInfo.helpArticle.full">
-          <template #helpArticle>
-            <doc-link to="central-entities/#testing-forms-with-entities">{{ $t('moreInfo.helpArticle.helpArticle') }}</doc-link>
-          </template>
-        </i18n-t>
+        <span class="icon-info-circle"></span>
+        <div>
+          <span>{{ $t('entitiesTesting') }}</span>
+          <sentence-separator/>
+          <i18n-t keypath="moreInfo.helpArticle.full">
+            <template #helpArticle>
+              <doc-link to="central-entities/#testing-forms-with-entities">{{ $t('moreInfo.helpArticle.helpArticle') }}</doc-link>
+            </template>
+          </i18n-t>
+        </div>
       </div>
 
       <loading :state="keys.initiallyLoading"/>
@@ -85,7 +88,21 @@ const hidePopover = () => { popoverData.target = null; };
 </script>
 
 <style lang="scss">
-#form-draft-testing-entities { margin-bottom: 25px; }
+@import '../../assets/scss/variables';
+
+#form-draft-testing-entities {
+  background-color: $color-page-background;
+  color: #666;
+  column-gap: $margin-right-icon;
+  display: flex;
+  margin-bottom: 15px;
+  padding: 12px;
+
+  .icon-info-circle {
+    color: #999;
+    font-size: 20px;
+  }
+}
 </style>
 
 <i18n lang="json5">


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It styles the info box about testing entities on the Edit Form page.

#### What has been done to verify that this works as intended?

I tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced