### PR TITLE
fixes 962: remove length of enketoId

### DIFF
--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -68,24 +68,23 @@ http {
     # whether to show a WebForm or an iframed Enketo.
     #
     # Following are the locations that serve a Form and these are redirected to the frontend:
-    # N.B: For Single submission Enketo ID (enketoOnceId) is 64 characters long otherwise it's 31 char
-    location ~ "^/-/single/(?<enketoId>[a-zA-Z0-9]{31}|[a-zA-Z0-9]{64})$" {
+    location ~ "^/-/single/(?<enketoId>[a-zA-Z0-9]+)$" {
       # Form fill link, public
       return 301 "/f/$enketoId$is_args$args";
     }
-    location ~ "^/-/edit/(?<enketoId>[a-zA-Z0-9]{31})$" {
+    location ~ "^/-/edit/(?<enketoId>[a-zA-Z0-9]+)$" {
       # Edit link
       return 301 "/f/$enketoId/edit$is_args$args";
     }
-    location ~ "^/-/preview/(?<enketoId>[a-zA-Z0-9]{31})$" {
+    location ~ "^/-/preview/(?<enketoId>[a-zA-Z0-9]+)$" {
       # preview link
       return 301 "/f/$enketoId/preview$is_args$args";
     }
-    location ~ "^/-/x/(?<enketoId>[a-zA-Z0-9]{31})$" {
+    location ~ "^/-/x/(?<enketoId>[a-zA-Z0-9]+)$" {
       # Offline new Submissions - can be public if it has st query parameter
       return 301 "/f/$enketoId/offline$is_args$args";
     }
-    location ~ "^/-/(?<enketoId>[a-zA-Z0-9]{31})$" {
+    location ~ "^/-/(?<enketoId>[a-zA-Z0-9]+)$" {
       # Form fill link (non-public), or Draft
       return 301 "/f/$enketoId/new$is_args$args";
     }

--- a/src/components/enketo-iframe.vue
+++ b/src/components/enketo-iframe.vue
@@ -98,7 +98,7 @@ const setEnketoSrc = () => {
   }
   // for actionType 'new', we don't need to add anything to the prefix.
 
-  if (props.enketoId.length === 64) {
+  if (props.enketoId === form.enketoOnceId) {
     lastSubmitted(props.enketoId)
       .then(result => {
         if (result) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -709,7 +709,7 @@ const routes = [
     }
   }),
   asyncRoute({
-    path: '/f/:enketoId([a-zA-Z0-9]{31})/:actionType(new|edit|preview)',
+    path: '/f/:enketoId([a-zA-Z0-9]+)/:actionType(new|edit|preview)',
     component: 'FormSubmission',
     name: 'EnketoRedirector',
     props: true,
@@ -719,7 +719,7 @@ const routes = [
     }
   }),
   asyncRoute({
-    path: '/f/:enketoId([a-zA-Z0-9]{31}|[a-zA-Z0-9]{64})/:offline(offline)?',
+    path: '/f/:enketoId([a-zA-Z0-9]+)/:offline(offline)?',
     component: 'FormSubmission',
     name: 'WebFormDirectLink',
     props: (route) => {
@@ -735,15 +735,6 @@ const routes = [
       restoreSession: true,
       requireLogin: false,
       title: () => [form.nameOrId]
-    },
-    // onceEnketoId can be used by only public-links as it doesn't support offline mode
-    beforeEnter: (to) => {
-      const { enketoId, actionType } = to.params;
-
-      if (enketoId.length === 64 && actionType === 'offline') {
-        return '/not-found';
-      }
-      return true;
     }
   }),
 


### PR DESCRIPTION
Closes getodk/central#962

**Background**

Enketo Express allows length of enketoId to be configurable between 4-31. That's why we don't want to hard code length of enketoId at our end.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced