### PR TITLE
Entity Search

### DIFF
--- a/src/components/entity/filters.vue
+++ b/src/components/entity/filters.vue
@@ -11,9 +11,6 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <span id="entity-filters">
-    <div class="form-group">
-      <span class="icon-filter"></span>
-    </div>
     <entity-filters-conflict :model-value="conflict" :disabled="disabled"
       :disabled-message="disabledMessage" @update:model-value="$emit('update:conflict', $event)"/>
   </span>

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -16,14 +16,14 @@ except according to the terms contained in the LICENSE file.
         <div class="form-group">
           <span class="icon-filter"></span>
         </div>
-         <label class="form-group">
-            <input v-model="searchTextbox" class="form-control search-textbox" :placeholder="$t('common.search')"
-              :aria-disabled="deleted" autocomplete="off" @keydown.enter="setSearchTerm">
-            <button v-show="searchTextbox" type="button" class="close"
-              :aria-label="$t('action.clearSearch')" @click="clearSearch">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </label>
+        <div class="form-group">
+          <input v-model="searchTextbox" class="form-control search-textbox" :placeholder="$t('common.search')"
+            :aria-label="$t('common.search')" :aria-disabled="deleted" autocomplete="off" @keydown.enter="setSearchTerm">
+          <button v-show="searchTextbox" type="button" class="close"
+            :aria-label="$t('action.clearSearch')" @click="clearSearch">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
         <entity-filters v-model:conflict="conflict" :disabled="deleted"
         :disabled-message="deleted ? $t('filterDisabledMessage') : null"/>
       </form>
@@ -145,7 +145,7 @@ export default {
 
     // works in conjunction with searchTextbox
     const searchTerm = useQueryRef({
-      fromQuery: (query) => query.search,
+      fromQuery: (query) => (typeof query.search === 'string' ? query.search : null),
       toQuery: (value) => ({
         search: !value ? null : value
       })
@@ -183,7 +183,7 @@ export default {
       now: new Date().toISOString(),
       snapshotFilter: '',
 
-      searchTextbox: this.searchTerm
+      searchTextbox: this.searchTerm ?? ''
     };
   },
   computed: {
@@ -251,10 +251,7 @@ export default {
         $filter += ` and ${this.odataFilter}`;
       }
 
-      let $search;
-      if (this.searchTerm) {
-        $search = this.searchTerm;
-      }
+      const $search = this.searchTerm ? this.searchTerm : undefined;
 
       this.odataEntities.request({
         url: apiPaths.odataEntities(
@@ -477,7 +474,6 @@ export default {
       this.fetchChunk(false);
     },
     clearSearch() {
-      this.searchTextbox = '';
       this.searchTerm = '';
     },
     setSearchTerm() {

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -447,7 +447,8 @@
     // This text is shown on its own before details about a warning.
     "warning": "Warning",
     "beta": "Beta",
-    "none": "(none)"
+    "none": "(none)",
+    "search": "Search"
   },
   "mixin": {
     "request": {

--- a/test/components/entity/list.spec.js
+++ b/test/components/entity/list.spec.js
@@ -1118,6 +1118,27 @@ describe('EntityList', () => {
         });
     });
 
+    it('should clear search textbox and reset table when clear(x) button is pressed', () => {
+      testData.extendedEntities.createPast(1);
+      return load('/projects/1/entity-lists/trees/entities?search=john', {
+        attachTo: document.body
+      })
+        .afterResponses(app => {
+          app.findComponent(EntityMetadataRow).exists().should.be.true;
+          app.get('.search-textbox').element.value.should.be.eql('john');
+        })
+        .request((c) => c.find('.search-textbox ~ .close').trigger('click'))
+        .beforeEachResponse((app, { url }) => {
+          app.findComponent(EntityMetadataRow).exists().should.be.false;
+          relativeUrl(url).searchParams.has('$search').should.be.false;
+        })
+        .respondWithData(testData.entityOData)
+        .afterResponse(app => {
+          app.findComponent(EntityMetadataRow).exists().should.be.true;
+          app.get('.search-textbox').element.value.should.be.eql('');
+        });
+    });
+
     it('should not update entities count in the dataset resource', () =>
       load('/projects/1/entity-lists/trees/entities', {
         attachTo: document.body

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -425,5 +425,19 @@ describe('EntityUpload', () => {
         const filters = app.getComponent(EntityFilters).props();
         filters.conflict.should.eql([true, false]);
       }));
+
+    it('resets the search', () =>
+      upload('?search=john').beforeEachResponse((app, { url }, i) => {
+        if (i === 0) return;
+        // There should be only snapshot $filter query parameter.
+        const { pathname, searchParams } = relativeUrl(url);
+        pathname.should.be.eql('/v1/projects/1/datasets/trees.svc/Entities');
+        searchParams.get('$filter').should.match(/__system\/createdAt le \S+ and \(__system\/deletedAt eq null or __system\/deletedAt gt \S+\)/);
+        searchParams.get('$top').should.be.eql('250');
+        searchParams.get('$count').should.be.eql('true');
+        expect(searchParams.get('$search')).to.be.null;
+
+        app.getComponent(OdataLoadingMessage).props().filter.should.be.false;
+      }));
   });
 });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -958,6 +958,9 @@
     },
     "none": {
       "string": "(none)"
+    },
+    "search": {
+      "string": "Search"
     }
   },
   "mixin": {


### PR DESCRIPTION
Closes getodk/central#1009

#### What has been done to verify that this works as intended?

Added tests and manual verification.

Known issue: if you type something in the search textbox (don't press enter) and click on "deleted entities" button then search textbox doesn't get emptied. I am thinking to fix that as part of getodk/central#1023

#### Why is this the best possible solution? Were any other approaches considered?

Uses existing pattern. 

I considered combining search textbox with the filters in the component and computed `odataFilter` but it could have complicated `fetchChunk` function further.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Behavior after entities upload should be tested as well

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Added in https://github.com/getodk/docs/issues/1951

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced