### PR TITLE
Modal CSS changes to change padding and remove gray bar

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -117,7 +117,7 @@ $padding-modal-header: 24px;
 $padding-modal-actions: 24px;
 $padding-modal-content-spacing: 16px;
 $border-radius-modal: 6px;
-$padding-modal-top-actions-close: 20px;
+$padding-modal-top-actions-close: 16px;
 
 // PageBody
 $margin-top-page-body: 20px;

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -112,11 +112,12 @@ $hpadding-feed-entry: 15px;
 $padding-file-drop-zone: 15px;
 
 // Modal
-$padding-modal-body: 40px;
-$padding-modal-header: 40px;
-$padding-modal-actions: 15px;
+$padding-modal-body: 24px;
+$padding-modal-header: 24px;
+$padding-modal-actions: 24px;
+$padding-modal-content-spacing: 16px;
 $border-radius-modal: 6px;
-$padding-modal-top-actions-close: 16px;
+$padding-modal-top-actions-close: 20px;
 
 // PageBody
 $margin-top-page-body: 20px;

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -274,7 +274,7 @@ const titleId = `modal-title${id}`;
       .close {
         position: absolute;
         // x symbol has some top spacing
-        top: calc($padding-modal-top-actions-close - 4px);
+        top: calc($padding-modal-top-actions-close - 2px);
         right: $padding-modal-top-actions-close;
         color: $color-input;
         font-weight: normal;

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -330,7 +330,7 @@ const titleId = `modal-title${id}`;
       }
 
       // Modal-actions are nested within the modal-body because they are
-      // defined by the defined by the specific modal in the body slot.
+      // defined by the specific modal in the body slot.
       .modal-actions {
         // Undo padding from body because modal-actions
         // are nested within modal-body

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -273,7 +273,8 @@ const titleId = `modal-title${id}`;
 
       .close {
         position: absolute;
-        top: $padding-modal-top-actions-close;
+        // x symbol has some top spacing
+        top: calc($padding-modal-top-actions-close - 4px);
         right: $padding-modal-top-actions-close;
         color: $color-input;
         font-weight: normal;
@@ -288,38 +289,71 @@ const titleId = `modal-title${id}`;
     .modal-header {
       border-bottom: 0px;
       color: $color-text;
-      padding: $padding-modal-header $padding-modal-header 20px $padding-modal-header;
+      padding: $padding-modal-header;
+      padding-bottom: $padding-modal-content-spacing;
 
       h4 {
         @include text-overflow-ellipsis;
         font-size: 18px;
         font-weight: bold;
-        letter-spacing: -0.02em;
+      }
+    }
+
+    .modal-body {
+      padding: $padding-modal-body;
+      padding-block: 0px;
+
+      // Only add padding below modal-introduction if not right
+      // above modal-action buttons
+      .modal-introduction:not(:has(+ .modal-actions)) {
+        margin-bottom: $padding-modal-content-spacing;
+      }
+
+      p {
+        max-width: 100%;
+        margin: 0 0 $padding-modal-content-spacing;
+
+        // If p is the last element or right before modal-actions, remove bottom spacing
+        &:last-child,
+        &:has(+ .modal-actions) {
+          margin-bottom: 0;
+        }
+      }
+
+      // When form-group (e.g. text input) is last thing in modal
+      // before buttons, remove extra spacing on bottom.
+      // (It will keep a bit of padding.)
+      .form-group {
+        &:has(+ .modal-actions) {
+        margin-bottom: 0px;
+        }
+      }
+
+      // Modal-actions are nested within the modal-body because they are
+      // defined by the defined by the specific modal in the body slot.
+      .modal-actions {
+        // Undo padding from body because modal-actions
+        // are nested within modal-body
+        margin-left: -$padding-modal-body;
+        margin-right: -$padding-modal-body;
+
+        background: white;
+        border-bottom-left-radius: 6px;
+        border-bottom-right-radius: 6px;
+        padding: $padding-modal-actions;
+        text-align: right;
       }
     }
   }
 }
 
-.modal-body {
-  padding: $padding-modal-body;
-  padding-block: 0px;
-}
-
+// Not sure which modal does not have actions
 .modal-body:not(:has(.modal-actions)) {
   padding-block-end: calc($padding-modal-body / 2);
 }
 
-.modal-actions {
-  background: $color-subpanel-background;
-  border-bottom-left-radius: 6px;
-  border-bottom-right-radius: 6px;
-  margin: -$padding-modal-body;
-  margin-top: $padding-modal-body;
-  padding: $padding-modal-actions;
-  text-align: right;
-}
-
 .modal-full {
+  // This is the space around the margin and the edge of the browser window
   $margin: 40px;
   // Because we set margin-left and width, we don't need to set margin-right.
   margin: $margin 0 $margin $margin;
@@ -343,10 +377,6 @@ const titleId = `modal-title${id}`;
   }
 }
 
-.modal-warnings, .modal-introduction, .modal-body .help-block {
-  line-height: 1.2;
-}
-
 .modal-warnings, .modal-introduction {
   ul {
     @include text-list;
@@ -364,6 +394,4 @@ const titleId = `modal-title${id}`;
     margin-bottom: 0;
   }
 }
-
-.modal-introduction { margin-bottom: 18px; }
 </style>

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -63,7 +63,7 @@ describe('Modal', () => {
       modal.emitted().shown.should.eql([[]]);
     });
 
-    it.skip('emits a resize event', () => {
+    it('emits a resize event', () => {
       const modal = mountComponent({
         props: { state: true },
         slots: {
@@ -71,7 +71,7 @@ describe('Modal', () => {
         },
         attachTo: document.body
       });
-      modal.emitted().resize.should.eql([[30]]);
+      modal.emitted().resize.should.eql([[10]]);
     });
   });
 
@@ -124,7 +124,7 @@ describe('Modal', () => {
       modal.should.alert();
     });
 
-    it.skip('emits a resize event', async () => {
+    it('emits a resize event', async () => {
       const modal = mountComponent({
         slots: {
           body: { template: '<div id="div" style="height: 10px;"></div>' }
@@ -132,11 +132,11 @@ describe('Modal', () => {
         attachTo: document.body
       });
       await modal.setProps({ state: false });
-      modal.emitted().resize.should.eql([[30], [0]]);
+      modal.emitted().resize.should.eql([[10], [0]]);
     });
   });
 
-  it.skip('emits a resize event after the height of the modal changes', async () => {
+  it('emits a resize event after the height of the modal changes', async () => {
     const modal = mountComponent({
       slots: {
         body: { template: '<div id="div" style="height: 10px;"></div>' }
@@ -145,7 +145,7 @@ describe('Modal', () => {
     });
     modal.get('#div').element.setAttribute('style', 'height: 20px;');
     await nextTick();
-    modal.emitted().resize.should.eql([[30], [40]]);
+    modal.emitted().resize.should.eql([[10], [20]]);
   });
 
   describe('mutation', () => {

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -63,7 +63,7 @@ describe('Modal', () => {
       modal.emitted().shown.should.eql([[]]);
     });
 
-    it('emits a resize event', () => {
+    it.skip('emits a resize event', () => {
       const modal = mountComponent({
         props: { state: true },
         slots: {
@@ -124,7 +124,7 @@ describe('Modal', () => {
       modal.should.alert();
     });
 
-    it('emits a resize event', async () => {
+    it.skip('emits a resize event', async () => {
       const modal = mountComponent({
         slots: {
           body: { template: '<div id="div" style="height: 10px;"></div>' }
@@ -136,7 +136,7 @@ describe('Modal', () => {
     });
   });
 
-  it('emits a resize event after the height of the modal changes', async () => {
+  it.skip('emits a resize event after the height of the modal changes', async () => {
     const modal = mountComponent({
       slots: {
         body: { template: '<div id="div" style="height: 10px;"></div>' }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1044

Before:
* modal body padding was 40px;
* modal actions bar padding was 15px and background was gray
* close button was about 16px from corner
* letter and line spacing was altered

After
* modal actions bar background is white
* padding around modal header, body, and action bar is consistent 24px
* close button is 16px from corner
* spacing between title and content, and some spacing between inner content, is 16px
* letter spacing is reset to default
* line spacing is reset (looks vertically spaced out)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced