### PR TITLE
Fixes: don't pass snapshot filters to download button

### DIFF
--- a/src/components/entity/download-button.vue
+++ b/src/components/entity/download-button.vue
@@ -41,7 +41,6 @@ import { useRequestData } from '../../request-data';
 
 const props = defineProps({
   odataFilter: String,
-  snapshotFilter: String,
   disabled: Boolean
 });
 
@@ -49,10 +48,10 @@ const projectId = inject('projectId');
 const datasetName = inject('datasetName');
 
 const href = computed(() =>
-  apiPaths.entities(projectId, datasetName, '.csv', { $filter: props.snapshotFilter }));
+  apiPaths.entities(projectId, datasetName, '.csv'));
 
 const filteredHref = computed(() =>
-  apiPaths.entities(projectId, datasetName, '.csv', { $filter: `${props.snapshotFilter} and ${props.odataFilter}` }));
+  apiPaths.entities(projectId, datasetName, '.csv', { $filter: props.odataFilter }));
 
 const { dataset, odataEntities } = useRequestData();
 const { t } = useI18n();

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -24,7 +24,7 @@ except according to the terms contained in the LICENSE file.
       </button>
       <teleport-if-exists v-if="odataEntities.dataExists" to=".dataset-entities-heading-row">
         <entity-download-button :odata-filter="deleted ? null : odataFilter"
-        :snapshot-filter="snapshotFilter" :disabled="deleted"
+        :disabled="deleted"
         v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"/>
       </teleport-if-exists>
     </div>

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -526,9 +526,8 @@ export default {
       this.fetchChunk(false);
     },
     showDownloadModal(filtered = false) {
-      this.downloadModal.odataFilter = this.snapshotFilter;
       if (filtered) {
-        this.downloadModal.odataFilter += ` and ${this.odataFilter}`;
+        this.downloadModal.odataFilter = this.odataFilter;
       }
       this.downloadModal.show();
     }

--- a/test/components/entity/download-button.spec.js
+++ b/test/components/entity/download-button.spec.js
@@ -5,12 +5,9 @@ import { mergeMountOptions, mount } from '../../util/lifecycle';
 import { relativeUrl } from '../../util/request';
 import { testRequestData } from '../../util/request-data';
 
-const snapshotFilter = '__system/createdAt le 2025-01-01';
-
 const mountComponent = (options = undefined) => {
   const dataset = testData.extendedDatasets.last();
   return mount(EntityDownloadButton, mergeMountOptions(options, {
-    props: { snapshotFilter },
     global: {
       provide: { projectId: '1', datasetName: dataset.name }
     },
@@ -71,7 +68,7 @@ describe('EntityDownloadButton', () => {
       const { href } = mountComponent().find('.btn-primary').attributes();
       const url = relativeUrl(href);
       url.pathname.should.equal('/v1/projects/1/datasets/%C3%A1/entities.csv');
-      url.searchParams.get('$filter').should.eql(snapshotFilter);
+      expect(url.searchParams.get('$filter')).to.be.null;
     });
 
     describe('entities are filtered', () => {
@@ -84,7 +81,7 @@ describe('EntityDownloadButton', () => {
         const { href } = component.find('li:nth-of-type(1) a').attributes();
         const url = relativeUrl(href);
         url.pathname.should.equal('/v1/projects/1/datasets/%C3%A1/entities.csv');
-        url.searchParams.get('$filter').should.equal(`${snapshotFilter} and __system/conflict ne null`);
+        url.searchParams.get('$filter').should.equal('__system/conflict ne null');
       });
 
       it('sets the correct attribute for downloading all entities', () => {
@@ -95,7 +92,7 @@ describe('EntityDownloadButton', () => {
         const { href } = component.find('li:nth-of-type(2) a').attributes();
         const url = relativeUrl(href);
         url.pathname.should.equal('/v1/projects/1/datasets/%C3%A1/entities.csv');
-        url.searchParams.get('$filter').should.equal(snapshotFilter);
+        expect(url.searchParams.get('$filter')).to.be.null;
       });
     });
   });

--- a/test/components/submission/download.spec.js
+++ b/test/components/submission/download.spec.js
@@ -75,7 +75,7 @@ describe('SubmissionDownload', () => {
     });
   });
 
-  it('passes all filters to the download links when download filtered submission button is click', () => {
+  it('passes selected filters to the download links when download filtered submission button is click', () => {
     testData.extendedForms.createPast(1);
     return load('/projects/1/forms/f/submissions?reviewState=null')
       .complete()
@@ -85,14 +85,12 @@ describe('SubmissionDownload', () => {
         await component.find('#submission-download-button li:nth-of-type(1) button').trigger('click');
         const modal = component.getComponent(SubmissionDownload);
         const urls = modal.findAll('a').map(aUrl);
-        // Assert that it includes snapshot filters
-        urls[0].searchParams.get('$filter').should.match(/submissionDate/);
         // Assert that it includes odata filters
         urls[0].searchParams.get('$filter').should.match(/reviewState/);
       });
   });
 
-  it('passes only snapshot filters to the download links when download filtered submission button is click', () => {
+  it('passes no filters to the download links when download all submission button is click', () => {
     testData.extendedForms.createPast(1);
     return load('/projects/1/forms/f/submissions?reviewState=null')
       .complete()
@@ -102,10 +100,7 @@ describe('SubmissionDownload', () => {
         await component.find('#submission-download-button li:nth-of-type(2) button').trigger('click');
         const modal = component.getComponent(SubmissionDownload);
         const urls = modal.findAll('a').map(aUrl);
-        // Assert that it includes snapshot filters
-        urls[0].searchParams.get('$filter').should.match(/submissionDate/);
-        // Assert that it doesn't include odata filters
-        urls[0].searchParams.get('$filter').should.not.match(/reviewState/);
+        expect(urls[0].searchParams.get('$filter')).to.be.null;
       });
   });
 


### PR DESCRIPTION
Closes  getodk/central#1032

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

Frontend maintains a record of deleted rows and doesn't show them in the table after receiving response from the server. However, we can't do similar thing for download button. With this change, downloading csv will return all the active records, which means that there can be discrepancy between what's in the frontend table and what's in the csv if other users delete/undelete entities/submissions. I guess that's fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't see this change impacting other functionality of the app. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced