### PR TITLE
Add joinSentences() to join using sentenceSeparator

### DIFF
--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -94,6 +94,9 @@ const listFormatOptions = {
   long: { style: 'long' }
 };
 
+export const joinSentences = (i18n, sentences) =>
+  sentences.join(locales.get(i18n.locale).sentenceSeparator);
+
 const useGlobalUtils = memoizeForContainer(({ i18n }) => {
   const numberFormats = {};
   const getNumberFormat = (key) => {
@@ -130,7 +133,8 @@ const useGlobalUtils = memoizeForContainer(({ i18n }) => {
       getListFormat(key).formatToParts(list),
 
     sentenceSeparator: computed(() =>
-      locales.get(i18n.locale).sentenceSeparator)
+      locales.get(i18n.locale).sentenceSeparator),
+    joinSentences: joinSentences.bind(null, i18n)
   };
 });
 

--- a/test/unit/i18n.spec.js
+++ b/test/unit/i18n.spec.js
@@ -222,5 +222,19 @@ describe('util/i18n', () => {
         sentenceSeparator.value.should.equal('');
       });
     });
+
+    describe('joinSentences()', () => {
+      it('uses a space for en', () => {
+        const { joinSentences } = withSetup(useI18nUtils);
+        joinSentences(['foo.', 'bar.']).should.equal('foo. bar.');
+      });
+
+      it('does not use a space for ja', () => {
+        const container = createTestContainer();
+        const { joinSentences } = withSetup(useI18nUtils, { container });
+        container.i18n.locale = 'ja';
+        joinSentences(['ほげ。', 'ふが。']).should.equal('ほげ。ふが。');
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds a function named `joinSentences()` to join two separately translated sentences. In English, there should be a space between the two sentences, but in Japanese and Chinese, there shouldn't be. Often when there are multiple sentences, they are included in the same i18n message. In that case, `joinSentences()` isn't needed. It's only useful when combining separate messages.

Components already have an alternative to `joinSentences()` in the `SentenceSeparator` component. They also have access to the `sentenceSeparator` computed ref via the `useI18nUtils()` composable. However, we need a way for non-component code to do something similar. I also think `joinSentences()` may be useful even in component code in certain situations.

I've added two versions of `joinSentences()`. One is returned by `useI18nUtils()` with the rest of our i18n utility functions. The other can be used outside component code and doesn't need the composable. The one returned by `useI18nUtils()` doesn't need to be passed `i18n` because it knows it automatically. I think we may want to follow a similar pattern for our other i18n utility functions: return one version from `useI18nUtils()` that doesn't require `i18n` (this is what we do today), but then make another version available that does take `i18n` and can be used outside component code.

The primary motivation for this change is getodk/central#1030. There are some new toast messages where we want to be able to join separately translated sentences.

#### What has been done to verify that this works as intended?

New tests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced