### PR TITLE
fix: adds response type when fetching edit instance's attachments

### DIFF
--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -191,13 +191,7 @@ const fetchSubmissionXml = () => {
 
 const fetchSubmissionAttachments = () => {
   const requestUrl = apiPaths.submissionAttachments(form.projectId, form.xmlFormId, props.instanceId);
-  return submissionAttachments.request({
-    url: requestUrl,
-    alert: false,
-    responseType: 'blob', // Handle all file types for attachments.
-  })
-    .then(transformAttachmentResponse)
-    .catch(noop);
+  return submissionAttachments.request({ url: requestUrl, alert: false }).catch(noop);
 };
 
 const fetchSubmissionAttachment = (attachmentName) => {

--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -193,7 +193,8 @@ const fetchSubmissionAttachments = () => {
   const requestUrl = apiPaths.submissionAttachments(form.projectId, form.xmlFormId, props.instanceId);
   return submissionAttachments.request({
     url: requestUrl,
-    alert: false
+    alert: false,
+    responseType: 'blob', // Handle all file types for attachments.
   })
     .then(transformAttachmentResponse)
     .catch(noop);
@@ -204,7 +205,8 @@ const fetchSubmissionAttachment = (attachmentName) => {
   const requestUrl = apiPaths.submissionAttachment(form.projectId, form.xmlFormId, false, props.instanceId, attachmentName);
   return request({
     url: requestUrl,
-    alert: false
+    alert: false,
+    responseType: 'blob', // Handle all file types for attachments.
   })
     .then(transformAttachmentResponse)
     .catch(noop);


### PR DESCRIPTION
Closes https://github.com/getodk/central-frontend/issues/1301

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Test video: creates and edits submission of image question type 
 

https://github.com/user-attachments/assets/bd3c872c-72bb-4f5d-84e3-79570f50b6fc


Loads GeoJSON and select with images


<img width="700" alt="Screenshot 2025-06-16 at 10 43 26 AM" src="https://github.com/user-attachments/assets/ad5d7c6d-3166-45f0-a3bb-dd668c2bafd7" />


#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced