### PR TITLE
Fix: don't split css into multiple files

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -53,7 +53,8 @@ export default defineConfig(({ mode }) => ({
   build: {
     target: buildTarget,
     // `false` during dev for performance reasons
-    reportCompressedSize: mode === 'production'
+    reportCompressedSize: mode === 'production',
+    cssCodeSplit: false
   },
   // Not sure why this is needed in addition to build.target above and why it's
   // only an issue in development. `npm run dev` doesn't work without this.


### PR DESCRIPTION
Closes getodk/central#1034

#### What has been done to verify that this works as intended?

Locally I don't see any splashes on the home page. Deployed this change on dev server as well, there are no more splashes on Home or Submission pages

#### Why is this the best possible solution? Were any other approaches considered?

There is an open issue (https://github.com/vitejs/vite/issues/3924) in vite related to this. I think loading component dynamically causes js to load before css. I feel vite/vue should have ability to wait for css loading before adding elements in the DOM. I think we would be able to fix this issue in much clearer way in https://github.com/getodk/central-frontend/issues/1212.

This change fixes the problem in smallest possible way without having any significant impact. I'm also thinking if there is any benefit of serving component css and js file separately in our situation?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced