### PR TITLE
Remove trailing slash on breadcrumbs

### DIFF
--- a/src/components/breadcrumbs.vue
+++ b/src/components/breadcrumbs.vue
@@ -13,10 +13,14 @@ except according to the terms contained in the LICENSE file.
   <div class="breadcrumbs">
     <template v-for="(link, index) in links" :key="index">
       <div class="breadcrumb-item" v-tooltip.text>
-        <router-link :to="link.path">
+        <router-link v-if="link.path != null" :to="link.path">
           <span v-if="link.icon" :class="link.icon"></span>
           {{ link.text }}
         </router-link>
+        <template v-else>
+          <span v-if="link.icon" :class="link.icon"></span>
+          {{ link.text }}
+        </template>
       </div>
       <span v-if="index < links.length - 1" class="separator">/</span>
     </template>
@@ -29,7 +33,7 @@ defineProps({
     type: Array,
     required: true,
     validator(value) {
-      return value.every(link => 'text' in link && 'path' in link);
+      return value.every(link => 'text' in link);
     }
   }
 });

--- a/src/components/breadcrumbs.vue
+++ b/src/components/breadcrumbs.vue
@@ -18,7 +18,7 @@ except according to the terms contained in the LICENSE file.
           {{ link.text }}
         </router-link>
       </div>
-      <span class="separator">/</span>
+      <span v-if="index < links.length - 1" class="separator">/</span>
     </template>
   </div>
 </template>

--- a/src/components/breadcrumbs.vue
+++ b/src/components/breadcrumbs.vue
@@ -13,14 +13,10 @@ except according to the terms contained in the LICENSE file.
   <div class="breadcrumbs">
     <template v-for="(link, index) in links" :key="index">
       <div class="breadcrumb-item" v-tooltip.text>
-        <router-link v-if="link.path != null" :to="link.path">
+        <linkable :to="link.path">
           <span v-if="link.icon" :class="link.icon"></span>
           {{ link.text }}
-        </router-link>
-        <template v-else>
-          <span v-if="link.icon" :class="link.icon"></span>
-          {{ link.text }}
-        </template>
+        </linkable>
       </div>
       <span v-if="index < links.length - 1" class="separator">/</span>
     </template>
@@ -28,6 +24,8 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import Linkable from './linkable.vue';
+
 defineProps({
   links: {
     type: Array,

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -161,7 +161,7 @@ const branchData = modalData('EntityBranchData');
 const breadcrumbLinks = computed(() => [
   { text: project.dataExists ? project.nameWithArchived : t('resource.project'), path: projectPath('entity-lists'), icon: 'icon-archive' },
   { text: props.datasetName, path: datasetPath(), icon: 'icon-database' },
-  { text: entity.currentVersion.label, path: '' }
+  { text: entity.currentVersion.label }
 ]);
 
 </script>

--- a/src/components/entity/show.vue
+++ b/src/components/entity/show.vue
@@ -161,7 +161,7 @@ const branchData = modalData('EntityBranchData');
 const breadcrumbLinks = computed(() => [
   { text: project.dataExists ? project.nameWithArchived : t('resource.project'), path: projectPath('entity-lists'), icon: 'icon-archive' },
   { text: props.datasetName, path: datasetPath(), icon: 'icon-database' },
-  { text: entity.dataExists ? entity.currentVersion.label : t('resource.entity'), path: datasetPath('entities') }
+  { text: entity.currentVersion.label, path: '' }
 ]);
 
 </script>

--- a/src/components/submission/show.vue
+++ b/src/components/submission/show.vue
@@ -110,7 +110,7 @@ export default {
       return [
         { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath(), icon: 'icon-archive' },
         { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.formPath(), icon: 'icon-file' },
-        { text: this.submission.dataExists ? this.submission.instanceNameOrId : this.$t('resource.submission'), path: this.formPath('submissions') }
+        { text: this.submission.instanceNameOrId, path: '' }
       ];
     }
   },

--- a/src/components/submission/show.vue
+++ b/src/components/submission/show.vue
@@ -110,7 +110,7 @@ export default {
       return [
         { text: this.project.dataExists ? this.project.nameWithArchived : this.$t('resource.project'), path: this.projectPath(), icon: 'icon-archive' },
         { text: this.form.dataExists ? this.form.nameOrId : this.$t('resource.form'), path: this.formPath(), icon: 'icon-file' },
-        { text: this.submission.instanceNameOrId, path: '' }
+        { text: this.submission.instanceNameOrId }
       ];
     }
   },

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -52,7 +52,7 @@ describe('EntityShow', () => {
     links[1].text.should.equal('á');
     links[1].path.should.equal('/projects/1/entity-lists/%C3%A1');
     links[2].text.should.equal('My Entity');
-    links[2].path.should.equal('');
+    should.not.exist(links[2].path);
   });
 
   it('shows the entity label', async () => {

--- a/test/components/entity/show.spec.js
+++ b/test/components/entity/show.spec.js
@@ -52,7 +52,7 @@ describe('EntityShow', () => {
     links[1].text.should.equal('á');
     links[1].path.should.equal('/projects/1/entity-lists/%C3%A1');
     links[2].text.should.equal('My Entity');
-    links[2].path.should.equal('/projects/1/entity-lists/%C3%A1/entities');
+    links[2].path.should.equal('');
   });
 
   it('shows the entity label', async () => {

--- a/test/components/page/breadcrumbs.spec.js
+++ b/test/components/page/breadcrumbs.spec.js
@@ -19,7 +19,7 @@ describe('Breadcrumbs', () => {
       }
     });
     const breadcrumbs = component.get('.breadcrumbs');
-    breadcrumbs.text().should.equal('Projects/ Forms/');
+    breadcrumbs.text().should.equal('Projects/ Forms');
   });
 
   it('renders a link', () => {

--- a/test/components/page/breadcrumbs.spec.js
+++ b/test/components/page/breadcrumbs.spec.js
@@ -35,6 +35,23 @@ describe('Breadcrumbs', () => {
     link.text().should.equal('Forms');
   });
 
+  it('renders text without link if no path provided', () => {
+    const component = mountComponent({
+      props: {
+        links: [
+          { text: 'Forms', path: '/projects/1' },
+          { text: 'Submission 1' }
+        ]
+      }
+    });
+    const crumbs = component.findAll('.breadcrumb-item');
+    crumbs[0].text().should.equal('Forms');
+    crumbs[0].getComponent(RouterLinkStub).props().to.should.equal('/projects/1');
+
+    crumbs[1].text().should.equal('Submission 1');
+    crumbs[1].findComponent(RouterLinkStub).exists().should.be.false;
+  });
+
   it('renders an icon if provided', () => {
     const component = mountComponent({
       props: {

--- a/test/components/submission/show.spec.js
+++ b/test/components/submission/show.spec.js
@@ -29,7 +29,7 @@ describe('SubmissionShow', () => {
     links[1].text.should.equal('My Form');
     links[1].path.should.equal('/projects/1/forms/a%20b');
     links[2].text.should.equal('s');
-    links[2].path.should.equal('/projects/1/forms/a%20b/submissions');
+    links[2].path.should.equal('');
   });
 
   it('renders the xmlformid of the form in the breadcrumb if it has no name', async () => {
@@ -45,7 +45,7 @@ describe('SubmissionShow', () => {
     links[1].text.should.equal('a b');
     links[1].path.should.equal('/projects/1/forms/a%20b');
     links[2].text.should.equal('s');
-    links[2].path.should.equal('/projects/1/forms/a%20b/submissions');
+    links[2].path.should.equal('');
   });
 
   it('shows the instance name if the submission has one', async () => {

--- a/test/components/submission/show.spec.js
+++ b/test/components/submission/show.spec.js
@@ -29,7 +29,7 @@ describe('SubmissionShow', () => {
     links[1].text.should.equal('My Form');
     links[1].path.should.equal('/projects/1/forms/a%20b');
     links[2].text.should.equal('s');
-    links[2].path.should.equal('');
+    should.not.exist(links[2].path);
   });
 
   it('renders the xmlformid of the form in the breadcrumb if it has no name', async () => {
@@ -45,7 +45,7 @@ describe('SubmissionShow', () => {
     links[1].text.should.equal('a b');
     links[1].path.should.equal('/projects/1/forms/a%20b');
     links[2].text.should.equal('s');
-    links[2].path.should.equal('');
+    should.not.exist(links[2].path);
   });
 
   it('shows the instance name if the submission has one', async () => {


### PR DESCRIPTION
Related to issue https://github.com/getodk/central/issues/924
Followup to PR https://github.com/getodk/central-frontend/pull/1156

Changes:
- Removed the trailing slash.
- Made final crumb on entity and submission show pages into plain text (no link). For the parent pages (form or entity list), the name of the form/entity list is a link because those pages have multiple tabs and the link goes to the root tab.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced