### PR TITLE
fix: revert web forms style override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
-        "@getodk/web-forms": "^0.11.0",
+        "@getodk/web-forms": "^0.11.1",
         "axios": "^1.6.2",
         "bootstrap": "~3",
         "dompurify": "^3.2.5",
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@getodk/web-forms": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.11.0.tgz",
-      "integrity": "sha512-4AXNInOxD3djkrY50Adm4YiAncx9tuWiSA3E9ptwophokj7wxC3vW08JDseJO7I0XoyGOZG8nEF3zjV38hLebA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.11.1.tgz",
+      "integrity": "sha512-cJiCoo1KFEjqUdfp3mxrx87+zji5xOqTxLNwmcLMIxeuKQfqBu5Vhz+mQroxmirm7tQpGbvLDTHvnXAk8SC6ww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mdi/js": "^7.4.47",
@@ -14750,9 +14750,9 @@
       }
     },
     "@getodk/web-forms": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.11.0.tgz",
-      "integrity": "sha512-4AXNInOxD3djkrY50Adm4YiAncx9tuWiSA3E9ptwophokj7wxC3vW08JDseJO7I0XoyGOZG8nEF3zjV38hLebA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@getodk/web-forms/-/web-forms-0.11.1.tgz",
+      "integrity": "sha512-cJiCoo1KFEjqUdfp3mxrx87+zji5xOqTxLNwmcLMIxeuKQfqBu5Vhz+mQroxmirm7tQpGbvLDTHvnXAk8SC6ww==",
       "requires": {
         "@mdi/js": "^7.4.47",
         "vue-draggable-plus": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",
-    "@getodk/web-forms": "^0.11.0",
+    "@getodk/web-forms": "^0.11.1",
     "axios": "^1.6.2",
     "bootstrap": "~3",
     "dompurify": "^3.2.5",

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -952,16 +952,8 @@ becomes more complicated.
 }
 [data-mark-rows-deleted="false"] { display: none; }
 
-
 ////////////////////////////////////////////////////////////////////////////////
-// Don't let styles defined in Central bleed into new Web Forms Component
-
-.odk-form :not(svg|*) {
-  all: revert;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// The action bar shown above the data table 
+// The action bar shown above the data table
 
 .table-actions-bar {
   background-color: $color-subpanel-background;

--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -435,14 +435,6 @@ onUnmounted(() => {
 <style lang="scss">
 @import '../assets/scss/_variables.scss';
 
-:root:has(.odk-form) {
-  font-size: 16px;
-}
-html, body {
-  &:has(.odk-form) {
-    box-shadow: none;
-  }
-}
 #web-form-renderer-submission-modal pre {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Depends on https://github.com/getodk/web-forms/pull/409 (Edit: PR already merged, and this one is unblocked)

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I have set up Central, running with the latest local WF, and have been testing the minimalistic reset stylesheet and the scoping by.odk-form To see if anything is wrong.

#### Why is this the best possible solution? Were any other approaches considered?

WF is adding these styles

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be seamless 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No 

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced