### PR TITLE
Prevent Data Collector from navigating to ODK Web Forms for closing form

### DIFF
--- a/src/components/form/submission.vue
+++ b/src/components/form/submission.vue
@@ -137,7 +137,7 @@ const hasAccess = computed(() => {
   if (!project.permits('form.read') && !project.permits('open_form.read'))
     result = false;
 
-  if (!project.permits('form.read') && project.permits('open_form.read') && form.state === 'closed')
+  if (!project.permits('form.read') && project.permits('open_form.read') && form.state !== 'open')
     result = false;
 
   return result;

--- a/test/components/form/submission.spec.js
+++ b/test/components/form/submission.spec.js
@@ -112,6 +112,15 @@ describe('FormSubmission', () => {
           });
       });
 
+      it('cannot access new submission page if form is closing', async () => {
+        testData.extendedForms.createPast(1, { xmlFormId: 'b', webformsEnabled: true, state: 'closing' });
+        await load('/projects/1/forms/b/submissions/new', mountOptions())
+          .respondFor('/', { users: false })
+          .afterResponses(app => {
+            app.vm.$route.path.should.equal('/');
+          });
+      });
+
       it('cannot access edit submission page', () =>
         load('/projects/1/forms/a/submissions/1/edit', mountOptions())
           .respondFor('/', { users: false })


### PR DESCRIPTION
- Right now, if I’m a Data Collector, and the form I fill regularly is in the closing state, I won’t see a button in Central to fill the form. Instead, I’ll see an indication that the form is in the closing state. (This happens in the `FormRow` component.)
- However, if the form uses ODK Web Forms, and I navigate directly to the form (e.g., because I bookmarked the URL), I will be able to fill the form and submit it.
- This is different from how things work in Enketo. If you navigate directly to a closing form that uses Enketo, Enketo will show an error.

@lognaturel wrote on Slack about the closing form state:

> The idea is that an offline client can stop showing the blank form but any pending submissions can still be sent. Doesn’t work at all with a single-screen online client. So yeah, I think for now WF can treat it the same as closed.

#### What has been done to verify that this works as intended?

New test.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced