### PR TITLE
Teleport modals

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -29,6 +29,7 @@ except according to the terms contained in the LICENSE file.
       <router-view/>
     </template>
 
+    <div id="modals"></div>
     <div id="tooltips"></div>
     <hover-cards/>
   </div>

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -22,11 +22,11 @@ except according to the terms contained in the LICENSE file.
         <span class="icon-refresh"></span>{{ $t('action.refresh') }}
         <spinner :state="refreshing"/>
       </button>
-      <Teleport v-if="odataEntities.dataExists" to=".dataset-entities-heading-row">
+      <teleport-if-exists v-if="odataEntities.dataExists" to=".dataset-entities-heading-row">
         <entity-download-button :odata-filter="deleted ? null : odataFilter"
         :snapshot-filter="snapshotFilter" :disabled="deleted"
         v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"/>
-      </Teleport>
+      </teleport-if-exists>
     </div>
     <entity-table v-show="odataEntities.dataExists" ref="table"
       :properties="dataset.properties"
@@ -75,6 +75,7 @@ import EntityResolve from './resolve.vue';
 import OdataLoadingMessage from '../odata-loading-message.vue';
 import Spinner from '../spinner.vue';
 import Pagination from '../pagination.vue';
+import TeleportIfExists from '../teleport-if-exists.vue';
 
 import useQueryRef from '../../composables/query-ref';
 import useRequest from '../../composables/request';
@@ -97,6 +98,7 @@ export default {
     OdataLoadingMessage,
     Pagination,
     Spinner,
+    TeleportIfExists
   },
   inject: ['alert'],
   props: {

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -14,29 +14,31 @@ except according to the terms contained in the LICENSE file.
 may add the `in` class to the element, and the checkScroll() method may add the
 `has-scroll` class. -->
 <template>
-  <div ref="el" class="modal" tabindex="-1"
-    :data-backdrop="backdrop ? 'static' : 'false'" data-keyboard="false"
-    role="dialog" :aria-labelledby="titleId" @mousedown="modalMousedown"
-    @click="modalClick" @keydown.esc="hideIfCan" @focusout="refocus">
-    <div class="modal-dialog" :class="sizeClass" role="document">
-      <div class="modal-content">
-        <div class="modal-top-actions">
-          <button type="button" class="close" :aria-disabled="!hideable"
-            :aria-label="$t('action.close')" @click="hideIfCan">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <div class="modal-banner"><slot name="banner"></slot></div>
-        </div>
-        <div class="modal-header">
-          <h4 :id="titleId" class="modal-title"><slot name="title"></slot></h4>
-        </div>
-        <div ref="body" class="modal-body">
-          <Alert/>
-          <slot name="body"></slot>
+  <teleport-if-exists to="#modals">
+    <div ref="el" v-bind="$attrs" class="modal" tabindex="-1"
+      :data-backdrop="backdrop ? 'static' : 'false'" data-keyboard="false"
+      role="dialog" :aria-labelledby="titleId" @mousedown="modalMousedown"
+      @click="modalClick" @keydown.esc="hideIfCan" @focusout="refocus">
+      <div class="modal-dialog" :class="sizeClass" role="document">
+        <div class="modal-content">
+          <div class="modal-top-actions">
+            <button type="button" class="close" :aria-disabled="!hideable"
+              :aria-label="$t('action.close')" @click="hideIfCan">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <div class="modal-banner"><slot name="banner"></slot></div>
+          </div>
+          <div class="modal-header">
+            <h4 :id="titleId" class="modal-title"><slot name="title"></slot></h4>
+          </div>
+          <div ref="body" class="modal-body">
+            <Alert/>
+            <slot name="body"></slot>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </teleport-if-exists>
 </template>
 
 <script>
@@ -47,6 +49,7 @@ import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, watch, wat
 import 'bootstrap/js/modal';
 
 import Alert from './alert.vue';
+import TeleportIfExists from './teleport-if-exists.vue';
 
 import { noop } from '../util/util';
 
@@ -64,6 +67,9 @@ We do this for two reasons:
   - It is needed to implement the `hideable` prop.
 */
 
+defineOptions({
+  inheritAttrs: false
+});
 const props = defineProps({
   state: Boolean,
   // Indicates whether the user is able to hide the modal by clicking ×,

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -42,17 +42,15 @@ except according to the terms contained in the LICENSE file.
           {{ $t('action.refresh') }}
           <spinner :state="refreshing"/>
         </button>
-        <!-- Have to add v-if and conditional :to, otherwise Teleport tries to locate
-          .form-submission-heading-row, can't find it and throws error -->
-        <Teleport v-if="formVersion.dataExists && odata.dataExists" :disabled="draft"
-          :to="!draft ? '.form-submissions-heading-row' : null">
+        <teleport-if-exists v-if="formVersion.dataExists && odata.dataExists"
+          :to="'.form-submissions-heading-row'">
           <submission-download-button :form-version="formVersion"
             :aria-disabled="deleted"
             :filtered="odataFilter != null && !deleted"
             v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"
             @download="showDownloadModal"
             @download-filtered="showDownloadModal(true)"/>
-        </Teleport>
+        </teleport-if-exists>
       </div>
       <submission-table v-show="odata.dataExists"
         ref="table" :project-id="projectId" :xml-form-id="xmlFormId"
@@ -95,7 +93,7 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 import { DateTime } from 'luxon';
-import { shallowRef, watch, reactive, Teleport } from 'vue';
+import { shallowRef, watch, reactive } from 'vue';
 
 import EnketoFill from '../enketo/fill.vue';
 import Loading from '../loading.vue';
@@ -110,6 +108,7 @@ import SubmissionUpdateReviewState from './update-review-state.vue';
 import SubmissionDelete from './delete.vue';
 import SubmissionRestore from './restore.vue';
 import Pagination from '../pagination.vue';
+import TeleportIfExists from '../teleport-if-exists.vue';
 
 import useFields from '../../request-data/fields';
 import useQueryRef from '../../composables/query-ref';
@@ -138,7 +137,7 @@ export default {
     SubmissionRestore,
     SubmissionTable,
     SubmissionUpdateReviewState,
-    Teleport
+    TeleportIfExists
   },
   inject: ['alert'],
   props: {

--- a/src/components/submission/update-review-state.vue
+++ b/src/components/submission/update-review-state.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     :hideable="!awaitingResponse" backdrop @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
-      <form @submit.prevent="submit">
+      <form ref="form" @submit.prevent="submit">
         <div class="row">
           <div class="col-xs-4">
             <div v-for="reviewState of selectableStates" :key="reviewState"
@@ -99,7 +99,7 @@ export default {
           ? currentState
           : 'approved';
         this.$nextTick(() => {
-          this.$el.querySelector('input:checked').focus();
+          this.$refs.form.querySelector('input:checked').focus();
         });
       } else {
         this.notes = '';

--- a/src/components/teleport-if-exists.vue
+++ b/src/components/teleport-if-exists.vue
@@ -1,0 +1,45 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <teleport v-if="exists" :to="to">
+    <slot></slot>
+  </teleport>
+  <template v-else>
+    <slot></slot>
+  </template>
+</template>
+
+<script setup>
+/*
+This component teleports content if the teleport `to` target exists in the DOM.
+If the target does not exist, the content is rendered where it is without being
+teleported.
+
+This can be useful in testing. Even if the teleport `to` target always exists in
+production, a particular test might not render the target if the test doesn't
+mount the entire app. In that case, we still want to render the content; we just
+won't teleport it. Usually it doesn't matter to tests whether content is
+teleported. If it matters, the test should make sure that the teleport `to`
+target exists by mounting the whole app and attaching it to the document body.
+*/
+
+const props = defineProps({
+  to: {
+    type: String,
+    required: true
+  }
+});
+
+// This is not reactive. Making it reactive is outside the scope/intention of
+// this component.
+const exists = document.querySelector(props.to) != null;
+</script>

--- a/test/components/field-key/new.spec.js
+++ b/test/components/field-key/new.spec.js
@@ -58,7 +58,7 @@ describe('FieldKeyNew', () => {
     const create = (series) => series
       .request(async (app) => {
         await app.get('.heading-with-button button').trigger('click');
-        const modal = app.getComponent(FieldKeyNew);
+        const modal = app.get('#field-key-new');
         await modal.get('input').setValue('input', 'My App User');
         return modal.get('form').trigger('submit');
       })

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -212,7 +212,7 @@ describe('Modal', () => {
             attachTo: document.body
           });
           await nextTick();
-          modal.classes('has-scroll').should.be.true;
+          modal.get('.modal').classes('has-scroll').should.be.true;
         });
 
         it('does not add class if modal does not overflow', async () => {
@@ -221,7 +221,7 @@ describe('Modal', () => {
             attachTo: document.body
           });
           await nextTick();
-          modal.classes('has-scroll').should.be.false;
+          modal.get('.modal').classes('has-scroll').should.be.false;
         });
 
         it('adds class if .modal-body changes, causing overflow', async () => {
@@ -233,10 +233,10 @@ describe('Modal', () => {
             attachTo: document.body
           });
           await nextTick();
-          modal.classes('has-scroll').should.be.false;
+          modal.get('.modal').classes('has-scroll').should.be.false;
           modal.get('#div').element.setAttribute('style', 'height: 10000px;');
           await wait();
-          modal.classes('has-scroll').should.be.true;
+          modal.get('.modal').classes('has-scroll').should.be.true;
         });
       });
     });

--- a/test/components/web-form-renderer.spec.js
+++ b/test/components/web-form-renderer.spec.js
@@ -1,4 +1,7 @@
 import sinon from 'sinon';
+
+import Modal from '../../src/components/modal.vue';
+
 import { mockHttp } from '../util/http';
 import createTestContainer from '../util/container';
 import { mockRouter } from '../util/router';
@@ -98,7 +101,7 @@ describe('WebFormRenderer', () => {
       .request((c) => c.find('.odk-form .footer button').trigger('click'))
       .respondWithData(() => ({ currentVersion: { instanceId: '123' } }));
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-title').text().should.equal('Form successfully sent!');
     modal.find('.modal-introduction').text().should.equal('You can fill this Form out again or close if you’re done.');
@@ -116,7 +119,7 @@ describe('WebFormRenderer', () => {
       })
       .respondWithData(() => ({ currentVersion: { instanceId: '123' } }));
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-title').text().should.equal('Form successfully sent!');
     modal.find('.modal-introduction').text().should.equal('You can fill this Form out again or close if you’re done.');
@@ -132,7 +135,7 @@ describe('WebFormRenderer', () => {
       .request((c) => c.find('.odk-form .footer button').trigger('click'))
       .respondWithProblem({ code: 409.1, message: 'duplication instance ID' });
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-title').text().should.equal('Submission error');
     modal.find('.modal-introduction').text().should.match(/Your data was not submitted.*duplication instance ID/);
@@ -149,7 +152,7 @@ describe('WebFormRenderer', () => {
       .request((c) => c.find('.odk-form .footer button').trigger('click'))
       .respondWithProblem(403.1);
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.getComponent(Modal);
 
     modal.find('.modal-title').text().should.equal('Session expired');
     modal.find('.modal-introduction').text().should.equal('Please log in here in a different browser tab and try again.');
@@ -161,14 +164,14 @@ describe('WebFormRenderer', () => {
 
     const component = await mountComponent({ props: { actionType: 'preview' } })
       .testModalToggles({
-        modal: '#web-form-renderer-submission-modal',
+        modal: Modal,
         show: '.odk-form .footer button',
         hide: '.btn-primary'
       });
 
     await component.find('.odk-form .footer button').trigger('click');
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-introduction').text().should.equal('The data you entered is valid, but it was not submitted because this is a Form preview.');
     modal.find('.modal-title').text().should.equal('Data is valid');
@@ -181,7 +184,7 @@ describe('WebFormRenderer', () => {
       .complete()
       .request((c) => c.find('.odk-form .footer button').trigger('click'))
       .beforeEachResponse(c => {
-        const modal = c.findComponent('#web-form-renderer-submission-modal');
+        const modal = c.findComponent(Modal);
         modal.props().state.should.be.true;
         modal.find('.modal-title').text().should.equal('Sending Submission');
       })
@@ -206,7 +209,7 @@ describe('WebFormRenderer', () => {
       .respondWithData(() => ({ currentVersion: { instanceId: '123' } }))
       .respondWithSuccess(); // upload attachment successful
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-title').text().should.equal('Form successfully sent!');
     modal.find('.modal-introduction').text().should.equal('You can fill this Form out again or close if you’re done.');
@@ -224,7 +227,7 @@ describe('WebFormRenderer', () => {
       .respondWithData(() => ({ currentVersion: { instanceId: '123' } }))
       .respondWithProblem(); // upload attachment error
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-title').text().should.equal('Submission error');
     modal.find('.modal-introduction').text().should.match(/Your data was not fully submitted.*Please press the “Try again” button to retry/);
@@ -243,7 +246,7 @@ describe('WebFormRenderer', () => {
       .respondWithProblem() // upload attachment error
       .complete()
       .request(async (c) => {
-        const modal = c.getComponent('#web-form-renderer-submission-modal');
+        const modal = c.get('#web-form-renderer-submission-modal');
         modal.find('.modal-title').text().should.equal('Submission error');
         return modal.find('.btn-primary').trigger('click');
       })
@@ -257,7 +260,7 @@ describe('WebFormRenderer', () => {
         }
       ]);
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.get('#web-form-renderer-submission-modal');
 
     modal.find('.modal-title').text().should.equal('Form successfully sent!');
     modal.find('.modal-introduction').text().should.equal('You can fill this Form out again or close if you’re done.');
@@ -275,7 +278,7 @@ describe('WebFormRenderer', () => {
       .respondWithData(() => ({ currentVersion: { instanceId: '123' } }))
       .respondWithProblem(403.1);
 
-    const modal = component.getComponent('#web-form-renderer-submission-modal');
+    const modal = component.getComponent(Modal);
 
     modal.find('.modal-title').text().should.equal('Session expired');
     modal.find('.modal-introduction').text().should.equal('Please log in here in a different browser tab and try again.');

--- a/test/util/http/common.js
+++ b/test/util/http/common.js
@@ -99,6 +99,11 @@ export function testModalToggles({
   // shown
   respond = (series) => series
 }) {
+  if (typeof modal === 'string')
+    throw new Error('modal must be a component, not a string');
+  const getModal = (component) => (modal === Modal
+    ? component.getComponent(Modal)
+    : component.getComponent(modal).getComponent(Modal));
   return this
     // First, test that the show button actually shows the modal.
     .afterResponses(component => {
@@ -107,7 +112,7 @@ export function testModalToggles({
     .request(component => component.get(show).trigger('click'))
     .modify(respond)
     .afterResponses(async (component) => {
-      const m = component.getComponent(modal);
+      const m = getModal(component);
       m.props().state.should.be.true;
 
       // Next, test that `modal` listens for `hide` events from Modal.
@@ -118,7 +123,7 @@ export function testModalToggles({
     .request(component => component.get(show).trigger('click'))
     .modify(respond)
     .afterResponses(async (component) => {
-      const m = component.getComponent(modal);
+      const m = getModal(component);
       m.props().state.should.be.true;
       await m.get(hide).trigger('click');
       m.props().state.should.be.false;

--- a/test/util/lifecycle.js
+++ b/test/util/lifecycle.js
@@ -48,7 +48,10 @@ export const mount = (component, options = {}) => {
   g.mocks = { $container: container, ...g.mocks };
   if (g.mixins != null) throw new Error('unexpected mixin');
   g.mixins = [shadowRouterProps];
-  g.stubs = { ...g.stubs, 'transition-group': { inheritAttrs: false, template: '<slot />' }, teleport: true };
+  g.stubs = {
+    ...g.stubs,
+    'transition-group': { inheritAttrs: false, template: '<slot />' },
+  };
   return vtuMount(component, { ...mountOptions, global: g });
 };
 


### PR DESCRIPTION
The Bootstrap [docs](https://getbootstrap.com/docs/3.4/javascript/#modals) say about modals:

> Always try to place a modal's HTML code in a top-level position in your document to avoid other components affecting the modal's appearance and/or functionality.

I've wanted to do this for a while. However, it wasn't super easy to do it in Vue. However, now that we have [teleport](https://vuejs.org/guide/built-ins/teleport) in Vue 3, it's something we can do.

I haven't confirmed yet, but I'm hopeful that this change will close getodk/central#1003. That issue is happening because the modal is a descendant element of the drop zone component. But if we move the modal somewhere else in the document, that won't be the case anymore.

#### What has been done to verify that this works as intended?

I'm hoping to get this in before regression testing so that if this approach doesn't work for any modal, we'll learn about it.

#### Why is this the best possible solution? Were any other approaches considered?

The main issue I ran up against was in testing. I kept running into errors and warnings. I tried stubbing `Teleport` in a few different ways, but it didn't work. I ended up running with a different approach, adding the component `TeleportIfExists`. I actually think it might have value on its own. For example, I think it works well in `SubmissionList`.

Here's how I tried stubbing `Teleport`. None of these worked:

1. What's on `master`: `teleport: true`
2. The same as what we do for `transition-group`: `{ inheritAttrs: false, template: '<slot />' }`
3. I tried this single file component:
```vue
<template>
  <slot v-bind="$attrs"></slot>
</template>

<script setup>
defineOptions({
  inheritAttrs: false
});
defineProps({
  to: {
    type: String,
    required: true
  }
});
</script>
```

Vue Test Utils [suggests](https://test-utils.vuejs.org/guide/advanced/teleport.html#Mounting-the-Component) creating the teleport target in the DOM in a `beforeEach` hook, but that seemed more cumbersome to me.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced