### PR TITLE
Log list of big files because github actions doesn't show colors

### DIFF
--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -40,7 +40,10 @@ log('---');
 const tooBigs = files.filter(f => f.tooBig);
 if (tooBigs.length) {
   log('!!!');
-  log(`!!! ${tooBigs.length} file(s) are too big !!!`);
+  log(`!!! ${tooBigs.length} file(s) are too big:`);
+  log('!!!');
+  tooBigs.map(f => log(`!!! * ${f.path}`));
+  log('!!!');
   log('!!!');
   log('!!! Please check what may have changed, and either fix');
   log('!!! the issue, or adjust expectations in this script.');


### PR DESCRIPTION
split from #1319

 https://github.com/getodk/central-frontend/actions/runs/17078821495/job/48427136906 doesn't show colors for the name of the files which are too large