### PR TITLE
Fixing a test about scrolling that started failing in CircleCI

### DIFF
--- a/test/components/entity/activity.spec.js
+++ b/test/components/entity/activity.spec.js
@@ -231,13 +231,13 @@ describe('EntityActivity', () => {
       await wait();
       const yForV40 = window.scrollY;
       yForV40.should.be.above(0);
-      pxTo(app.get('[data-version="40"]')).should.equal(10);
+      pxTo(app.get('[data-version="40"]')).should.within(9, 10);
 
-      // Scroll to v20 even farther below.
+      // Scroll to v30 even farther below.
       await app.vm.$router.push('/projects/1/entity-lists/trees/entities/e#v30');
       await wait();
       window.scrollY.should.be.above(yForV40);
-      pxTo(app.get('[data-version="30"]')).should.equal(10);
+      pxTo(app.get('[data-version="30"]')).should.be.within(9, 10);
     });
 
     it('waits for the scroll target to appear in the DOM', async () => {

--- a/test/components/entity/activity.spec.js
+++ b/test/components/entity/activity.spec.js
@@ -234,10 +234,10 @@ describe('EntityActivity', () => {
       pxTo(app.get('[data-version="40"]')).should.equal(10);
 
       // Scroll to v20 even farther below.
-      await app.vm.$router.push('/projects/1/entity-lists/trees/entities/e#v20');
+      await app.vm.$router.push('/projects/1/entity-lists/trees/entities/e#v30');
       await wait();
       window.scrollY.should.be.above(yForV40);
-      pxTo(app.get('[data-version="20"]')).should.equal(10);
+      pxTo(app.get('[data-version="30"]')).should.equal(10);
     });
 
     it('waits for the scroll target to appear in the DOM', async () => {


### PR DESCRIPTION
This test was failing, and it was failing differently on my local machine vs. CircleCI

In `test/components/entity/activity.spec.js`: 
```
1) scrolls to a target that already exists in the DOM
     EntityActivity scroll behavior
     AssertionError: expected 9 to equal 10
    at Context.<anonymous> (dist/commons.js:308637:51)
```

I made two changes: 
- Locally, the assertion error was `expected 109 to equal 10` so I changed the target being scrolled to to be a bit closer to the initial target position. It scrolls from version 40 (near the top of the activity feed) to **version 30** now, instead of version 20. 
- Sadiq noticed the Chrome 135 vs 136 distinction which was slightly changing the value from `getBoundingClientRect()` so I uses a suggestion from Matt to check for a values of 9 or 10.
    > I was running chrome 135 and my tests were passing everytime. Checked the version on CircleCI, it is 136. So I upgraded my chrome and boom tests fail






<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced