### PR TITLE
Change hover/focus style of infonav dropdown button

### DIFF
--- a/src/components/infonav.vue
+++ b/src/components/infonav.vue
@@ -66,14 +66,19 @@ const toggleId = `${idPrefix}-toggle`;
     .btn {
       font-size: 15px;
       box-shadow: none;
-
-      &:hover {
-        background-color: #fff;
-        color: $color-action-foreground;
-      }
-
     }
-    button:focus {
+
+    &:not(.open) > .btn:focus {
+      // overrides bootstrap .btn focus
+      color: $color-action-foreground;
+    }
+
+    &:not(.open):hover > .btn {
+      background-color: white;
+      color: $color-action-foreground;
+    }
+
+    &.open > .btn {
         background-color: $color-action-background;
         color: #fff;
       }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/953

I think the issue is describing how if you click on the dropdown button and drag off, it leaves the button focused. Prior to this code, that meant that the background of the button was bright blue. (Though when you moused over it, it was white.)

I think there were a couple awkward things that I've tried to fix. Mainly the fact that hovering over the buttons highlighted them in white, but then when you opened the dropdown, the white highlight remained unless you moused off the button, in which case it turned the bright blue (because it was focused).

I stopped using this focus check to set the dropdown button color and now look at whether or not the dropdown is open. That means when you click on it and open the dropdown, the button/menu header turns blue and stays blue (no more weird hovering blue/white switching) as long as it's open, and then goes back to the previous behavior when closed.

I made the default focus text color into the blue foreground color so if you do happen to click and drag off the button, it now has blue text that matches the other infonav button. In the case that you do this click and drag off, the buttons wont turn back to gray, though, since they are still focused. I think that's fine though? Overall it feels a bit better than before.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced