### PR TITLE
Update tab icon for Edit Form page

### DIFF
--- a/src/components/form/head.vue
+++ b/src/components/form/head.vue
@@ -65,11 +65,11 @@ except according to the terms contained in the LICENSE file.
             </span>
           </router-link>
         </li>
-        <li v-if="canRoute(tabPath('draft'))" :class="tabClass('draft')"
-          role="presentation">
+        <li v-if="canRoute(tabPath('draft'))" id="form-head-draft-tab"
+          :class="tabClass('draft')" role="presentation">
           <router-link :to="tabPath('draft')">
-            {{ $t('formHead.tab.editForm') }}
-            <span class="icon-pencil-square"></span>
+            <span>{{ $t('formHead.tab.editForm') }}</span>
+            <span class="icon-pencil"></span>
           </router-link>
         </li>
         <li :class="formTabClass('versions')" role="presentation">
@@ -154,17 +154,16 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../assets/scss/variables';
+#form-head-draft-tab {
+  a {
+    align-items: center;
+    column-gap: 5px;
+    display: flex;
+  }
 
-#form-head {
-  .icon-pencil-square {
-    color: $color-accent-primary;
-    font-size: 18px;
-    margin-left: 3px;
-
-    vertical-align: bottom;
-    position: relative;
-    bottom: 1px;
+  .icon-pencil {
+    color: #555;
+    font-size: 16px;
   }
 }
 </style>


### PR DESCRIPTION
This PR closes getodk/central#1053:

- It uses `icon-pencil` instead of `icon-pencil-square`.
- It makes the icon gray instead of magenta.

#### What has been done to verify that this works as intended?

I tried it out locally.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced