### PR TITLE
Add tests of user preferences

### DIFF
--- a/test/data/users.js
+++ b/test/data/users.js
@@ -25,10 +25,7 @@ export const extendedUsers = dataStore({
     verbs = verbsByRole(role),
     createdAt = undefined,
     deletedAt = undefined,
-    preferences = {
-      site: {},
-      projects: {},
-    },
+    preferences = undefined
   }) => ({
     id,
     type: 'user',
@@ -40,7 +37,10 @@ export const extendedUsers = dataStore({
       : (inPast ? fakePastDate([lastCreatedAt]) : new Date().toISOString()),
     updatedAt: null,
     deletedAt,
-    preferences,
+    preferences: {
+      site: preferences?.site ?? {},
+      projects: preferences?.projects ?? {}
+    }
   }),
   sort: (administrator1, administrator2) =>
     administrator1.email.localeCompare(administrator2.email)

--- a/test/request-data/user-preferences/normalizers.spec.js
+++ b/test/request-data/user-preferences/normalizers.spec.js
@@ -1,0 +1,84 @@
+import UserPreferences from '../../../src/request-data/user-preferences/preferences';
+
+import createTestContainer from '../../util/container';
+import { mockHttp } from '../../util/http';
+
+const setupPreferences = () => {
+  const container = createTestContainer();
+  const preferences = new UserPreferences({ site: {}, projects: {} }, container);
+  return { container, preferences };
+};
+
+describe('user preference normalizers', () => {
+  describe('site preferences', () => {
+    const cases = {
+      projectSortMode: [
+        ['alphabetical', 'alphabetical'],
+        ['latest', 'latest'],
+        ['newest', 'newest'],
+        [undefined, 'latest'],
+        [null, 'latest'],
+        ['foo', 'latest'],
+        [1, 'latest'],
+        [{ foo: 'bar' }, 'latest']
+      ],
+      outdatedVersionWarningDismissDate: [
+        ['2025-01-02T12:34:56.789Z', '2025-01-02T12:34:56.789Z'],
+        [new Date('2025-01-02T12:34:56.789Z'), '2025-01-02T12:34:56.789Z'],
+        [undefined, null],
+        [null, null],
+        ['foo', null],
+        [1, null],
+        [{ foo: 'bar' }, null]
+      ],
+    };
+    for (const [key, keyCases] of Object.entries(cases)) {
+      describe(key, () => {
+        for (const [raw, normalized] of keyCases) {
+          it(`normalizes ${raw} as ${normalized}`, () => {
+            const { container, preferences } = setupPreferences();
+            return mockHttp(container)
+              .request(() => {
+                preferences.site[key] = raw;
+              })
+              .respondWithSuccess()
+              .afterResponse(() => {
+                expect(preferences.site[key]).to.equal(normalized);
+              });
+          });
+        }
+      });
+    }
+  });
+
+  describe('project preferences', () => {
+    const cases = {
+      formTrashCollapsed: [
+        [true, true],
+        [false, false],
+        [undefined, false],
+        [null, false],
+        ['foo', false],
+        [1, false],
+        [{ foo: 'bar' }, false]
+      ],
+    };
+    for (const [key, keyCases] of Object.entries(cases)) {
+      describe(key, () => {
+        for (const [raw, normalized] of keyCases) {
+          it(`normalizes ${raw} as ${normalized}`, () => {
+            const { container, preferences } = setupPreferences();
+            return mockHttp(container)
+              .request(() => {
+                preferences.projects[123][key] = raw;
+              })
+              .respondWithSuccess()
+              .afterResponse(() => {
+                expect(preferences.projects[123][key]).to.equal(normalized);
+              });
+          });
+        }
+      });
+    }
+  });
+});

--- a/test/request-data/user-preferences/preferences.spec.js
+++ b/test/request-data/user-preferences/preferences.spec.js
@@ -1,0 +1,209 @@
+import sinon from 'sinon';
+import { watch } from 'vue';
+
+import UserPreferences from '../../../src/request-data/user-preferences/preferences';
+
+import createTestContainer from '../../util/container';
+import testData from '../../data';
+import { mockHttp } from '../../util/http';
+
+const setupPreferences = (data = {}) => {
+  const user = testData.extendedUsers.createNew({ preferences: data });
+  const container = createTestContainer();
+  const preferences = new UserPreferences(user.preferences, container);
+  return { container, preferences };
+};
+
+describe('UserPreferences', () => {
+  it('returns preferences that have been set', () => {
+    const { preferences } = setupPreferences({
+      site: { projectSortMode: 'alphabetical' },
+      projects: {
+        123: { formTrashCollapsed: true }
+      }
+    });
+    preferences.site.projectSortMode.should.equal('alphabetical');
+    preferences.projects[123].formTrashCollapsed.should.be.true;
+  });
+
+  it('returns an object for a project without preferences', () => {
+    const { preferences } = setupPreferences();
+    expect(preferences.projects[123]).to.be.an('object');
+  });
+
+  it('returns the same object each time for a project without preferences', () => {
+    const { preferences } = setupPreferences();
+    expect(preferences.projects[123]).to.equal(preferences.projects[123]);
+  });
+
+  it("returns default values for preferences that aren't set", () => {
+    const { preferences } = setupPreferences();
+    expect(preferences.site.projectSortMode).to.equal('latest');
+    expect(preferences.projects[123].formTrashCollapsed).to.be.false;
+  });
+
+  it('normalizes a value before returning it', () => {
+    const { preferences } = setupPreferences({
+      projectSortMode: 'someOldModeThatIsNoLongerSupported'
+    });
+    preferences.site.projectSortMode.should.equal('latest');
+  });
+
+  describe('requests', () => {
+    it('sends a PUT request after a site preference is set', () => {
+      const { container, preferences } = setupPreferences({
+        site: { projectSortMode: 'latest' }
+      });
+      return mockHttp(container)
+        .request(() => {
+          preferences.site.projectSortMode = 'alphabetical';
+        })
+        .respondWithSuccess()
+        .testRequests([{
+          method: 'PUT',
+          url: '/v1/user-preferences/site/projectSortMode',
+          data: { propertyValue: 'alphabetical' }
+        }]);
+    });
+
+    it('sends a DELETE request after a site preference is deleted', () => {
+      const { container, preferences } = setupPreferences({
+        site: { projectSortMode: 'latest' }
+      });
+      return mockHttp(container)
+        .request(() => {
+          delete preferences.site.projectSortMode;
+        })
+        .respondWithSuccess()
+        .testRequests([{
+          method: 'DELETE',
+          url: '/v1/user-preferences/site/projectSortMode'
+        }]);
+    });
+
+    it('sends a PUT request after a project preference is set', () => {
+      const { container, preferences } = setupPreferences({
+        projects: {
+          123: { formTrashCollapsed: false }
+        }
+      });
+      return mockHttp(container)
+        .request(() => {
+          preferences.projects[123].formTrashCollapsed = true;
+        })
+        .respondWithSuccess()
+        .testRequests([{
+          method: 'PUT',
+          url: '/v1/user-preferences/project/123/formTrashCollapsed',
+          data: { propertyValue: true }
+        }]);
+    });
+
+    it('sends a DELETE request after a project preference is deleted', () => {
+      const { container, preferences } = setupPreferences({
+        projects: {
+          123: { formTrashCollapsed: false }
+        }
+      });
+      return mockHttp(container)
+        .request(() => {
+          delete preferences.projects[123].formTrashCollapsed;
+        })
+        .respondWithSuccess()
+        .testRequests([{
+          method: 'DELETE',
+          url: '/v1/user-preferences/project/123/formTrashCollapsed'
+        }]);
+    });
+
+    it('updates the property immediately without regard for the response', () => {
+      const { container, preferences } = setupPreferences({
+        site: { projectSortMode: 'latest' }
+      });
+      return mockHttp(container)
+        .request(() => {
+          preferences.site.projectSortMode = 'alphabetical';
+          preferences.site.projectSortMode.should.equal('alphabetical');
+        })
+        // Even if there is an error response, the property does not revert.
+        .respondWithProblem()
+        .afterResponse(() => {
+          preferences.site.projectSortMode.should.equal('alphabetical');
+        });
+    });
+
+    it('supports concurrent requests', () => {
+      const { container, preferences } = setupPreferences();
+      return mockHttp(container)
+        .request(() => {
+          preferences.site.projectSortMode = 'alphabetical';
+          preferences.projects[123].formTrashCollapsed = true;
+          preferences.projects[456].formTrashCollapsed = true;
+        })
+        .respondWithSuccess()
+        .respondWithSuccess()
+        .respondWithSuccess()
+        .testRequests([
+          {
+            method: 'PUT',
+            url: '/v1/user-preferences/site/projectSortMode',
+            data: { propertyValue: 'alphabetical' }
+          },
+          {
+            method: 'PUT',
+            url: '/v1/user-preferences/project/123/formTrashCollapsed',
+            data: { propertyValue: true }
+          },
+          {
+            method: 'PUT',
+            url: '/v1/user-preferences/project/456/formTrashCollapsed',
+            data: { propertyValue: true }
+          }
+        ]);
+    });
+  });
+
+  it('normalizes a value when setting it', () => {
+    const { container, preferences } = setupPreferences({
+      site: { projectSortMode: 'alphabetical' }
+    });
+    return mockHttp(container)
+      .request(() => {
+        // An unknown sort mode falls back to the default, which is 'latest'.
+        preferences.site.projectSortMode = 'foo';
+        preferences.site.projectSortMode.should.equal('latest');
+      })
+      .respondWithSuccess()
+      .testRequests([{
+        method: 'PUT',
+        url: '/v1/user-preferences/site/projectSortMode',
+        data: { propertyValue: 'latest' }
+      }]);
+  });
+
+  it('triggers reactive effects', () => {
+    const { container, preferences } = setupPreferences({
+      site: { projectSortMode: 'latest' },
+      projects: {
+        123: { formTrashCollapsed: false }
+      }
+    });
+    const fake = sinon.fake();
+    watch(() => preferences.site.projectSortMode, fake);
+    watch(() => preferences.projects[123].formTrashCollapsed, fake);
+    // Project without preferences
+    watch(() => preferences.projects[456].formTrashCollapsed, fake);
+    return mockHttp(container)
+      .request(() => {
+        preferences.site.projectSortMode = 'alphabetical';
+        preferences.projects[123].formTrashCollapsed = true;
+        preferences.projects[456].formTrashCollapsed = true;
+      })
+      .respondWithSuccess()
+      .respondWithSuccess()
+      .respondWithSuccess()
+      .afterResponses(() => {
+        fake.callCount.should.equal(3);
+      });
+  });
+});


### PR DESCRIPTION
This PR closes #1049, adding tests of user preferences. The goals of this PR are to:

- Prevent someone from accidentally deleting all user preference functionality outright.
- Make it clear how to read and write user preferences in Frontend / what the contract is.
- Provide a template for future tests. Quite possibly the core functionality won't ever need to change, but as we add new specific preferences, we'll also need to write new preference normalizers. It was with that in mind that I added tests of the existing normalizers.

I didn't write tests for absolutely all behavior. I also didn't write any new tests of components that read or write user preferences. However, I did write more than the 3 or 4 tests that the comment on the issue suggests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced