### PR TITLE
Change attachment popup title and buttons

### DIFF
--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -180,6 +180,7 @@ $popup-width: 300px;
   .dialog-header {
     padding: 15px;
     background-color: $color-action-background;
+    color: #fff;
 
     .icon-cloud-upload {
       animation-direction: alternate;

--- a/src/components/form-attachment/popups.vue
+++ b/src/components/form-attachment/popups.vue
@@ -56,14 +56,14 @@ some point. -->
                 </template>
               </i18n-t>
             </p>
-            <p>
-              <button type="button" class="btn btn-primary"
-                @click="$emit('confirm')">
-                {{ $t('action.looksGood') }}
-              </button>
+            <p class="modal-actions">
               <button type="button" class="btn btn-link"
                 @click="$emit('cancel')">
                 {{ $t('action.cancel') }}
+              </button>
+              <button type="button" class="btn btn-primary"
+                @click="$emit('confirm')">
+                {{ $t('action.looksGood') }}
               </button>
             </p>
           </template>
@@ -71,7 +71,7 @@ some point. -->
             <p>
               {{ $tc('afterSelection.noneMatched', unmatchedFiles.length) }}
             </p>
-            <p>
+            <p class="modal-actions">
               <button type="button" class="btn btn-primary"
                 @click="$emit('cancel')">
                 {{ $t('action.ok') }}
@@ -240,6 +240,10 @@ $popup-width: 300px;
         margin-top: 1px;
         position: absolute;
       }
+    }
+
+    .modal-actions {
+      text-align: right;
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1060

The title definitely changed from white to dark in PR #1181 when the modal title went from white on color to black on white. This changes it back for this specific type of popup.

See screenshots of buttons being reordered and repositioned to the left.

<img width="323" alt="Screenshot 2025-05-13 at 4 21 26 PM" src="https://github.com/user-attachments/assets/f8b55a44-bd92-4b43-9442-fb4e95e29f84" />
<img width="325" alt="Screenshot 2025-05-13 at 4 17 54 PM" src="https://github.com/user-attachments/assets/49348aaf-9ebe-45f2-aa06-b3617a62584d" />
<img width="329" alt="Screenshot 2025-05-13 at 4 19 39 PM" src="https://github.com/user-attachments/assets/f6f76169-0f2c-4b5e-8b20-08f11bd38959" />



<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced