### PR TITLE
Add a slot for modal banner

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -115,6 +115,8 @@ $padding-file-drop-zone: 15px;
 $padding-modal-body: 40px;
 $padding-modal-header: 40px;
 $padding-modal-actions: 15px;
+$border-radius-modal: 6px;
+$padding-modal-top-actions-close: 16px;
 
 // PageBody
 $margin-top-page-body: 20px;

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -25,9 +25,7 @@ may add the `in` class to the element, and the checkScroll() method may add the
             :aria-label="$t('action.close')" @click="hideIfCan">
             <span aria-hidden="true">&times;</span>
           </button>
-          <div class="modal-banner">
-            <slot name="banner"></slot>
-          </div>
+          <div class="modal-banner"><slot name="banner"></slot></div>
         </div>
         <div class="modal-header">
           <h4 :id="titleId" class="modal-title"><slot name="title"></slot></h4>
@@ -257,9 +255,14 @@ const titleId = `modal-title${id}`;
       .modal-banner {
         display: contents;
         width: 100%;
-        z-index: 1; // Behind the close button.
         padding: 0px;
         margin: 0px;
+
+        // Force child of banner (e.g. image) to have rounded corners
+        &>* {
+          border-top-left-radius: 6px;
+          border-top-right-radius: 6px;
+        }
       }
 
       .close {
@@ -269,7 +272,6 @@ const titleId = `modal-title${id}`;
         color: $color-input;
         font-weight: normal;
         opacity: 1;
-        z-index: 2; // Close button is on top of the banner.
 
         &[aria-disabled="true"] {
           cursor: not-allowed;

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -25,6 +25,9 @@ may add the `in` class to the element, and the checkScroll() method may add the
             :aria-label="$t('action.close')" @click="hideIfCan">
             <span aria-hidden="true">&times;</span>
           </button>
+          <div class="modal-banner">
+            <slot name="banner"></slot>
+          </div>
         </div>
         <div class="modal-header">
           <h4 :id="titleId" class="modal-title"><slot name="title"></slot></h4>
@@ -250,15 +253,23 @@ const titleId = `modal-title${id}`;
     box-shadow: $box-shadow-panel-main;
 
     .modal-top-actions {
-      text-align: right;
-      padding-right: 16px;
-      padding-top: 16px;
+
+      .modal-banner {
+        display: contents;
+        width: 100%;
+        z-index: 1; // Behind the close button.
+        padding: 0px;
+        margin: 0px;
+      }
 
       .close {
-        float: none;
+        position: absolute;
+        top: 16px;
+        right: 16px;
         color: $color-input;
         font-weight: normal;
         opacity: 1;
+        z-index: 2; // Close button is on top of the banner.
 
         &[aria-disabled="true"] {
           cursor: not-allowed;
@@ -269,7 +280,7 @@ const titleId = `modal-title${id}`;
     .modal-header {
       border-bottom: 0px;
       color: $color-text;
-      padding: 0px $padding-modal-header 20px $padding-modal-header;
+      padding: $padding-modal-header $padding-modal-header 20px $padding-modal-header;
 
       h4 {
         @include text-overflow-ellipsis;

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -260,15 +260,15 @@ const titleId = `modal-title${id}`;
 
         // Force child of banner (e.g. image) to have rounded corners
         &>* {
-          border-top-left-radius: 6px;
-          border-top-right-radius: 6px;
+          border-top-left-radius: $border-radius-modal;
+          border-top-right-radius: $border-radius-modal;
         }
       }
 
       .close {
         position: absolute;
-        top: 16px;
-        right: 16px;
+        top: $padding-modal-top-actions-close;
+        right: $padding-modal-top-actions-close;
         color: $color-input;
         font-weight: normal;
         opacity: 1;

--- a/src/components/whats-new.vue
+++ b/src/components/whats-new.vue
@@ -11,6 +11,17 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <modal :state="isVisible" backdrop :hideable="true" @hide="hideModal">
+    <template #banner>
+      <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="150px">
+        <defs>
+          <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" style="stop-color:#8d0050;stop-opacity:1"/>
+            <stop offset="100%" style="stop-color:#f7f7f7;stop-opacity:1"/>
+          </linearGradient>
+        </defs>
+        <rect width="100%" height="150" fill="url(#gradient)"/>
+      </svg>
+    </template>
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <p class="modal-introduction">

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -37,10 +37,10 @@ describe('Modal', () => {
   it('uses the banner slot', () => {
     const modal = mountComponent({
       slots: {
-        banner: { template: '<img src="foo"/>' }
+        banner: { template: '<div class="test-banner">foo</div>' }
       }
     });
-    modal.get('.modal-banner img').attributes('src').should.equal('foo');
+    modal.get('.modal-banner .test-banner').text().should.equal('foo');
   });
 
   it('shows any alert', () => {

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -34,6 +34,15 @@ describe('Modal', () => {
     modal.get('.modal-body pre').text().should.equal('foo');
   });
 
+  it('uses the banner slot', () => {
+    const modal = mountComponent({
+      slots: {
+        banner: { template: '<img src="foo"/>' }
+      }
+    });
+    modal.get('.modal-banner img').attributes('src').should.equal('foo');
+  });
+
   it('shows any alert', () => {
     mountComponent().findComponent(Alert).exists().should.be.true;
   });


### PR DESCRIPTION
Part of https://github.com/getodk/central/issues/944

Here's how an image COULD look as a banner in a modal. This was set up as a test (with a local image file on my machine) because we're waiting on vite to load images properly.
<img width="691" alt="Screenshot 2025-05-02 at 1 19 27 PM" src="https://github.com/user-attachments/assets/1cc0090f-8b4b-455b-9a76-10a857681a4d" />

This PR includes this SVG gradient in the What's New modal as an example usage of the banner slot:
<img width="642" alt="Screenshot 2025-05-02 at 1 02 17 PM" src="https://github.com/user-attachments/assets/39c0f218-8248-457b-bce7-cb0f715f19de" />

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced