### PR TITLE
Allow user to make another submission

### DIFF
--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -5138,10 +5138,16 @@
       },
       "submissionModal": {
         "title": {
-          "string": "Submission successful"
+          "string": "Form successfully sent!"
         },
         "body": {
-          "string": "Your data was submitted."
+          "string": "You can fill this Form out again or close if you’re done."
+        },
+        "action": {
+          "fillOutAgain": {
+            "string": "Fill out again",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
         }
       },
       "thankYouModal": {


### PR DESCRIPTION
Closes getodk/central#928

#### What has been done to verify that this works as intended?

Added a test and manually verified it.

#### Why is this the best possible solution? Were any other approaches considered?

Initially I created a `clearForm` function to call the OWF callback, which was called from the hideSubmissionModal function. Current `callback` function is called immediately after all attachment upload, which makes the code clean.

Later we can pass a promise to this `callback` function to communicate to OWF that the submission is being sent to the server. See https://getodk.slack.com/archives/C01TKJ7TG7J/p1744395959590219

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
-->