### PR TITLE
Fixes: e2e tests

### DIFF
--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
   use: {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
+    serviceWorkers: 'allow'
   },
 
   /* Configure projects for major browsers */
@@ -43,12 +44,6 @@ export default defineConfig({
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
-      dependencies: ['setup'],
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
       dependencies: ['setup'],
     }
   ]

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -51,6 +51,7 @@ else
   export ODK_URL="${ODK_PROTOCOL}${ODK_DOMAIN}:$ODK_PORT"
 fi
 
+export PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1
 if [[ ${CI-} = true ]]; then
   log "Installing apt dependencies..."
   sudo apt-get install -y wait-for-it


### PR DESCRIPTION
Closes #1213

Added additional test to verify that offline submission is queued when offline and submitted when user comes online again.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced