### PR TITLE
Improve requestData toRefs()

### DIFF
--- a/test/request-data/resource.spec.js
+++ b/test/request-data/resource.spec.js
@@ -1,5 +1,7 @@
 import sinon from 'sinon';
+import { isRef, ref } from 'vue';
 
+import { createResource } from '../../src/request-data/resource';
 import { noop } from '../../src/util/util';
 
 import createTestContainer from '../util/container';
@@ -225,6 +227,76 @@ describe('createResource()', () => {
         .beforeAnyResponse(() => { roles.cancelRequest(); })
         .respondWithProblem()
         .afterResponse(() => { alert.state.should.be.false; });
+    });
+  });
+
+  describe('toRefs()', () => {
+    it('converts getters to refs', async () => {
+      const container = createTestContainer();
+      const refProp = ref(false);
+      const resource = createResource(container, 'myResource', () => ({
+        refProp,
+        nonRefProp: 'foo'
+      }));
+      const refs = resource.toRefs();
+
+      // Test awaitingResponse and setAt.
+      const { awaitingResponse, setAt } = refs;
+      isRef(awaitingResponse).should.be.true;
+      awaitingResponse.value.should.be.false;
+      isRef(setAt).should.be.true;
+      should.not.exist(setAt.value);
+      await mockHttp(container)
+        .request(() => resource.request({ url: '/v1/projects/1' }))
+        .beforeAnyResponse(() => {
+          awaitingResponse.value.should.be.true;
+        })
+        .respondWithData(() => testData.standardProjects.createNew());
+      awaitingResponse.value.should.be.false;
+      expect(setAt.value).to.be.an.instanceOf(Date);
+
+      // Test `data`.
+      const { data } = refs;
+      isRef(data).should.be.true;
+      should.exist(data.value);
+      data.value.should.equal(resource.data);
+
+      // Test refs added via the setup function (here, refProp).
+      isRef(refs.refProp).should.be.true;
+      refs.refProp.value.should.be.false;
+      refProp.value = true;
+      refs.refProp.value.should.be.true;
+
+      // No refs are created from properties without a getter.
+      for (const prop of ['resourceName', 'request', 'nonRefProp']) {
+        should.exist(resource[prop]);
+        should.not.exist(refs[prop]);
+      }
+    });
+
+    it('returns refs that are read-only or not depending on whether there is a setter', () => {
+      const { requestData } = createTestContainer({
+        requestData: { project: testData.extendedProjects.createNew() }
+      });
+      const { awaitingResponse, data } = requestData.project.toRefs();
+
+      // You can't set awaitingResponse because there's no setter on the
+      // resource.
+      awaitingResponse.value.should.be.false;
+      // There's no error on setting awaitingResponse, but Vue does log a
+      // warning.
+      const warn = sinon.fake();
+      sinon.replace(console, 'warn', warn);
+      awaitingResponse.value = true;
+      warn.called.should.be.true;
+      // The value of `true` was ignored.
+      awaitingResponse.value.should.be.false;
+
+      // You can set `data` because there is a setter.
+      should.exist(data.value);
+      data.value = null;
+      should.not.exist(data.value);
+      should.not.exist(requestData.project.data);
     });
   });
 });


### PR DESCRIPTION
In #1341, I added two new properties to the reactive store underlying each resource object: `setAt` and `patchedAt`. The `toRefs()` method of the resource object is intended to return refs for reactive properties like these. Here are a couple of examples of how `toRefs()` is used:

https://github.com/getodk/central-frontend/blob/b24c3b7779789a80eb89f2e1e8b9642fad9b359f/src/components/project/archive.vue#L60

https://github.com/getodk/central-frontend/blob/b24c3b7779789a80eb89f2e1e8b9642fad9b359f/src/components/project/form-row.vue#L125

However, as mentioned at https://github.com/getodk/central-frontend/pull/1341#discussion_r2354231211, I decided not to add new refs to `toRefs()` for `setAt` and `patchedAt`. That's because I wanted to rework `toRefs()` in a couple of ways:

- Currently, `toRefs()` needs to be patched whenever a new reactive property is added to a resource object. I think it'd be better for `toRefs()` to be self-contained and not require maintenance/modification.
- Currently, whenever `toRefs()` is called, it generates all the refs that could possibly be accessed. However, components generally only need to grab a single ref off `toRefs()`. It seems wasteful to eagerly generate new refs for `setAt` and `patchedAt` every time `toRefs()` is called, knowing that those refs won't typically be used.

This PR solves for those concerns by changing `toRefs()` to return a proxy object. The proxy will generate refs on the fly rather than doing so eagerly.

The use of a proxy makes `toRefs()` a little more complicated. However, that logic is self-contained and won't need to be modified on a recurring basis. The proxy also eliminates the need for overriding `toRefs()` via inheritance, which was needed before and was a source of complexity. Overall, I think it's an improvement in clarity.

#### What has been done to verify that this works as intended?

Existing tests continue to pass. I also added new unit tests of `toRefs()`, which I think help clarify exactly how the method behaves.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced