### PR TITLE
Fix test failure where timestamp might or might not be in the past

### DIFF
--- a/test/components/form/row.spec.js
+++ b/test/components/form/row.spec.js
@@ -221,7 +221,7 @@ describe('FormRow', () => {
       it('does not render a link for last submission', () => {
         const nonLink = mountComponent().get('.last-submission');
         nonLink.find('a').exists().should.be.false;
-        nonLink.text().should.match(/ago$/);
+        nonLink.findComponent(DateTime).exists().should.be.true;
       });
 
       it('does not render a link for submission count', () => {

--- a/test/components/project/form-row.spec.js
+++ b/test/components/project/form-row.spec.js
@@ -277,7 +277,7 @@ describe('ProjectFormRow', () => {
       it('does not render a link for last submission', () => {
         const nonLink = mountComponent().get('.last-submission');
         nonLink.find('a').exists().should.be.false;
-        nonLink.text().should.match(/ago$/);
+        nonLink.findComponent(DateTime).exists().should.be.true;
       });
 
       it('does not render a link for submission count', () => {


### PR DESCRIPTION
This PR addresses the following intermittent test failure:

```
1) does not render a link for last submission
     ProjectFormRow all submission links Data Collector
     AssertionError: expected '2025/05/18 11:59:40' to match /ago$/
    at Context.<anonymous> (dist/commons.js:204917:31)
```

Looking at the test, the `beforeEach` hook creates a form with a `lastSubmission`, but it doesn't specify an exact value for `lastSubmission`. The result is that `lastSubmission` defaults to the current timestamp. If the test runs quickly enough — if no milliseconds elapse between when the form is created and the assertion is made — then the test will fail. That's because if `lastSubmission` is the same as the current timestamp, it is not in the past, so the text will not contain the word "ago".

#### Why is this the best possible solution? Were any other approaches considered?

I thought about changing the default value of `lastSubmission` to sometime in the past, but that seemed more complicated. Logically, `lastSubmission` should be later than some other timestamps, e.g., `form.createdAt`. The easiest way to ensure that is to make `lastSubmission` as late as possible, i.e., to make it equal to the current timestamp.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced