### PR TITLE
Automatically reseed testData after testData.reset()

### DIFF
--- a/test/data/index.js
+++ b/test/data/index.js
@@ -45,7 +45,11 @@ const testData = Object.assign( // eslint-disable-line prefer-object-spread
   Users
 );
 
-testData.seed = seed;
-testData.reset = resetDataStores;
+seed();
+
+testData.reset = () => {
+  resetDataStores();
+  seed();
+};
 
 export default testData;

--- a/test/index.js
+++ b/test/index.js
@@ -28,8 +28,6 @@ window.expect = expect;
 // async components associated with the route.
 beforeAll(loadAsyncRouteComponents);
 
-beforeEach(testData.seed);
-
 enableAutoUnmount(afterEach);
 afterEach(() => {
   const app = document.querySelector('[data-v-app]');


### PR DESCRIPTION
This PR changes `testData.reset()` so that it automatically reseeds `testData` after resetting the data. Currently, resetting and reseeding are two separate operations. However, in practice, I don't think there's a reason to distinguish between the two.

Making this change allows us to remove a `beforeEach` hook in test/index.js. More importantly, it makes it easy for individual tests to reset and reseed `testData`. That need doesn't come up too often, but when it does, it's nice for there to be an easy way to accomplish it. This came up recently at https://github.com/getodk/central-frontend/pull/1344#discussion_r2356562529.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced