### PR TITLE
Add CTA to toasts

### DIFF
--- a/src/alert.js
+++ b/src/alert.js
@@ -12,43 +12,63 @@ except according to the terms contained in the LICENSE file.
 import { shallowReactive } from 'vue';
 
 class AlertData {
+  #data;
+
   constructor() {
-    this._data = shallowReactive({
+    this.#data = shallowReactive({
       // The alert's "contextual" type: 'success', 'info', 'warning', or
       // 'danger'.
       type: 'danger',
       message: null,
       // `true` if the alert should be visible and `false` if not.
       state: false,
-      // The time at which the alert was last set
-      at: new Date()
+      // The time at which the alert was last shown
+      at: new Date(),
+      // Information about the Call to Action (CTA) button that's shown in the
+      // alert
+      cta: null
     });
   }
 
-  get type() { return this._data.type; }
-  get message() { return this._data.message; }
-  get state() { return this._data.state; }
-  get at() { return this._data.at; }
+  get type() { return this.#data.type; }
+  get message() { return this.#data.message; }
+  get state() { return this.#data.state; }
+  get at() { return this.#data.at; }
+  get ctaText() { return this.#data.cta?.text; }
+  get ctaHandler() { return this.#data.cta?.handler; }
 
-  _set(type, message) {
-    this._data.type = type;
-    this._data.message = message;
-    this._data.state = true;
-    this._data.at = new Date();
+  #show(type, message) {
+    Object.assign(this.#data, {
+      type,
+      message,
+      state: true,
+      at: new Date(),
+      cta: null
+    });
+    // Return the alert object for chaining.
+    return this;
   }
 
-  success(message) { this._set('success', message); }
-  info(message) { this._set('info', message); }
-  warning(message) { this._set('warning', message); }
-  danger(message) { this._set('danger', message); }
+  success(message) { return this.#show('success', message); }
+  info(message) { return this.#show('info', message); }
+  warning(message) { return this.#show('warning', message); }
+  danger(message) { return this.#show('danger', message); }
+
+  // `text` is the text of the CTA. `handler` is a function to call when the
+  // user clicks the CTA.
+  cta(text, handler) { this.#data.cta = { text, handler }; }
 
   blank() {
-    this._data.state = false;
-    this._data.message = null;
+    this.#data.state = false;
+    this.#data.message = null;
+    this.#data.cta = null;
   }
 }
 
-// Only a single alert is shown at a time. This function returns an object that
-// manages the data for the alert. Regardless of where an alert is rendered, its
-// data will be stored in this object.
-export default () => new AlertData();
+// Returns an object to manage the reactive data for the toast, which is called
+// the "alert" in the codebase. Only a single alert is shown at a time. It may
+// be shown at the top of the page or in a modal. Regardless of where the alert
+// is shown, its data will be stored in this object.
+const createAlert = () => new AlertData();
+
+export default createAlert;

--- a/src/components/account/login.vue
+++ b/src/components/account/login.vue
@@ -64,7 +64,7 @@ import { useRequestData } from '../../request-data';
 export default {
   name: 'AccountLogin',
   components: { FormGroup, Spinner },
-  inject: ['container', 'alert', 'config'],
+  inject: ['container', 'alert', 'config', 'location'],
   beforeRouteLeave() {
     return !this.disabled;
   },
@@ -105,7 +105,10 @@ export default {
       const sessionExpires = localStore.getItem('sessionExpires');
       const newSession = sessionExpires == null ||
         Number.parseInt(sessionExpires, 10) < Date.now();
-      if (!newSession) this.alert.info(this.$t('alert.alreadyLoggedIn'));
+      if (!newSession) {
+        this.alert.info(this.$t('alert.alreadyLoggedIn'))
+          .cta(this.$t('action.refresh'), () => { this.location.reload(); });
+      }
       return newSession;
     },
     loginByOIDC(event) {

--- a/src/components/alert.vue
+++ b/src/components/alert.vue
@@ -17,6 +17,10 @@ except according to the terms contained in the LICENSE file.
       <span aria-hidden="true">&times;</span>
     </button>
     <span class="alert-message">{{ alert.message }}</span>
+    <button v-if="alert.ctaText != null" type="button"
+      class="alert-cta btn btn-default" @click="alert.ctaHandler">
+      {{ alert.ctaText }}
+    </button>
   </div>
 </template>
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -59,7 +59,7 @@ export default {
     FeedbackButton: defineAsyncComponent(loadAsync('FeedbackButton')),
     OutdatedVersion: defineAsyncComponent(loadAsync('OutdatedVersion'))
   },
-  inject: ['alert', 'config'],
+  inject: ['alert', 'config', 'location'],
   setup() {
     const { visiblyLoggedIn } = useSessions();
     useDisabled();
@@ -113,7 +113,10 @@ export default {
           // even if there is another alert (say, about session expiration).
           this.callWait(
             'alertVersionChange',
-            () => { this.alert.info(this.$t('alert.versionChange')); },
+            () => {
+              this.alert.info(this.$t('alert.versionChange'))
+                .cta(this.$t('action.refreshPage'), () => { this.location.reload(); });
+            },
             (count) => (count === 0 ? 0 : 60000)
           );
           return true;

--- a/src/components/async-route.vue
+++ b/src/components/async-route.vue
@@ -32,7 +32,7 @@ import { noop } from '../util/util';
 export default {
   name: 'AsyncRoute',
   components: { Loading, PageBody },
-  inject: ['alert'],
+  inject: ['alert', 'location'],
   inheritAttrs: false,
   // See routes.js for more information about these props.
   props: {
@@ -118,7 +118,8 @@ export default {
             // example, if there is a 404 because Frontend was rebuilt, the
             // resulting error is a ChunkLoadError with a `type` property equal
             // to 'error'.
-            this.alert.danger(this.$t('alert.loadError'));
+            this.alert.danger(this.$t('alert.loadError'))
+              .cta(this.$t('action.refresh'), () => { this.location.reload(); });
             this.showsLoading = false;
           }
         });

--- a/src/container.js
+++ b/src/container.js
@@ -26,6 +26,7 @@ const provide = [
   'unsavedChanges',
   'config',
   'http',
+  'location',
   'logger'
 ];
 

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -201,6 +201,7 @@
     "proceed": "Proceed",
     // This is the text of a button that refreshes data.
     "refresh": "Refresh",
+    "refreshPage": "Refresh page",
     "resetPassword": "Reset password",
     "review": "Review",
     // @transifexKey component.EntityMetadataRow.reviewParallelUpdates

--- a/src/util/session.js
+++ b/src/util/session.js
@@ -82,7 +82,7 @@ const removeSessionFromStorage = () => {
   localStore.removeItem('sessionExpires');
 };
 
-const requestLogout = ({ i18n, alert, http }) => http.delete(apiPaths.currentSession())
+const requestLogout = ({ i18n, alert, http, location }) => http.delete(apiPaths.currentSession())
   .catch(error => {
     // logOutBeforeSessionExpires() and logOutAfterStorageChange() may try to
     // log out a session that has already been logged out. That will result in
@@ -96,6 +96,7 @@ const requestLogout = ({ i18n, alert, http }) => http.delete(apiPaths.currentSes
     alert.danger(i18n.t('util.session.alert.logoutError', {
       message: requestAlertMessage(i18n, error)
     }));
+    alert.cta(i18n.t('action.refresh'), () => { location.reload(); });
     throw error;
   });
 

--- a/test/alert.spec.js
+++ b/test/alert.spec.js
@@ -1,4 +1,5 @@
 import createAlert from '../src/alert';
+import { noop } from '../src/util/util';
 
 describe('createAlert()', () => {
   for (const type of ['success', 'info', 'warning', 'danger']) {
@@ -13,13 +14,31 @@ describe('createAlert()', () => {
     });
   }
 
+  describe('cta()', () => {
+    it('updates the data', () => {
+      const alert = createAlert();
+      should.not.exist(alert.ctaText);
+      should.not.exist(alert.ctaHandler);
+
+      alert.info('Something happened!');
+      should.not.exist(alert.ctaText);
+      should.not.exist(alert.ctaHandler);
+
+      alert.cta('Click here', noop);
+      alert.ctaText.should.equal('Click here');
+      alert.ctaHandler.should.equal(noop);
+    });
+  });
+
   describe('blank()', () => {
     it('updates the data', () => {
       const alert = createAlert();
-      alert.info('Something happened!');
+      alert.info('Something happened!').cta('Click here', noop);
       alert.blank();
       alert.state.should.be.false;
       should.not.exist(alert.message);
+      should.not.exist(alert.ctaText);
+      should.not.exist(alert.ctaHandler);
     });
   });
 });

--- a/test/components/alert.spec.js
+++ b/test/components/alert.spec.js
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+
 import Alert from '../../src/components/alert.vue';
 
 import createTestContainer from '../util/container';
@@ -18,6 +20,17 @@ describe('Alert', () => {
 
   it('adds a contextual class', () => {
     mountComponent().classes('alert-info').should.be.true;
+  });
+
+  it('shows the CTA button', async () => {
+    const container = createTestContainer();
+    const { alert } = container;
+    const fake = sinon.fake();
+    alert.info('Something happened!').cta('Click here', fake);
+    const button = mount(Alert, { container }).get('.alert-cta');
+    button.text().should.equal('Click here');
+    await button.trigger('click');
+    fake.called.should.be.true;
   });
 
   it('clicking the .close button hides the alert', async () => {

--- a/test/components/app.spec.js
+++ b/test/components/app.spec.js
@@ -44,7 +44,10 @@ describe('App', () => {
     describe('after a version change', () => {
       it('shows an alert', () => {
         const clock = sinon.useFakeTimers(Date.now());
-        return load('/')
+        const reload = sinon.fake();
+        return load('/', {
+          container: { location: { reload } }
+        })
           .complete()
           .request(() => {
             clock.tick(15000);
@@ -64,11 +67,13 @@ describe('App', () => {
             clock.tick(60000);
           })
           .respondWithData(() => '(v2024.1.3-sha)')
-          .afterResponse(app => {
-            clock.tick(0);
+          .afterResponse(async (app) => {
+            await clock.tickAsync(0);
             app.should.alert('info', (message) => {
               message.should.startWith('The server has been updated.');
             });
+            await app.get('.alert-cta').trigger('click');
+            reload.called.should.be.true;
           });
       });
 

--- a/test/components/async-route.spec.js
+++ b/test/components/async-route.spec.js
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+
 import AsyncRoute from '../../src/components/async-route.vue';
 import Loading from '../../src/components/loading.vue';
 import PageBody from '../../src/components/page/body.vue';
@@ -8,22 +10,23 @@ import TestUtilSpan from '../util/components/span.vue';
 
 import { loadedAsync, setLoader } from '../../src/util/load-async';
 
-import { mount } from '../util/lifecycle';
+import { mergeMountOptions, mount } from '../util/lifecycle';
 import { wait, waitUntil } from '../util/util';
 
-const mountComponent = (props) => mount(AsyncRoute, {
+const mountComponent = (options) => mount(AsyncRoute, mergeMountOptions(options, {
   props: {
     props: {},
     loading: 'tab',
-    k: '0',
-    ...props
+    k: '0'
   }
-});
+}));
 
 describe('AsyncRoute', () => {
   it('renders the async component', async () => {
     setLoader('MyComponent', async () => ({ default: TestUtilP }));
-    const asyncRoute = mountComponent({ componentName: 'MyComponent' });
+    const asyncRoute = mountComponent({
+      props: { componentName: 'MyComponent' }
+    });
     await wait();
     asyncRoute.findComponent(TestUtilP).exists().should.be.true;
   });
@@ -31,8 +34,10 @@ describe('AsyncRoute', () => {
   it('passes the props to the component', async () => {
     setLoader('MyComponent', async () => ({ default: TestUtilIcon }));
     const asyncRoute = mountComponent({
-      componentName: 'MyComponent',
-      props: { icon: 'angle-right' }
+      props: {
+        componentName: 'MyComponent',
+        props: { icon: 'angle-right' }
+      }
     });
     await wait();
     asyncRoute.find('.icon-angle-right').exists().should.be.true;
@@ -42,8 +47,7 @@ describe('AsyncRoute', () => {
     it('renders correctly for a page', async () => {
       setLoader('MyComponent', async () => ({ default: TestUtilP }));
       const asyncRoute = mountComponent({
-        componentName: 'MyComponent',
-        loading: 'page'
+        props: { componentName: 'MyComponent', loading: 'page' }
       });
       const { state } = asyncRoute.getComponent(PageBody).getComponent(Loading).props();
       state.should.be.true;
@@ -54,8 +58,7 @@ describe('AsyncRoute', () => {
     it('renders correctly for a tab', async () => {
       setLoader('MyComponent', async () => ({ default: TestUtilP }));
       const asyncRoute = mountComponent({
-        componentName: 'MyComponent',
-        loading: 'tab'
+        props: { componentName: 'MyComponent', loading: 'tab' }
       });
       asyncRoute.getComponent(Loading).props().state.should.be.true;
       await wait();
@@ -65,7 +68,9 @@ describe('AsyncRoute', () => {
 
   it('re-renders the component if the k prop changes', async () => {
     setLoader('MyComponent', async () => ({ default: TestUtilP }));
-    const asyncRoute = mountComponent({ componentName: 'MyComponent', k: '0' });
+    const asyncRoute = mountComponent({
+      props: { componentName: 'MyComponent', k: '0' }
+    });
     await wait();
     const { vm } = asyncRoute.getComponent(TestUtilP);
     await asyncRoute.setProps({ k: '1' });
@@ -75,21 +80,33 @@ describe('AsyncRoute', () => {
   describe('after a load error', () => {
     it('shows a danger alert', async () => {
       setLoader('MyComponent', () => Promise.reject());
-      const asyncRoute = mountComponent({ componentName: 'MyComponent' });
+      const reload = sinon.fake();
+      const asyncRoute = mountComponent({
+        props: { componentName: 'MyComponent' },
+        container: {
+          location: { reload }
+        }
+      });
       await wait();
       asyncRoute.should.alert('danger');
+      asyncRoute.vm.$container.alert.ctaHandler();
+      reload.called.should.be.true;
     });
 
     it('does not show a loading message', async () => {
       setLoader('MyComponent', () => Promise.reject());
-      const asyncRoute = mountComponent({ componentName: 'MyComponent' });
+      const asyncRoute = mountComponent({
+        props: { componentName: 'MyComponent' }
+      });
       await wait();
       asyncRoute.getComponent(Loading).props().state.should.be.false;
     });
 
     it('does not show an alert if AsyncRoute component has been unmounted', async () => {
       setLoader('MyComponent', () => Promise.reject());
-      const asyncRoute = mountComponent({ componentName: 'MyComponent' });
+      const asyncRoute = mountComponent({
+        props: { componentName: 'MyComponent' }
+      });
       asyncRoute.unmount();
       await wait();
       asyncRoute.should.not.alert();
@@ -100,7 +117,9 @@ describe('AsyncRoute', () => {
     it('shows a loading message', async () => {
       setLoader('First', async () => ({ default: TestUtilP }));
       setLoader('Second', async () => ({ default: TestUtilSpan }));
-      const asyncRoute = mountComponent({ componentName: 'First', k: '0' });
+      const asyncRoute = mountComponent({
+        props: { componentName: 'First', k: '0' }
+      });
       await wait();
       await asyncRoute.setProps({ componentName: 'Second', props: {}, k: '1' });
       asyncRoute.getComponent(Loading).props().state.should.be.true;
@@ -111,7 +130,9 @@ describe('AsyncRoute', () => {
     it('renders the new component', async () => {
       setLoader('First', async () => ({ default: TestUtilP }));
       setLoader('Second', async () => ({ default: TestUtilSpan }));
-      const asyncRoute = mountComponent({ componentName: 'First', k: '0' });
+      const asyncRoute = mountComponent({
+        props: { componentName: 'First', k: '0' }
+      });
       await wait();
       asyncRoute.setProps({ componentName: 'Second', props: {}, k: '1' });
       await wait();
@@ -125,7 +146,9 @@ describe('AsyncRoute', () => {
           return { default: TestUtilP };
         });
         setLoader('Second', async () => ({ default: TestUtilSpan }));
-        const asyncRoute = mountComponent({ componentName: 'First', k: '0' });
+        const asyncRoute = mountComponent({
+          props: { componentName: 'First', k: '0' }
+        });
         await wait();
         asyncRoute.findComponent(TestUtilP).exists().should.be.false;
         asyncRoute.setProps({ componentName: 'Second', props: {}, k: '1' });
@@ -139,7 +162,9 @@ describe('AsyncRoute', () => {
           return Promise.reject();
         });
         setLoader('Second', async () => ({ default: TestUtilSpan }));
-        const asyncRoute = mountComponent({ componentName: 'First', k: '0' });
+        const asyncRoute = mountComponent({
+          props: { componentName: 'First', k: '0' }
+        });
         await wait();
         asyncRoute.setProps({ componentName: 'Second', props: {}, k: '1' });
         await waitUntil(() => loadedAsync('Second'));

--- a/test/unit/session.spec.js
+++ b/test/unit/session.spec.js
@@ -388,9 +388,11 @@ describe('util/session', () => {
       });
 
       it('shows a danger alert', () => {
+        const reload = sinon.fake();
         const container = createTestContainer({
           router: mockRouter(),
-          requestData: { session: testData.sessions.createNew() }
+          requestData: { session: testData.sessions.createNew() },
+          location: { reload }
         });
         const { alert } = container;
         return mockHttp(container)
@@ -407,6 +409,8 @@ describe('util/session', () => {
             alert.type.should.equal('danger');
             alert.message.should.startWith('There was a problem, and you were not fully logged out.');
             alert.message.should.endWith('logOut() problem.');
+            alert.ctaHandler();
+            reload.called.should.be.true;
           });
       });
 

--- a/test/util/container.js
+++ b/test/util/container.js
@@ -1,7 +1,7 @@
 import createContainer from '../../src/container';
 
 import { mockAxios } from './axios';
-import { mockLogger } from './util';
+import { mockLocation, mockLogger } from './util';
 import { testRequestData } from './request-data';
 
 /*
@@ -17,13 +17,19 @@ createTestContainer() creates a container with sensible defaults for testing.
   initial navigation. To not set the config, specify `false`. You can also set
   the config with values different from the default.
 */
-export default ({ requestData, config = {}, ...options } = {}) => {
+export default ({
+  requestData,
+  config = {},
+  location = {},
+  ...options
+} = {}) => {
   const container = createContainer({
     router: null,
     requestData: typeof requestData === 'function'
       ? requestData
       : testRequestData([], requestData),
     http: mockAxios(),
+    location: mockLocation(location),
     logger: mockLogger(),
     buildMode: 'test',
     ...options

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -2,6 +2,13 @@ import sinon from 'sinon';
 
 export const mockLogger = () => ({ log: sinon.fake(), error: sinon.fake() });
 
+export const mockLocation = (mockedProperties) => new Proxy({}, {
+  get: (_, name) =>
+    (Object.prototype.hasOwnProperty.call(mockedProperties, name)
+      ? mockedProperties[name]
+      : window.location[name])
+});
+
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -405,6 +405,10 @@
       "string": "Refresh",
       "developer_comment": "This is the text of a button that refreshes data."
     },
+    "refreshPage": {
+      "string": "Refresh page",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
+    },
     "resetPassword": {
       "string": "Reset password",
       "developer_comment": "This is the text for an action, for example, the text of a button."


### PR DESCRIPTION
This PR makes progress on getodk/central#1011 and getodk/central#1030:

- It adds a mechanism for showing a Call to Action (CTA) in a toast. This is called for in [#1011](https://github.com/getodk/central/issues/1011).
- It adds the specific CTAs listed in [#1030](https://github.com/getodk/central/issues/1030). All of them happen to be about refreshing the page, but the CTA mechanism as a whole is generic.

The CTA is not styled/positioned correctly yet. I'll do that in a follow-up PR as I continue working on #1011. I'm making this change now so that I can close out #1030 quickly. This is what the CTA looks like now:

![Image](https://github.com/user-attachments/assets/2dbfb938-c0e1-4690-8287-77fcafa8bd3f)

#### What has been done to verify that this works as intended?

New tests. I also tried out one of the CTAs locally.

#### Why is this the best possible solution? Were any other approaches considered?

My goal was to make it as simple as possible as possible to add a CTA. I think that's going to be a relatively common pattern. For example, I don't want us to have to write a component/HTML whenever we want to add a CTA. I wanted something generic/reusable.

We also need something that will work outside of component code. For example, src/util/session.js needs to add a CTA.

I'll also add comments explaining individual lines.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced