### PR TITLE
Usage metrics for 2025.2 counting owner only entity lists

### DIFF
--- a/src/components/analytics/metrics-table.vue
+++ b/src/components/analytics/metrics-table.vue
@@ -136,6 +136,7 @@ export default {
       "uses_external_blob_store": "Server uses external S3-compatible storage",
       "num_offline_entity_submissions_force_processed": "Number of force-processed Offline Entity Submissions",
       "max_entity_branch_delay": "Maximum time to process offline Entity update chain",
+      "num_owner_only_datasets": "Number of Entity Lists restricted to Owner Only",
       "num_xml_only_form_defs": "Number of Form Definitions with no associated XLSForm",
       "num_blob_files": "Number of binary files",
       "num_blob_files_on_s3": "Number of binary files currently stored in S3-compatible storage",

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -1412,6 +1412,9 @@
         "max_entity_branch_delay": {
           "string": "Maximum time to process offline Entity update chain"
         },
+        "num_owner_only_datasets": {
+          "string": "Number of Entity Lists restricted to Owner Only"
+        },
         "num_xml_only_form_defs": {
           "string": "Number of Form Definitions with no associated XLSForm"
         },


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1071

<img width="860" alt="Screenshot 2025-06-04 at 3 11 11 PM" src="https://github.com/user-attachments/assets/241abc17-111f-4ec9-953b-fe082043f650" />


Corresponding backend PR: https://github.com/getodk/central-backend/pull/1507

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced