### PR TITLE
Correctly position FormAttachmentPopups in wide viewport

### DIFF
--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -157,7 +157,6 @@ export default {
 </script>
 
 <style lang="scss">
-@use 'sass:math';
 @import '../../assets/scss/variables';
 
 $z-index-backdrop: 1;

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -173,7 +173,7 @@ $popup-width: 300px;
 #form-attachment-popups-main {
   bottom: $edge-offset;
   position: fixed;
-  right: calc($edge-offset + max(50% - #{math.div($max-width-page-body, 2)}, 0px));
+  right: $edge-offset;
   width: $popup-width;
   z-index: $z-index-main;
 


### PR DESCRIPTION
Closes getodk/central#964.

#### What has been done to verify that this works as intended?

One thing that was telling to me was that I could only reproduce the issue when my viewport was wide. When my window was smaller and not full-screen, I saw that the popup was at the bottom-right as expected.

I tried out this change locally. With this change, I'm no longer able to reproduce the issue.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced