### PR TITLE
Reorder buttons for publishing or abandoning form draft

### DIFF
--- a/src/components/form/edit/draft-controls.vue
+++ b/src/components/form/edit/draft-controls.vue
@@ -13,13 +13,13 @@ except according to the terms contained in the LICENSE file.
   <form-edit-section id="form-edit-draft-controls" icon="pencil">
     <template #title>{{ $t('title') }}</template>
     <template #body>
-      <button id="form-edit-publish-button" type="button"
-        class="btn btn-primary" @click="$emit('publish')">
-        <span class="icon-star"></span>{{ $t('action.publish') }}
-      </button>
       <button id="form-edit-abandon-button" type="button" class="btn btn-danger"
         @click="$emit('abandon')">
         <span class="icon-trash"></span>{{ abandonText }}
+      </button>
+      <button id="form-edit-publish-button" type="button"
+        class="btn btn-primary" @click="$emit('publish')">
+        <span class="icon-star"></span>{{ $t('action.publish') }}
       </button>
     </template>
   </form-edit-section>
@@ -47,7 +47,7 @@ const abandonText = computed(() => (!form.dataExists
 </script>
 
 <style lang="scss">
-#form-edit-abandon-button { margin-left: 10px; }
+#form-edit-publish-button { margin-left: 10px; }
 </style>
 
 <i18n lang="json5">


### PR DESCRIPTION
This PR addresses https://github.com/getodk/central/issues/728#issuecomment-2792116638. It moves the Publish Draft button to the left of Abandon Draft / Delete Form. It reverts 0e112b0113cc6e224df0bd817c792c57f979df8a from #1164.

#### What has been done to verify that this works as intended?

Tests continue to pass. I also tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced