### PR TITLE
Fix getodk/central#937: Bubble up iframe message event

### DIFF
--- a/src/components/enketo-iframe.vue
+++ b/src/components/enketo-iframe.vue
@@ -87,13 +87,19 @@ watchEffect(() => {
 });
 
 function handleIframeMessage(event) {
-  let eventData;
-  try { eventData = JSON.parse(event.data); } catch {}
+  if (event.origin === window.location.origin) {
+    // For the cases where this page is embedded in external iframe, pass the event data to the
+    // parent.
+    if (window.location !== window.parent.location) {
+      window.parent.postMessage(event.data, route.query.parentWindowOrigin);
+    }
 
-  if (event.origin === window.location.origin &&
-    eventData?.enketoEvent === 'submissionsuccess' &&
-    redirectUrl.value) {
-    router.push((new URL(redirectUrl.value)).pathname);
+    let eventData;
+    try { eventData = JSON.parse(event.data); } catch {}
+
+    if (eventData?.enketoEvent === 'submissionsuccess' && redirectUrl.value) {
+      router.push((new URL(redirectUrl.value)).pathname);
+    }
   }
 }
 useEventListener(window, 'message', handleIframeMessage, false);


### PR DESCRIPTION
Part of getodk/central#937

#### What has been done to verify that this works as intended?

Added a test to verify event is raised. Manual verification by embedding a form from dev server to a local custom application. Posted the html code for the custom app below.

#### Why is this the best possible solution? Were any other approaches considered?

NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Added to https://github.com/getodk/docs/issues/1896

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced