### PR TITLE
Fix: modals without actions should have bottom padding

### DIFF
--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -349,13 +349,15 @@ const titleId = `modal-title${id}`;
         text-align: right;
       }
     }
+
+    // WebFormRenderer has few modals without actions
+    .modal-body:not(:has(.modal-actions)) {
+      padding-block-end: calc($padding-modal-body / 2);
+    }
   }
 }
 
-// Not sure which modal does not have actions
-.modal-body:not(:has(.modal-actions)) {
-  padding-block-end: calc($padding-modal-body / 2);
-}
+
 
 .modal-full {
   // This is the space around the margin and the edge of the browser window

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -71,7 +71,7 @@ describe('Modal', () => {
         },
         attachTo: document.body
       });
-      modal.emitted().resize.should.eql([[10]]);
+      modal.emitted().resize.should.eql([[22]]);
     });
   });
 
@@ -132,7 +132,7 @@ describe('Modal', () => {
         attachTo: document.body
       });
       await modal.setProps({ state: false });
-      modal.emitted().resize.should.eql([[10], [0]]);
+      modal.emitted().resize.should.eql([[22], [0]]);
     });
   });
 
@@ -145,7 +145,7 @@ describe('Modal', () => {
     });
     modal.get('#div').element.setAttribute('style', 'height: 20px;');
     await nextTick();
-    modal.emitted().resize.should.eql([[10], [20]]);
+    modal.emitted().resize.should.eql([[22], [32]]);
   });
 
   describe('mutation', () => {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b90c5673-cb0c-49fb-9a86-b42427ce4649)

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced