### PR TITLE
fixes getodk/central#958: $route became unreactive due to globalProperties destructuring in WebFormRenderer

### DIFF
--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -99,10 +99,8 @@ const app = createApp({});
 app.use(webFormsPlugin);
 const inst = getCurrentInstance();
 // webFormsPlugin just adds globalProperty ($primevue)
-inst.appContext.config.globalProperties = {
-  ...inst.appContext.config.globalProperties,
-  ...app._context.config.globalProperties
-};
+Object.assign(inst.appContext.config.globalProperties, app._context.config.globalProperties);
+
 
 const { initiallyLoading, dataExists } = props.actionType === 'edit' ? resourceStates([formVersionXml, submissionAttachments]) : resourceStates([formVersionXml]);
 


### PR DESCRIPTION
Closes getodk/central#958

#### What has been done to verify that this works as intended?

Manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Root cause: `globalProperties` destructing in WebFormRenderer was making `$route` un-reactive, probably other properties as well. `Object.assign` serves the purpose well here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced