### PR TITLE
Fixes download filtered submissions: don't reset state on modal hide

### DIFF
--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -78,7 +78,7 @@ except according to the terms contained in the LICENSE file.
     </div>
 
     <submission-download v-bind="downloadModal" :form-version="formVersion"
-      @hide="downloadModal.hide()"/>
+      @hide="downloadModal.hide(false)"/>
     <submission-update-review-state v-bind="reviewModal" :project-id="projectId"
       :xml-form-id="xmlFormId" @hide="reviewModal.hide()"
       @success="afterReview"/>
@@ -523,9 +523,7 @@ export default {
       this.fetchChunk(false);
     },
     showDownloadModal(filtered = false) {
-      if (filtered) {
-        this.downloadModal.odataFilter = this.odataFilter;
-      }
+      this.downloadModal.odataFilter = filtered ? this.odataFilter : null;
       this.downloadModal.show();
     }
   }


### PR DESCRIPTION
Closes getodk/central#1168

This was kinda hard bug to fix. 

**What's happening:** When you hover on the hyperlink, you see the correct link but when you click on it, another function runs and hides the modal resulting in resetting of modal state/data, so when default event handler of browser is run it sees no odatafilter query parameter.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced