### PR TITLE
Render offline Enketo directly

### DIFF
--- a/main.nginx.conf
+++ b/main.nginx.conf
@@ -80,10 +80,6 @@ http {
       # preview link
       return 301 "/f/$enketoId/preview$is_args$args";
     }
-    location ~ "^/-/x/(?<enketoId>[a-zA-Z0-9]+)$" {
-      # Offline new Submissions - can be public if it has st query parameter
-      return 301 "/f/$enketoId/offline$is_args$args";
-    }
     location ~ "^/-/(?!thanks$)(?<enketoId>[a-zA-Z0-9]+)$" {
       # Form fill link (non-public), or Draft
       return 301 "/f/$enketoId/new$is_args$args";

--- a/src/components/enketo-iframe.vue
+++ b/src/components/enketo-iframe.vue
@@ -85,8 +85,9 @@ const setEnketoSrc = () => {
   query.parentWindowOrigin = location.origin;
 
   if (props.actionType === 'offline') {
-    prefix += '/x';
-  } else if (props.actionType === 'public-link') {
+    return; // we don't render offline Enketo through central-frontend
+  }
+  if (props.actionType === 'public-link') {
     prefix += '/single';
   } else if (props.actionType === 'edit') {
     prefix += `/${props.actionType}`;

--- a/src/components/form/submission.vue
+++ b/src/components/form/submission.vue
@@ -77,7 +77,7 @@ const route = useRoute();
 const router = useRouter();
 const { project, resourceStates, form } = useRequestData();
 const { t } = useI18n();
-const { ensureCanonicalPath } = useEnketoRedirector();
+const { ensureEnketoOfflinePath, ensureCanonicalPath } = useEnketoRedirector();
 
 const resources = computed(() => (props.projectId ? [project, form] : [form]));
 
@@ -94,9 +94,8 @@ const EnketoIframe = defineAsyncComponent(loadAsync('EnketoIframe'));
 
 const fetchProject = () => project.request({
   url: apiPaths.project(props.projectId),
-  extended: true,
+  extended: true
 }).catch(noop);
-
 
 const fetchForm = () => {
   let formUrl = '';
@@ -113,7 +112,12 @@ const fetchForm = () => {
       (problem.code === 404.1 ? t('formNotFound') : null)
   })
     .then(() => {
-      ensureCanonicalPath(props.actionType);
+      const redirected = ensureEnketoOfflinePath(props.actionType);
+      if (redirected) {
+        project.cancelRequest();
+      } else {
+        ensureCanonicalPath(props.actionType);
+      }
     })
     .catch(noop);
 };

--- a/src/composables/enketo-redirector.js
+++ b/src/composables/enketo-redirector.js
@@ -10,6 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
 
+import { inject } from 'vue';
 import { useRoute } from 'vue-router';
 import { memoizeForContainer } from '../util/composable';
 import { queryString } from '../util/request';
@@ -21,6 +22,7 @@ export default memoizeForContainer(({ router, requestData }) => {
   const route = useRoute();
   const { form } = requestData;
   const { submissionPath, newSubmissionPath, formPreviewPath, offlineSubmissionPath } = useRoutes();
+  const { location } = inject('container');
 
   const ensureCanonicalPath = (actionType) => {
     let target;
@@ -52,7 +54,17 @@ export default memoizeForContainer(({ router, requestData }) => {
     }
   };
 
+  const ensureEnketoOfflinePath = (actionType) => {
+    if (actionType === 'offline' && form.dataExists && !form.webformsEnabled) {
+      const enketoId = route.params.enketoId ?? form.enketoId;
+      location.replace(`/-/x/${enketoId}${queryString(route.query)}`);
+      return true;
+    }
+
+    return false;
+  };
+
   return {
-    ensureCanonicalPath
+    ensureCanonicalPath, ensureEnketoOfflinePath
   };
 });

--- a/test/components/enketo-iframe.spec.js
+++ b/test/components/enketo-iframe.spec.js
@@ -31,7 +31,6 @@ describe('EnketoIframe', () => {
     { actionType: 'new', expected: `/enketo-passthrough/${enketoId}` },
     { actionType: 'public-link', expected: `/enketo-passthrough/single/${enketoId}` },
     { actionType: 'preview', expected: `/enketo-passthrough/preview/${enketoId}` },
-    { actionType: 'offline', expected: `/enketo-passthrough/x/${enketoId}` },
   ].forEach(({ actionType, expected }) => {
     it(`renders iframe with correct src when actionType is ${actionType}`, () => {
       const wrapper = mountComponent({

--- a/test/components/form/submission.spec.js
+++ b/test/components/form/submission.spec.js
@@ -150,7 +150,7 @@ describe('FormSubmission', () => {
           }));
 
       it('cannot access new submission - offline', () => {
-        testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+        testData.extendedForms.createPast(1, { xmlFormId: 'a', webformsEnabled: true });
         return load(`/f/${enketoId}/offline`)
           .respondFor('/', { users: false })
           .afterResponses(app => {

--- a/test/composables/enketo-redirector.spec.js
+++ b/test/composables/enketo-redirector.spec.js
@@ -1,102 +1,168 @@
+import sinon from 'sinon';
 import testData from '../data';
 import { load } from '../util/http';
+import { mergeMountOptions } from '../util/lifecycle';
 import { mockLogin } from '../util/session';
 
 const enketoId = 'sCTIfjC5LrUto4yVXRYJkNKzP7e53vo';
 
+const mountOptions = (options) => mergeMountOptions(options, {
+  global: {
+    stubs: {
+      WebFormRenderer: {
+        template: '<div class="odk-form">dummy renderer</div>'
+      }
+    }
+  }
+});
 describe('useEnketoRedirector', () => {
   beforeEach(() => {
     mockLogin();
   });
 
-  it('should redirect to new submission page', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    return load(`/f/${enketoId}/new`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new');
-      });
-  });
-
-  it('should redirect to new draft submission page', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
-    return load(`/f/${enketoId}/new`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/draft/submissions/new');
-      });
-  });
-
-  it('should redirect to edit submission page', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    return load(`/f/${enketoId}/edit?instance_id=123`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/123/edit');
-        app.vm.$route.query.should.be.deep.equal({});
-      });
-  });
-
-  it('should show Page Not Found when instance ID is missing for edit', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    return load(`/f/${enketoId}/edit`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/submissions//edit');
-        app.find('.panel-title').text().should.equal('Page Not Found');
-      });
-  });
-
-  it('should redirect to Form preview page', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    return load(`/f/${enketoId}/preview`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/preview');
-      });
-  });
-
-  it('should redirect to draft Form preview page', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
-    return load(`/f/${enketoId}/preview`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/draft/preview');
-      });
-  });
-
-  it('should redirect to new submission page - offline', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    return load(`/f/${enketoId}/offline`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new/offline');
-      });
-  });
-
-  it('should redirect to new draft submission page - offline', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
-    return load(`/f/${enketoId}/offline`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/draft/submissions/new/offline');
-      });
-  });
-
-  it('should preserve form data while redirecting', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    let formRequestCount = 0;
-    return load(`/f/${enketoId}/new`)
-      .beforeEachResponse((app, { url }) => {
-        if (url.match(/form/)) formRequestCount += 1;
-      })
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new');
-        formRequestCount.should.equal(1);
-      });
-  });
-
-  it('should pass query parameter to the target', () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-    return load(`/f/${enketoId}/new?return_url=http%3A%2F%2Fexample.com&d[/data/first_name]=john`)
-      .afterResponses(app => {
-        app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new');
-        app.vm.$route.query.should.deep.equal({
-          return_url: 'http://example.com',
-          'd[/data/first_name]': 'john'
+  describe('ensureCanonicalPath', () => {
+    it('should redirect to new submission page', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/new`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new');
         });
-      });
+    });
+
+    it('should redirect to new draft submission page', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
+      return load(`/f/${enketoId}/new`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/draft/submissions/new');
+        });
+    });
+
+    it('should redirect to edit submission page', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/edit?instance_id=123`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/123/edit');
+          app.vm.$route.query.should.be.deep.equal({});
+        });
+    });
+
+    it('should show Page Not Found when instance ID is missing for edit', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/edit`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions//edit');
+          app.find('.panel-title').text().should.equal('Page Not Found');
+        });
+    });
+
+    it('should redirect to Form preview page', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/preview`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/preview');
+        });
+    });
+
+    it('should redirect to draft Form preview page', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
+      return load(`/f/${enketoId}/preview`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/draft/preview');
+        });
+    });
+
+    it('should redirect to new submission page when webforms is enabled - offline', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a', webformsEnabled: true });
+      return load(`/f/${enketoId}/offline`, mountOptions())
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new/offline');
+        });
+    });
+
+    it('should redirect to new draft submission page when webforms is enabled - offline', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true, webformsEnabled: true });
+      return load(`/f/${enketoId}/offline`, mountOptions())
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/draft/submissions/new/offline');
+        });
+    });
+
+    it('should preserve form data while redirecting', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      let formRequestCount = 0;
+      return load(`/f/${enketoId}/new`)
+        .beforeEachResponse((app, { url }) => {
+          if (url.match(/form/)) formRequestCount += 1;
+        })
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new');
+          formRequestCount.should.equal(1);
+        });
+    });
+
+    it('should pass query parameter to the target', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/new?return_url=http%3A%2F%2Fexample.com&d[/data/first_name]=john`)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/new');
+          app.vm.$route.query.should.deep.equal({
+            return_url: 'http://example.com',
+            'd[/data/first_name]': 'john'
+          });
+        });
+    });
+  });
+
+  describe('ensureEnketoOfflinePath', () => {
+    it('should redirect to Enketo offline page from public link', () => {
+      const fakeLocationReplace = sinon.fake();
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/offline?st=123`, mountOptions({
+        container: {
+          location: {
+            replace: (url) => {
+              fakeLocationReplace(url);
+            }
+          }
+        }
+      }))
+        .afterResponses(() => {
+          fakeLocationReplace.calledWith(`/-/x/${enketoId}?st=123`).should.be.true;
+        });
+    });
+
+    it('should redirect to Enketo offline page from canonical path', () => {
+      const fakeLocationReplace = sinon.fake();
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load('/projects/1/forms/a/submissions/new/offline', mountOptions({
+        container: {
+          location: {
+            replace: (url) => {
+              fakeLocationReplace(url);
+            }
+          }
+        }
+      }))
+        .afterResponses(() => {
+          fakeLocationReplace.calledWith('/-/x/xyz').should.be.true;
+        });
+    });
+
+    it('should redirect to Enketo offline page from draft canonical path', () => {
+      const fakeLocationReplace = sinon.fake();
+      testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
+      return load('/projects/1/forms/a/draft/submissions/new/offline', mountOptions({
+        container: {
+          location: {
+            replace: (url) => {
+              fakeLocationReplace(url);
+            }
+          }
+        }
+      }))
+        .afterResponses(() => {
+          fakeLocationReplace.calledWith('/-/x/xyz').should.be.true;
+        });
+    });
   });
 });


### PR DESCRIPTION
Closes getodk/central#998

**Changes:**
- Render offline Enketo directly
- Redirect /offline suffix to /-/x/

**Root cause:**

Enketo registers service worker with the scope of `/-/x/`, therefore `/f/:enketoId` or the canonical URL of new Submission don't became available offline. Additionally from the frontend we send `/form` request before rendering Enketo of Web Forms to determine which technology to use, Enketo can't possibly cache that request. This PR implements the simplest solution of rendering offline Enketo directly. 

Other option was to implement service worker in frontend, which is quite a bigger task to take on at this point.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced