### PR TITLE
Improve test for entity downlaod button when disabled on deleted page

### DIFF
--- a/test/components/entity/download-button.spec.js
+++ b/test/components/entity/download-button.spec.js
@@ -96,4 +96,15 @@ describe('EntityDownloadButton', () => {
       });
     });
   });
+
+  describe('disabled (on deleted entity page)', () => {
+    it('disables the button', async () => {
+      testData.extendedDatasets.createPast(1, { entities: 2000 });
+      const component = mountComponent({
+        props: { disabled: true }
+      });
+      const button = component.find('.btn-primary');
+      button.classes().should.include('disabled');
+    });
+  });
 });

--- a/test/components/entity/list.spec.js
+++ b/test/components/entity/list.spec.js
@@ -1046,18 +1046,21 @@ describe('EntityList', () => {
         });
     });
 
-    // it.only('disables download button', () => {
-    //   testData.extendedEntities.createPast(1, { label: 'My Entity' });
-    //   testData.extendedEntities.createPast(1, { label: 'deleted 1', deletedAt: new Date().toISOString() });
-    //   return load('/projects/1/entity-lists/trees/entities', { root: false, container: { router: testRouter() } })
-    //     .complete()
-    //     .request(component =>
-    //       component.get('.toggle-deleted-entities').trigger('click'))
-    //     .respondWithData(testData.entityDeletedOData)
-    //     .afterResponses((component) => {
-    //       // component.find('#entity-download-button').attributes('aria-disabled').should.equal('true');
-    //     });
-    // });
+    it('disables download button', async () => {
+      testData.extendedEntities.createPast(1, { label: 'My Entity' });
+      testData.extendedEntities.createPast(1, { label: 'deleted 1', deletedAt: new Date().toISOString() });
+      const app = await load(
+        '/projects/1/entity-lists/trees/entities?deleted=true',
+        { root: false, attachTo: document.body },
+        {
+          deletedEntityCount: false,
+          odataEntities: testData.entityDeletedOData
+        }
+      );
+      const button = app.getComponent('#entity-download-button');
+      button.get('.btn-primary').classes().should.include('disabled');
+      await button.should.have.tooltip('Download is unavailable for deleted Entities');
+    });
   });
 
   describe('search', () => {


### PR DESCRIPTION
Closes https://github.com/getodk/central-frontend/issues/1220

The props I wanted to [revisit](https://github.com/getodk/central-frontend/pull/1133/files#r2074149550) were
* `snapshotFilter` (removed in https://github.com/getodk/central-frontend/pull/1228)
* `disabled` (Entity download button is disabled when shown on the Deleted Entities page)

This PR adds test of the disabled prop on the `EntityDownloadButton` and of the disabled functionality and tooltop on the `EntityList` page when being used to show deleted entities. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced