### PR TITLE
New string for 2025.1 usage metric about webforms

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -92,6 +92,7 @@ export default {
       "num_forms_with_geospatial": "Number of Forms with geodata",
       "num_forms_with_encryption": "Number of Forms with encryption",
       "num_forms_with_audits": "Number of Forms with audits",
+      "num_forms_webforms_enabled": "Number of Forms with Web Forms enabled",
       "num_reused_form_ids": "Number of reused Form IDs",
       "num_open_forms": "Number of open Forms",
       "num_closing_forms": "Number of closing Forms",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1273,6 +1273,9 @@
         "num_forms_with_audits": {
           "string": "Number of Forms with audits"
         },
+        "num_forms_webforms_enabled": {
+          "string": "Number of Forms with Web Forms enabled"
+        },
         "num_reused_form_ids": {
           "string": "Number of reused Form IDs"
         },


### PR DESCRIPTION
Frontend part of issue https://github.com/getodk/central/issues/861
Backend PR https://github.com/getodk/central-backend/pull/1490 

<img width="864" alt="Screenshot 2025-05-06 at 1 44 24 PM" src="https://github.com/user-attachments/assets/2d626ec9-6529-4c8d-b593-2ecd7708705e" />


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced