### PR TITLE
Fix #1360: Change Entities filter label from "At" to "Created at"

### DIFF
--- a/src/components/entity/filters.vue
+++ b/src/components/entity/filters.vue
@@ -70,7 +70,7 @@ defineEmits(['update:conflict', 'update:creationDate', 'update:creatorId']);
     "field": {
       // This is the text of a form field that allows the user to filter
       // Entities by a date range.
-      "creationDate": "At"
+      "creationDate": "Created at"
     },
     // @transifexKey component.SubmissionFilters.allSubmissionDateSelected
     "allCreationDateSelected": "All time"


### PR DESCRIPTION
### Summary
Fixes issue #1360 by updating the Entities page filter label from **"At"** to **"Created at"**.

### Steps to verify
1. Navigate to a project with Entities.
2. Go to **Entity Lists → Any Entity**.
3. Check the filter with the calendar icon.
4. The label should now correctly read **"Created at"**.

---

Closes getodk/central#1360