### PR TITLE
e2e-tests: reduce git clone data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
     - name: Clone getodk/central repo
       run: |
-        git clone -b next https://github.com/getodk/central.git
+        git clone --depth 1 --single-branch --branch next https://github.com/getodk/central.git
         cd central
         git submodule set-branch -b master server
         git submodule update --init --remote server


### PR DESCRIPTION
Only check out the branch of the `odk-central` repo which will be used in testing.

# Effect:

## Without new flags: 660 KB

	$ git clone -b next https://github.com/getodk/central.git
	Cloning into 'central'...
	remote: Enumerating objects: 2848, done.
	remote: Counting objects: 100% (596/596), done.
	remote: Compressing objects: 100% (174/174), done.
	remote: Total 2848 (delta 525), reused 429 (delta 422), pack-reused 2252 (from 2)
	Receiving objects: 100% (2848/2848), 660.15 KiB | 2.44 MiB/s, done.
	Resolving deltas: 100% (1719/1719), done.

## With new flags: 69 KB

	$ git clone --depth 1 --single-branch --branch next https://github.com/getodk/central.git
	Cloning into 'central'...
	remote: Enumerating objects: 102, done.
	remote: Counting objects: 100% (102/102), done.
	remote: Compressing objects: 100% (81/81), done.
	remote: Total 102 (delta 9), reused 52 (delta 6), pack-reused 0 (from 0)
	Receiving objects: 100% (102/102), 69.30 KiB | 1.03 MiB/s, done.
	Resolving deltas: 100% (9/9), done.

This difference should increase over time.

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

No.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced