### PR TITLE
Fixes getodk/central#1185: Pass $search to EntityDownload component

### DIFF
--- a/src/components/entity/download-button.vue
+++ b/src/components/entity/download-button.vue
@@ -12,7 +12,7 @@ except according to the terms contained in the LICENSE file.
 <template>
   <div id="entity-download-button" class="dropdown">
     <a class="btn btn-primary" :class="{ disabled }" :href="href"
-      :data-toggle="odataFilter ? 'dropdown' : null">
+      :data-toggle="odataFilter || searchTerm ? 'dropdown' : null">
       <span class="icon-arrow-circle-down"></span>
       <span>{{ $t('action.download') }}</span>
     </a>
@@ -41,6 +41,7 @@ import { useRequestData } from '../../request-data';
 
 const props = defineProps({
   odataFilter: String,
+  searchTerm: String,
   disabled: Boolean
 });
 
@@ -51,7 +52,7 @@ const href = computed(() =>
   apiPaths.entities(projectId, datasetName, '.csv'));
 
 const filteredHref = computed(() =>
-  apiPaths.entities(projectId, datasetName, '.csv', { $filter: props.odataFilter }));
+  apiPaths.entities(projectId, datasetName, '.csv', { $filter: props.odataFilter, $search: props.searchTerm }));
 
 const { dataset, odataEntities } = useRequestData();
 const { t } = useI18n();
@@ -91,10 +92,10 @@ const downloadFiltered = computed(() => (odataEntities.dataExists
       "download": {
         "unfiltered": "Download {count} Entity | Download all {count} Entities",
         "filtered": {
-          "withCount": "Download {count} Entity matching the filter | Download {count} Entities matching the filter",
+          "withCount": "Download {count} matching Entity | Download {count} matching Entities",
           // This is the text of a button. This text is shown when the number of
           // matching Entities is unknown.
-          "withoutCount": "Download all Entities matching the filter"
+          "withoutCount": "Download all matching Entities"
         }
       }
     }

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -25,6 +25,7 @@ except according to the terms contained in the LICENSE file.
       </button>
       <teleport-if-exists v-if="odataEntities.dataExists" to=".dataset-entities-heading-row">
         <entity-download-button :odata-filter="deleted ? null : odataFilter"
+        :search-term="deleted ? null : searchTerm"
         :disabled="deleted"
         v-tooltip.aria-describedby="deleted ? $t('downloadDisabled') : null"/>
       </teleport-if-exists>

--- a/test/components/entity/download-button.spec.js
+++ b/test/components/entity/download-button.spec.js
@@ -23,10 +23,26 @@ describe('EntityDownloadButton', () => {
     });
 
     describe('entities are filtered', () => {
-      it('show the dropdown menu', () => {
+      it('show the dropdown menu when odataFilter is set', () => {
         testData.extendedDatasets.createPast(1);
         const component = mountComponent({
           props: { odataFilter: '__system/conflict ne null' }
+        });
+        component.find('.btn-primary').attributes()['data-toggle'].should.be.eql('dropdown');
+      });
+
+      it('show the dropdown menu when searchTerm is set', () => {
+        testData.extendedDatasets.createPast(1);
+        const component = mountComponent({
+          props: { searchTerm: 'lorem ipsum' }
+        });
+        component.find('.btn-primary').attributes()['data-toggle'].should.be.eql('dropdown');
+      });
+
+      it('show the dropdown menu when both odataFilter and searchTerm are set', () => {
+        testData.extendedDatasets.createPast(1);
+        const component = mountComponent({
+          props: { odataFilter: '__system/conflict ne null', searchTerm: 'lorem ipsum' }
         });
         component.find('.btn-primary').attributes()['data-toggle'].should.be.eql('dropdown');
       });
@@ -36,7 +52,7 @@ describe('EntityDownloadButton', () => {
         const component = mountComponent({
           props: { odataFilter: '__system/conflict ne null' }
         });
-        component.find('li:nth-of-type(1)').text().should.equal('Download all Entities matching the filter');
+        component.find('li:nth-of-type(1)').text().should.equal('Download all matching Entities');
       });
 
       it('shows correct text after first chunk of entities has loaded for the first button', () => {
@@ -49,7 +65,7 @@ describe('EntityDownloadButton', () => {
             }
           }
         });
-        component.find('li:nth-of-type(1)').text().should.equal('Download 1,000 Entities matching the filter');
+        component.find('li:nth-of-type(1)').text().should.equal('Download 1,000 matching Entities');
       });
 
       it('shows correct text for the second button', () => {
@@ -72,8 +88,7 @@ describe('EntityDownloadButton', () => {
     });
 
     describe('entities are filtered', () => {
-      // I am here, add href test for two menu items
-      it('sets the correct attribute for downloading filtered entities', () => {
+      it('sets the correct attribute for downloading filtered entities with odataFilter', () => {
         testData.extendedDatasets.createPast(1, { name: 'á' });
         const component = mountComponent({
           props: { odataFilter: '__system/conflict ne null' }
@@ -82,6 +97,29 @@ describe('EntityDownloadButton', () => {
         const url = relativeUrl(href);
         url.pathname.should.equal('/v1/projects/1/datasets/%C3%A1/entities.csv');
         url.searchParams.get('$filter').should.equal('__system/conflict ne null');
+      });
+
+      it('sets the correct attribute for downloading filtered entities with searchTerm', () => {
+        testData.extendedDatasets.createPast(1, { name: 'á' });
+        const component = mountComponent({
+          props: { searchTerm: 'lorem ipsum' }
+        });
+        const { href } = component.find('li:nth-of-type(1) a').attributes();
+        const url = relativeUrl(href);
+        url.pathname.should.equal('/v1/projects/1/datasets/%C3%A1/entities.csv');
+        url.searchParams.get('$search').should.equal('lorem ipsum');
+      });
+
+      it('sets the correct attribute for downloading filtered entities with both odataFilter and searchTerm', () => {
+        testData.extendedDatasets.createPast(1, { name: 'á' });
+        const component = mountComponent({
+          props: { odataFilter: '__system/conflict ne null', searchTerm: 'lorem ipsum' }
+        });
+        const { href } = component.find('li:nth-of-type(1) a').attributes();
+        const url = relativeUrl(href);
+        url.pathname.should.equal('/v1/projects/1/datasets/%C3%A1/entities.csv');
+        url.searchParams.get('$filter').should.equal('__system/conflict ne null');
+        url.searchParams.get('$search').should.equal('lorem ipsum');
       });
 
       it('sets the correct attribute for downloading all entities', () => {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -2234,11 +2234,11 @@
           },
           "filtered": {
             "withCount": {
-              "string": "{count, plural, one {Download {count} Entity matching the filter} other {Download {count} Entities matching the filter}}",
+              "string": "{count, plural, one {Download {count} matching Entity} other {Download {count} matching Entities}}",
               "developer_comment": "This is the text for an action, for example, the text of a button."
             },
             "withoutCount": {
-              "string": "Download all Entities matching the filter",
+              "string": "Download all matching Entities",
               "developer_comment": "This is the text of a button. This text is shown when the number of matching Entities is unknown."
             }
           }


### PR DESCRIPTION
Closes getodk/central#1185

#### What has been done to verify that this works as intended?

Added tests and manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

It's quite straight forward, no special decision made.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced