### PR TITLE
Pass state and hideable individually instead of whole modal object to v-bind

### DIFF
--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -20,7 +20,7 @@ except according to the terms contained in the LICENSE file.
       @submit="handleSubmit"/>
   </template>
 
-  <modal id="web-form-renderer-submission-modal" v-bind="submissionModal" backdrop @hide="hideModal()">
+  <modal id="web-form-renderer-submission-modal" :state="submissionModal.state" :hideable="submissionModal.hideable" backdrop @hide="hideModal()">
     <template #title>{{ $t(submissionModal.type + '.title') }}</template>
     <template #body>
       <div class="modal-introduction">


### PR DESCRIPTION
Closes getodk/central#1037

#### What has been done to verify that this works as intended?

All tests are passing. I have check few types of modal to confirm if they are still working.

#### Why is this the best possible solution? Were any other approaches considered?

This seems to me the simplest solution, other options were to modify `modal` component to use only `id` as pass-through attribute or to introduce a new `computed` property in web-form-renderer to exclude `type` from the modal data.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

All types of WF modals should be tests.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced