### PR TITLE
Show tag about new or changed form attachments

### DIFF
--- a/src/components/form-attachment/link-dataset.vue
+++ b/src/components/form-attachment/link-dataset.vue
@@ -70,7 +70,8 @@ export default {
         url: apiPaths.formAttachment(this.form.projectId, this.form.xmlFormId, true, this.attachment.name),
         data: { dataset: true }
       })
-        .then(() => {
+        .then(({ data }) => {
+          Object.assign(this.attachment, data);
           this.$emit('success', this.form);
         })
         .catch(noop);

--- a/src/components/form-attachment/link-dataset.vue
+++ b/src/components/form-attachment/link-dataset.vue
@@ -71,8 +71,7 @@ export default {
         data: { dataset: true }
       })
         .then(({ data }) => {
-          Object.assign(this.attachment, data);
-          this.$emit('success', this.form);
+          this.$emit('success', data);
         })
         .catch(noop);
     }

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -291,9 +291,10 @@ export default {
           if (updates.length === this.uploadStatus.total)
             this.alert.success(this.$tcn('alert.success', updates.length));
 
-          for (const update of updates) {
-            Object.assign(this.draftAttachments.get(update.name), update);
-            this.updatedAttachments.add(update.name);
+          for (const updatedAttachment of updates) {
+            const { name } = updatedAttachment;
+            this.draftAttachments.set(name, updatedAttachment);
+            this.updatedAttachments.add(name);
           }
 
           this.uploadStatus = { total: 0, remaining: 0, current: null, progress: 0 };
@@ -307,12 +308,12 @@ export default {
         resend: false
       }).catch(noop);
     },
-    afterLinkDataset() {
-      const { attachment } = this.linkDatasetModal;
+    afterLinkDataset(updatedAttachment) {
       this.linkDatasetModal.hide();
       this.alert.success(this.$t('alert.link', {
-        attachmentName: attachment.name
+        attachmentName: updatedAttachment.name
       }));
+      this.draftAttachments.set(updatedAttachment.name, updatedAttachment);
     }
   }
 };

--- a/src/components/form-attachment/list.vue
+++ b/src/components/form-attachment/list.vue
@@ -266,12 +266,7 @@ export default {
           });
         }
       })
-        .then(() => {
-          // This may differ a little from updatedAt on the server, but that
-          // should be OK.
-          const updatedAt = new Date().toISOString();
-          updates.push([attachment.name, updatedAt]);
-        });
+        .then(({ data }) => { updates.push(data); });
     },
     uploadFiles() {
       this.alert.blank();
@@ -296,14 +291,9 @@ export default {
           if (updates.length === this.uploadStatus.total)
             this.alert.success(this.$tcn('alert.success', updates.length));
 
-          for (const [name, updatedAt] of updates) {
-            const attachment = this.draftAttachments.get(name);
-            attachment.blobExists = true;
-            attachment.datasetExists = false;
-            attachment.exists = true;
-            attachment.updatedAt = updatedAt;
-
-            this.updatedAttachments.add(name);
+          for (const update of updates) {
+            Object.assign(this.draftAttachments.get(update.name), update);
+            this.updatedAttachments.add(update.name);
           }
 
           this.uploadStatus = { total: 0, remaining: 0, current: null, progress: 0 };
@@ -323,10 +313,6 @@ export default {
       this.alert.success(this.$t('alert.link', {
         attachmentName: attachment.name
       }));
-
-      attachment.datasetExists = true;
-      attachment.blobExists = false;
-      attachment.exists = true;
     }
   }
 };

--- a/src/components/form/edit/attachments.vue
+++ b/src/components/form/edit/attachments.vue
@@ -43,8 +43,7 @@ import Loading from '../../loading.vue';
 import { useI18nUtils } from '../../../util/i18n';
 import { useRequestData } from '../../../request-data';
 
-const { form, publishedAttachments, draftAttachments, resourceStates } = useRequestData();
-const { dataExists } = resourceStates([form, publishedAttachments, draftAttachments]);
+const { publishedAttachments, draftAttachments } = useRequestData();
 
 const hasAttachments = computed(() =>
   draftAttachments.dataExists && draftAttachments.size !== 0);
@@ -54,8 +53,7 @@ const hasMissing = computed(() =>
 const { t } = useI18n();
 const { tn, formatList } = useI18nUtils();
 const tag = computed(() => {
-  if (!(dataExists.value && hasAttachments.value && form.publishedAt != null))
-    return '';
+  if (!(hasAttachments.value && publishedAttachments.dataExists)) return '';
 
   let newCount = 0;
   let changedCount = 0;
@@ -94,8 +92,8 @@ const tag = computed(() => {
     "diff": {
       "newCount": "{count} new attachment | {count} new attachments",
       "changedCount": "{count} changed attachment | {count} changed attachments",
-      // {changes} describes the changes that have been made to Form
-      // attachments. For example: "1 new attachment and 2 changed attachments"
+      // {changes} describes changes that have been made to Form attachments.
+      // For example: "1 new attachment and 2 changed attachments"
       "summary": "{changes} since the published version"
     }
   }

--- a/src/components/form/edit/attachments.vue
+++ b/src/components/form/edit/attachments.vue
@@ -21,6 +21,7 @@ except according to the terms contained in the LICENSE file.
         {{ $tcn('count.attachments', draftAttachments.size) }}
       </template>
     </template>
+    <template #tag>{{ tag }}</template>
     <template #body>
       <loading :state="draftAttachments.initiallyLoading"/>
       <template v-if="draftAttachments.dataExists">
@@ -33,19 +34,47 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import FormAttachmentList from '../../form-attachment/list.vue';
 import FormEditSection from './section.vue';
 import Loading from '../../loading.vue';
 
+import { useI18nUtils } from '../../../util/i18n';
 import { useRequestData } from '../../../request-data';
 
-const { draftAttachments } = useRequestData();
+const { form, publishedAttachments, draftAttachments, resourceStates } = useRequestData();
+const { dataExists } = resourceStates([form, publishedAttachments, draftAttachments]);
 
 const hasAttachments = computed(() =>
   draftAttachments.dataExists && draftAttachments.size !== 0);
 const hasMissing = computed(() =>
   draftAttachments.dataExists && draftAttachments.missingCount !== 0);
+
+const { t } = useI18n();
+const { tn, formatList } = useI18nUtils();
+const tag = computed(() => {
+  if (!(dataExists.value && hasAttachments.value && form.publishedAt != null))
+    return '';
+
+  let newCount = 0;
+  let changedCount = 0;
+  for (const draftAttachment of draftAttachments.values()) {
+    const publishedAttachment = publishedAttachments.get(draftAttachment.name);
+    if (publishedAttachment == null)
+      newCount += 1;
+    else if (draftAttachment.hash !== publishedAttachment.hash ||
+      draftAttachment.datasetExists !== publishedAttachment.datasetExists)
+      changedCount += 1;
+  }
+
+  const parts = [];
+  if (newCount !== 0) parts.push(tn('diff.newCount', newCount));
+  if (changedCount !== 0) parts.push(tn('diff.changedCount', changedCount));
+  return parts.length !== 0
+    ? t('diff.summary', { changes: formatList(parts, 'long') })
+    : '';
+});
 </script>
 
 <style lang="scss">
@@ -61,7 +90,14 @@ const hasMissing = computed(() =>
     // "Definition" refers to a Form Definition, and "attachments" refers to
     // Form Attachments.
     "noAttachments": "This definition requires no attachments, so there is nothing to upload.",
-    "missingCount": "{count} missing attachment | {count} missing attachments"
+    "missingCount": "{count} missing attachment | {count} missing attachments",
+    "diff": {
+      "newCount": "{count} new attachment | {count} new attachments",
+      "changedCount": "{count} changed attachment | {count} changed attachments",
+      // {changes} describes the changes that have been made to Form
+      // attachments. For example: "1 new attachment and 2 changed attachments"
+      "summary": "{changes} since the published version"
+    }
   }
 }
 </i18n>

--- a/src/request-data/form.js
+++ b/src/request-data/form.js
@@ -9,7 +9,7 @@ https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
 including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
-import { reactive, shallowReactive, watchSyncEffect } from 'vue';
+import { shallowReactive, watchSyncEffect } from 'vue';
 
 import { computeIfExists, setupOption, transformForm, transformForms } from './util';
 import { useRequestData } from './index';
@@ -25,13 +25,13 @@ export default () => {
   const formDraft = createResource('formDraft', () =>
     setupOption(data => shallowReactive(transformForm(data))));
 
-  const transformAttachments = ({ data }) => data.reduce(
-    (map, attachment) => map.set(attachment.name, reactive(attachment)),
+  const mapAttachments = (attachments) => attachments.reduce(
+    (map, attachment) => map.set(attachment.name, attachment),
     new Map()
   );
   // Form draft attachments
   const draftAttachments = createResource('draftAttachments', () => ({
-    transformResponse: transformAttachments,
+    transformResponse: ({ data }) => shallowReactive(mapAttachments(data)),
     missingCount: computeIfExists(() => {
       let count = 0;
       for (const attachment of draftAttachments.values()) {
@@ -42,7 +42,7 @@ export default () => {
   }));
   // Published form attachments
   const publishedAttachments = createResource('publishedAttachments', () => ({
-    transformResponse: transformAttachments,
+    transformResponse: ({ data }) => mapAttachments(data),
     linkedDatasets: computeIfExists(() => {
       const datasets = [];
       for (const attachment of publishedAttachments.values()) {

--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -102,6 +102,7 @@ const useGlobalUtils = memoizeForContainer(({ i18n }) => {
     const existingFormat = numberFormats[locale][key];
     if (existingFormat != null) return existingFormat;
     const options = i18n.getNumberFormat(locale)[key];
+    if (options == null) throw new Error('unknown key');
     const numberFormat = new Intl.NumberFormat(locale, options);
     numberFormats[locale][key] = numberFormat;
     return numberFormat;
@@ -113,7 +114,9 @@ const useGlobalUtils = memoizeForContainer(({ i18n }) => {
     if (listFormats[locale] == null) listFormats[locale] = {};
     const existingFormat = listFormats[locale][key];
     if (existingFormat != null) return existingFormat;
-    const listFormat = new Intl.ListFormat(locale, listFormatOptions[key]);
+    const options = listFormatOptions[key];
+    if (options == null) throw new Error('unknown key');
+    const listFormat = new Intl.ListFormat(locale, options);
     listFormats[locale][key] = listFormat;
     return listFormat;
   };

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -83,7 +83,7 @@ describe('FormAttachmentList', () => {
 
       it('correctly renders an attachment that has never been uploaded', async () => {
         testData.standardFormAttachments.createPast(1, {
-          exists: false,
+          blobExists: false,
           hasUpdatedAt: false
         });
         const component = await load('/projects/1/forms/f/draft', {
@@ -98,7 +98,7 @@ describe('FormAttachmentList', () => {
 
       it('correctly renders a deleted attachment', async () => {
         testData.standardFormAttachments.createPast(1, {
-          exists: false,
+          blobExists: false,
           hasUpdatedAt: true
         });
         const component = await load('/projects/1/forms/f/draft', {
@@ -447,11 +447,11 @@ describe('FormAttachmentList', () => {
         .beforeAnyResponse(component => {
           component.get('#form-attachment-popups-backdrop').should.be.visible();
         })
-        .respondWithSuccess());
+        .respondWithData(() => testData.standardFormAttachments.update(0)));
 
     it('shows the popup with the correct text', () =>
       upload('a')
-        .respondWithSuccess()
+        .respondWithData(() => testData.standardFormAttachments.update(0))
         .beforeEachResponse((component, { data }) => {
           const popup = component.get('#form-attachment-popups-main');
           component.should.be.visible();
@@ -462,52 +462,63 @@ describe('FormAttachmentList', () => {
 
     describe('the upload succeeds', () => {
       describe('updatedAt', () => {
-        it('updates the table for an existing attachment', () =>
-          upload('a')
-            .respondWithSuccess()
+        it('updates the table for an existing attachment', () => {
+          const oldUpdatedAt = testData.standardFormAttachments.sorted()
+            .map(attachment => attachment.updatedAt);
+          return upload('a')
+            .respondWithData(() => testData.standardFormAttachments.update(0))
             .afterResponse(component => {
-              const oldUpdatedAt = testData.standardFormAttachments.sorted()
-                .map(attachment => attachment.updatedAt);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
               isBefore(oldUpdatedAt[0], newUpdatedAt[0]).should.be.true;
               should.not.exist(newUpdatedAt[1]);
               newUpdatedAt[2].should.equal(oldUpdatedAt[2]);
-            }));
+            });
+        });
 
-        it('updates table for an attachment that has never been uploaded', () =>
-          upload('b')
-            .respondWithSuccess()
+        it('updates table for an attachment that has never been uploaded', () => {
+          const oldUpdatedAt = testData.standardFormAttachments.sorted()
+            .map(attachment => attachment.updatedAt);
+          return upload('b')
+            .respondWithData(() => testData.standardFormAttachments.update(1, {
+              blobExists: true,
+              exists: true,
+              hash: 'foo'
+            }))
             .afterResponse(component => {
-              const oldUpdatedAt = testData.standardFormAttachments.sorted()
-                .map(attachment => attachment.updatedAt);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
               newUpdatedAt[0].should.equal(oldUpdatedAt[0]);
               should.exist(newUpdatedAt[1]);
               newUpdatedAt[2].should.equal(oldUpdatedAt[2]);
-            }));
+            });
+        });
 
-        it('updates the table for a deleted attachment', () =>
-          upload('c')
-            .respondWithSuccess()
+        it('updates the table for a deleted attachment', () => {
+          const oldUpdatedAt = testData.standardFormAttachments.sorted()
+            .map(attachment => attachment.updatedAt);
+          return upload('c')
+            .respondWithData(() => testData.standardFormAttachments.update(2, {
+              blobExists: true,
+              exists: true,
+              hash: 'foo'
+            }))
             .afterResponse(component => {
-              const oldUpdatedAt = testData.standardFormAttachments.sorted()
-                .map(attachment => attachment.updatedAt);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
               newUpdatedAt[0].should.equal(oldUpdatedAt[0]);
               should.not.exist(newUpdatedAt[1]);
               isBefore(oldUpdatedAt[2], newUpdatedAt[2]).should.be.true;
-            }));
+            });
+        });
       });
 
       it('shows a success alert', () =>
         upload('a')
-          .respondWithSuccess()
+          .respondWithData(() => testData.standardFormAttachments.update(0))
           .afterResponse(component => {
             component.should.alert('success', '1 file has been successfully uploaded.');
           }));
@@ -515,7 +526,7 @@ describe('FormAttachmentList', () => {
       describe('highlight', () => {
         it('highlights the updated attachment', () =>
           upload('a')
-            .respondWithSuccess()
+            .respondWithData(() => testData.standardFormAttachments.update(0))
             .afterResponse(component => {
               const rows = component.findAllComponents(FormAttachmentRow);
               const success = rows.map(row => row.classes('success'));
@@ -524,7 +535,7 @@ describe('FormAttachmentList', () => {
 
         it('unhighlights the attachment once a new drag starts', () =>
           upload('a')
-            .respondWithSuccess()
+            .respondWithData(() => testData.standardFormAttachments.update(0))
             .afterResponse(async (component) => {
               await component.get('#form-attachment-list').trigger('dragenter', {
                 dataTransfer: fileDataTransfer(blankFiles(['d']))
@@ -534,7 +545,7 @@ describe('FormAttachmentList', () => {
 
         it('unhighlights the attachment after a file input selection', () =>
           upload('a')
-            .respondWithSuccess()
+            .respondWithData(() => testData.standardFormAttachments.update(0))
             .afterResponse(async (component) => {
               const input = component.get('#form-attachment-upload-files input');
               await setFiles(input, blankFiles(['d']));
@@ -544,19 +555,20 @@ describe('FormAttachmentList', () => {
     });
 
     describe('the upload does not succeed', () => {
-      it('does not update the table', () =>
-        upload('a')
+      it('does not update the table', () => {
+        const oldUpdatedAt = testData.standardFormAttachments.sorted()
+          .map(attachment => attachment.updatedAt);
+        return upload('a')
           .respondWithProblem()
           .afterResponse(component => {
-            const oldUpdatedAt = testData.standardFormAttachments.sorted()
-              .map(attachment => attachment.updatedAt);
             const { draftAttachments } = component.vm.$container.requestData.localResources;
             const newUpdatedAt = [...draftAttachments.values()]
               .map(attachment => attachment.updatedAt);
             newUpdatedAt[0].should.equal(oldUpdatedAt[0]);
             should.not.exist(newUpdatedAt[1]);
             newUpdatedAt[2].should.equal(oldUpdatedAt[2]);
-          }));
+          });
+      });
 
       it('shows a danger alert', () =>
         upload('a')
@@ -640,8 +652,14 @@ describe('FormAttachmentList', () => {
               })
               .modify(series => {
                 let withResponses = series;
-                for (let i = 0; i < successCount; i += 1)
-                  withResponses = withResponses.respondWithSuccess();
+                for (let i = 0; i < successCount; i += 1) {
+                  withResponses = withResponses.respondWithData(() =>
+                    testData.standardFormAttachments.update(i, {
+                      blobExists: true,
+                      exists: true,
+                      hash: 'foo'
+                    }));
+                }
                 if (successCount < 3) {
                   withResponses = withResponses
                     .respondWithProblem({ code: 500.1, message: 'Failed.' });
@@ -669,9 +687,9 @@ describe('FormAttachmentList', () => {
 
           describe('all uploads succeed', () => {
             it('updates the table', async () => {
-              const component = await confirmUploads(3);
               const oldUpdatedAt = testData.standardFormAttachments.sorted()
                 .map(attachment => attachment.updatedAt);
+              const component = await confirmUploads(3);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
@@ -712,9 +730,9 @@ describe('FormAttachmentList', () => {
 
           describe('only 2 uploads succeed', () => {
             it('updates the table', async () => {
-              const component = await confirmUploads(2);
               const oldUpdatedAt = testData.standardFormAttachments.sorted()
                 .map(attachment => attachment.updatedAt);
+              const component = await confirmUploads(2);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
@@ -741,9 +759,9 @@ describe('FormAttachmentList', () => {
 
           describe('only 1 upload succeeds', () => {
             it('updates the table', async () => {
-              const component = await confirmUploads(1);
               const oldUpdatedAt = testData.standardFormAttachments.sorted()
                 .map(attachment => attachment.updatedAt);
+              const component = await confirmUploads(1);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
@@ -770,9 +788,9 @@ describe('FormAttachmentList', () => {
 
           describe('no uploads succeed', () => {
             it('does not update the table', async () => {
-              const component = await confirmUploads(0);
               const oldUpdatedAt = testData.standardFormAttachments.sorted()
                 .map(attachment => attachment.updatedAt);
+              const component = await confirmUploads(0);
               const { draftAttachments } = component.vm.$container.requestData.localResources;
               const newUpdatedAt = [...draftAttachments.values()]
                 .map(attachment => attachment.updatedAt);
@@ -1085,7 +1103,11 @@ describe('FormAttachmentList', () => {
             await component.get('td.form-attachment-list-action .btn-link-dataset').trigger('click');
             return component.get('#form-attachment-link-dataset .btn-link-dataset').trigger('click');
           })
-          .respondWithSuccess()
+          .respondWithData(() => testData.standardFormAttachments.update(0, {
+            blobExists: false,
+            datasetExists: true,
+            hash: null
+          }))
           .afterResponse(component => {
             component.get('td.form-attachment-list-uploaded .dataset-label').text().should.equal('Linked to Entity List shovels');
             component.get('td.form-attachment-list-action').text().should.equal('Upload a file to override.');

--- a/test/components/form/edit/attachments.spec.js
+++ b/test/components/form/edit/attachments.spec.js
@@ -1,6 +1,7 @@
 import FormEditSection from '../../../../src/components/form/edit/section.vue';
 
 import testData from '../../../data';
+import { dragAndDrop } from '../../../util/trigger';
 import { load } from '../../../util/http';
 import { mockLogin } from '../../../util/session';
 
@@ -41,5 +42,161 @@ describe('FormEditAttachments', () => {
     const app = await load('/projects/1/forms/f/draft');
     const section = app.get('#form-edit-attachments').getComponent(FormEditSection);
     section.props().warning.should.be.true;
+  });
+
+  describe('tag', () => {
+    const testCases = [
+      {
+        text: '1 new attachment',
+        published: [],
+        draft: [{ name: 'foo' }]
+      },
+      {
+        text: '2 new attachments',
+        published: [{ name: 'foo' }],
+        draft: [{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]
+      },
+      {
+        text: '1 changed attachment',
+        published: [{ name: 'foo', hash: '1' }],
+        draft: [{ name: 'foo', hash: '2' }]
+      },
+      {
+        text: '1 changed attachment',
+        published: [{ name: 'foo', hash: null }],
+        draft: [{ name: 'foo', hash: '1' }]
+      },
+      {
+        text: '1 changed attachment',
+        published: [{ name: 'foo', hash: '1' }],
+        draft: [{ name: 'foo', hash: null }]
+      },
+      {
+        text: '1 changed attachment',
+        published: [{ name: 'foo', blobExists: false, datasetExists: false }],
+        draft: [{ name: 'foo', datasetExists: true }]
+      },
+      {
+        text: '1 changed attachment',
+        published: [{ name: 'foo', datasetExists: true }],
+        draft: [{ name: 'foo', blobExists: false, datasetExists: false }]
+      },
+      {
+        text: '2 changed attachments',
+        published: [
+          { name: 'foo', hash: '1' },
+          { name: 'bar', hash: '2' },
+          { name: 'baz', hash: '3' }
+        ],
+        draft: [
+          { name: 'foo', hash: '1' },
+          { name: 'bar', hash: '4' },
+          { name: 'baz', hash: '5' }
+        ]
+      },
+      {
+        text: '1 new attachment and 1 changed attachment',
+        published: [{ name: 'foo', hash: '1' }],
+        draft: [{ name: 'foo', hash: '2' }, { name: 'bar' }]
+      },
+      {
+        text: '',
+        published: [{ name: 'foo' }],
+        draft: [{ name: 'foo' }]
+      },
+      {
+        text: '',
+        published: [],
+        draft: []
+      },
+      {
+        text: '',
+        published: [{ name: 'foo' }],
+        draft: []
+      },
+      {
+        text: '',
+        published: [{ name: 'foo' }, { name: 'bar' }],
+        draft: [{ name: 'foo' }]
+      }
+    ];
+    for (const [i, testCase] of testCases.entries()) {
+      it(`shows the correct text for case ${i} (expected: '${testCase.text}')`, async () => {
+        testData.extendedForms.createPast(1);
+        testData.extendedFormVersions.createPast(1, { draft: true });
+        for (const options of testCase.published)
+          testData.standardFormAttachments.createPast(1, options);
+        const publishedAttachments = testData.standardFormAttachments.sorted();
+        testData.standardFormAttachments.splice(0);
+        for (const options of testCase.draft)
+          testData.standardFormAttachments.createPast(1, options);
+        const app = await load('/projects/1/forms/f/draft', {}, {
+          publishedAttachments: () => publishedAttachments
+        });
+        const tag = app.get('#form-edit-attachments .form-edit-section-tag').text();
+        if (testCase.text === '')
+          tag.should.equal('');
+        else
+          tag.should.startWith(`${testCase.text} since `);
+      });
+    }
+
+    it('is not shown if the form is a draft', async () => {
+      testData.extendedForms.createPast(1, { draft: true });
+      testData.standardFormAttachments.createPast(1);
+      const app = await load('/projects/1/forms/f/draft');
+      const tag = app.get('#form-edit-attachments .form-edit-section-tag').text();
+      tag.should.equal('');
+    });
+
+    it('updates the tag after a file is uploaded', async () => {
+      testData.extendedForms.createPast(1);
+      testData.extendedFormVersions.createPast(1, { draft: true });
+      testData.standardFormAttachments.createPast(1, {
+        name: 'foo',
+        blobExists: false
+      });
+      return load('/projects/1/forms/f/draft')
+        .complete()
+        .request(app => dragAndDrop(
+          app.get('.form-attachment-row'),
+          [new File([''], 'foo')]
+        ))
+        .respondWithData(() => testData.standardFormAttachments.update(0, {
+          blobExists: true,
+          exists: true,
+          hash: '1'
+        }))
+        .afterResponse(app => {
+          const tag = app.get('#form-edit-attachments .form-edit-section-tag').text();
+          tag.should.startWith('1 changed attachment since ');
+        });
+    });
+
+    it('updates the tag after linking to an entity list', async () => {
+      testData.extendedProjects.createPast(1, { forms: 1, datasets: 1 });
+      testData.extendedForms.createPast(1);
+      testData.extendedFormVersions.createPast(1, { draft: true });
+      testData.standardFormAttachments.createPast(1, {
+        type: 'file',
+        name: 'trees.csv',
+        blobExists: false
+      });
+      testData.extendedDatasets.createPast(1, { name: 'trees' });
+      return load('/projects/1/forms/f/draft')
+        .complete()
+        .request(async (component) => {
+          await component.get('.form-attachment-row .btn-link-dataset').trigger('click');
+          return component.get('#form-attachment-link-dataset .btn-link-dataset').trigger('click');
+        })
+        .respondWithData(() => testData.standardFormAttachments.update(0, {
+          datasetExists: true,
+          exists: true
+        }))
+        .afterResponse(app => {
+          const tag = app.get('#form-edit-attachments .form-edit-section-tag').text();
+          tag.should.startWith('1 changed attachment since ');
+        });
+    });
   });
 });

--- a/test/components/form/edit/attachments.spec.js
+++ b/test/components/form/edit/attachments.spec.js
@@ -82,6 +82,11 @@ describe('FormEditAttachments', () => {
         draft: [{ name: 'foo', blobExists: false, datasetExists: false }]
       },
       {
+        text: '1 changed attachment',
+        published: [{ name: 'foo', blobExists: true }],
+        draft: [{ name: 'foo', datasetExists: true }]
+      },
+      {
         text: '2 changed attachments',
         published: [
           { name: 'foo', hash: '1' },

--- a/test/data/form-attachments.js
+++ b/test/data/form-attachments.js
@@ -24,15 +24,14 @@ export const standardFormAttachments = dataStore({
       : extendedForms.createPast(1).last(),
     type = 'image',
     name = fakeName(type),
+    hash = undefined,
     datasetExists = false,
-    hasUpdatedAt = undefined,
-    blobExists = inPast && !datasetExists && hasUpdatedAt == null
+    blobExists = hash != null || (inPast && !datasetExists),
+    hasUpdatedAt = blobExists
   }) => {
     if (!inPast) {
       if (blobExists)
         throw new Error('blobExists cannot be true for a new form attachment');
-      if (datasetExists)
-        throw new Error('datasetExists cannot be true for a new form attachment');
       if (hasUpdatedAt === true)
         throw new Error('hasUpdatedAt cannot be true for a new form attachment');
     } else if (blobExists && hasUpdatedAt === false) {
@@ -47,6 +46,7 @@ export const standardFormAttachments = dataStore({
       blobExists,
       datasetExists,
       exists: blobExists || datasetExists,
+      hash: hash ?? (blobExists ? 'a'.repeat(32) : null),
       updatedAt: hasUpdatedAt ?? inPast ? fakePastDate([form.createdAt]) : null
     };
   },

--- a/test/data/form-attachments.js
+++ b/test/data/form-attachments.js
@@ -26,30 +26,17 @@ export const standardFormAttachments = dataStore({
     name = fakeName(type),
     hash = undefined,
     datasetExists = false,
-    blobExists = hash != null || (inPast && !datasetExists),
-    hasUpdatedAt = blobExists
-  }) => {
-    if (!inPast) {
-      if (blobExists)
-        throw new Error('blobExists cannot be true for a new form attachment');
-      if (hasUpdatedAt === true)
-        throw new Error('hasUpdatedAt cannot be true for a new form attachment');
-    } else if (blobExists && hasUpdatedAt === false) {
-      throw new Error('blobExists and hasUpdatedAt are inconsistent');
-    } else if (blobExists && datasetExists) {
-      throw new Error('blobExists and datasetExists cannot both be true');
-    }
-
-    return {
-      type,
-      name,
-      blobExists,
-      datasetExists,
-      exists: blobExists || datasetExists,
-      hash: hash ?? (blobExists ? 'a'.repeat(32) : null),
-      updatedAt: hasUpdatedAt ?? inPast ? fakePastDate([form.createdAt]) : null
-    };
-  },
+    blobExists = hash != null || (inPast && hash !== null && !datasetExists),
+    hasUpdatedAt = inPast
+  }) => ({
+    type,
+    name,
+    blobExists,
+    datasetExists,
+    exists: blobExists || datasetExists,
+    hash: hash ?? (blobExists ? 'a'.repeat(32) : null),
+    updatedAt: hasUpdatedAt ? fakePastDate([form.createdAt]) : null
+  }),
   sort: (attachment1, attachment2) =>
     attachment1.name.localeCompare(attachment2.name)
 });

--- a/test/unit/i18n.spec.js
+++ b/test/unit/i18n.spec.js
@@ -164,6 +164,11 @@ describe('util/i18n', () => {
         formatList(['x', 'y']).should.equal('x、y');
         formatList(['x', 'y', 'z']).should.equal('x、y、z');
       });
+
+      it('uses the specified format', () => {
+        const { formatList } = withSetup(useI18nUtils);
+        formatList(['x', 'y'], 'long').should.equal('x and y');
+      });
     });
 
     describe('formatListToParts()', () => {
@@ -183,6 +188,15 @@ describe('util/i18n', () => {
         formatListToParts(['x', 'y']).should.eql([
           { type: 'element', value: 'x' },
           { type: 'literal', value: '、' },
+          { type: 'element', value: 'y' }
+        ]);
+      });
+
+      it('uses the specified format', () => {
+        const { formatListToParts } = withSetup(useI18nUtils);
+        formatListToParts(['x', 'y'], 'long').should.eql([
+          { type: 'element', value: 'x' },
+          { type: 'literal', value: ' and ' },
           { type: 'element', value: 'y' }
         ]);
       });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3023,6 +3023,18 @@
       },
       "missingCount": {
         "string": "{count, plural, one {{count} missing attachment} other {{count} missing attachments}}"
+      },
+      "diff": {
+        "newCount": {
+          "string": "{count, plural, one {{count} new attachment} other {{count} new attachments}}"
+        },
+        "changedCount": {
+          "string": "{count, plural, one {{count} changed attachment} other {{count} changed attachments}}"
+        },
+        "summary": {
+          "string": "{changes} since the published version",
+          "developer_comment": "{changes} describes the changes that have been made to Form attachments. For example: \"1 new attachment and 2 changed attachments\""
+        }
       }
     },
     "FormEditCreateDraft": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3033,7 +3033,7 @@
         },
         "summary": {
           "string": "{changes} since the published version",
-          "developer_comment": "{changes} describes the changes that have been made to Form attachments. For example: \"1 new attachment and 2 changed attachments\""
+          "developer_comment": "{changes} describes changes that have been made to Form attachments. For example: \"1 new attachment and 2 changed attachments\""
         }
       }
     },


### PR DESCRIPTION
This PR makes progress on getodk/central#728. It implements the following release criteria:

> I should see a “{# new file(s)} {and} {# changed file(s)} since the published version” tag if any files are different, where I should only see nonzero {parts}

#### What has been done to verify that this works as intended?

New tests. I also tried out some cases locally.

#### Why is this the best possible solution? Were any other approaches considered?

We determine the number of changed files by comparing blob hashes. But that means that when we upload a file, we need Backend to tell us its hash. That required a change to Backend: see getodk/central-backend#1471. That PR has additional notes about this change and the reasoning behind it.

One aspect of the release criteria is that it requires us to pluralize "# new file(s)" separately from "# changed file(s)". After we pluralize them, we add the rest of the text ("since the published version") using another i18n message, `diff.summary`. I didn't want there to be multiple versions of `diff.summary` — one for when there is only one {part} and one for when there are two — so I expanded our `formatList()` function to combine "# new file(s)" and "# changed file(s)". `formatList()` is responsible for adding the "and" between them. The browser knows how to do this automatically using `Intl.ListFormat`. Previously, `formatList()` only knew how to format lists in one way, but now it knows how to do so in two ways: it now accepts an optional `key` argument that determines the list style. In this way, we handle `formatList()` and `Intl.ListFormat` in a very similar way as `formatRange()` and `Intl.NumberFormat`.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced