### PR TITLE
Fixes: pass query parameters as it is to the enketo iframe

### DIFF
--- a/e2e-tests/tests/enketo.spec.js
+++ b/e2e-tests/tests/enketo.spec.js
@@ -250,4 +250,21 @@ test.describe('Enketo', () => {
 
     await expect(frame.getByRole('heading', { name: 'Successful' })).toBeVisible();
   });
+
+  test('default value is consistent between rendering enketo directly or via iframe', async ({ page }) => {
+    await login(page);
+
+    const queryWithSpaces = '?d[/data/first_name]=hello earth + hello mars %20 hello jupiter %2B hello saturn';
+
+    await page.goto(`${appUrl}/enketo-passthrough/${publishedForm.enketoId}${queryWithSpaces}`);
+    await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+
+    const defaultValueInEnketo = await page.getByLabel('First Name').inputValue();
+
+    await page.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new${queryWithSpaces}`);
+    const iframe = await page.frameLocator('iframe');
+    await expect(iframe.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+
+    await expect(iframe.getByLabel('First Name')).toHaveValue(defaultValueInEnketo);
+  });
 });

--- a/test/components/enketo-iframe.spec.js
+++ b/test/components/enketo-iframe.spec.js
@@ -141,6 +141,32 @@ describe('EnketoIframe', () => {
 
     postMessage.called.should.be.false;
   });
+
+  it('encodes spaces as %20 instead of + in query parameters', () => {
+    const wrapper = mountComponent({
+      props: { enketoId, actionType: 'new' },
+      container: {
+        router: mockRouter('/?d[/some/path]=hello world')
+      }
+    });
+    const iframe = wrapper.find('iframe');
+    const src = iframe.attributes('src');
+
+    src.should.contain('hello%20world');
+  });
+
+  it('passes + sign as it is', () => {
+    const wrapper = mountComponent({
+      props: { enketoId, actionType: 'new' },
+      container: {
+        router: mockRouter('/?d[/some/path]=hello + world')
+      }
+    });
+    const iframe = wrapper.find('iframe');
+    const src = iframe.attributes('src');
+
+    src.should.contain('hello%20+%20world');
+  });
 });
 
 


### PR DESCRIPTION
Closes https://forum.getodk.org/t/when-prefilling-the-value-in-enketo-web-form-the-space-is-getting-replaced-with-a/55937 

#### What has been done to verify that this works as intended?

Added tests and did manual verification

#### Why is this the best possible solution? Were any other approaches considered?

This solution passes provided query parameters as it is to the iframe, which will be no surprise for the user.

Previously I considered just replacing '+' with '%20' in the output of the `queryString()` but that didn't handle the case where user actually wants to pass `+` sign to the Enketo Form because `route.query` returns space for both space and `+`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be tested with various special characters in prefill data to ensure no other encoding issues, compare the behavior of various special and multi-lingual characters with opening iframe in a new tab.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced