### PR TITLE
Track when requestData resource is set or patched

### DIFF
--- a/src/request-data/resource.js
+++ b/src/request-data/resource.js
@@ -45,6 +45,8 @@ class BaseResource {
   }
 
   get awaitingResponse() { return this[_store].awaitingResponse; }
+  get setAt() { return this[_store].setAt; }
+  get patchedAt() { return this[_store].patchedAt; }
 
   get dataExists() { return this[_store].data != null; }
   get initiallyLoading() { return this.awaitingResponse && !this.dataExists; }
@@ -62,14 +64,24 @@ const _container = Symbol('container');
 const _abortController = Symbol('abortController');
 class Resource extends BaseResource {
   constructor(container, name) {
-    const store = shallowReactive({ data: null, awaitingResponse: false });
+    const store = shallowReactive({
+      data: null,
+      awaitingResponse: false,
+      setAt: null,
+      patchedAt: null
+    });
     super(name, store);
     this[_container] = container;
     this[_abortController] = null;
   }
 
   get data() { return this[_store].data; }
-  set data(value) { this[_store].data = value; }
+
+  set data(value) {
+    this[_store].data = value;
+    this[_store].setAt = new Date();
+  }
+
   toRefs() { return { ...super.toRefs(), data: toRef(this[_store], 'data') }; }
 
   cancelRequest() { if (this.awaitingResponse) this[_abortController].abort(); }
@@ -277,6 +289,7 @@ class Resource extends BaseResource {
         } else {
           if (!this.dataExists) throw new Error('data does not exist');
           patch(response, this);
+          this[_store].patchedAt = new Date();
         }
       });
   }

--- a/src/request-data/resource.js
+++ b/src/request-data/resource.js
@@ -45,7 +45,11 @@ class BaseResource {
   }
 
   get awaitingResponse() { return this[_store].awaitingResponse; }
+  // `Date` object for when the `data` property was last set (including setting
+  // it to `null`)
   get setAt() { return this[_store].setAt; }
+  // `Date` object for when the `data` property was last patched. See the
+  // `patch` option of the request() method below.
   get patchedAt() { return this[_store].patchedAt; }
 
   get dataExists() { return this[_store].data != null; }


### PR DESCRIPTION
This PR changes `requestData` resources so that they remember when they were last set or patched. The PR doesn't have any immediate user-facing effects, but it should facilitate the following issues:

- getodk/central#1300
  - As the user navigates between pages, we often preserve data. But that can lead to data becoming stale. It'd be nice to be able to clear data that has become stale. To do so, it'd be helpful to know when the data was last set.
- getodk/central#1106
  - This issue calls for displaying a timestamp for when data was last received.

#### What has been done to verify that this works as intended?

New unit tests.

#### Why is this the best possible solution? Were any other approaches considered?

I'll add comments about specific decisions I made.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced