### PR TITLE
Link Edit button in SubmissionActivity to ODK Web Forms

### DIFF
--- a/src/components/submission/activity.vue
+++ b/src/components/submission/activity.vue
@@ -58,7 +58,7 @@ import PageSection from '../page/section.vue';
 import SubmissionComment from './comment.vue';
 import SubmissionFeedEntry from './feed-entry.vue';
 
-import { apiPaths } from '../../util/request';
+import useRoutes from '../../composables/routes';
 import { useRequestData } from '../../request-data';
 
 export default {
@@ -82,18 +82,22 @@ export default {
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.
-    const { project, submission, audits, comments, diffs, fields, resourceStates } = useRequestData();
+    const { project, form, submission, audits, comments, diffs, fields, resourceStates } = useRequestData();
+    const { editSubmissionPath } = useRoutes();
     return {
-      project, submission, audits, comments, diffs, fields,
-      ...resourceStates([audits, comments, diffs, fields])
+      project, form, submission, audits, comments, diffs, fields,
+      ...resourceStates([audits, comments, diffs, fields]),
+      editSubmissionPath
     };
   },
   computed: {
     editPath() {
-      return apiPaths.editSubmission(
+      if (!this.form.dataExists) return null;
+      return this.editSubmissionPath(
         this.projectId,
         this.xmlFormId,
-        this.instanceId
+        this.instanceId,
+        this.form.webformsEnabled
       );
     },
     feed() {

--- a/src/components/submission/metadata-row.vue
+++ b/src/components/submission/metadata-row.vue
@@ -88,7 +88,6 @@ import SubmissionReviewState from './review-state.vue';
 
 import { useRequestData } from '../../request-data';
 import useRoutes from '../../composables/routes';
-import { apiPaths } from '../../util/request';
 
 export default {
   name: 'SubmissionMetadataRow',
@@ -123,8 +122,8 @@ export default {
   },
   setup() {
     const { form } = useRequestData();
-    const { submissionPath } = useRoutes();
-    return { form, submissionPath };
+    const { submissionPath, editSubmissionPath } = useRoutes();
+    return { form, submissionPath, editSubmissionPath };
   },
   computed: {
     missingAttachment() {
@@ -133,15 +132,11 @@ export default {
         __system.attachmentsPresent !== __system.attachmentsExpected;
     },
     editPath() {
-      if (this.form.webformsEnabled) {
-        return this.submissionPath(this.projectId, this.xmlFormId, this.submission.__id, 'edit');
-      }
-      // Although we now have canonical path to edit submission, we still need to go through backend
-      // if Enketo is enable to provide Enketo with submission data
-      return apiPaths.editSubmission(
+      return this.editSubmissionPath(
         this.projectId,
         this.xmlFormId,
-        this.submission.__id
+        this.submission.__id,
+        this.form.webformsEnabled
       );
     },
     editLabel() {

--- a/src/composables/routes.js
+++ b/src/composables/routes.js
@@ -14,6 +14,7 @@ except according to the terms contained in the LICENSE file.
 
 import { useRoute } from 'vue-router';
 
+import { apiPaths } from '../util/request';
 import { canRoute } from '../util/router';
 import { memoizeForContainer } from '../util/composable';
 
@@ -116,6 +117,14 @@ export default memoizeForContainer(({ router, requestData }) => {
     }
     return result;
   };
+  const editSubmissionPath = (projectId, xmlFormId, instanceId, webformsEnabled) => {
+    if (webformsEnabled) {
+      return submissionPath(projectId, xmlFormId, instanceId, 'edit');
+    }
+    // Although we now have canonical path to edit submission, we still need to go through backend
+    // if Enketo is enable to provide Enketo with submission data
+    return apiPaths.editSubmission(projectId, xmlFormId, instanceId);
+  };
 
   const datasetPath = (projectIdOrSuffix, datasetName, suffix) => {
     if (datasetName == null) {
@@ -135,7 +144,7 @@ export default memoizeForContainer(({ router, requestData }) => {
   return {
     projectPath,
     formPath, publishedFormPath, primaryFormPath, formPreviewPath,
-    submissionPath, newSubmissionPath, offlineSubmissionPath,
+    submissionPath, newSubmissionPath, offlineSubmissionPath, editSubmissionPath,
     datasetPath,
     entityPath,
     userPath,

--- a/test/components/submission/activity.spec.js
+++ b/test/components/submission/activity.spec.js
@@ -31,7 +31,7 @@ const mountComponent = () => {
       router: mockRouter('/projects/1/submissions/s'),
       requestData: testRequestData(
         [useSubmission, useFields],
-        { project, submission, audits, comments, diffs, fields }
+        { project, form, submission, audits, comments, diffs, fields }
       )
     }
   });

--- a/test/composables/routes.spec.js
+++ b/test/composables/routes.spec.js
@@ -107,6 +107,22 @@ describe('useRoutes()', () => {
     });
   });
 
+  describe('editSubmissionPath()', () => {
+    it('returns the correct path if webformsEnabled is true', () => {
+      const container = createTestContainer({ router: mockRouter('/') });
+      const { editSubmissionPath } = withSetup(useRoutes, { container });
+      const path = editSubmissionPath(1, 'a b', 'c d', true);
+      path.should.equal('/projects/1/forms/a%20b/submissions/c%20d/edit');
+    });
+
+    it('returns the correct path if webformsEnabled is false', () => {
+      const container = createTestContainer({ router: mockRouter('/') });
+      const { editSubmissionPath } = withSetup(useRoutes, { container });
+      const path = editSubmissionPath(1, 'a b', 'c d', false);
+      path.should.equal('/v1/projects/1/forms/a%20b/submissions/c%20d/edit');
+    });
+  });
+
   describe('datasetPath()', () => {
     it('returns a path if given three arguments', () => {
       const container = createTestContainer({ router: mockRouter('/') });


### PR DESCRIPTION
This PR addresses https://github.com/getodk/central-frontend/pull/1258#issuecomment-2885022176. If ODK Web Forms is enabled for a form, then the Edit button in the submissions table will link to the Web Form. However, the Edit button on the submission details page still links to Backend, which redirects to Enketo. The redirects actually end up working out: as far as I can tell, you can still use the Edit button on the submission details page to edit a submission in Web Forms. However, I think it makes sense to make the two buttons consistent and to cut out the unneeded request to Backend and the subsequent redirects.

#### What has been done to verify that this works as intended?

I wrote tests of a new function. I also tried it out locally.

#### Why is this the best possible solution? Were any other approaches considered?

My approach is to add the function `editSubmissionPath()` to the `useRoutes()` composable. If `webformsEnabled` is `true`, the function will send the user to ODK Web Forms, staying within Frontend. If it is `false`, it will link to Backend. It's a little unusual for a function in `useRoutes()` to link to Backend, but I think it makes sense in this case. My main goal is to centralize the logic in a single place and not duplicate it between `SubmissionMetadataRow` and `SubmissionActivity`.

I considered adding a component to do this. It would be something similar to `EnketoFill` or `EnketoPreview`. However, that felt like more than what was needed in this case. Unlike `EnketoFill` or `EnketoPreview`, we never disable the Edit button.

I also thought about always linking to `FormSubmission`, then having `FormSubmission` redirect to the Backend link as needed. However, I think that just adds complexity and another layer of redirecting.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced