### PR TITLE
Fix: %20 / space turns into `+`

### DIFF
--- a/e2e-tests/tests/enketo.spec.js
+++ b/e2e-tests/tests/enketo.spec.js
@@ -251,7 +251,7 @@ test.describe('Enketo', () => {
     await expect(frame.getByRole('heading', { name: 'Successful' })).toBeVisible();
   });
 
-  test('default value is consistent between rendering enketo directly or via iframe', async ({ page }) => {
+  test('default value is consistent between rendering enketo directly and via iframe', async ({ page }) => {
     await login(page);
 
     const queryWithSpaces = '?d[/data/first_name]=hello earth + hello mars %20 hello jupiter %2B hello saturn';
@@ -259,12 +259,13 @@ test.describe('Enketo', () => {
     await page.goto(`${appUrl}/enketo-passthrough/${publishedForm.enketoId}${queryWithSpaces}`);
     await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
 
-    const defaultValueInEnketo = await page.getByLabel('First Name').inputValue();
+    await expect(page.getByLabel('First Name')).toHaveValue('hello earth + hello mars   hello jupiter + hello saturn');
 
     await page.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new${queryWithSpaces}`);
     const iframe = await page.frameLocator('iframe');
     await expect(iframe.getByRole('heading', { name: publishedForm.name })).toBeVisible();
 
-    await expect(iframe.getByLabel('First Name')).toHaveValue(defaultValueInEnketo);
+    // except we transform + into space as well in iframe
+    await expect(iframe.getByLabel('First Name')).toHaveValue('hello earth   hello mars   hello jupiter + hello saturn');
   });
 });

--- a/src/components/enketo-iframe.vue
+++ b/src/components/enketo-iframe.vue
@@ -77,15 +77,14 @@ const setEnketoSrc = () => {
     basePath = `/#${basePath}`;
   }
   let prefix = basePath;
-  const { search } = new URL(route.fullPath, location.origin);
+  const { return_url: _, returnUrl: __, ...query } = route.query;
 
-  // pass URL query parameters as it is to the Enketo iframe after stripping return URLs
-  let qs = `?parentWindowOrigin=${encodeURIComponent(location.origin)}`;
-  qs += (!search ? ''
-    : `&${search.substring(1)
-      .split('&')
-      .filter(queryParameter => !queryParameter.startsWith('return_url=') && !queryParameter.startsWith('returnUrl='))
-      .join('&')}`);
+  query.parentWindowOrigin = location.origin;
+
+
+  const qs = `?${Object.entries(query)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&')}`;
 
   if (props.actionType === 'offline') {
     return; // we don't render offline Enketo through central-frontend

--- a/test/components/account/login.spec.js
+++ b/test/components/account/login.spec.js
@@ -168,6 +168,23 @@ describe('AccountLogin', () => {
       external.called.should.be.false;
     });
 
+    it.only('should pass %20 in query param as it is', () => {
+      testData.extendedForms.createPast(1);
+      testData.extendedUsers.createPast(1, { email: 'test@email.com', role: 'none' });
+      return load('/login?next=%2Fprojects%2F1%2Fforms%2Ff%2Fsubmissions%2Fnew%3Fd%5Bfirstname%5D%3Djohn%2520doe')
+        .restoreSession(false)
+        .complete()
+        .request(submit)
+        .respondWithData(() => testData.sessions.createNew())
+        .respondWithData(() => testData.extendedUsers.first())
+        .respondWithData(() => ({})) //analytics
+        .respondWithData(() => testData.extendedProjects.first())
+        .respondWithData(() => testData.extendedForms.last())
+        .afterResponses(app => {
+          app.vm.$route.fullPath.should.be.equal('/projects/1/forms/f/submissions/new?d[firstname]=john%20doe');
+        });
+    });
+
     it('uses the param after the user submits the form', () => {
       testData.extendedUsers.createPast(1, { email: 'test@email.com', role: 'none' });
       return load('/login?next=%2Faccount%2Fedit')

--- a/test/components/account/login.spec.js
+++ b/test/components/account/login.spec.js
@@ -168,23 +168,6 @@ describe('AccountLogin', () => {
       external.called.should.be.false;
     });
 
-    it.only('should pass %20 in query param as it is', () => {
-      testData.extendedForms.createPast(1);
-      testData.extendedUsers.createPast(1, { email: 'test@email.com', role: 'none' });
-      return load('/login?next=%2Fprojects%2F1%2Fforms%2Ff%2Fsubmissions%2Fnew%3Fd%5Bfirstname%5D%3Djohn%2520doe')
-        .restoreSession(false)
-        .complete()
-        .request(submit)
-        .respondWithData(() => testData.sessions.createNew())
-        .respondWithData(() => testData.extendedUsers.first())
-        .respondWithData(() => ({})) //analytics
-        .respondWithData(() => testData.extendedProjects.first())
-        .respondWithData(() => testData.extendedForms.last())
-        .afterResponses(app => {
-          app.vm.$route.fullPath.should.be.equal('/projects/1/forms/f/submissions/new?d[firstname]=john%20doe');
-        });
-    });
-
     it('uses the param after the user submits the form', () => {
       testData.extendedUsers.createPast(1, { email: 'test@email.com', role: 'none' });
       return load('/login?next=%2Faccount%2Fedit')

--- a/test/components/enketo-iframe.spec.js
+++ b/test/components/enketo-iframe.spec.js
@@ -3,6 +3,8 @@ import EnketoIframe from '../../src/components/enketo-iframe.vue';
 import { mergeMountOptions, mount } from '../util/lifecycle';
 import { mockRouter } from '../util/router';
 import { wait } from '../util/util';
+import testData from '../data';
+import { load } from '../util/http';
 
 const enketoId = 'sCTIfjC5LrUto4yVXRYJkNKzP7e53vo';
 
@@ -22,6 +24,13 @@ const postMessageToParent = async (iframe, data) => {
   script.textContent = `window.parent.postMessage('${data}', "*");`;
   iframe.element.contentDocument.body.appendChild(script);
   await wait();
+};
+
+const submit = async (component) => {
+  const form = component.get('#account-login form');
+  await form.get('input[type="email"]').setValue('test@email.com');
+  await form.get('input[type="password"]').setValue('foo');
+  return form.trigger('submit');
 };
 
 describe('EnketoIframe', () => {
@@ -155,7 +164,7 @@ describe('EnketoIframe', () => {
     src.should.contain('hello%20world');
   });
 
-  it('passes + sign as it is', () => {
+  it('passes + sign as %20', () => {
     const wrapper = mountComponent({
       props: { enketoId, actionType: 'new' },
       container: {
@@ -165,7 +174,26 @@ describe('EnketoIframe', () => {
     const iframe = wrapper.find('iframe');
     const src = iframe.attributes('src');
 
-    src.should.contain('hello%20+%20world');
+    src.should.contain('hello%20%20%20world');
+  });
+
+  it('should pass %20 to the iframe after login redirect', () => {
+    testData.extendedForms.createPast(1);
+    testData.extendedUsers.createPast(1, { email: 'test@email.com', role: 'none' });
+    return load('/login?next=%2Fprojects%2F1%2Fforms%2Ff%2Fsubmissions%2Fnew%3Fd%5Bfirstname%5D%3Djohn%2520doe')
+      .restoreSession(false)
+      .complete()
+      .request(submit)
+      .respondWithData(() => testData.sessions.createNew())
+      .respondWithData(() => testData.extendedUsers.first())
+      .respondWithData(() => ({})) //analytics
+      .respondWithData(() => testData.extendedProjects.first())
+      .respondWithData(() => testData.extendedForms.last())
+      .afterResponses(app => {
+        const iframe = app.find('iframe');
+        const src = iframe.attributes('src');
+        src.should.contain('john%20doe');
+      });
   });
 });
 

--- a/test/composables/enketo-redirector.spec.js
+++ b/test/composables/enketo-redirector.spec.js
@@ -29,6 +29,14 @@ describe('useEnketoRedirector', () => {
         });
     });
 
+    it.only('should keep query parameters as it is after redirection', () => {
+      testData.extendedForms.createPast(1, { xmlFormId: 'a' });
+      return load(`/f/${enketoId}/new?d[firstname]=john%20doe`)
+        .afterResponses(app => {
+          app.vm.$route.fullPath.should.equal('/projects/1/forms/a/submissions/new?d[firstname]=john%20doe');
+        });
+    });
+
     it('should redirect to new draft submission page', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a', publishedAt: null, draft: true });
       return load(`/f/${enketoId}/new`)

--- a/test/composables/enketo-redirector.spec.js
+++ b/test/composables/enketo-redirector.spec.js
@@ -29,11 +29,13 @@ describe('useEnketoRedirector', () => {
         });
     });
 
-    it.only('should keep query parameters as it is after redirection', () => {
+    it('should pass query parameters as it is after redirection', () => {
       testData.extendedForms.createPast(1, { xmlFormId: 'a' });
       return load(`/f/${enketoId}/new?d[firstname]=john%20doe`)
         .afterResponses(app => {
-          app.vm.$route.fullPath.should.equal('/projects/1/forms/a/submissions/new?d[firstname]=john%20doe');
+          const iframe = app.find('iframe');
+          const src = iframe.attributes('src');
+          src.should.contain('john%20doe');
         });
     });
 


### PR DESCRIPTION
Issue: After redirection whether from login page with `next` or from `/f/:enketoId` to canonical path, space character or `%20` is changed into `+` because internally $router.replace/push mimics the behavior of URLSearchParams.

### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Our only solution is to treat `+` in the value of default values coming from URL as space. `$router.replace` always converts space into `+` matching the behavior of URLSearchParams, replacing `$router.replace` with something written from scratch would be huge undertaking. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Default/prefill values for Enketo should be tested thoroughly. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Subtle change in behavior should be posted on Forum, previously when default value contained `+` then Enketo form showed the `+` sign but now it will show ` ` (space), to show `+` sign user would need to use `%2B`

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
