### PR TITLE
Increase z-index in FormAttachmentPopups

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -21,6 +21,9 @@ $screen-sm-min: 768px;
 $screen-md-min: 992px;
 $screen-lg-min: 1200px;
 
+$z-index-modal: 1050;
+$z-index-modal-backdrop: 1040;
+
 // Text
 $color-text: #333;
 $font-family-monospace: Monaco, Menlo, Consolas, "Courier New", monospace;

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -160,9 +160,6 @@ export default {
 @use 'sass:math';
 @import '../../assets/scss/variables';
 
-$z-index-backdrop: 1;
-$z-index-main: $z-index-backdrop + 1;
-
 $edge-offset: 25px;
 $popup-width: 300px;
 
@@ -175,7 +172,7 @@ $popup-width: 300px;
   position: fixed;
   right: calc($edge-offset + max(50% - #{math.div($max-width-page-body, 2)}, 0px));
   width: $popup-width;
-  z-index: $z-index-main;
+  z-index: $z-index-modal;
 
   &.modal-content {
     border-radius: 0px;
@@ -255,7 +252,7 @@ $popup-width: 300px;
   position: fixed;
   right: 0;
   top: 0;
-  z-index: $z-index-backdrop;
+  z-index: $z-index-modal-backdrop;
 }
 
 @keyframes bob {


### PR DESCRIPTION
Closes getodk/central#955.

#### What has been done to verify that this works as intended?

I tried it out locally.

#### Why is this the best possible solution? Were any other approaches considered?

Previously, `FormAttachmentPopups` set `z-index` to as small a value as possible. It didn't need to be higher, so it wasn't. However, now that the page in which the component is shown includes other elements with a `z-index`, the `z-index` in `FormAttachmentPopups` needs to be higher. Specifically:

- `TableFreeze` sets `z-index: 1;`
- `.form-group .form-control` sets `z-index: 1;`

These elements weren't present on the page before.

I've increased the `z-index` to much higher, to match the `z-index` used in modals.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced