### PR TITLE
Fixes #1252: use waitUntil instead of wait

### DIFF
--- a/test/components/web-form-renderer.spec.js
+++ b/test/components/web-form-renderer.spec.js
@@ -15,7 +15,7 @@ import formWithAttachmentXml from '../data/xml/with-attachment/form.xml';
 import { mockLogin } from '../util/session';
 import { mergeMountOptions } from '../util/lifecycle';
 import { setFiles } from '../util/trigger';
-import { wait } from '../util/util';
+import { waitUntil } from '../util/util';
 
 describe('WebFormRenderer', () => {
   let WebFormRenderer;
@@ -348,8 +348,8 @@ describe('WebFormRenderer', () => {
         .respondWithData(() => imageUploaderSubmission)
         .respondWithData(() => 'dummy content');
 
-      await wait(1); // Not 100% sure, but OWF is probably using setTimeout before loading the Form
-      component.find('.odk-form').exists().should.be.true;
+      await waitUntil(() => component.find('.odk-form').exists());
+      component.find('.odk-form h1').text().should.be.equal('Display Picture');
     });
 
     it('should make not requests for attachment data when attachment doesnt exist - relies on OWF', async () => {
@@ -364,8 +364,8 @@ describe('WebFormRenderer', () => {
         .respondWithData(() => [{ name: '1746140510984.jpg', exists: false }])
         .respondWithData(() => imageUploaderSubmission);
 
-      await wait(1); // Not 100% sure, but OWF is probably using setTimeout before loading the Form
-      component.find('.odk-form').exists().should.be.true;
+      await waitUntil(() => component.find('.odk-form').exists());
+      component.find('.odk-form h1').text().should.be.equal('Display Picture');
     });
   });
 });


### PR DESCRIPTION
Closes #1252

I believe this will fixed the intermittent test failure, my theory is that on local environment with high specs WF loads within 1ms but on circleCI that's not always true hence causing failure.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced