### PR TITLE
Update style on home page info cards

### DIFF
--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -11,7 +11,6 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div>
-    <div id="home-heading">{{ $t('heading[0]') }}</div>
     <home-summary/>
     <page-body>
       <div id="home-news-container">
@@ -50,17 +49,6 @@ const config = inject('config');
 
 <style lang="scss">
 @import '../assets/scss/variables';
-
-#home-heading {
-  background: $color-subpanel-background;
-  color: $color-accent-primary;
-  font-size: 35px;
-  font-weight: 600;
-  letter-spacing: -0.03em;
-  margin-left: -15px;
-  margin-right: -15px;
-  padding: 20px 15px 15px 15px;
-}
 
 #home-news-container {
   display: flex;

--- a/src/components/home/summary.vue
+++ b/src/components/home/summary.vue
@@ -21,7 +21,7 @@ except according to the terms contained in the LICENSE file.
             <spinner inline/>
           </template>
         </template>
-        <template #subheader>{{ $tc('plural.project', projects.length) }}</template>
+        <template #subheader>{{ $tc('plural.project', projects.length ?? 0) }}</template>
         <template #body>{{ $t('projects.body') }}</template>
       </home-summary-item>
       <home-summary-item v-if="currentUser.can('user.list')" to="/users" icon="user-circle">
@@ -33,7 +33,7 @@ except according to the terms contained in the LICENSE file.
             <spinner inline/>
           </template>
         </template>
-        <template #subheader>{{ $tc('plural.user', users.length) }}</template>
+        <template #subheader>{{ $tc('plural.user', users.length ?? 0) }}</template>
         <template #body>{{ $t('users.body') }}</template>
       </home-summary-item>
       <home-summary-item to="https://docs.getodk.org/central-intro/"
@@ -93,7 +93,7 @@ if (currentUser.can('user.list'))
       "body": "Central is organized into Projects, each containing its own Forms and related data."
     },
     "users": {
-      "body": "Users can be assigned to Projects to manage them, collect data, or review submissions."
+      "body": "Users can be assigned to Projects to manage them, collect data, or review Submissions."
     },
     "docs": {
       "body": "A Getting Started Guide and user documentation are available on the ODK Docs website."

--- a/src/components/home/summary.vue
+++ b/src/components/home/summary.vue
@@ -10,33 +10,39 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div id="home-summary">
-    <div>
-      <loading :state="projects.initiallyLoading"/>
-      <home-summary-item v-if="projects.dataExists" icon="archive"
-        :count="projects.length">
-        <template #title>{{ $tc('plural.project', projects.length) }}</template>
+  <div id="home-summary-container">
+    <div id="home-summary">
+      <home-summary-item icon="archive">
+        <template #header>
+          <template v-if="!projects.initiallyLoading">
+            {{ $n(projects.length, 'default') }}
+          </template>
+          <template v-else>
+            <spinner inline/>
+          </template>
+        </template>
+        <template #subheader>{{ $tc('plural.project', projects.length) }}</template>
         <template #body>{{ $t('projects.body') }}</template>
       </home-summary-item>
-    </div>
-    <div v-if="currentUser.can('user.list')">
-      <loading :state="users.initiallyLoading"/>
-      <home-summary-item v-if="users.dataExists" to="/users" icon="user-circle"
-        :count="users.length">
-        <template #title>{{ $tc('plural.user', users.length) }}</template>
+      <home-summary-item v-if="currentUser.can('user.list')" to="/users" icon="user-circle">
+        <template #header>
+          <template v-if="!users.initiallyLoading">
+            {{ $n(users.length, 'default') }}
+          </template>
+          <template v-else>
+            <spinner inline/>
+          </template>
+        </template>
+        <template #subheader>{{ $tc('plural.user', users.length) }}</template>
         <template #body>{{ $t('users.body') }}</template>
       </home-summary-item>
-    </div>
-    <div>
       <home-summary-item to="https://docs.getodk.org/central-intro/"
         icon="book">
-        <template #title>{{ $t('common.docs') }}</template>
+        <template #header>{{ $t('common.docs') }}</template>
         <template #body>{{ $t('docs.body') }}</template>
       </home-summary-item>
-    </div>
-    <div>
       <home-summary-item to="https://forum.getodk.org/" icon="comments-o">
-        <template #title>{{ $t('common.forum') }}</template>
+        <template #header>{{ $t('common.forum') }}</template>
         <template #body>{{ $t('forum.body') }}</template>
       </home-summary-item>
     </div>
@@ -45,7 +51,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import HomeSummaryItem from './summary/item.vue';
-import Loading from '../loading.vue';
+import Spinner from '../spinner.vue';
 
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
@@ -64,33 +70,19 @@ if (currentUser.can('user.list'))
 @use 'sass:math';
 @import '../../assets/scss/variables';
 
+#home-summary-container {
+  background-color: $color-subpanel-background;
+  margin-left: -15px;
+  margin-right: -15px;
+  padding: 20px;
+}
+
 #home-summary {
-  background: $color-subpanel-background;
-  border-bottom: 2px solid $color-subpanel-border;
   display: flex;
-  margin: 0 -15px 35px;
-  padding-bottom: 20px;
-  padding-left: 15px;
-  padding-right: 15px;
-
-  > div {
-    $border-width: 1px;
-    $padding-left: 20px;
-    $padding-right: 12px;
-    border-left: $border-width solid $color-subpanel-border;
-    box-sizing: content-box;
-    padding-bottom: 3px;
-    padding-left: $padding-left;
-    padding-right: $padding-right;
-    // width(#home-summary) = 4 * width(#home-summary > div) + 3 * $padding-right + 3 * $border-width + 3 * $padding-left
-    width: calc(25% - #{math.ceil(math.div(3 * $padding-right + 3 * $border-width + 3 * $padding-left, 4))});
-
-    &:first-child {
-      border-left: none;
-      padding-left: 0;
-    }
-    &:last-child { padding-right: 0; }
-  }
+  gap: 20px;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: $max-width-page-body;
 }
 </style>
 
@@ -98,16 +90,16 @@ if (currentUser.can('user.list'))
 {
   "en": {
     "projects": {
-      "body": "Central is organized into Projects, which each contain their own Forms and related data."
+      "body": "Central is organized into Projects, each containing its own Forms and related data."
     },
     "users": {
-      "body": "Users can be assigned to Projects to manage them, or to collect or review submitted data."
+      "body": "Users can be assigned to Projects to manage them, collect data, or review submissions."
     },
     "docs": {
-      "body": "There is a getting started guide and user documentation available on the ODK Docs website."
+      "body": "A Getting Started Guide and user documentation are available on the ODK Docs website."
     },
     "forum": {
-      "body": "You can always get help from others on the forum, where you can also search previous questions."
+      "body": "Need help? Visit the forum to ask questions or browse past discussions."
     }
   }
 }

--- a/src/components/home/summary/item.vue
+++ b/src/components/home/summary/item.vue
@@ -14,13 +14,11 @@ except according to the terms contained in the LICENSE file.
     <div class="heading">
       <span :class="`icon-${icon}`"></span>
       <div>
-        <div v-if="count != null" class="count">{{ $n(count, 'default') }}</div>
-        <div class="title">
-          <span><slot name="title"></slot></span>
-          <!-- If the Linkable is not a link, we hide the icon by making it
-          transparent. We always render the icon in order to keep the height of
-          .title consistent. -->
-          <span class="icon-angle-right"></span>
+        <div class="header">
+          <slot name="header"></slot>
+        </div>
+        <div class="subheader">
+          <slot name="subheader"></slot>
         </div>
       </div>
     </div>
@@ -39,8 +37,7 @@ export default {
     icon: {
       type: String,
       required: true
-    },
-    count: Number
+    }
   }
 };
 </script>
@@ -49,43 +46,41 @@ export default {
 @import '../../../assets/scss/mixins';
 
 .home-summary-item {
+  padding: 16px;
+  background-color: white;
+  border-radius: 12px;
+  border: 1px solid #E3E4E4;
+
   .heading {
-    align-items: flex-end;
+    align-items: center;
     display: flex;
-    margin-bottom: 4px;
+    gap: 16px;
+    margin-bottom: 16px;
 
     > [class^="icon-"] {
-      color: #555;
-      font-size: 62px;
-      margin-bottom: 2px;
-      margin-right: 9px;
+      font-size: 24px;
+      padding: 10px;
+      border-radius: 6px;
+      color: $color-accent-primary;
+      background-color: rgba($color-accent-primary, 0.1);
     }
   }
 
-  .count {
-    font-size: 35px;
+  .header {
+    font-size: 16px;
+    margin-bottom: 0;
     line-height: 1;
-    margin-bottom: -4px;
-  }
-
-  .title {
-    align-items: center;
-    display: flex;
-    font-size: 12px;
     font-weight: 600;
   }
 
-  .icon-angle-right {
-    color: $color-accent-primary;
-    font-size: 21px;
-    margin-left: 7px;
+  .subheader {
+    font-size: 14px;
   }
 
   .body {
-    font-size: 13px;
-    line-height: 1.2;
+    font-size: 12px;
+    line-height: 16px;
     margin-bottom: 0;
   }
 }
-div.home-summary-item .icon-angle-right { color: transparent; }
 </style>

--- a/src/components/home/summary/item.vue
+++ b/src/components/home/summary/item.vue
@@ -50,6 +50,7 @@ export default {
   background-color: white;
   border-radius: 12px;
   border: 1px solid #E3E4E4;
+  flex: 1 1 0px;
 
   .heading {
     align-items: center;
@@ -67,14 +68,9 @@ export default {
   }
 
   .header {
-    font-size: 16px;
     margin-bottom: 0;
     line-height: 1;
     font-weight: 600;
-  }
-
-  .subheader {
-    font-size: 14px;
   }
 
   .body {

--- a/test/components/home/summary.spec.js
+++ b/test/components/home/summary.spec.js
@@ -36,7 +36,9 @@ describe('HomeSummary', () => {
       .mount(HomeSummary, mountOptions())
       .respondWithData(() => testData.standardUsers.sorted())
       .afterResponse(component => {
-        component.getComponent(HomeSummaryItem).props().count.should.equal(2);
+        const item = component.findAllComponents(HomeSummaryItem)[0];
+        item.get('.header').text().should.equal('2');
+        item.get('.subheader').text().should.equal('Projects');
       });
   });
 
@@ -47,9 +49,9 @@ describe('HomeSummary', () => {
       .respondWithData(() => testData.standardUsers.sorted())
       .afterResponse(component => {
         const item = component.findAllComponents(HomeSummaryItem)[1];
-        const { to, count } = item.props();
-        to.should.equal('/users');
-        count.should.equal(1);
+        item.props().to.should.equal('/users');
+        item.get('.header').text().should.equal('1');
+        item.get('.subheader').text().should.equal('User');
       });
   });
 

--- a/test/components/home/summary/item.spec.js
+++ b/test/components/home/summary/item.spec.js
@@ -8,7 +8,8 @@ const mountComponent = (options = undefined) =>
   mount(HomeSummaryItem, mergeMountOptions(options, {
     props: { icon: 'user-circle' },
     slots: {
-      title: { template: '<span id="title">Some Title</span>' },
+      header: { template: '<span id="header">Some Header</span>' },
+      subheader: { template: '<span id="subheader">Some Subheader</span>' },
       body: { template: '<span id="body">Some body text</span>' }
     },
     container: { router: mockRouter('/') }
@@ -19,8 +20,12 @@ describe('HomeSummaryItem', () => {
     mountComponent().find('.icon-user-circle').exists().should.be.true;
   });
 
-  it('uses the title slot', () => {
-    mountComponent().find('#title').exists().should.be.true;
+  it('uses the header slot', () => {
+    mountComponent().find('#header').exists().should.be.true;
+  });
+
+  it('uses the subheader slot', () => {
+    mountComponent().find('#subheader').exists().should.be.true;
   });
 
   it('uses the body slot', () => {
@@ -32,12 +37,5 @@ describe('HomeSummaryItem', () => {
       props: { to: '/users' }
     });
     component.getComponent(Linkable).props().to.should.equal('/users');
-  });
-
-  it('renders a count if one is specified', () => {
-    const component = mountComponent({
-      props: { count: 1234 }
-    });
-    component.get('.count').text().should.equal('1,234');
   });
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3553,22 +3553,22 @@
     "HomeSummary": {
       "projects": {
         "body": {
-          "string": "Central is organized into Projects, which each contain their own Forms and related data."
+          "string": "Central is organized into Projects, each containing its own Forms and related data."
         }
       },
       "users": {
         "body": {
-          "string": "Users can be assigned to Projects to manage them, or to collect or review submitted data."
+          "string": "Users can be assigned to Projects to manage them, collect data, or review submissions."
         }
       },
       "docs": {
         "body": {
-          "string": "There is a getting started guide and user documentation available on the ODK Docs website."
+          "string": "A Getting Started Guide and user documentation are available on the ODK Docs website."
         }
       },
       "forum": {
         "body": {
-          "string": "You can always get help from others on the forum, where you can also search previous questions."
+          "string": "Need help? Visit the forum to ask questions or browse past discussions."
         }
       }
     },

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3558,7 +3558,7 @@
       },
       "users": {
         "body": {
-          "string": "Users can be assigned to Projects to manage them, collect data, or review submissions."
+          "string": "Users can be assigned to Projects to manage them, collect data, or review Submissions."
         }
       },
       "docs": {


### PR DESCRIPTION
Part of https://github.com/getodk/central/issues/924

<img width="1868" alt="Screenshot 2025-04-07 at 1 30 17 PM" src="https://github.com/user-attachments/assets/0e05b7cf-22a9-4b7f-ae08-64aadf801b91" />


Style changes: 
- Updates content blocks to cards
- Changes icon styling
- Updated font sizes in cards
- "Welcome to Central" header removed (cards are now at top of page)
- Cards fill only main page body and are responsive
- Text copy changed slightly

Under the hood:
- Shows a spinner where the number is when loading the data for the count of projects or users but leaves the rest of the card visible
- More use of slots (to manage spinner, loading data)
- Puts i18n count responsibilities on home summary
- Home summary item is more generic and only has slots for header, subheader, and body.

Not included:
- changing the icons (see https://github.com/getodk/central/issues/931)
- changing anything about the navbar (could be a separate issue)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced