### PR TITLE
Attempt to stop intermittent WhatsNew test failure

### DIFF
--- a/test/components/whats-new.spec.js
+++ b/test/components/whats-new.spec.js
@@ -25,7 +25,7 @@ describe('WhatsNew modal', () => {
     });
 
     it('shows modal to project manager with 1 project', async () => {
-      mockLogin({ role: 'none' });
+      mockLogin({ role: 'none', createdAt: '2025-01-01' });
       testData.extendedProjects.createPast(1, { role: 'manager' });
       const app = await load('/', { root: false }, { users: false });
       const baseModal = app.findComponent(WhatsNew).findComponent(Modal);


### PR DESCRIPTION
Closes https://github.com/getodk/central-frontend/issues/1262

The modal only shows if the user createdAt date is before 05-06-2025 and this date was sometimes randomly initialized to past this date, causing the modal to not show.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced