### PR TITLE
Fix SubmissionDownload so that alert is shown for incorrect passphrase

### DIFF
--- a/src/components/submission/download.vue
+++ b/src/components/submission/download.vue
@@ -133,7 +133,7 @@ import { getCookieValue } from '../../util/util';
 export default {
   name: 'SubmissionDownload',
   components: { FormGroup, Modal },
-  inject: ['alert', 'logger'],
+  inject: ['toast', 'redAlert', 'logger'],
   props: {
     state: Boolean,
     formVersion: Object,
@@ -194,9 +194,10 @@ export default {
         // same options. Preserving the form fields is also needed for the
         // "Try again" link to work.
         this.passphrase = '';
-
-        this.cancelCall('checkForProblem');
       }
+    },
+    'toast.state': function toastState(state) {
+      if (!state) this.cancelCall('checkForProblem');
     }
   },
   methods: {
@@ -276,9 +277,9 @@ export default {
         problem = JSON.parse(doc.body.textContent);
       } catch (e) {
         this.logger.log(doc.body.textContent);
-        this.alert.danger(this.$t('alert.parseError'));
+        this.redAlert.show(this.$t('alert.parseError'));
       }
-      if (isProblem(problem)) this.alert.danger(problem.message);
+      if (isProblem(problem)) this.redAlert.show(problem.message);
       return true;
     },
     decrypt(action) {
@@ -288,7 +289,7 @@ export default {
       // example, what if the user submits the form, but then closes the modal
       // before the iframe finishes loading?)
       if (this.$refs.iframe.contentWindow.document.readyState === 'loading') {
-        this.alert.danger('alert.unavailable');
+        this.redAlert.show('alert.unavailable');
         return;
       }
 
@@ -318,7 +319,7 @@ export default {
       if (willDownload) {
         this.$emit('hide');
 
-        const { cta } = this.alert.info(this.$t('alert.submit'));
+        const { cta } = this.toast.show(this.$t('alert.submit'));
         if (this.managedKey == null)
           cta(this.$t('action.tryAgain'), () => { a.click(); });
       }

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -342,13 +342,18 @@ Assertion.addMethod('redAlert', function assertRedAlert(message = undefined) {
 
 Assertion.addMethod('alert', function assertAlert(type = undefined, message = undefined) {
   expect(this._obj).to.be.instanceof(VueWrapper);
-  const { toast, redAlert, alert } = this._obj.vm.$container;
-  this.assert(
-    alert.state,
-    'expected the component to show an alert',
-    'expected the component not to show an alert'
-  );
-  if (checkNegate(this, [type, message])) return;
-  if (type != null) alert.last.should.equal(type === 'danger' ? redAlert : toast);
-  if (message != null) alert.message.should.stringMatch(message);
+  if (type == null) {
+    const { alert } = this._obj.vm.$container;
+    this.assert(
+      alert.state,
+      'expected the component to show an alert',
+      'expected the component not to show an alert'
+    );
+  } else {
+    if (checkNegate(this, [type, message])) return;
+    if (type === 'danger')
+      this._obj.should.redAlert(message);
+    else
+      this._obj.should.toast(message);
+  }
 });

--- a/test/components/submission/download.spec.js
+++ b/test/components/submission/download.spec.js
@@ -469,10 +469,11 @@ describe('SubmissionDownload', () => {
       onSubmit.called.should.be.true;
     });
 
-    it('shows an info alert', async () => {
+    it('hides the modal and shows a toast', async () => {
       const modal = await setup();
       modal.get('a').trigger('click');
       modal.emitted('hide').should.eql([[]]);
+      await modal.setProps({ state: false });
       modal.should.alert('info');
       should.not.exist(modal.vm.$container.alert.cta);
     });
@@ -487,6 +488,7 @@ describe('SubmissionDownload', () => {
       });
       modal.get('a').element.dispatchEvent(event).should.be.false;
       onSubmit.called.should.be.false;
+      should.not.exist(modal.emitted('hide'));
       modal.should.not.alert();
     });
 
@@ -496,6 +498,7 @@ describe('SubmissionDownload', () => {
       const a = modal.get('a');
       a.element.setAttribute('href', '/test/files/problem.html');
       a.trigger('click');
+      await modal.setProps({ state: false });
       const iframe = modal.get('iframe').element;
       await waitForIframe(iframe, '/test/files/problem.html');
       clock.tick(1000);
@@ -514,6 +517,7 @@ describe('SubmissionDownload', () => {
           body.textContent = '500 Internal Server Error';
         });
         modal.get('a').trigger('click');
+        await modal.setProps({ state: false });
         clock.tick(1000);
         modal.should.alert('danger', 'Something went wrong while requesting your data.');
       });
@@ -526,6 +530,7 @@ describe('SubmissionDownload', () => {
           body.textContent = '500 Internal Server Error';
         });
         modal.get('a').trigger('click');
+        await modal.setProps({ state: false });
         clock.tick(1000);
         const { logger } = modal.vm.$container;
         logger.log.calledWith('500 Internal Server Error').should.be.true;
@@ -537,6 +542,7 @@ describe('SubmissionDownload', () => {
       const modal = await setup();
       const checkForProblem = sinon.spy(modal.vm, 'checkForProblem');
       modal.get('a').trigger('click');
+      await modal.setProps({ state: false });
       clock.tick(1000);
       checkForProblem.callCount.should.equal(1);
       // Calling tickAsync() rather than tick() so that the callWait promise


### PR DESCRIPTION
Closes #

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced