### PR TITLE
Expand entity properties by default on edit form page

### DIFF
--- a/src/components/dataset/summary/row.vue
+++ b/src/components/dataset/summary/row.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <expandable-row class="dataset-summary-row">
+  <expandable-row class="dataset-summary-row" initially-expanded>
     <template #title>
       <div class="dataset-name-wrap">
         <div class="dataset-name">

--- a/src/components/expandable-row.vue
+++ b/src/components/expandable-row.vue
@@ -40,7 +40,7 @@ defineOptions({
   name: 'ExpandableRow'
 });
 
-const expanded = ref(false);
+const expanded = ref(true);
 const toggleExpanded = () => { expanded.value = !expanded.value; };
 </script>
 

--- a/src/components/expandable-row.vue
+++ b/src/components/expandable-row.vue
@@ -40,7 +40,14 @@ defineOptions({
   name: 'ExpandableRow'
 });
 
-const expanded = ref(true);
+const props = defineProps({
+  initiallyExpanded: {
+    type: Boolean,
+    default: false
+  },
+});
+
+const expanded = ref(props.initiallyExpanded);
 const toggleExpanded = () => { expanded.value = !expanded.value; };
 </script>
 

--- a/test/components/expandable-row.spec.js
+++ b/test/components/expandable-row.spec.js
@@ -34,24 +34,24 @@ describe('ExpandableRow', () => {
     component.get('.caption-cell').text().should.be.equal('2 of 10 properties');
   });
 
-  it('is not expanded initially', () => {
-    component.get('.expanded-row').should.be.hidden();
-  });
-
-  it('expands details', async () => {
-    await component.get('.button-cell button').trigger('click');
+  it('is expanded initially', () => {
     component.get('.expanded-row').should.be.visible();
-    component.get('.expanded-row').text().should.be.eql('height, type');
   });
 
   it('collapses details', async () => {
-    // expand
     await component.get('.button-cell button').trigger('click');
-    component.get('.expanded-row').should.be.visible();
+    component.get('.expanded-row').should.be.hidden();
     component.get('.expanded-row').text().should.be.eql('height, type');
+  });
 
+  it('expands details', async () => {
     // collapse
     await component.get('.button-cell button').trigger('click');
     component.get('.expanded-row').should.be.hidden();
+    component.get('.expanded-row').text().should.be.eql('height, type');
+
+    // expand
+    await component.get('.button-cell button').trigger('click');
+    component.get('.expanded-row').should.be.visible();
   });
 });

--- a/test/components/expandable-row.spec.js
+++ b/test/components/expandable-row.spec.js
@@ -34,24 +34,24 @@ describe('ExpandableRow', () => {
     component.get('.caption-cell').text().should.be.equal('2 of 10 properties');
   });
 
-  it('is expanded initially', () => {
-    component.get('.expanded-row').should.be.visible();
-  });
-
-  it('collapses details', async () => {
-    await component.get('.button-cell button').trigger('click');
+  it('is not expanded initially', () => {
     component.get('.expanded-row').should.be.hidden();
-    component.get('.expanded-row').text().should.be.eql('height, type');
   });
 
   it('expands details', async () => {
-    // collapse
     await component.get('.button-cell button').trigger('click');
-    component.get('.expanded-row').should.be.hidden();
+    component.get('.expanded-row').should.be.visible();
     component.get('.expanded-row').text().should.be.eql('height, type');
+  });
 
+  it('collapses details', async () => {
     // expand
     await component.get('.button-cell button').trigger('click');
     component.get('.expanded-row').should.be.visible();
+    component.get('.expanded-row').text().should.be.eql('height, type');
+
+    // collapse
+    await component.get('.button-cell button').trigger('click');
+    component.get('.expanded-row').should.be.hidden();
   });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1055

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced