### PR TITLE
fix: handle all file types for attachments

### DIFF
--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -151,7 +151,7 @@ const transformAttachmentResponse = (axiosResponse) => {
   }
 
   let body;
-  if (typeof (data) === 'string') {
+  if (typeof (data) === 'string' || data instanceof Blob) {
     body = data;
   } else if (headers['content-type'].includes('application/json') ||
             headers['content-type'].includes('application/geo+json')) {
@@ -260,7 +260,8 @@ const getAttachment = (url) => {
   ));
   return request({
     url: requestUrl,
-    alert: false
+    alert: false,
+    responseType: 'blob', // Handle all file types for attachments.
   }).then(transformAttachmentResponse);
 };
 


### PR DESCRIPTION
When working on [Select with images](https://github.com/getodk/web-forms/pull/417) I noticed that PNG images weren't rendering. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
The All Types form renders images and GeoJSON. Please suggest any other test I should make

<img width="700" alt="Screenshot 2025-05-28 at 3 23 05 PM" src="https://github.com/user-attachments/assets/5015d1bb-7de6-4f35-985a-fa46b1db6c7a" />


#### Why is this the best possible solution? Were any other approaches considered?

This fix treats attachments as a blob, since it can be any file (audio, video, image, text, etc.)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced