### PR TITLE
Add <tr> elements to TestUtilColumnGrow

### DIFF
--- a/test/util/components/column-grow.vue
+++ b/test/util/components/column-grow.vue
@@ -1,14 +1,18 @@
 <template>
   <table v-if="render" v-show="visible" id="column-grow" class="table">
     <thead>
-      <th ref="th"></th>
-      <th></th>
-      <th></th>
+      <tr>
+        <th ref="th"></th>
+        <th></th>
+        <th></th>
+      </tr>
     </thead>
     <tbody>
-      <td><div :style="{ width: px(contentWidth) }"></div></td>
-      <td></td>
-      <td></td>
+      <tr>
+        <td><div :style="{ width: px(contentWidth) }"></div></td>
+        <td></td>
+        <td></td>
+      </tr>
     </tbody>
   </table>
 </template>


### PR DESCRIPTION
When I run `npm run test`, I see warnings about `<th>` being a direct child of `<thead>` and `<td>` being a child of `<tbody>` in the `TestUtilColumnGrow` component. Looking at that component, it definitely needs `<tr>` elements. I'm pretty sure I just omitted them accidentally during testing. Nothing yelled at us about it before, so I didn't realize.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced