### PR TITLE
Fixes: exclude instance_id from query parameter after enketo redirect

### DIFF
--- a/src/composables/enketo-redirector.js
+++ b/src/composables/enketo-redirector.js
@@ -46,7 +46,8 @@ export default memoizeForContainer(({ router, requestData }) => {
 
       // `target` can't be falsey here because all possible actionType is checked above.
       if (target) {
-        router.replace(`${target}${queryString(route.query)}`);
+        const { instance_id: _, ...query } = route.query;
+        router.replace(`${target}${queryString(query)}`);
       }
     }
   };

--- a/test/composables/enketo-redirector.spec.js
+++ b/test/composables/enketo-redirector.spec.js
@@ -30,10 +30,11 @@ describe('useEnketoRedirector', () => {
     return load(`/f/${enketoId}/edit?instance_id=123`)
       .afterResponses(app => {
         app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/123/edit');
+        app.vm.$route.query.should.be.deep.equal({});
       });
   });
 
-  it('should redirect to edit submission page', () => {
+  it('should show Page Not Found when instance ID is missing for edit', () => {
     testData.extendedForms.createPast(1, { xmlFormId: 'a' });
     return load(`/f/${enketoId}/edit`)
       .afterResponses(app => {


### PR DESCRIPTION
instance ID is part of path so passing as query parameter is redundant. There is no functional impact either way, but this looks nice.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced