### PR TITLE
Show tag for repeat group on entity list properties page

### DIFF
--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -25,7 +25,7 @@ except according to the terms contained in the LICENSE file.
                 :to="publishedFormPath(form.projectId, form.xmlFormId)"
                 v-tooltip.text/>
               <span v-if="form.repeatPath" class="repeat-tag"
-                v-tooltip.aria-describedby="form.repeatPath">
+                v-tooltip.no-aria="form.repeatPath">
                 <span class="icon-refresh"></span>
                 {{ form.repeatPath.split('/').filter(Boolean).pop() }}</span>
             </div>

--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -27,7 +27,8 @@ except according to the terms contained in the LICENSE file.
               <span v-if="form.repeatPath" class="repeat-tag"
                 v-tooltip.no-aria="form.repeatPath">
                 <span class="icon-refresh"></span>
-                {{ form.repeatPath.split('/').filter(Boolean).pop() }}</span>
+                <!-- Path includes leading and trailing slashes e.g. /plot/tree/ -->
+                {{ form.repeatPath.slice(0, -1).split('/').pop() }}</span>
             </div>
           </template>
           <template #caption>

--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -24,9 +24,10 @@ except according to the terms contained in the LICENSE file.
               <form-link :form="form"
                 :to="publishedFormPath(form.projectId, form.xmlFormId)"
                 v-tooltip.text/>
-              <span v-if="form.repeatPath" class="repeat-tag">
+              <span v-if="form.repeatPath" class="repeat-tag"
+                v-tooltip.aria-describedby="form.repeatPath">
                 <span class="icon-refresh"></span>
-                {{ form.repeatPath }}</span>
+                {{ form.repeatPath.split('/').filter(Boolean).pop() }}</span>
             </div>
           </template>
           <template #caption>

--- a/src/components/dataset/overview/connection-to-forms.vue
+++ b/src/components/dataset/overview/connection-to-forms.vue
@@ -24,6 +24,9 @@ except according to the terms contained in the LICENSE file.
               <form-link :form="form"
                 :to="publishedFormPath(form.projectId, form.xmlFormId)"
                 v-tooltip.text/>
+              <span v-if="form.repeatPath" class="repeat-tag">
+                <span class="icon-refresh"></span>
+                {{ form.repeatPath }}</span>
             </div>
           </template>
           <template #caption>
@@ -101,6 +104,23 @@ export default {
 
     .form-name {
       @include text-overflow-ellipsis;
+    }
+
+    .repeat-tag {
+      // CSS
+      border-radius: 100px;
+      background: #D0E7F1;
+      font-size: 12px;
+
+      // Layout
+      display: inline-flex;
+      height: 24px;
+      min-width: 22px;
+      margin-left: 8px;
+      padding: 4px 8px;
+      justify-content: center;
+      align-items: center;
+      gap: 4px;
     }
   }
 

--- a/test/components/dataset/overview/connection-to-forms.spec.js
+++ b/test/components/dataset/overview/connection-to-forms.spec.js
@@ -85,4 +85,38 @@ describe('ConnectionToForms', () => {
     const component = mountComponent();
     component.get('.summary-item-heading').text().should.be.equal('0');
   });
+
+  it('shows repeat indicator pill for source forms where dataset came from repeat group', () => {
+    testData.extendedDatasets.createPast(1, {
+      name: 'trees',
+      properties: [],
+      sourceForms: [
+        { name: 'Tree Registration', xmlFormId: 'tree_registration', repeatPath: '/farm/plot/trees/' },
+        { name: 'Form with no properties', xmlFormId: 'form_with_no_prop' }
+      ]
+    });
+    const component = mountComponent();
+
+    const rows = component.findAllComponents(ExpandableRow);
+    // Pill text is the last part of the repeat path
+    rows[0].get('.repeat-tag').text().should.be.eql('trees');
+
+    // No pill on  form where dataset is not from repeat
+    rows[1].find('.repeat-tag').exists().should.be.false;
+  });
+
+  it('shows repeat indicator pill with full path as tooltip', async () => {
+    testData.extendedDatasets.createPast(1, {
+      name: 'trees',
+      properties: [],
+      sourceForms: [
+        { name: 'Tree Registration', xmlFormId: 'tree_registration', repeatPath: '/farm/plot/trees/' }
+      ]
+    });
+    const component = mountComponent();
+
+    const row = component.findAllComponents(ExpandableRow)[0];
+
+    await row.get('.repeat-tag').should.have.tooltip('/farm/plot/trees/');
+  });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1303

In backend, I added a property to the list of source forms that includes the name of the repeat group if the dataset is from a repeat group.

Leaving this as a draft because I still need to add tests. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced