### PR TITLE
Style changes for breadcrumbs, home page cards

### DIFF
--- a/src/components/breadcrumbs.vue
+++ b/src/components/breadcrumbs.vue
@@ -63,7 +63,7 @@ defineProps({
 }
 
 .separator {
-  padding: 0px 12px;
+  padding: 0px 10px;
   color: #bbb;
 }
 </style>

--- a/src/components/breadcrumbs.vue
+++ b/src/components/breadcrumbs.vue
@@ -53,8 +53,8 @@ defineProps({
   max-width: 275px;
 
   a [class^="icon-"] {
-    margin-left: 5px;
-    margin-right: 0;
+    margin-left: 0;
+    margin-right: 3px;
   }
 }
 
@@ -63,7 +63,7 @@ defineProps({
 }
 
 .separator {
-  padding: 0px 9px;
+  padding: 0px 12px;
   color: #bbb;
 }
 </style>

--- a/src/components/home/summary.vue
+++ b/src/components/home/summary.vue
@@ -79,10 +79,21 @@ if (currentUser.can('user.list'))
 
 #home-summary {
   display: flex;
+  flex-wrap: wrap;
   gap: 20px;
+
+  @media (max-width: 768px) {
+    > * {
+      flex: 1 1 calc(50% - 20px);
+    }
+  }
   margin-left: auto;
   margin-right: auto;
   max-width: $max-width-page-body;
+
+  .header {
+    font-size: 16px;
+  }
 }
 </style>
 

--- a/src/components/home/summary.vue
+++ b/src/components/home/summary.vue
@@ -82,7 +82,7 @@ if (currentUser.can('user.list'))
   flex-wrap: wrap;
   gap: 20px;
 
-  @media (max-width: 768px) {
+  @media (max-width: $screen-sm-min) {
     > * {
       flex: 1 1 calc(50% - 20px);
     }
@@ -90,10 +90,6 @@ if (currentUser.can('user.list'))
   margin-left: auto;
   margin-right: auto;
   max-width: $max-width-page-body;
-
-  .header {
-    font-size: 16px;
-  }
 }
 </style>
 

--- a/src/components/home/summary/item.vue
+++ b/src/components/home/summary/item.vue
@@ -68,6 +68,7 @@ export default {
   }
 
   .header {
+    font-size: 16px;
     margin-bottom: 0;
     line-height: 1;
     font-weight: 600;

--- a/src/components/page/head.vue
+++ b/src/components/page/head.vue
@@ -43,7 +43,8 @@ defineOptions({
 }
 
 #page-head-title-infonav {
-  padding: 10px 0px;
+  padding-top: 5px;
+  padding-bottom: 20px;
   display: flex;
   align-items: center;
 }

--- a/src/components/submission/basic-details.vue
+++ b/src/components/submission/basic-details.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <page-section id="submission-basic-details">
-    <template #heading><span><span class="icon-file-o"></span>{{ $t('submissionDetails') }}</span></template>
+    <template #heading><span><span class="icon-file"></span>{{ $t('submissionDetails') }}</span></template>
     <template #body>
       <loading :state="initiallyLoading"/>
       <dl v-if="dataExists">
@@ -113,7 +113,7 @@ export default {
 @import '../../assets/scss/mixins';
 
 #submission-basic-details {
-  .icon-file-o {
+  .icon-file {
     font-size: 20px;
     padding: 10px;
     border-radius: 6px;


### PR DESCRIPTION
- Vertical spacing around breadcrumbs and header
- Card title header font size is 16px
- Cards stack when page is smaller
- Padding on left of left breadcrumb icon removed to make it line up with title
- Icon on submission detail page matches breadcrumb submission page

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced