### PR TITLE
Enable buttons to preview/fill form if Web Forms is enabled

### DIFF
--- a/src/components/enketo/fill.vue
+++ b/src/components/enketo/fill.vue
@@ -41,6 +41,7 @@ export default {
   },
   computed: {
     disabledDescription() {
+      if (this.formVersion.webformsEnabled) return null;
       if (this.formVersion.publishedAt != null &&
         this.formVersion.state !== 'open')
         return this.$t('disabled.notOpen');

--- a/src/components/enketo/preview.vue
+++ b/src/components/enketo/preview.vue
@@ -10,16 +10,16 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <a v-if="disabledDescription == null" :class="enketoClass" :href="enketoPath"
+  <a v-if="disabledDescription == null" class="enketo-preview btn" :class="btnClass" :href="previewPath"
     target="_blank">
     <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </a>
-  <button v-else type="button" :class="enketoClass" aria-disabled="true"
+  <button v-else type="button" class="enketo-preview btn" :class="btnClass" aria-disabled="true"
     v-tooltip.aria-describedby="disabledDescription">
     <span class="icon-eye"></span>{{ $t('action.showPreview') }}
   </button>
 
-  <router-link class="btn btn-default btn-web-form" :to="webFormsPath"
+  <router-link class="btn btn-web-form" :class="btnClass" :to="webFormsPath"
     target="_blank">
     <span class="icon-eye"></span>{{ $t('action.newPreview') }}
   </router-link>
@@ -44,6 +44,7 @@ export default {
   },
   computed: {
     disabledDescription() {
+      if (this.formVersion.webformsEnabled) return null;
       if (this.formVersion.publishedAt != null &&
         this.formVersion.state !== 'open')
         return this.$t('disabled.notOpen');
@@ -51,12 +52,10 @@ export default {
         return this.$t('disabled.processing');
       return null;
     },
-    enketoClass() {
-      const result = ['enketo-preview', 'btn'];
-      result.push(this.outlined ? 'btn-outlined' : 'btn-default');
-      return result;
+    btnClass() {
+      return this.outlined ? 'btn-outlined' : 'btn-default';
     },
-    enketoPath() {
+    previewPath() {
       return this.formPreviewPath(
         this.formVersion.projectId,
         this.formVersion.xmlFormId,

--- a/test/components/enketo/fill.spec.js
+++ b/test/components/enketo/fill.spec.js
@@ -3,22 +3,22 @@ import EnketoFill from '../../../src/components/enketo/fill.vue';
 import TestUtilSpan from '../../util/components/span.vue';
 
 import testData from '../../data';
-import { mount } from '../../util/lifecycle';
+import { mergeMountOptions, mount } from '../../util/lifecycle';
 import { mockRouter } from '../../util/router';
 
-const container = {
-  router: mockRouter()
-};
+const mountComponent = (options) =>
+  mount(EnketoFill, mergeMountOptions(options, {
+    slots: { default: TestUtilSpan },
+    container: { router: mockRouter() }
+  }));
 
 describe('EnketoFill', () => {
   it('renders correctly for an open form with an enketoId', () => {
     const form = testData.extendedForms
       .createPast(1, { enketoId: 'xyz', state: 'open' })
       .last();
-    const button = mount(EnketoFill, {
+    const button = mountComponent({
       props: { formVersion: form },
-      slots: { default: TestUtilSpan },
-      container
     });
     button.element.tagName.should.equal('A');
     button.attributes().href.should.equal('/projects/1/forms/f/submissions/new');
@@ -29,10 +29,8 @@ describe('EnketoFill', () => {
     const form = testData.extendedForms
       .createPast(1, { enketoId: null, state: 'open' })
       .last();
-    const button = mount(EnketoFill, {
+    const button = mountComponent({
       props: { formVersion: form },
-      slots: { default: TestUtilSpan },
-      container
     });
     button.element.tagName.should.equal('BUTTON');
     button.attributes('aria-disabled').should.equal('true');
@@ -46,10 +44,8 @@ describe('EnketoFill', () => {
       const form = testData.extendedForms
         .createPast(1, { enketoId: 'xyz', state: 'closing' })
         .last();
-      const button = mount(EnketoFill, {
+      const button = mountComponent({
         props: { formVersion: form },
-        slots: { default: TestUtilSpan },
-        container
       });
       button.element.tagName.should.equal('BUTTON');
       button.should.have.ariaDescription('This Form is not accepting new Submissions right now.');
@@ -63,12 +59,22 @@ describe('EnketoFill', () => {
         state: 'closing'
       });
       const draft = testData.extendedFormDrafts.last();
-      const button = mount(EnketoFill, {
+      const button = mountComponent({
         props: { formVersion: draft },
-        slots: { default: TestUtilSpan },
-        container
       });
       button.element.tagName.should.equal('A');
     });
+  });
+
+  it('does not disable the button if Web Forms is enabled', () => {
+    // The form is not open and also does not have an enketoId. Yet since Web
+    // Forms is enabled, it should not be disabled.
+    const form = testData.extendedForms
+      .createPast(1, { enketoId: null, state: 'closing', webformsEnabled: true })
+      .last();
+    const button = mountComponent({
+      props: { formVersion: form }
+    });
+    button.element.tagName.should.equal('A');
   });
 });

--- a/test/components/enketo/fill.spec.js
+++ b/test/components/enketo/fill.spec.js
@@ -68,7 +68,7 @@ describe('EnketoFill', () => {
 
   it('does not disable the button if Web Forms is enabled', () => {
     // The form is not open and also does not have an enketoId. Yet since Web
-    // Forms is enabled, it should not be disabled.
+    // Forms is enabled, the button should not be disabled.
     const form = testData.extendedForms
       .createPast(1, { enketoId: null, state: 'closing', webformsEnabled: true })
       .last();

--- a/test/components/enketo/preview.spec.js
+++ b/test/components/enketo/preview.spec.js
@@ -66,7 +66,7 @@ describe('EnketoPreview', () => {
 
   it('does not disable the button if Web Forms is enabled', () => {
     // The form is not open and also does not have an enketoId. Yet since Web
-    // Forms is enabled, it should not be disabled.
+    // Forms is enabled, the button should not be disabled.
     const form = testData.extendedForms
       .createPast(1, { enketoId: null, state: 'closing', webformsEnabled: true })
       .last();

--- a/test/components/enketo/preview.spec.js
+++ b/test/components/enketo/preview.spec.js
@@ -63,4 +63,16 @@ describe('EnketoPreview', () => {
       component.get('.enketo-preview').element.tagName.should.equal('A');
     });
   });
+
+  it('does not disable the button if Web Forms is enabled', () => {
+    // The form is not open and also does not have an enketoId. Yet since Web
+    // Forms is enabled, it should not be disabled.
+    const form = testData.extendedForms
+      .createPast(1, { enketoId: null, state: 'closing', webformsEnabled: true })
+      .last();
+    const component = mountComponent({
+      props: { formVersion: form }
+    });
+    component.get('.enketo-preview').element.tagName.should.equal('A');
+  });
 });


### PR DESCRIPTION
Right now, `EnketoPreview` and `EnketoFill` are disabled if the form doesn't have an `enketoId`. That's true even if `webformsEnabled` is `true`, in which case `enketoId` isn't needed. This PR changes it so that `EnketoPreview` and `EnketoFill` are never disabled when `webformsEnabled` is `true`. See getodk/central#1065.

Note that because `WebFormRenderer` uses the REST API instead of OpenRosa, we also don't need to check the form state. The buttons don't need to be disabled if the form is closed or closing.

#### What has been done to verify that this works as intended?

New tests. I also tried it out locally by changing a form's state to closing. I was able to preview and fill the form using Web Forms.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced