### PR TITLE
Refactor getodk/central#1114: remove dead code for Enketo edit

### DIFF
--- a/src/components/enketo-iframe.vue
+++ b/src/components/enketo-iframe.vue
@@ -21,7 +21,6 @@ import { queryString } from '../util/request';
 import { useRequestData } from '../request-data';
 
 import useEventListener from '../composables/event-listener';
-import useRoutes from '../composables/routes';
 import { getCookieValue } from '../util/util';
 
 defineOptions({
@@ -47,7 +46,6 @@ const { location, buildMode } = inject('container');
 const { form } = useRequestData();
 const route = useRoute();
 const router = useRouter();
-const { submissionPath } = useRoutes();
 
 const redirectUrl = computed(() => {
   const { return_url: returnUrlPascalCase, returnUrl } = route.query;
@@ -89,13 +87,11 @@ const setEnketoSrc = () => {
   }
   if (props.actionType === 'public-link') {
     prefix += '/single';
-  } else if (props.actionType === 'edit') {
-    prefix += `/${props.actionType}`;
-    query.instance_id = props.instanceId;
   } else if (props.actionType === 'preview') {
     prefix += `/${props.actionType}`;
   }
   // for actionType 'new', we don't need to add anything to the prefix.
+  // we no longer render Enketo for Edit Submission from central-frontend.
 
   if (props.enketoId === form.enketoOnceId) {
     lastSubmitted(props.enketoId)
@@ -130,10 +126,7 @@ const handleIframeMessage = (event) => {
     try { eventData = JSON.parse(event.data); } catch {}
 
     if (eventData?.enketoEvent === 'submissionsuccess') {
-      if (props.actionType === 'edit') {
-        // for edit we always redirect to Submission details page
-        router.push(submissionPath(form.projectId, form.xmlFormId, props.instanceId));
-      } else if (props.actionType === 'public-link' && redirectUrl.value) {
+      if (props.actionType === 'public-link' && redirectUrl.value) {
         // for public link, we read return value from query parameter. The value could be 3rd party
         // site as well, typically a thank you page
         try {

--- a/src/components/form/submission.vue
+++ b/src/components/form/submission.vue
@@ -14,12 +14,13 @@ except according to the terms contained in the LICENSE file.
   <page-body v-if="loadingState">
     <loading :state="true"/>
   </page-body>
-  <web-form-renderer v-if="dataExists && form.webformsEnabled && hasAccess"
+  <not-found v-if="dataExists && !form.webformsEnabled && actionType === 'edit'"/>
+  <web-form-renderer v-else-if="dataExists && form.webformsEnabled && hasAccess"
     :action-type="actionType"
     :instance-id="instanceId"
     @loaded="hideLoading"/>
   <!-- enketoId can be enketoOnceId so first try to read it from the prop (route.params)-->
-  <enketo-iframe v-if="dataExists && !form.webformsEnabled && hasAccess"
+  <enketo-iframe v-else-if="dataExists && !form.webformsEnabled && hasAccess"
     :enketo-id="enketoId ?? form.enketoId"
     :action-type="actionType"
     :instance-id="instanceId"
@@ -33,6 +34,7 @@ import { useI18n } from 'vue-i18n';
 
 import Loading from '../loading.vue';
 import PageBody from '../page/body.vue';
+import notFound from '../not-found.vue';
 
 import { noop } from '../../util/util';
 import { apiPaths } from '../../util/request';
@@ -54,7 +56,7 @@ const props = defineProps({
  * **preview**:     Displays the Form in preview mode. Submissions cannot be created.
  *
  * **edit**:        Displays the Form pre-filled with data from an existing Submission (instance),
- *                  which can be modified.
+ *                  which can be modified. Only OWF is supported via central-frontend
  *
  * **public-link**: Displays the Form for creating a new Submission. After a successful Submission,
  *                  a thank-you message/page is shown. This route is intended for anonymous users;

--- a/src/composables/enketo-redirector.js
+++ b/src/composables/enketo-redirector.js
@@ -21,7 +21,7 @@ import useRoutes from './routes';
 export default memoizeForContainer(({ router, requestData }) => {
   const route = useRoute();
   const { form } = requestData;
-  const { submissionPath, newSubmissionPath, formPreviewPath, offlineSubmissionPath } = useRoutes();
+  const { newSubmissionPath, formPreviewPath, offlineSubmissionPath } = useRoutes();
   const { location } = inject('container');
 
   const ensureCanonicalPath = (actionType) => {
@@ -32,11 +32,6 @@ export default memoizeForContainer(({ router, requestData }) => {
     if (route.path.startsWith('/f/') && !route.query.st && form.dataExists) {
       if (actionType === 'new') {
         target = newSubmissionPath(form.projectId, form.xmlFormId, !form.publishedAt);
-      } else if (actionType === 'edit') {
-        // note: we don't support editing of draft submissions
-        // if route.query.instance_id is not there then it will not match any path and page not found
-        // will be displayed.
-        target = submissionPath(form.projectId, form.xmlFormId, route.query.instance_id ?? '', 'edit');
       } else if (actionType === 'preview') {
         target = formPreviewPath(form.projectId, form.xmlFormId, !form.publishedAt);
       } else if (actionType === 'offline') {

--- a/src/routes.js
+++ b/src/routes.js
@@ -716,7 +716,7 @@ const routes = [
     }
   }),
   asyncRoute({
-    path: '/f/:enketoId([a-zA-Z0-9]+)/:actionType(new|edit|preview)',
+    path: '/f/:enketoId([a-zA-Z0-9]+)/:actionType(new|preview)',
     component: 'FormSubmission',
     name: 'EnketoRedirector',
     props: true,

--- a/test/components/enketo-iframe.spec.js
+++ b/test/components/enketo-iframe.spec.js
@@ -3,8 +3,6 @@ import EnketoIframe from '../../src/components/enketo-iframe.vue';
 import { mergeMountOptions, mount } from '../util/lifecycle';
 import { mockRouter } from '../util/router';
 import { wait } from '../util/util';
-import { testRequestData } from '../util/request-data';
-import testData from '../data';
 
 const enketoId = 'sCTIfjC5LrUto4yVXRYJkNKzP7e53vo';
 
@@ -40,50 +38,6 @@ describe('EnketoIframe', () => {
       iframe.exists().should.be.true;
       iframe.attributes('src').should.contain(expected);
     });
-  });
-
-  it('renders iframe with correct src when actionType is edit', () => {
-    const wrapper = mountComponent({
-      props: { actionType: 'edit', instanceId: 'test-instance' }
-    });
-    const iframe = wrapper.find('iframe');
-    iframe.exists().should.be.true;
-    iframe.attributes('src').should.contain(`/enketo-passthrough/edit/${enketoId}`);
-    iframe.attributes('src').should.contain('instance_id=test-instance');
-  });
-
-  it('passes all query parameters except return_url to the iframe', () => {
-    const wrapper = mountComponent({
-      props: { actionType: 'edit', instanceId: 'test-instance' },
-      container: {
-        router: mockRouter('/?return_url=http%3A%2F%2Flocalhost%2Fprojects%2F1&d[/data/first_name]=john')
-      }
-    });
-    const iframe = wrapper.find('iframe');
-    iframe.exists().should.be.true;
-
-    iframe.attributes('src').should.not.contain('return_url');
-    iframe.attributes('src').should.contain('instance_id=test-instance');
-    iframe.attributes('src').should.contain(`${encodeURIComponent('d[/data/first_name]')}=john`);
-  });
-
-  it('redirects to Submission details page after edit', async () => {
-    testData.extendedForms.createPast(1, { xmlFormId: 'a', webformsEnabled: true });
-
-    const wrapper = mountComponent({
-      props: { enketoId, actionType: 'edit', instanceId: 'test-instance' },
-      container: {
-        router: mockRouter('/'),
-        requestData: testRequestData([], {
-          form: testData.extendedForms.last()
-        }),
-      }
-    });
-    const iframe = wrapper.find('iframe');
-    const data = JSON.stringify({ enketoEvent: 'submissionsuccess' });
-    await postMessageToParent(iframe, data);
-
-    wrapper.vm.$router.push.calledWith('/projects/1/forms/a/submissions/test-instance').should.be.true;
   });
 
   it('redirects on submissionsuccess message with return_url - internal', async () => {

--- a/test/components/form/submission.spec.js
+++ b/test/components/form/submission.spec.js
@@ -79,6 +79,17 @@ describe('FormSubmission', () => {
 
       webForm.exists().should.be.true;
     });
+
+    it('shows not found when edit is requested with Enketo', async () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+
+      const app = await load('/projects/1/forms/a/submissions/uuid:1/edit', mountOptions())
+        .complete();
+
+      app.find('iframe').exists().should.be.false;
+
+      app.find('.panel-title').text().should.be.equal('Page Not Found');
+    });
   });
 
   describe('hasAccess', () => {

--- a/test/composables/enketo-redirector.spec.js
+++ b/test/composables/enketo-redirector.spec.js
@@ -37,24 +37,6 @@ describe('useEnketoRedirector', () => {
         });
     });
 
-    it('should redirect to edit submission page', () => {
-      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-      return load(`/f/${enketoId}/edit?instance_id=123`)
-        .afterResponses(app => {
-          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions/123/edit');
-          app.vm.$route.query.should.be.deep.equal({});
-        });
-    });
-
-    it('should show Page Not Found when instance ID is missing for edit', () => {
-      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
-      return load(`/f/${enketoId}/edit`)
-        .afterResponses(app => {
-          app.vm.$route.path.should.equal('/projects/1/forms/a/submissions//edit');
-          app.find('.panel-title').text().should.equal('Page Not Found');
-        });
-    });
-
     it('should redirect to Form preview page', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a' });
       return load(`/f/${enketoId}/preview`)


### PR DESCRIPTION
Closes getodk/central#1114

#### What has been done to verify that this works as intended?

All tests are still passing. Add one additional test to verify that "Page Not Found" is displayed when canonical submission edit URL is hit and Enketo is enabled.

#### Why is this the best possible solution? Were any other approaches considered?

No other approach considered, it is just removal of dead code.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
