### PR TITLE
Fixes getodk/central#1140: don't change submission count on the click of 'deleted submissions' button

### DIFF
--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -312,7 +312,7 @@ export default {
         // view sets this.odata, as some submissions might not have geo data and
         // won't appear on the map.
         if (this.formVersion.dataExists && this.odata.dataExists &&
-          this.dataView === 'table' && !this.odataFilter)
+          this.dataView === 'table' && !this.odataFilter && !this.deleted)
           this.formVersion.submissions = this.odata.count;
       }
     },

--- a/test/components/form/submissions.spec.js
+++ b/test/components/form/submissions.spec.js
@@ -45,6 +45,25 @@ describe('FormSubmissions', () => {
           findTab(app, 'Submissions').get('.badge').text().should.equal('11');
         });
     });
+
+    it('should not change submission count when viewing deleted submissions', () => {
+      testData.extendedForms.createPast(1, { submissions: 5 });
+      testData.extendedSubmissions.createPast(5);
+      testData.extendedSubmissions.createPast(2, { deletedAt: new Date().toISOString() });
+      return load('/projects/1/forms/f/submissions')
+        .afterResponses(app => {
+          findTab(app, 'Submissions').get('.badge').text().should.equal('5');
+        })
+        .complete()
+        .request(app => {
+          app.find('.toggle-deleted-submissions').text().should.equal('2 deleted Submissions');
+          return app.find('.toggle-deleted-submissions').trigger('click');
+        })
+        .respondWithData(() => testData.submissionDeletedOData())
+        .afterResponses(app => {
+          findTab(app, 'Submissions').get('.badge').text().should.equal('5');
+        });
+    });
   });
 
   describe('deleted submissions', () => {


### PR DESCRIPTION
Closes getodk/central#1140

#### What has been done to verify that this works as intended?

Manual verification and added a tests.

#### Why is this the best possible solution? Were any other approaches considered?

~~It was unexpectedly tricky, original issue got fixed by just adding `!this.deleted` in the `odata.count` watcher. However, while testing I noticed that if I deleted few submissions and then clicked on "deleted submission" button then the count on the tab changed to incorrect value. To fix that I introduced a temporary non-reactive variable `originalSubmissionCount`, which is set whenever we receive odata for live(non-deleted) submissions or when we switch the view between deleted & live submissions.~~

~~The change in this PR solves the issue but I'm not totally happy with it, it's quite hard to reason about it.~~

Just added `!this.deleted`. Found a related issue, which is fixed in [subsequent PR](https://github.com/getodk/central-frontend/pull/1352)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced