### PR TITLE
Add comments explaining the name ProjectOverview

### DIFF
--- a/src/components/project/overview.vue
+++ b/src/components/project/overview.vue
@@ -25,6 +25,10 @@ import FormTrashList from '../form/trash-list.vue';
 import { useRequestData } from '../../request-data';
 
 defineOptions({
+  // Today, this component only renders forms, so ProjectForms would be an
+  // appropriate name for it. It's named ProjectOverview for historical reasons:
+  // it used to be the project overview page, rendering additional things beyond
+  // forms.
   name: 'ProjectOverview'
 });
 defineProps({

--- a/src/components/project/overview/description.vue
+++ b/src/components/project/overview/description.vue
@@ -31,6 +31,9 @@ import useRoutes from '../../../composables/routes';
 import { styleBox } from '../../../util/dom';
 
 defineOptions({
+  // This component is now rendered in ProjectShow: it is shown on every project
+  // page. However, it used to only be shown in ProjectOverview. That's why its
+  // name is ProjectOverviewDescription, not ProjectDescription.
   name: 'ProjectOverviewDescription'
 });
 


### PR DESCRIPTION
This PR closes getodk/central#901. As of getodk/central#863, we've completed an effective replacement of the project overview page with a forms page. The tab for the page is Forms, and the page only shows forms. The issue suggested either renaming/moving the `ProjectOverview` component or adding comments about its name. I opted for the latter, since it required minimal code changes. We can always rename the component later if we decide that'd be clearer.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced