### PR TITLE
Fixes getodk/central#1047: Update filter styles

### DIFF
--- a/src/components/audit/filters/action.vue
+++ b/src/components/audit/filters/action.vue
@@ -11,6 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <label id="audit-filters-action" class="form-group">
+    <span class="form-label">{{ $t('field.type') }}</span>
     <select class="form-control" :value="modelValue"
       @change="$emit('update:modelValue', $event.target.value)">
       <option v-for="option of options" :key="option.value"
@@ -18,7 +19,7 @@ except according to the terms contained in the LICENSE file.
         {{ option.text }}
       </option>
     </select>
-    <span class="form-label">{{ $t('field.type') }}</span>
+    <span class="icon-angle-down"></span>
   </label>
 </template>
 
@@ -105,8 +106,34 @@ export default {
 </script>
 
 <style lang="scss">
-.audit-filters-action-category {
-  // Not all browsers support styling an <option> element this way.
-  font-weight: bold;
+#audit-filters-action {
+  select {
+    appearance: none;
+    cursor: pointer;
+    padding-top: 23px;
+    padding-right: 25px;
+    height: 48px;
+  }
+  .form-label {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    z-index: 2;
+  }
+  .icon-angle-down {
+    font-size: 16px;
+    color: #555555;
+    font-weight: bold;
+    position: absolute;
+    right: 10px;
+    top: 25px;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  .audit-filters-action-category {
+    // Not all browsers support styling an <option> element this way.
+      font-weight: bold;
+    }
 }
 </style>

--- a/src/components/date-range-picker.vue
+++ b/src/components/date-range-picker.vue
@@ -14,6 +14,7 @@ except according to the terms contained in the LICENSE file.
     <!-- We use a class to indicate whether the input is required, because
     flatpickr does not support the `required` attribute:
     https://github.com/ankurk91/vue-flatpickr-component/issues/47 -->
+    <span class="form-label">{{ requiredLabel(label, required) }}</span>
     <flatpickr id="datepicker" ref="flatpickr" v-model="flatpickrValue" :config="config"
       class="form-control"
       :class="{ required, 'flatpickr-input': true, 'has-value': modelValue.length === 2, none: modelValue.length === 0 }"
@@ -29,7 +30,6 @@ except according to the terms contained in the LICENSE file.
     </template>
     <span v-show="required || modelValue.length < 2" aria-hidden="true" class="icon-angle-down">
     </span>
-    <span class="form-label">{{ requiredLabel(label, required) }}</span>
   </label>
 </template>
 
@@ -227,6 +227,10 @@ export default {
 
   .form-label {
     transform: translateY(2px);
+  }
+
+  .close {
+    top: 20px;
   }
 }
 </style>

--- a/src/components/multiselect.vue
+++ b/src/components/multiselect.vue
@@ -15,6 +15,9 @@ except according to the terms contained in the LICENSE file.
     not show a menu with the placeholder option. This approach seems to work
     across browsers. -->
     <div :data-toggle="(options == null || disabled) ? null : 'dropdown'">
+      <span v-show="!hideLabel" class="form-label">
+        {{ label }}
+      </span>
       <select :id="toggleId" ref="toggle" class="form-control"
         :class="{ none: modelValue?.length === options?.length || modelValue?.length === 0 }"
         :aria-disabled="options == null || disabled"
@@ -24,9 +27,6 @@ except according to the terms contained in the LICENSE file.
         @keydown="toggleAfterEnter" @mousedown.prevent @click="verifyAttached">
         <option value="">{{ selectOption }}</option>
       </select>
-      <span v-show="!hideLabel" class="form-label">
-        {{ label }}
-      </span>
       <span class="icon-angle-down"></span>
     </div>
     <!-- Specifying @click.stop so that clicking the .dropdown-menu does not
@@ -446,7 +446,7 @@ const emptyMessage = computed(() => (searchValue.value === ''
     font-weight: bold;
     position: absolute;
     right: 0;
-    top: 10px;
+    top: 26px;
     pointer-events: none;
     z-index: 1;
   }

--- a/src/components/submission/field-dropdown.vue
+++ b/src/components/submission/field-dropdown.vue
@@ -13,7 +13,7 @@ except according to the terms contained in the LICENSE file.
   <multiselect id="submission-field-dropdown" :model-value="modelValue"
     :options="options" :label="$t('field.columns')" :placeholder="placeholder"
     :all="$t('action.select.all')" :none="$t('action.select.none')"
-    :search="$t('field.search')" :hide-label="true"
+    :search="$t('field.search')"
     @update:model-value="$emit('update:modelValue', $event)">
     <template #after-list="{ selected }">
       <template v-if="selected.size > 100">
@@ -58,16 +58,6 @@ const placeholder = (counts) => t('placeholder', counts);
 @import '../../assets/scss/mixins';
 
 #submission-field-dropdown {
-  select {
-    background-color: #777;
-    color: #fff;
-    padding-right: 20px;
-  }
-
-  .icon-angle-down {
-    color: #fff;
-    right: 5px;
-  }
 
   .dropdown-menu { width: 275px; }
   .after-list {
@@ -85,7 +75,7 @@ const placeholder = (counts) => t('placeholder', counts);
     // This is the text of a dropdown that allows the user to select which
     // columns to display in a table. {selected} is the number of columns
     // selected; {total} is the total number of columns.
-    "placeholder": "{selected} of {total} column shown | {selected} of {total} columns shown",
+    "placeholder": "{selected} of {total}",
     "field": {
       // This is shown beneath text that indicates the number of columns that
       // the user has selected to display in a table. For example, that text may

--- a/src/components/submission/filters.vue
+++ b/src/components/submission/filters.vue
@@ -20,7 +20,7 @@ except according to the terms contained in the LICENSE file.
     <date-range-picker :model-value="submissionDate"
       :label="$t('field.submissionDate')"
       :disabled="disabled" :disabled-message="disabledMessage"
-      :placeholder="$t('noSubmissionDateSelected')"
+      :placeholder="$t('allSubmissionDateSelected')"
       @update:model-value="$emit('update:submissionDate', $event)"/>
     <submission-filters-review-state :model-value="reviewState"
       :disabled="disabled" :disabled-message="disabledMessage"
@@ -74,8 +74,8 @@ export default {
       // Submissions by a date range.
       "submissionDate": "Submitted at"
     },
-    // Text shown when no Submission date is selected in the filter
-    "noSubmissionDateSelected": "(none)"
+    // Text shown when in Submission date filter when Submissions for all dates are shown
+    "allSubmissionDateSelected": "(All)"
   }
 }
 </i18n>

--- a/src/components/submission/filters/review-state.vue
+++ b/src/components/submission/filters/review-state.vue
@@ -46,7 +46,7 @@ const options = reviewStates.map(reviewState => ({
 
 const { t } = useI18n();
 const placeholder = (counts) => {
-  if (counts.total === counts.selected) return t('noReviewStateSelected');
+  if (counts.total === counts.selected) return t('allReviewStateSelected');
   return t('placeholder', counts);
 };
 </script>
@@ -84,8 +84,8 @@ const placeholder = (counts) => {
         "none": "None"
       }
     },
-    // Text shown when no Review State is selected in the filter
-    "noReviewStateSelected": "(none)"
+    // Text shown when all Review States are selected in the filter
+    "allReviewStateSelected": "(All)"
   }
 }
 </i18n>

--- a/src/components/submission/filters/submitter.vue
+++ b/src/components/submission/filters/submitter.vue
@@ -90,7 +90,7 @@ const update = (value) => {
 };
 
 const placeholder = (counts) => {
-  if (counts.total === counts.selected) return t('noSubmitterSelected');
+  if (counts.total === counts.selected) return t('allSubmitterSelected');
 
   return t('placeholder', counts);
 };
@@ -137,8 +137,8 @@ const placeholder = (counts) => {
       }
     },
     "unknown": "Unknown submitter",
-    // Text shown when no Submitter is selected in the filter
-    "noSubmitterSelected": "(none)"
+    // Text shown when all Submitters are selected in the filter
+    "allSubmitterSelected": "(All)"
   }
 }
 </i18n>

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -37,7 +37,7 @@ except according to the terms contained in the LICENSE file.
           v-model="selectedFields"/>
         </form>
         <button id="submission-list-refresh-button" type="button"
-          class="btn btn-outlined" :class="{ 'move-right': draft }" :aria-disabled="refreshing"
+          class="btn btn-outlined move-right" :aria-disabled="refreshing"
           @click="fetchChunk(false, true)">
           <span class="icon-refresh"></span>{{ $t('action.refresh') }}
           <spinner :state="refreshing"/>
@@ -553,10 +553,6 @@ export default {
   // the download button can wrap above the other actions if the viewport is not
   // wide enough.
   gap: 10px;
-
-  .field-dropdown-form {
-    margin-left: auto;
-  }
 }
 #submission-field-dropdown {
   // This is the entire spacing between the dropdown and the filters to its

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -4736,7 +4736,7 @@
     },
     "SubmissionFieldDropdown": {
       "placeholder": {
-        "string": "{count, plural, one {{selected} of {total} column shown} other {{selected} of {total} columns shown}}",
+        "string": "{selected} of {total}",
         "developer_comment": "This is the text of a dropdown that allows the user to select which columns to display in a table. {selected} is the number of columns selected; {total} is the total number of columns."
       },
       "field": {
@@ -4772,9 +4772,9 @@
           "developer_comment": "This is the text of a form field that allows the user to filter Submissions by a date range."
         }
       },
-      "noSubmissionDateSelected": {
-        "string": "(none)",
-        "developer_comment": "Text shown when no Submission date is selected in the filter"
+      "allSubmissionDateSelected": {
+        "string": "(All)",
+        "developer_comment": "Text shown when in Submission date filter when Submissions for all dates are shown"
       }
     },
     "SubmissionFiltersReviewState": {
@@ -4794,9 +4794,9 @@
           }
         }
       },
-      "noReviewStateSelected": {
-        "string": "(none)",
-        "developer_comment": "Text shown when no Review State is selected in the filter"
+      "allReviewStateSelected": {
+        "string": "(All)",
+        "developer_comment": "Text shown when all Review States are selected in the filter"
       }
     },
     "SubmissionFiltersSubmitter": {
@@ -4829,9 +4829,9 @@
       "unknown": {
         "string": "Unknown submitter"
       },
-      "noSubmitterSelected": {
-        "string": "(none)",
-        "developer_comment": "Text shown when no Submitter is selected in the filter"
+      "allSubmitterSelected": {
+        "string": "(All)",
+        "developer_comment": "Text shown when all Submitters are selected in the filter"
       }
     },
     "SubmissionList": {


### PR DESCRIPTION
Closes getodk/central#1047

![image](https://github.com/user-attachments/assets/3082554b-6d5b-440e-92b5-5f8ff7d7a7b7)

Besides changes requested in the issue, I have made the "type" dropdown on audits pages to open on click of label as well (not 100% true, actually dropdown is now bigger and label is on a upper z-index because we can't open select on the click of label - not even using JS). Also added custom icon-arrow for it, default looked different than the other filter arrow icon.

I also took the liberty to move column selected to the left, it was not aligning well with the refresh button after matching its style with other filters.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced