### PR TITLE
Handle session timeout for Web Forms

### DIFF
--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -40,6 +40,14 @@ except according to the terms contained in the LICENSE file.
             <a href="emailto:support@getodk.org">support@getodk.org</a>
           </template>
         </i18n-t>
+        <i18n-t v-else-if="submissionModal.type === 'sessionTimeoutModal'" tag="p" keypath="sessionTimeoutModal.body">
+          <template #here>
+              <a href="/login" target="_blank">{{ $t('sessionTimeoutModal.here') }}</a>
+          </template>
+          <template #supportEmail>
+            <a href="emailto:support@getodk.org">support@getodk.org</a>
+          </template>
+        </i18n-t>
         <p v-else>
           {{ $t(submissionModal.type + '.body') }}
         </p>
@@ -269,7 +277,11 @@ const postPrimaryInstance = (file) => {
   })
     .then(({ data }) => {
       if (isProblem(data)) {
-        showModal(submissionModal, { type: 'errorModal', errorMessage: data.message });
+        if (data.code === 403.1) {
+          showModal(submissionModal, { type: 'sessionTimeoutModal' });
+        } else {
+          showModal(submissionModal, { type: 'errorModal', errorMessage: data.message });
+        }
         return false;
       }
       return data.currentVersion.instanceId;
@@ -386,6 +398,11 @@ html, body {
       "sendingDataModal": {
         "title": "Sending Submission",
         "body": "Your data is being submitted. Please don’t close this window until it’s finished."
+      },
+      "sessionTimeoutModal": {
+        "title": "Session expired",
+        "body": "Please log in {here} in a different browser tab and try again.",
+        "here": "here"
       }
     }
   }

--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -40,12 +40,9 @@ except according to the terms contained in the LICENSE file.
             <a href="emailto:support@getodk.org">support@getodk.org</a>
           </template>
         </i18n-t>
-        <i18n-t v-else-if="submissionModal.type === 'sessionTimeoutModal'" tag="p" keypath="sessionTimeoutModal.body">
+        <i18n-t v-else-if="submissionModal.type === 'sessionTimeoutModal'" tag="p" keypath="sessionTimeoutModal.body.full">
           <template #here>
-              <a href="/login" target="_blank">{{ $t('sessionTimeoutModal.here') }}</a>
-          </template>
-          <template #supportEmail>
-            <a href="emailto:support@getodk.org">support@getodk.org</a>
+              <a href="/login" target="_blank">{{ $t('sessionTimeoutModal.body.here') }}</a>
           </template>
         </i18n-t>
         <p v-else>
@@ -401,8 +398,10 @@ html, body {
       },
       "sessionTimeoutModal": {
         "title": "Session expired",
-        "body": "Please log in {here} in a different browser tab and try again.",
-        "here": "here"
+        "body": {
+          "full": "Please log in {here} in a different browser tab and try again.",
+          "here": "here"
+        }
       }
     }
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -53,8 +53,8 @@ Route Meta Fields
 
 The following meta fields are supported for bottom-level routes:
 
-  Login
-  -----
+  Login/Logout
+  ------------
 
   - restoreSession (default: true). The router looks to restoreSession right
     after the user has navigated to Frontend, when the router is navigating to
@@ -77,6 +77,10 @@ The following meta fields are supported for bottom-level routes:
     In almost all cases, a route either requires login or requires anonymity.
     However, NotFound requires neither: a user can navigate to NotFound whether
     they are logged in or anonymous.
+
+  - skipAutoLogout (default: false): If `true`, no alert will be displayed when
+    session is about to expire. Also user will be not be redirected to login
+    page when session has expired.
 
   requestData
   -----------
@@ -162,9 +166,6 @@ The following meta fields are supported for bottom-level routes:
   - standalone (default: false): If standalone is `true` then application layout
     elements like navigation bar, background color, etc are not rendered.
 
-  - skipAutoLogout (default: false): If `true`, no alert will be displayed when
-    session is about to expire. Also user will be not be redirected to login
-    page when session has expired.
 */
 
 /*
@@ -772,6 +773,7 @@ const routesByName = new Map();
     preserveData: [],
     fullWidth: false,
     standalone: false,
+    skipAutoLogout: false,
     ...meta,
     validateData: meta == null || meta.validateData == null
       ? []

--- a/src/routes.js
+++ b/src/routes.js
@@ -161,6 +161,10 @@ The following meta fields are supported for bottom-level routes:
 
   - standalone (default: false): If standalone is `true` then application layout
     elements like navigation bar, background color, etc are not rendered.
+
+  - skipAutoLogout (default: false): If `true`, no alert will be displayed when
+    session is about to expire. Also user will be not be redirected to login
+    page when session has expired.
 */
 
 /*
@@ -667,6 +671,7 @@ const routes = [
     loading: 'page',
     meta: {
       standalone: true,
+      skipAutoLogout: true,
       // validateData is done inside FormSubmission component
       title: () => [form.nameOrId],
     }
@@ -685,6 +690,7 @@ const routes = [
     loading: 'page',
     meta: {
       standalone: true,
+      skipAutoLogout: true,
       // validateData is done inside FormSubmission component
       title: () => [form.nameOrId],
     }
@@ -734,6 +740,7 @@ const routes = [
       standalone: true,
       restoreSession: true,
       requireLogin: false,
+      skipAutoLogout: true,
       title: () => [form.nameOrId]
     }
   }),

--- a/src/util/session.js
+++ b/src/util/session.js
@@ -150,10 +150,11 @@ export const logOut = (container, setNext) => {
 // approach rather than using setTimeout() to schedule logout, because
 // setTimeout() does not seem to clock time while the computer is asleep.
 const logOutBeforeSessionExpires = (container) => {
-  const { i18n, requestData, alert } = container;
+  const { i18n, requestData, alert, router } = container;
   const { session } = requestData;
   let alerted;
   return () => {
+    if (router.currentRoute.value.meta.skipAutoLogout) return;
     if (!session.dataExists) return;
     const millisUntilExpires = Date.parse(session.expiresAt) - Date.now();
     const millisUntilLogout = millisUntilExpires - 60000;
@@ -177,7 +178,7 @@ const logOutBeforeSessionExpires = (container) => {
 const logOutAfterStorageChange = (container) => (event) => {
   // event.key == null if the user clears local storage in Chrome.
   if ((event.key == null || event.key === 'sessionExpires') &&
-    container.requestData.session.dataExists) {
+    container.requestData.session.dataExists && !container.router.currentRoute.value.meta.skipAutoLogout) {
     logOut(container, true).catch(noop);
   }
 };

--- a/test/components/web-form-renderer.spec.js
+++ b/test/components/web-form-renderer.spec.js
@@ -133,6 +133,20 @@ describe('WebFormRenderer', () => {
     modal.find('.modal-introduction').text().should.match(/Your data was not submitted.*duplication instance ID/);
   });
 
+  it('should show error modal in case of submission failure', async () => {
+    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+
+    const component = await mountComponent()
+      .complete()
+      .request((c) => c.find('.odk-form .footer button').trigger('click'))
+      .respondWithProblem(403.1);
+
+    const modal = component.getComponent('#web-form-renderer-submission-modal');
+
+    modal.find('.modal-title').text().should.equal('Session expired');
+    modal.find('.modal-introduction').text().should.equal('Please log in here in a different browser tab and try again.');
+  });
+
   it('shows preview modal', async () => {
     testData.extendedForms.createPast(1, { xmlFormId: 'a' });
 

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -658,6 +658,27 @@ describe('util/session', () => {
           clock.tick(240000);
         });
     });
+
+    it('does not logout when skipAutoLogout is true', () => {
+      const clock = sinon.useFakeTimers();
+      testData.extendedUsers.createPast(1, { role: 'none' });
+      const container = createTestContainer({ router: mockRouter('/') });
+      container.router.currentRoute.value.meta.skipAutoLogout = true;
+      withSetup(useSessions, { container });
+      const { session } = setRequestData(container.requestData, {
+        session: testData.sessions.createNew({ expiresAt: '1970-01-01T00:05:00Z' })
+      });
+      return mockHttp(container)
+        .request(() => logIn(container, true))
+        .respondWithData(() => testData.extendedUsers.first())
+        .complete()
+        .testNoRequest(() => {
+          clock.tick(240000);
+        })
+        .afterResponse(() => {
+          session.dataExists.should.be.true;
+        });
+    });
   });
 
   describe('logout after session expiration', () => {
@@ -774,6 +795,25 @@ describe('util/session', () => {
         .respondWithSuccess()
         .afterResponse(() => {
           alert.blank();
+          clock.tick(120000);
+          alert.state.should.be.false;
+        });
+    });
+
+    it('does not show alert if skipAutoLogout is true', () => {
+      const clock = sinon.useFakeTimers();
+      testData.extendedUsers.createPast(1, { role: 'none' });
+      const container = createTestContainer({ router: mockRouter('/') });
+      container.router.currentRoute.value.meta.skipAutoLogout = true;
+      withSetup(useSessions, { container });
+      const { requestData, alert } = container;
+      setRequestData(requestData, {
+        session: testData.sessions.createNew({ expiresAt: '1970-01-01T00:05:00Z' })
+      });
+      return mockHttp(container)
+        .request(() => logIn(container, true))
+        .respondWithData(() => testData.extendedUsers.first())
+        .afterResponse(() => {
           clock.tick(120000);
           alert.state.should.be.false;
         });

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -867,6 +867,29 @@ describe('util/session', () => {
         });
     });
 
+    it('does not logs out if skipAutoLogout is true', () => {
+      testData.extendedUsers.createPast(1, { role: 'none' });
+      const container = createTestContainer({ router: mockRouter('/') });
+      container.router.currentRoute.value.meta.skipAutoLogout = true;
+      withSetup(useSessions, { container });
+      const { session } = setRequestData(container.requestData, {
+        session: testData.sessions.createNew()
+      });
+      return mockHttp(container)
+        .request(() => logIn(container, true))
+        .respondWithData(() => testData.extendedUsers.first())
+        .complete()
+        .testNoRequest(() => {
+          window.dispatchEvent(new StorageEvent('storage', {
+            key: null,
+            url: window.location.href
+          }));
+        })
+        .afterResponse(() => {
+          session.dataExists.should.be.true;
+        });
+    });
+
     it('sets the ?next query parameter', () => {
       mockLogin();
       return load('/users')

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -5187,10 +5187,14 @@
           "string": "Session expired"
         },
         "body": {
-          "string": "Please log in {here} in a different browser tab and try again."
-        },
-        "here": {
-          "string": "here"
+          "full": {
+            "string": "Please log in {here} in a different browser tab and try again.",
+            "developer_comment": "{here} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nhere"
+          },
+          "here": {
+            "string": "here",
+            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {here} is in the following text:\n\nPlease log in {here} in a different browser tab and try again."
+          }
         }
       }
     }

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -5181,6 +5181,17 @@
         "body": {
           "string": "Your data is being submitted. Please don’t close this window until it’s finished."
         }
+      },
+      "sessionTimeoutModal": {
+        "title": {
+          "string": "Session expired"
+        },
+        "body": {
+          "string": "Please log in {here} in a different browser tab and try again."
+        },
+        "here": {
+          "string": "here"
+        }
       }
     }
   },


### PR DESCRIPTION
Closes getodk/central#910


### Changes:

- Skip auto logout and session expiring alert for Enketo/Web Form submissions.
- Show modal on submit button if session has expired and ask user to login in another tab



<!--

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

-->

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced