### PR TITLE
Make it easy to undo mockLogin()

### DIFF
--- a/test/util/session.js
+++ b/test/util/session.js
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { clone } from 'ramda';
-
 import { faker } from '@faker-js/faker';
+
 import testData from '../data';
 
 let loggedIn = false;
@@ -18,10 +18,10 @@ export const mockLogin = (options = undefined) => {
     DateTime.fromISO(expiresAt).toMillis().toString()
   );
 
-  loggedIn = true;
-
   const csrf = faker.string.alphanumeric(64);
   document.cookie = `__csrf=${csrf}`;
+
+  loggedIn = true;
 };
 
 mockLogin.setRequestData = (requestData) => {
@@ -37,4 +37,23 @@ mockLogin.setRequestData = (requestData) => {
   }
 };
 
-mockLogin.reset = () => { loggedIn = false; };
+// Undoes the effects of mockLogin().
+mockLogin.reset = () => {
+  if (!loggedIn) return;
+
+  if (testData.extendedUsers.size === 1 && testData.sessions.size === 1) {
+    testData.extendedUsers.reset();
+    testData.sessions.reset();
+  } else {
+    testData.extendedUsers.splice(0, 1);
+    testData.sessions.splice(0, 1);
+  }
+
+  localStorage.removeItem('sessionExpires');
+
+  document.cookie = document.cookie.split('; ')
+    .filter(cookie => !cookie.startsWith('__csrf='))
+    .join('; ');
+
+  loggedIn = false;
+};


### PR DESCRIPTION
It comes up from time to time that a test needs to undo the effects of `mockLogin()`. For example, a `describe()` block with `beforeEach(mockLogin)` where just one test in the block doesn't want to log in, or wants to log in in a particular way. This PR makes it easy to undo `mockLogin()` by calling `mockLogin.reset()`. `mockLogin.reset()` already existed, but this PR extends it so that it fully resets `mockLogin()`.

I've wanted to make this change for a while, but I just thought of it again in the context of https://github.com/getodk/central-frontend/pull/1344#discussion_r2356562529.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced