### PR TITLE
Show label when dragging and dropping over a missing attachment

### DIFF
--- a/src/components/form-attachment/row.vue
+++ b/src/components/form-attachment/row.vue
@@ -42,7 +42,10 @@ except according to the terms contained in the LICENSE file.
           <span class="icon-exclamation-triangle"></span>
           <span>{{ $t('notUploaded.text') }}</span>
         </span>
-        <span class="sr-only">&nbsp;{{ $t('notUploaded.title') }}</span>
+        <span class="sr-only">&nbsp;{{ $t('notUploaded.title') }}&nbsp;</span>
+        <span v-show="targeted" class="label label-primary">
+          {{ $t('action.upload') }}
+        </span>
       </template>
     </td>
     <td class="form-attachment-list-action">

--- a/test/components/form-attachment/list.spec.js
+++ b/test/components/form-attachment/list.spec.js
@@ -149,17 +149,18 @@ describe('FormAttachmentList', () => {
         targeted.should.eql([true, true, false]);
       });
 
-      it('shows a Replace label for the correct row', async () => {
+      it('shows the correct labels', async () => {
         const component = await load('/projects/1/forms/f/draft', {
           root: false
         });
         await select(component, blankFiles(['a', 'b', 'd']));
-        const rows = component.findAllComponents(FormAttachmentRow);
-        rows[0].get('.label').should.be.visible();
-        rows[1].find('.label').exists().should.be.false;
-        // The label of the third row should either not exist or be hidden.
-        const label = rows[2].find('.label');
-        if (label.exists()) label.should.be.hidden();
+        const labels = component.findAllComponents(FormAttachmentRow)
+          .map(row => row.get('.label'));
+        labels[0].should.be.visible();
+        labels[0].text().should.equal('Replace');
+        labels[1].should.be.visible();
+        labels[1].text().should.equal('Upload');
+        labels[2].should.be.hidden();
       });
     });
 
@@ -314,29 +315,33 @@ describe('FormAttachmentList', () => {
         targeted.should.eql([true, false, false, false]);
       });
 
-      describe('Replace label', () => {
-        it('shows label when file matches an existing attachment', async () => {
+      describe('label', () => {
+        it('shows the correct text for an existing attachment', async () => {
           const component = await load('/projects/1/forms/f/draft', {
             root: false
           });
           await select(component, blankFiles(['a']));
-          const rows = component.findAllComponents(FormAttachmentRow);
-          rows[0].get('.label').should.be.visible();
-          rows[1].find('.label').exists().should.be.false;
-          rows[2].get('.label').should.be.hidden();
-          rows[3].find('.label').exists().should.be.false;
+          const labels = component.findAllComponents(FormAttachmentRow)
+            .map(row => row.get('.label'));
+          labels[0].should.be.visible();
+          labels[0].text().should.equal('Replace');
+          labels[1].should.be.hidden();
+          labels[2].should.be.hidden();
+          labels[3].should.be.hidden();
         });
 
-        it('does not show label when file matches a missing attachment', async () => {
+        it('shows the correct text for a missing attachment', async () => {
           const component = await load('/projects/1/forms/f/draft', {
             root: false
           });
           await select(component, blankFiles(['b']));
-          const rows = component.findAllComponents(FormAttachmentRow);
-          rows[0].get('.label').should.be.hidden();
-          rows[1].find('.label').exists().should.be.false;
-          rows[2].get('.label').should.be.hidden();
-          rows[3].find('.label').exists().should.be.false;
+          const labels = component.findAllComponents(FormAttachmentRow)
+            .map(row => row.get('.label'));
+          labels[0].should.be.hidden();
+          labels[1].should.be.visible();
+          labels[1].text().should.equal('Upload');
+          labels[2].should.be.hidden();
+          labels[3].should.be.hidden();
         });
       });
 
@@ -922,11 +927,13 @@ describe('FormAttachmentList', () => {
         await rows[0].trigger('dragenter', {
           dataTransfer: fileDataTransfer(blankFiles(['a']))
         });
-        rows[0].get('.label').should.be.visible();
-        rows[1].get('.label').should.be.hidden();
+        const labels = rows.map(row => row.get('.label'));
+        labels[0].should.be.visible();
+        labels[0].text().should.equal('Replace');
+        labels[1].should.be.hidden();
       });
 
-      it('shows a Override label if the dataset exists', async () => {
+      it('shows an Override label if the dataset exists', async () => {
         testData.standardFormAttachments.createPast(2, { datasetExists: true });
         const component = await load('/projects/1/forms/f/draft', {
           root: false
@@ -935,20 +942,25 @@ describe('FormAttachmentList', () => {
         await rows[0].trigger('dragenter', {
           dataTransfer: fileDataTransfer(blankFiles(['a']))
         });
-        rows[0].get('.label').text().should.be.eql('Override');
-        rows[0].get('.label').should.be.visible();
-        rows[1].get('.label').should.be.hidden();
+        const labels = rows.map(row => row.get('.label'));
+        labels[0].should.be.visible();
+        labels[0].text().should.equal('Override');
+        labels[1].should.be.hidden();
       });
 
-      it('does not show a Replace label if attachment does not exist', async () => {
+      it('shows an Upload label if the attachment does not exist', async () => {
         testData.standardFormAttachments.createPast(2, { blobExists: false });
         const component = await load('/projects/1/forms/f/draft', {
           root: false
         });
-        await component.get('.form-attachment-row').trigger('dragenter', {
+        const rows = component.findAll('.form-attachment-row');
+        await rows[0].trigger('dragenter', {
           dataTransfer: fileDataTransfer(blankFiles(['a']))
         });
-        component.find('.form-attachment-row .label').exists().should.be.false;
+        const labels = rows.map(row => row.get('.label'));
+        labels[0].should.be.visible();
+        labels[0].text().should.equal('Upload');
+        labels[1].should.be.hidden();
       });
 
       it('shows the popup with the correct text', async () => {


### PR DESCRIPTION
This PR makes a change related to getodk/central#728.

Right now, if you drag and drop a file over a row of the form attachments table, a label is shown in certain cases:

- If a file has already been uploaded for the attachment (if `blobExists` is `true`), the label "Replace" is shown.
- If the attachment is linked to an entity list, the label "Override" is shown.

Here's an example of the "Replace" label:

<img width="774" alt="Screenshot 2025-04-04 at 1 22 37 PM" src="https://github.com/user-attachments/assets/e9e9c747-82c9-4ffe-9bb1-f261e136f380" />

However, if you drag and drop a file over a missing attachment, no label is shown. This PR changes that: it shows the label "Upload" for a missing attachment. As a result, whenever you drag and drop over an attachment, some label will be shown. As you move between rows of the table during the file drag, the text of the label may change, but you will consistently see some label.

<img width="673" alt="Screenshot 2025-04-04 at 1 22 52 PM" src="https://github.com/user-attachments/assets/00205490-2057-4aa4-9473-e576d2e26d4e" />

#### What has been done to verify that this works as intended?

Updated tests. I also tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced