### PR TITLE
Render OpenLayers map

### DIFF
--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -59,6 +59,7 @@ function isTooBig({ path, size }) {
   switch (simpleName) { // eslint-disable-line default-case
     case 'index.js':             return size >   450_000;
     case 'web-form-renderer.js': return size > 3_000_000;
+    case 'geojson-map.js':       return size >   500_000;
   }
 
   const type = extname(path).substr(1);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,14 +43,17 @@ module.exports = (config) => {
       { pattern: 'public/fonts/icomoon.ttf', served: true, included: false },
       { pattern: 'public/blank.html', served: true, included: false },
       { pattern: 'test/files/*', served: true, included: false },
-      { pattern: 'src/assets/images/whats-new/*', served: true, included: false }
+      { pattern: 'src/assets/images/**', served: true, included: false }
     ],
     proxies: {
       '/fonts/': '/base/public/fonts/',
       '/blank.html': '/base/public/blank.html',
       '/test/files/': '/base/test/files/',
+
+      // Images
       '/img/banner@2x.d6298b0b.png': '/base/src/assets/images/whats-new/banner@2x.png', // Image in what's new modal with hash
-      '/img/banner@1x.13a17571.png': '/base/src/assets/images/whats-new/banner@1x.png' // Smaller resolution for circleCI test
+      '/img/banner@1x.13a17571.png': '/base/src/assets/images/whats-new/banner@1x.png', // Smaller resolution for circleCI test
+      '/img/map-location.b523ce2d.svg': '/base/src/assets/images/geojson-map/map-location.svg'
     },
     preprocessors: {
       'test/index.js': ['webpack', 'sourcemap']

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jquery": "~3",
         "luxon": "~1",
         "marked": "~4",
+        "ol": "^10.6.1",
         "pako": "~1.0",
         "papaparse": "^5.4.1",
         "qrcode-generator": "~1",
@@ -1347,6 +1348,12 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true
     },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
@@ -2049,6 +2056,12 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -5166,6 +5179,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/easy-stack": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz",
@@ -6945,6 +6964,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -8528,6 +8572,12 @@
         "launch-editor": "^2.6.0"
       }
     },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -9751,6 +9801,23 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "node_modules/ol": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.6.1.tgz",
+      "integrity": "sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^2.1.3",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -10046,6 +10113,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10173,6 +10246,18 @@
       "dev": true,
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/picocolors": {
@@ -10902,6 +10987,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -11004,6 +11095,24 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
@@ -11076,6 +11185,15 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
       }
     },
     "node_modules/react-is": {
@@ -11280,6 +11398,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/restore-cursor": {
@@ -13286,6 +13413,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -13977,6 +14110,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -14245,6 +14384,12 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause"
     }
   },
   "dependencies": {
@@ -15020,6 +15165,11 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true
     },
+    "@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="
+    },
     "@playwright/test": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
@@ -15516,6 +15666,11 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ=="
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -17849,6 +18004,11 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="
+    },
     "easy-stack": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz",
@@ -19191,6 +19351,28 @@
       "dev": true,
       "peer": true
     },
+    "geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "requires": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+          "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        }
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -20344,6 +20526,11 @@
         "launch-editor": "^2.6.0"
       }
     },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -21258,6 +21445,18 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "ol": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.6.1.tgz",
+      "integrity": "sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==",
+      "requires": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^2.1.3",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0"
+      }
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -21481,6 +21680,11 @@
         }
       }
     },
+    "parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -21587,6 +21791,14 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true
+    },
+    "pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "requires": {
+        "resolve-protobuf-schema": "^2.1.0"
+      }
     },
     "picocolors": {
       "version": "1.1.1",
@@ -22059,6 +22271,11 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
+    "protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -22130,6 +22347,16 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ=="
+    },
+    "quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
+    },
     "ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
@@ -22183,6 +22410,14 @@
             "json5": "^2.1.2"
           }
         }
+      }
+    },
+    "rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "requires": {
+        "quickselect": "^3.0.0"
       }
     },
     "react-is": {
@@ -22335,6 +22570,14 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -23721,6 +23964,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="
+    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -24213,6 +24461,11 @@
       "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-3.1.2.tgz",
       "integrity": "sha512-Qyttmiy305unyg1ONpArT4FPDL3J+ohXWpMI1ecopClGMw53lCRHJ4FV/fVYHFU6qfEzMV0frqSlNaLo2dw15Q=="
     },
+    "xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA=="
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -24409,6 +24662,11 @@
           "dev": true
         }
       }
+    },
+    "zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jquery": "~3",
     "luxon": "~1",
     "marked": "~4",
+    "ol": "^10.6.1",
     "pako": "~1.0",
     "papaparse": "^5.4.1",
     "qrcode-generator": "~1",

--- a/src/assets/images/geojson-map/map-location.svg
+++ b/src/assets/images/geojson-map/map-location.svg
@@ -1,0 +1,23 @@
+<svg width="86" height="84" viewBox="0 0 86 84" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_3080_8764)">
+<g filter="url(#filter0_d_3080_8764)">
+<path d="M43.0003 7C29.1328 7 17.917 17.955 17.917 31.5C17.917 49.875 43.0003 77 43.0003 77C43.0003 77 68.0837 49.875 68.0837 31.5C68.0837 17.955 56.8678 7 43.0003 7ZM43.0003 40.25C38.0553 40.25 34.042 36.33 34.042 31.5C34.042 26.67 38.0553 22.75 43.0003 22.75C47.9453 22.75 51.9587 26.67 51.9587 31.5C51.9587 36.33 47.9453 40.25 43.0003 40.25Z" fill="#3E9FCC"/>
+</g>
+<circle cx="43" cy="32" r="10" fill="#E9F8FF"/>
+</g>
+<defs>
+<filter id="filter0_d_3080_8764" x="13.917" y="7" width="58.167" height="78" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_3080_8764"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_3080_8764" result="shape"/>
+</filter>
+<clipPath id="clip0_3080_8764">
+<rect width="86" height="84" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -104,16 +104,7 @@
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// UTILITIES
-
-@mixin clearfix {
-  &::before, &::after {
-    content: " ";
-    display: table;
-  }
-
-  &::after { clear: both; }
-}
+// FLOATING ELEMENTS
 
 @mixin floating-container {
   display: flex;
@@ -127,4 +118,33 @@
   pointer-events: none;
 
   & > * { pointer-events: auto; }
+}
+
+// Styles a .close button the same way as the modal close button.
+@mixin modal-close {
+  position: absolute;
+  // x symbol has some top spacing
+  top: calc($padding-modal-top-actions-close - 2px);
+  right: $padding-modal-top-actions-close;
+  color: $color-input;
+  font-weight: normal;
+  opacity: 1;
+
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+  }
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// UTILITIES
+
+@mixin clearfix {
+  &::before, &::after {
+    content: " ";
+    display: table;
+  }
+
+  &::after { clear: both; }
 }

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -126,13 +126,11 @@
   // x symbol has some top spacing
   top: calc($padding-modal-top-actions-close - 2px);
   right: $padding-modal-top-actions-close;
+  float: none;
+
   color: $color-input;
   font-weight: normal;
   opacity: 1;
-
-  &[aria-disabled="true"] {
-    cursor: not-allowed;
-  }
 }
 
 

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -1,7 +1,7 @@
 @import './variables';
 
 @mixin icon-box {
-  padding: 10px;
+  padding: min(0.5em, 10px);
   border-radius: 6px;
   color: $color-accent-primary;
   background-color: rgba($color-accent-primary, 0.1);  

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -67,6 +67,8 @@ $padding-top-btn: 6px;
 $font-size-dropdown-menu: $font-size-btn;
 $min-width-dropdown-menu: 150px;
 
+// <dl>
+$border-bottom-dl: 1px solid #ddd;
 $padding-block-dl: 10px;
 
 // Forms

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -41,7 +41,7 @@ h1, .h1 {
 p { @include text-block; }
 
 dl > * {
-  border-bottom: 1px solid #ddd;
+  border-bottom: $border-bottom-dl;
   padding-block: $padding-block-dl;
 
   &:first-of-type { padding-top: 0; }

--- a/src/components/dl-data.vue
+++ b/src/components/dl-data.vue
@@ -14,7 +14,9 @@ except according to the terms contained in the LICENSE file.
 from the user, e.g., entity data. The key and value will be truncated if they
 are too long. -->
 <template>
-  <dt class="dl-data-dt"><span v-tooltip.text>{{ name }}</span></dt>
+  <dt class="dl-data-dt">
+    <slot name="name"><span v-tooltip.text>{{ name }}</span></slot>
+  </dt>
 
   <dd v-if="value == null || value === ''" class="dl-data-dd empty">
     {{ $t('common.emptyValue') }}
@@ -29,10 +31,7 @@ defineOptions({
 defineProps({
   // "key" would have been a nice name for this prop, but sadly that's a
   // reserved name.
-  name: {
-    type: String,
-    required: true
-  },
+  name: String,
   value: String
 });
 </script>

--- a/src/components/dl-data.vue
+++ b/src/components/dl-data.vue
@@ -29,8 +29,12 @@ defineOptions({
   name: 'DlData'
 });
 defineProps({
-  // "key" would have been a nice name for this prop, but sadly that's a
-  // reserved name.
+  /*
+  "key" would have been a nice name for this prop, but sadly that's a reserved
+  name.
+
+  `name` can be passed in as a prop or as a slot.
+  */
   name: String,
   value: String
 });

--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -207,10 +207,6 @@ export default {
     margin-left: auto;
     font-size: initial;
   }
-
-  // We want the map view to stretch to the bottom of the page without being
-  // affected by this bottom margin.
-  .page-section:has(#submission-map-view) { margin-bottom: 0; }
 }
 </style>
 

--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -207,6 +207,10 @@ export default {
     margin-left: auto;
     font-size: initial;
   }
+
+  // We want the map view to stretch to the bottom of the page without being
+  // affected by this bottom margin.
+  .page-section:has(#submission-map-view) { margin-bottom: 0; }
 }
 </style>
 

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -185,8 +185,8 @@ const resize = () => {
 
 const fitView = (extent, options = undefined) => {
   mapInstance.getView().fit(extent, {
-    // Provide enough space for styled features.
-    padding: [40, 40, 40, 40],
+    // We need to provide enough space for styled features.
+    padding: [50, 50, 50, 50],
     // Avoid zooming in to an extreme degree.
     maxZoom: 16,
     ...options
@@ -303,7 +303,6 @@ const hide = () => {
 let selectedId;
 
 const hitDetectionOptions = {
-  hitTolerance: 6,
   layerFilter: (layer) => layer === featureLayer
 };
 
@@ -332,7 +331,7 @@ const selectCluster = (cluster) => {
   selectFeature(null);
 
   const features = cluster.get('features');
-  const duration = 600;
+  const duration = 1000;
   if (features.length < 1000) {
     const extent = createEmpty();
     for (const feature of features)

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -291,6 +291,18 @@ const hide = () => {
 
 let selectedId;
 
+const hitDetectionOptions = {
+  hitTolerance: 5,
+  layerFilter: (layer) => layer === featureLayer
+};
+
+// Updates the cursor based on whether the user is moving over a feature.
+const moveOverFeature = (event) => {
+  if (!shown.value || event.dragging) return;
+  const hit = mapInstance.hasFeatureAtPixel(event.pixel, hitDetectionOptions);
+  mapContainer.value.style.cursor = hit ? 'pointer' : '';
+};
+
 // Selects an individual feature (not a cluster) or deselects the selected
 // feature (if feature is `null`).
 const selectFeature = (feature) => {
@@ -333,10 +345,7 @@ const selectCluster = (cluster) => {
 };
 
 const selectFeatureAtPixel = (pixel) => {
-  const hits = mapInstance.getFeaturesAtPixel(pixel, {
-    hitTolerance: 5,
-    layerFilter: (layer) => layer === featureLayer
-  });
+  const hits = mapInstance.getFeaturesAtPixel(pixel, hitDetectionOptions);
   if (hits.length === 0) {
     selectFeature(null);
   } else {
@@ -376,6 +385,7 @@ const olOn = (target, type, callback) => {
 };
 
 olOn(mapInstance, 'moveend', () => { if (shown.value) countFeaturesInView(); });
+olOn(mapInstance, 'pointermove', moveOverFeature);
 
 // OpenLayers has a `singleclick` event, but it lags the actual click by 250
 // milliseconds in order to exclude double-clicks. Here, we listen for `click`
@@ -463,10 +473,10 @@ onBeforeUnmount(() => {
     position: absolute;
     top: 5px;
     left: 63px;
-    pointer-events: none;
 
     color: #000;
     font-size: 12px;
+    user-select: none;
   }
 }
 </style>

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -279,7 +279,7 @@ const show = async () => {
 
   shown.value = true;
   abortShow = noop;
-  countFeaturesInView();
+  inViewCount.value = featureCount.value;
   log('shown');
   emit('shown');
 };
@@ -426,9 +426,8 @@ watch(() => props.data, (newData, oldData) => {
       // set, even as the map remains transparent.
       show();
     else
-      // If the map isn't already shown, show() above will call
-      // countFeaturesInView(). But if the map is shown, we still need to call
-      // countFeaturesInView().
+      // If the map isn't already shown, then show() above will set
+      // inViewCount.value.
       countFeaturesInView();
   } else {
     hide();

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -289,19 +289,20 @@ const hide = () => {
 ////////////////////////////////////////////////////////////////////////////////
 // SELECT FEATURE
 
-let selectedFeature = null;
+let selectedId;
 
 // Selects an individual feature (not a cluster) or deselects the selected
-// feature.
+// feature (if feature is `null`).
 const selectFeature = (feature) => {
-  if (selectedFeature === feature) return;
+  const id = feature?.getId();
+  if (id === selectedId) return;
 
-  featureLayer.updateStyleVariables({ selectedId: feature?.getId() ?? '' });
-  selectedFeature = feature;
+  featureLayer.updateStyleVariables({ selectedId: id ?? '' });
+  selectedId = id;
 
   if (feature != null) {
     emit('selection-changed', {
-      id: feature.getId(),
+      id,
       properties: feature.getProperties(),
       coordinates: feature.getGeometry().getCoordinates()
     });

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -343,13 +343,6 @@ const selectFeatureAtPixel = (pixel) => {
 ////////////////////////////////////////////////////////////////////////////////
 // HOOKS - TIE EVERYTHING TOGETHER
 
-// OpenLayers event listeners
-const olListeners = [];
-const olOn = (target, type, callback) => {
-  target.on(type, callback);
-  olListeners.push([target, type, callback]);
-};
-
 // We may have attempted to show the map, but failed because the map hadn't been
 // sized. The main reason for that is that an ancestor element was hidden. This
 // ResizeObserver accounts for that case: once the ancestor element becomes
@@ -363,18 +356,23 @@ onMounted(() => {
   // If mapContainer.value is already visible, resizeObserver will run the
   // callback immediately.
   resizeObserver.observe(el.value);
+});
 
-  olOn(mapInstance, 'moveend', () => {
-    if (shown.value) countFeaturesInView();
-  });
+// OpenLayers event listeners
+const olListeners = [];
+const olOn = (target, type, callback) => {
+  target.on(type, callback);
+  olListeners.push([target, type, callback]);
+};
 
-  let lastClick = 0;
-  olOn(mapInstance, 'click', (event) => {
-    const now = Date.now();
-    // If a user double-clicks, ignore the second click.
-    if (now > lastClick + 300) selectFeatureAtPixel(event.pixel);
-    lastClick = now;
-  });
+olOn(mapInstance, 'moveend', () => { if (shown.value) countFeaturesInView(); });
+
+let lastClick = 0;
+olOn(mapInstance, 'click', (event) => {
+  const now = Date.now();
+  // If a user double-clicks, ignore the second click.
+  if (now > lastClick + 300) selectFeatureAtPixel(event.pixel);
+  lastClick = now;
 });
 
 watch(() => props.data, (newData, oldData) => {

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -49,7 +49,7 @@ const props = defineProps({
     default: noop
   }
 });
-const emit = defineEmits(['show', 'selection-changed']);
+const emit = defineEmits(['show', 'shown', 'selection-changed']);
 
 // Set to `true` for logging.
 const debug = false;
@@ -234,6 +234,7 @@ const show = async () => {
   resize();
   if (mapInstance.getSize().find(length => length === 0)) return;
 
+  emit('show');
   fitView(featureSource.getExtent());
 
   // Set abortShow.
@@ -262,7 +263,7 @@ const show = async () => {
   abortShow = noop;
   countFeaturesInView();
   log('shown');
-  emit('show');
+  emit('shown');
 };
 
 const hide = () => {

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -292,7 +292,7 @@ const hide = () => {
 let selectedId;
 
 const hitDetectionOptions = {
-  hitTolerance: 5,
+  hitTolerance: 6,
   layerFilter: (layer) => layer === featureLayer
 };
 

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -10,28 +10,451 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="geojson-map">
-    <p>GeoJSON loaded!</p>
-
-    <button v-if="json == null" type="button" class="btn btn-primary"
-      @click="showJson">
-      Show JSON
-    </button>
-    <pre v-else><code>{{ json }}</code></pre>
+  <div ref="el" class="geojson-map">
+    <div ref="mapContainer" class="map-container" :class="{ opaque: shown }" tabindex="0" :inert="!shown"></div>
+    <span v-show="shown" class="count">{{ countMessage }}</span>
   </div>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+// OpenLayers
+import Cluster from 'ol/source/Cluster';
+import Feature from 'ol/Feature';
+import GeoJSON from 'ol/format/GeoJSON';
+import Map from 'ol/Map';
+import OSM from 'ol/source/OSM';
+import Point from 'ol/geom/Point';
+import TileLayer from 'ol/layer/Tile';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import View from 'ol/View';
+import WebGLVectorLayer from 'ol/layer/WebGLVector';
+import Zoom from 'ol/control/Zoom';
+import { createEmpty, extend, getCenter } from 'ol/extent';
+
+import { computed, onBeforeUnmount, onMounted, useTemplateRef, ref, watch } from 'vue';
+import { equals } from 'ramda';
+import { useI18n } from 'vue-i18n';
+
+import useEventListener from '../composables/event-listener';
+import { getClusterSizeStyles, getSelectedStyles, getUnselectedStyles } from '../util/map-styles';
+import { noop } from '../util/util';
+import { px } from '../util/dom';
 
 const props = defineProps({
-  features: {
-    type: Object,
-    required: true
+  data: Object,
+  // Function to set the height of the map
+  sizer: {
+    type: Function,
+    default: noop
+  }
+});
+const emit = defineEmits(['show', 'selection-changed']);
+
+// Set to `true` for logging.
+const debug = false;
+// eslint-disable-next-line no-console
+const log = debug ? console.log.bind(console) : noop;
+
+const { t, n } = useI18n();
+
+const el = useTemplateRef('el');
+const mapContainer = useTemplateRef('mapContainer');
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// OPENLAYERS OBJECTS
+
+const baseLayer = new TileLayer({ source: new OSM() });
+
+const featureSource = new VectorSource();
+// Using WebGL instead of canvas for performance reasons.
+const featureLayer = new WebGLVectorLayer({
+  source: featureSource,
+  style: [...getUnselectedStyles(), ...getSelectedStyles()],
+  variables: { selectedId: '' }
+});
+
+const mapInstance = new Map({
+  layers: [baseLayer, featureLayer],
+  view: new View(),
+  controls: [new Zoom()]
+});
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// CLUSTERING
+
+const clusterSource = new Cluster({
+  source: featureSource,
+  distance: 40,
+  minDistance: 10,
+  geometryFunction: (feature) => {
+    const geometry = feature.getGeometry();
+    switch (geometry.getType()) {
+      case 'Point': return geometry;
+      case 'LineString': return new Point(geometry.getCoordinateAt(0.5));
+      case 'Polygon': return geometry.getInteriorPoint();
+      default: return new Point(getCenter(geometry.getExtent()));
+    }
+  },
+  createCluster: (point, features) => (features.length === 1
+    ? features[0]
+    : new Feature({
+      geometry: point,
+      features,
+      clusterSize: n(features.length, 'default')
+    }))
+});
+featureLayer.setSource(clusterSource);
+
+// WebGLVectorLayer doesn't seem to support text, so cluster sizes go in a
+// separate layer.
+mapInstance.addLayer(new VectorLayer({
+  source: clusterSource,
+  style: getClusterSizeStyles()
+}));
+
+const isCluster = (feature) => feature.get('clusterSize') != null;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// ADD/REMOVE FEATURES
+
+const featureCount = ref(0);
+
+const addFeatures = () => {
+  if (props.data == null) return;
+
+  const features = new GeoJSON().readFeatures(props.data, {
+    featureProjection: mapInstance.getView().getProjection()
+  });
+  if (features.length === 0) return;
+
+  // Copy each feature's id into properties so that it can be accessed from
+  // OpenLayers style rules.
+  for (const feature of features) feature.set('id', feature.getId());
+
+  featureSource.addFeatures(features);
+  featureCount.value = features.length;
+  log('features added');
+};
+
+const removeFeatures = () => {
+  if (featureCount.value === 0) return;
+  featureSource.clear(true);
+  featureCount.value = 0;
+  log('features removed');
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// RESIZE MAP
+
+const resize = () => {
+  const { sizer } = props;
+  const result = sizer();
+  if (result != null)
+    el.value.style.minHeight = typeof result === 'number' ? px(result) : result;
+  // .map-container seems to need a concrete height to be set on it (e.g.,
+  // setting `height: 100%;` in CSS didn't work).
+  mapContainer.value.style.height = px(el.value.getBoundingClientRect().height);
+
+  const oldSize = mapInstance.getSize();
+  mapInstance.updateSize();
+  if (!equals(mapInstance.getSize(), oldSize)) log('resized');
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// VIEW
+
+const fitView = (extent, options = undefined) => {
+  mapInstance.getView().fit(extent, {
+    // Provide enough space for styled features.
+    padding: [40, 40, 40, 40],
+    // Avoid zooming in to an extreme degree.
+    maxZoom: 16,
+    ...options
+  });
+};
+
+const forEachFeatureInView = (callback) => {
+  const extent = mapInstance.getView().calculateExtent();
+  return clusterSource.forEachFeatureIntersectingExtent(extent, callback);
+};
+
+const inViewCount = ref(0);
+const countFeaturesInView = () => {
+  let count = 0;
+  forEachFeatureInView(feature => {
+    // This counts the entire cluster even if not all features in the cluster
+    // are in view. That's imprecise on one hand, but also probably less
+    // confusing to users.
+    count += isCluster(feature) ? feature.get('features').length : 1;
+  });
+  inViewCount.value = count;
+};
+const countMessage = computed(() =>
+  t('showing', { count: n(inViewCount.value), total: n(featureCount.value) }));
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// SHOW/HIDE
+
+// The comments in <style> below about how we use opacity are also relevant
+// here.
+
+const shown = ref(false);
+let abortShow = noop;
+
+const show = async () => {
+  if (shown.value) return;
+
+  // show() is async, but it can also be called multiple times in a short period
+  // of time. Because of that, show() is abortable. Here, we abort any previous
+  // attempt to show(). That's needed to avoid emitting `show` twice.
+  abortShow();
+
+  if (featureCount.value === 0) return;
+
+  // Before the view can be fit, the map first needs to be sized: otherwise, the
+  // fit would be incorrect. If the map hasn't been sized, we return immediately
+  // and try again later.
+  if (mapInstance.getSize().find(length => length === 0)) return;
+
+  // Give the parent component an opportunity to resize the map right before
+  // it's shown.
+  resize();
+  if (mapInstance.getSize().find(length => length === 0)) return;
+
+  fitView(featureSource.getExtent());
+
+  // Set abortShow.
+  const abortController = new AbortController();
+  abortShow = () => {
+    abortController.abort();
+    abortShow = noop;
+  };
+
+  // Wait for the map to render fully (e.g., loading tiles) by listening for an
+  // OpenLayers `rendercomplete` event. That way, the user won't see the layers
+  // appear at different times as the tiles fade in. But if it takes too long,
+  // just proceed with showing the map.
+  await Promise.race([
+    new Promise(resolve => {
+      mapInstance.once('rendercomplete', resolve);
+      // Nudge mapInstance to render if it's not already doing so for some reason.
+      // Otherwise, the promise may never resolve.
+      mapInstance.render();
+    }),
+    new Promise(resolve => { setTimeout(resolve, 1500); })
+  ]);
+  if (abortController.signal.aborted) return;
+
+  shown.value = true;
+  abortShow = noop;
+  countFeaturesInView();
+  log('shown');
+  emit('show');
+};
+
+const hide = () => {
+  abortShow();
+
+  if (shown.value) {
+    shown.value = false;
+    log('hidden');
+  }
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// SELECT FEATURE
+
+let selectedFeature = null;
+
+// Selects an individual feature (not a cluster) or deselects the selected
+// feature.
+const selectFeature = (feature) => {
+  if (selectedFeature === feature) return;
+
+  featureLayer.updateStyleVariables({ selectedId: feature?.getId() ?? '' });
+  selectedFeature = feature;
+
+  if (feature != null) {
+    emit('selection-changed', {
+      id: feature.getId(),
+      properties: feature.getProperties(),
+      coordinates: feature.getGeometry().getCoordinates()
+    });
+  } else {
+    emit('selection-changed', null);
+  }
+};
+
+const selectCluster = (cluster) => {
+  // Deselect any feature that's currently selected.
+  selectFeature(null);
+
+  const features = cluster.get('features');
+  const duration = 600;
+  if (features.length < 1000) {
+    const extent = createEmpty();
+    for (const feature of features)
+      extend(extent, feature.getGeometry().getExtent());
+    fitView(extent, { duration });
+  } else {
+    const view = mapInstance.getView();
+    view.animate({
+      center: cluster.getGeometry().getCoordinates(),
+      zoom: view.getZoom() + 1,
+      duration
+    });
+  }
+};
+
+const selectFeatureAtPixel = (pixel) => {
+  const hits = mapInstance.getFeaturesAtPixel(pixel, {
+    hitTolerance: 5,
+    layerFilter: (layer) => layer === featureLayer
+  });
+  if (hits.length === 0) {
+    selectFeature(null);
+  } else {
+    const hit = hits[0];
+    if (isCluster(hit))
+      selectCluster(hit);
+    else
+      selectFeature(hit);
+  }
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// HOOKS - TIE EVERYTHING TOGETHER
+
+// OpenLayers event listeners
+const olListeners = [];
+const olOn = (target, type, callback) => {
+  target.on(type, callback);
+  olListeners.push([target, type, callback]);
+};
+
+// We may have attempted to show the map, but failed because the map hadn't been
+// sized. The main reason for that is that an ancestor element was hidden. This
+// ResizeObserver accounts for that case: once the ancestor element becomes
+// visible, this component will become visible, and the ResizeObserver will be
+// triggered.
+const resizeObserver = new ResizeObserver(show);
+
+onMounted(() => {
+  mapInstance.setTarget(mapContainer.value);
+  addFeatures();
+  // If mapContainer.value is already visible, resizeObserver will run the
+  // callback immediately.
+  resizeObserver.observe(el.value);
+
+  olOn(mapInstance, 'moveend', () => {
+    if (shown.value) countFeaturesInView();
+  });
+
+  let lastClick = 0;
+  olOn(mapInstance, 'click', (event) => {
+    const now = Date.now();
+    // If a user double-clicks, ignore the second click.
+    if (now > lastClick + 300) selectFeatureAtPixel(event.pixel);
+    lastClick = now;
+  });
+});
+
+watch(() => props.data, (newData, oldData) => {
+  log(newData != null
+    ? (oldData == null ? 'data set' : 'data updated')
+    : 'data cleared');
+
+  selectFeature(null);
+  removeFeatures();
+
+  if (newData != null) {
+    addFeatures();
+    if (!shown.value)
+      show();
+    else
+      // If the map isn't already shown, show() above will call
+      // countFeaturesInView(). But if the map is shown, we still need to call
+      // countFeaturesInView().
+      countFeaturesInView();
+  } else {
+    hide();
   }
 });
 
-const json = ref(null);
-const showJson = () => { json.value = JSON.stringify(props.features, null, 2); };
-watch(() => props.features, () => { json.value = null; });
+const resizeIfShown = () => { if (shown.value) resize(); };
+useEventListener(window, 'resize', resizeIfShown);
+
+onBeforeUnmount(() => {
+  for (const [target, type, callback] of olListeners) target.un(type, callback);
+  resizeObserver.disconnect();
+  mapInstance.setTarget(null);
+
+  // It might not be necessary to manually dispose of layers in this way. It's
+  // just an attempt to make sure that everything is garbage-collected.
+  featureSource.clear(true);
+  for (const layer of mapInstance.getLayers().getArray()) {
+    mapInstance.removeLayer(layer);
+    layer.setSource(null);
+    layer.dispose();
+  }
+});
 </script>
+
+<style lang="scss">
+.geojson-map {
+  position: relative;
+
+  .map-container {
+    min-height: 300px;
+
+    /*
+    Using opacity rather than v-show for a couple of reasons:
+
+    - Before showing the map to the user, we wait for the map to render fully.
+      But in order for the map to render, it needs to be visible. Using v-show
+      would prevent that.
+    - OpenLayers has to do work when it becomes visible / when its size is
+      updated. By us "hiding" the map via transparency, OpenLayers has less work
+      to do.
+    */
+    opacity: 0;
+    &.opaque { opacity: 1; }
+  }
+
+  .count {
+    position: absolute;
+    top: 5px;
+    left: 63px;
+    pointer-events: none;
+
+    color: #000;
+    font-size: 12px;
+  }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // {count} and {total} are both numbers.
+    "showing": "Showing {count} of {total}"
+  }
+}
+</i18n>

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -421,6 +421,7 @@ const resizeIfShown = () => { if (shown.value) resize(); };
 useEventListener(window, 'resize', resizeIfShown);
 
 onBeforeUnmount(() => {
+  abortShow();
   for (const [target, type, callback] of olListeners) target.un(type, callback);
   resizeObserver.disconnect();
   mapInstance.setTarget(null);

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -69,16 +69,10 @@ const mapContainer = useTemplateRef('mapContainer');
 
 const baseLayer = new TileLayer({ source: new OSM() });
 
-// We use WebGL when possible for performance reasons. If WebGL is not
-// available, we fall back to a basic 2D canvas. Our testing setup doesn't
-// support WebGL. Maybe some users don't as well.
-const supportsWebGL2 = document.createElement('canvas').getContext('webgl2') != null;
-if (!supportsWebGL2 && buildMode !== 'test')
-  // eslint-disable-next-line no-console
-  console.warn('WebGL2 not supported for map');
-const featureLayerClass = supportsWebGL2 ? WebGLVectorLayer : VectorLayer;
-
 const featureSource = new VectorSource();
+// We use WebGL for performance reasons. WebGL isn't available in our current
+// testing setup, so in test, we fall back to a basic 2D canvas.
+const featureLayerClass = buildMode !== 'test' ? WebGLVectorLayer : VectorLayer;
 const featureLayer = new featureLayerClass({ // eslint-disable-line new-cap
   source: featureSource,
   style: [...getUnselectedStyles(), ...getSelectedStyles()],

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -464,7 +464,7 @@ defineExpose({ deselect: () => { selectFeature(null); } });
   position: relative;
 
   .map-container {
-    min-height: 300px;
+    min-height: 350px;
 
     opacity: 0;
     &.opaque { opacity: 1; }

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -167,8 +167,12 @@ const removeFeatures = () => {
 const resize = () => {
   const { sizer } = props;
   const result = sizer();
-  if (result != null)
-    el.value.style.minHeight = typeof result === 'number' ? px(result) : result;
+  if (result != null) {
+    el.value.style.minHeight = typeof result === 'number'
+      ? (result > 0 ? px(result) : '')
+      : result;
+  }
+
   // .map-container seems to need a concrete height to be set on it (e.g.,
   // setting `height: 100%;` in CSS didn't work).
   mapContainer.value.style.height = px(el.value.getBoundingClientRect().height);

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -311,16 +311,9 @@ const selectFeature = (feature) => {
 
   featureLayer.updateStyleVariables({ selectedId: id ?? '' });
   selectedId = id;
-
-  if (feature != null) {
-    emit('selection-changed', {
-      id,
-      properties: feature.getProperties(),
-      coordinates: feature.getGeometry().getCoordinates()
-    });
-  } else {
-    emit('selection-changed', null);
-  }
+  emit('selection-changed', feature != null
+    ? { id, properties: feature.getProperties() }
+    : null);
 };
 
 const selectCluster = (cluster) => {
@@ -447,6 +440,8 @@ onBeforeUnmount(() => {
     layer.dispose();
   }
 });
+
+defineExpose({ deselect: () => { selectFeature(null); } });
 </script>
 
 <style lang="scss">

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -475,8 +475,13 @@ defineExpose({ deselect: () => { selectFeature(null); } });
     top: 5px;
     left: 63px;
 
+    background-color: #fff;
+    border-radius: 4px;
     color: #000;
     font-size: 12px;
+    line-height: 16px;
+    padding-block: 6px;
+    padding-inline: 8px;
     user-select: none;
   }
 }

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -194,8 +194,8 @@ const countFeaturesInView = () => {
   let count = 0;
   forEachFeatureInView(feature => {
     // This counts the entire cluster even if not all features in the cluster
-    // are in view. That's imprecise on one hand, but also probably less
-    // confusing to users.
+    // are in view. While that's arguably imprecise, it's probably less
+    // confusing to users that way.
     count += isCluster(feature) ? feature.get('features').length : 1;
   });
   inViewCount.value = count;
@@ -251,8 +251,8 @@ const show = async () => {
   await Promise.race([
     new Promise(resolve => {
       mapInstance.once('rendercomplete', resolve);
-      // Nudge mapInstance to render if it's not already doing so for some reason.
-      // Otherwise, the promise may never resolve.
+      // Nudge mapInstance to render if it's not already doing so for some
+      // reason. Otherwise, the promise may never resolve.
       mapInstance.render();
     }),
     new Promise(resolve => { setTimeout(resolve, 1500); })

--- a/src/components/geojson-map.vue
+++ b/src/components/geojson-map.vue
@@ -416,6 +416,7 @@ watch(() => props.data, (newData, oldData) => {
 
   if (newData != null) {
     addFeatures();
+
     if (!shown.value)
       show();
     else

--- a/src/components/hover-card.vue
+++ b/src/components/hover-card.vue
@@ -153,7 +153,7 @@ $border-radius: 12px;
 
   &.truncate-dt {
     dl { grid-template-columns: fit-content(50%) 1fr; }
-    dt { @include text-overflow-ellipsis; }
+    dt:not(.dl-data-dt) { @include text-overflow-ellipsis; }
   }
 }
 

--- a/src/components/map-popup.vue
+++ b/src/components/map-popup.vue
@@ -83,7 +83,6 @@ onBeforeUpdate(() => { body.value.scrollTo(0, 0); });
 }
 
 .map-popup-title {
-  @include text-overflow-ellipsis;
   font-weight: 600;
   // Buffer between the title and the close button
   margin-right: 12px;

--- a/src/components/map-popup.vue
+++ b/src/components/map-popup.vue
@@ -1,0 +1,98 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <div class="map-popup">
+    <div class="map-popup-heading">
+      <span :class="`icon-${icon}`"></span>
+      <span class="map-popup-title"><slot name="title"></slot></span>
+      <button type="button" class="close" :aria-label="$t('action.close')"
+        @click="$emit('hide')">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div ref="body" class="map-popup-body"><slot name="body"></slot></div>
+    <div class="map-popup-actions"><slot name="actions"></slot></div>
+  </div>
+</template>
+
+<script setup>
+import { onBeforeUpdate, useTemplateRef } from 'vue';
+
+defineProps({
+  icon: {
+    type: String,
+    required: true
+  }
+});
+defineEmits(['hide']);
+
+const body = useTemplateRef('body');
+onBeforeUpdate(() => { body.value.scrollTo(0, 0); });
+</script>
+
+<style lang="scss">
+@import '../assets/scss/mixins';
+
+.map-popup {
+  display: flex;
+  flex-direction: column;
+
+  position: absolute;
+  top: 15px;
+  right: 15px;
+
+  width: 315px;
+  max-height: 315px;
+
+  background-color: $color-page-background;
+  border-radius: 6px;
+  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2),
+              0 1px 1px 0 rgba(0, 0, 0, 0.14),
+              0 1px 3px 0 rgba(0, 0, 0, 0.12);
+
+  padding-block: $padding-panel-body;
+  // Setting the inline padding on the children rather than the root element,
+  // because .map-popup-body needs to be the full width of the popup. That's so
+  // its vertical scrollbar is all the way on the right.
+  > div { padding-inline: $padding-panel-body; }
+}
+
+.map-popup-heading, .map-popup-actions { flex-shrink: 0; }
+
+.map-popup-heading {
+  color: $color-accent-primary;
+  font-size: 20px;
+  padding-bottom: 12px;
+
+  > [class^="icon-"] {
+    @include icon-box;
+    font-size: 16px;
+    margin-right: $margin-right-icon;
+  }
+
+  .close { @include modal-close; }
+}
+
+.map-popup-title {
+  @include text-overflow-ellipsis;
+  font-weight: 600;
+  // Buffer between the title and the close button
+  margin-right: 12px;
+}
+
+.map-popup-body {
+  overflow-y: auto;
+
+  dl { margin-bottom: 0; }
+  dt:not(.dl-data-dt), dd:not(.dl-data-dd) { @include text-overflow-ellipsis; }
+}
+</style>

--- a/src/components/map-popup.vue
+++ b/src/components/map-popup.vue
@@ -93,6 +93,6 @@ onBeforeUpdate(() => { body.value.scrollTo(0, 0); });
   overflow-y: auto;
 
   dl { margin-bottom: 0; }
-  dt:not(.dl-data-dt), dd:not(.dl-data-dd) { @include text-overflow-ellipsis; }
+  dd:not(.dl-data-dd) { @include text-overflow-ellipsis; }
 }
 </style>

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -302,19 +302,7 @@ const titleId = `modal-title${id}`;
         }
       }
 
-      .close {
-        position: absolute;
-        // x symbol has some top spacing
-        top: calc($padding-modal-top-actions-close - 2px);
-        right: $padding-modal-top-actions-close;
-        color: $color-input;
-        font-weight: normal;
-        opacity: 1;
-
-        &[aria-disabled="true"] {
-          cursor: not-allowed;
-        }
-      }
+      .close { @include modal-close; }
     }
 
     .modal-header {

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -56,6 +56,10 @@ except according to the terms contained in the LICENSE file.
         </teleport-if-exists>
       </div>
 
+      <p v-show="emptyMessage" class="empty-table-message">
+        {{ emptyMessage }}
+      </p>
+
       <submission-table-view v-if="dataView === 'table'" ref="view"
         :project-id="projectId" :xml-form-id="xmlFormId" :draft="draft" :deleted="deleted"
         :filter="odataFilter" :fields="selectedFields"
@@ -67,9 +71,6 @@ except according to the terms contained in the LICENSE file.
       <submission-map-view v-else ref="view"
         :project-id="projectId" :xml-form-id="xmlFormId" :deleted="deleted"
         :filter="geojsonFilter"/>
-      <p v-show="emptyMessage" class="empty-table-message">
-        {{ emptyMessage }}
-      </p>
     </div>
 
     <submission-download v-bind="downloadModal" :form-version="formVersion"

--- a/src/components/submission/map-popup.vue
+++ b/src/components/submission/map-popup.vue
@@ -10,8 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <map-popup v-show="instanceId != null" id="submission-map-popup" icon="file"
-    @hide="$emit('hide')">
+  <map-popup v-show="submission.dataExists || submission.awaitingResponse"
+    id="submission-map-popup" icon="file" @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <loading :state="submission.awaitingResponse"/>
@@ -90,8 +90,7 @@ const fetchData = () => submission.request({
     props.xmlFormId,
     props.instanceId,
     { $wkt: true }
-  ),
-  alert: false
+  )
 }).catch(noop);
 watch(
   () => props.instanceId,

--- a/src/components/submission/map-popup.vue
+++ b/src/components/submission/map-popup.vue
@@ -1,0 +1,83 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <dl id="submission-map-popup" class="dl-horizontal">
+    <dt>{{ $t('title') }}</dt>
+    <dd></dd>
+
+    <dt>{{ $t('header.instanceId') }}</dt>
+    <dd v-tooltip.text>{{ instanceId }}</dd>
+
+    <dt v-tooltip.text>{{ fieldName }}</dt>
+    <dd v-tooltip.text>
+      <selectable><pre><code>{{ coordinateJson }}</code></pre></selectable>
+    </dd>
+  </dl>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import Selectable from '../selectable.vue';
+
+defineOptions({
+  name: 'SubmissionMapPopup'
+});
+const props = defineProps({
+  instanceId: {
+    type: String,
+    required: true
+  },
+  fieldpath: {
+    type: String,
+    required: true
+  },
+  coordinates: {
+    type: Array,
+    required: true
+  }
+});
+
+const coordinateJson = computed(() => JSON.stringify(props.coordinates, null, 2));
+const fieldName = computed(() => props.fieldpath.match(/\/([^/]+)$/)[1]);
+</script>
+
+<style lang="scss">
+@import '../../assets/scss/mixins';
+
+#submission-map-popup {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+
+  background-color: #fff;
+  max-width: 500px;
+  padding-block: $padding-block-dl;
+
+  dt, dd { @include text-overflow-ellipsis; }
+
+  pre {
+    background-color: transparent;
+    border: none;
+    margin-bottom: 0;
+  }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.SubmissionBasicDetails.submissionDetails
+    "title": "Submission Details"
+  }
+}
+</i18n>

--- a/src/components/submission/map-popup.vue
+++ b/src/components/submission/map-popup.vue
@@ -17,7 +17,7 @@ except according to the terms contained in the LICENSE file.
       <dl v-if="submission.dataExists">
         <div>
           <dt>{{ $t('header.submitterName') }}</dt>
-          <dd>{{ submission.__system.submitterName }}</dd>
+          <dd v-tooltip.text>{{ submission.__system.submitterName }}</dd>
         </div>
         <div>
           <dt>{{ $t('header.submissionDate') }}</dt>

--- a/src/components/submission/map-popup.vue
+++ b/src/components/submission/map-popup.vue
@@ -26,6 +26,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { computed } from 'vue';
+import { last } from 'ramda';
 
 import Selectable from '../selectable.vue';
 
@@ -48,7 +49,7 @@ const props = defineProps({
 });
 
 const coordinateJson = computed(() => JSON.stringify(props.coordinates, null, 2));
-const fieldName = computed(() => props.fieldpath.match(/\/([^/]+)$/)[1]);
+const fieldName = computed(() => last(props.fieldpath.split('/')));
 </script>
 
 <style lang="scss">

--- a/src/components/submission/map-popup.vue
+++ b/src/components/submission/map-popup.vue
@@ -15,17 +15,17 @@ except according to the terms contained in the LICENSE file.
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <loading :state="submission.awaitingResponse"/>
-      <dl v-if="submission.dataExists">
-        <div>
-          <dt>{{ $t('header.submitterName') }}</dt>
-          <dd v-tooltip.text>{{ submission.__system.submitterName }}</dd>
-        </div>
-        <div>
-          <dt>{{ $t('header.submissionDate') }}</dt>
-          <dd><date-time :iso="submission.__system.submissionDate"/></dd>
-        </div>
-      </dl>
-      <template v-if="fields.dataExists">
+      <div v-if="fields.dataExists" v-show="submission.dataExists">
+        <dl>
+          <div>
+            <dt>{{ $t('header.submitterName') }}</dt>
+            <dd v-tooltip.text>{{ submission?.__system?.submitterName }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('header.submissionDate') }}</dt>
+            <dd><date-time :iso="submission?.__system?.submissionDate"/></dd>
+          </div>
+        </dl>
         <div v-if="missingField != null">
           <span class="icon-warning"></span>
           <i18n-t keypath="missingField">
@@ -45,7 +45,7 @@ except according to the terms contained in the LICENSE file.
             </dl-data>
           </div>
         </dl>
-      </template>
+      </div>
     </template>
   </map-popup>
 </template>

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -31,6 +31,7 @@ import SubmissionMapPopup from './map-popup.vue';
 import { apiPaths } from '../../util/request';
 import { loadAsync } from '../../util/load-async';
 import { noargs, noop } from '../../util/util';
+import { styleBox } from '../../util/dom';
 import { useRequestData } from '../../request-data';
 
 defineOptions({
@@ -106,12 +107,9 @@ const el = useTemplateRef('el');
 const sizeMap = () => {
   const rect = el.value.getBoundingClientRect();
   if (rect.height === 0) return '';
-
-  const padding = 15;
-  // Not sure why this correction is needed. Without it, the map seems to
-  // overflow slightly.
-  const correction = -2;
-  return document.documentElement.clientHeight - rect.top - padding + correction;
+  const section = el.value.closest('.page-section');
+  const { marginBottom } = styleBox(getComputedStyle(section));
+  return document.documentElement.clientHeight - rect.top - marginBottom;
 };
 
 const selection = shallowRef(null);
@@ -125,5 +123,7 @@ defineExpose({ refresh });
 <style lang="scss">
 #submission-map-view {
   position: relative;
+
+  .page-section:has(&) { margin-bottom: 15px; }
 }
 </style>

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -12,7 +12,7 @@ except according to the terms contained in the LICENSE file.
 <template>
   <div id="submission-map-view" ref="el">
     <odata-loading-message :state="geojson.initiallyLoading || showingMap"
-      type="submission" :filter="filter != null" :total-count="0" :top="0"/>
+      type="submission" :filter="filter != null"/>
     <geojson-map :data="geojson.data" :sizer="sizeMap"
       @show="showMap(true)" @shown="showMap(false)"
       @selection-changed="selectionChanged"/>

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     <odata-loading-message :state="geojson.initiallyLoading || showingMap"
       type="submission" :filter="filter != null"/>
     <geojson-map :data="geojson.data" :sizer="sizeMap"
-      @show="showMap(true)" @shown="showMap(false)"
+      @show="setShowing(true)" @shown="setShowing(false)"
       @selection-changed="selectionChanged"/>
     <submission-map-popup v-if="selection != null" :instance-id="selection.id"
       :fieldpath="selection.properties.fieldpath"
@@ -94,7 +94,7 @@ watch([() => props.filter, () => props.deleted], noargs(fetchData));
 const refresh = () => fetchData(false);
 
 const showingMap = ref(false);
-const showMap = (showing) => { showingMap.value = showing; };
+const setShowing = (value) => { showingMap.value = value; };
 
 const el = useTemplateRef('el');
 // Stretches the map to the bottom of the screen.

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -11,9 +11,10 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div id="submission-map-view" ref="el">
-    <odata-loading-message :state="geojson.initiallyLoading || loadingMap"
+    <odata-loading-message :state="geojson.initiallyLoading || showingMap"
       type="submission" :filter="filter != null" :total-count="0" :top="0"/>
-    <geojson-map :data="geojson.data" :sizer="sizeMap" @show="loadedMap"
+    <geojson-map :data="geojson.data" :sizer="sizeMap"
+      @show="showMap(true)" @shown="showMap(false)"
       @selection-changed="selectionChanged"/>
     <submission-map-popup v-if="selection != null" :instance-id="selection.id"
       :fieldpath="selection.properties.fieldpath"
@@ -92,11 +93,8 @@ fetchData();
 watch([() => props.filter, () => props.deleted], noargs(fetchData));
 const refresh = () => fetchData(false);
 
-const loadingMap = ref(false);
-watch(() => geojson.dataExists, (dataExists) => {
-  loadingMap.value = dataExists;
-});
-const loadedMap = () => { loadingMap.value = false; };
+const showingMap = ref(false);
+const showMap = (showing) => { showingMap.value = showing; };
 
 const el = useTemplateRef('el');
 // Stretches the map to the bottom of the screen.

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -13,12 +13,12 @@ except according to the terms contained in the LICENSE file.
   <div id="submission-map-view" ref="el">
     <odata-loading-message :state="geojson.initiallyLoading || showingMap"
       type="submission" :filter="filter != null"/>
-    <geojson-map :data="geojson.data" :sizer="sizeMap"
+    <geojson-map ref="map" :data="geojson.data" :sizer="sizeMap"
       @show="setShowing(true)" @shown="setShowing(false)"
       @selection-changed="selectionChanged"/>
-    <submission-map-popup v-if="selection != null" :instance-id="selection.id"
-      :fieldpath="selection.properties.fieldpath"
-      :coordinates="selection.coordinates"/>
+    <submission-map-popup :project-id="projectId" :xml-form-id="xmlFormId"
+      :instance-id="selection?.id" :fieldpath="selection?.properties.fieldpath"
+      @hide="map.deselect()"/>
   </div>
 </template>
 
@@ -95,6 +95,8 @@ const refresh = () => fetchData(false);
 
 const showingMap = ref(false);
 const setShowing = (value) => { showingMap.value = value; };
+
+const map = useTemplateRef('map');
 
 const el = useTemplateRef('el');
 // Stretches the map to the bottom of the screen.

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -95,6 +95,11 @@ const refresh = () => fetchData(false);
 
 const showingMap = ref(false);
 const setShowing = (value) => { showingMap.value = value; };
+watch(() => geojson.dataExists, (dataExists) => {
+  // We need to set showingMap.value to `false` if the data is cleared between
+  // the `show` and `shown` events of the GeojsonMap.
+  if (!dataExists) setShowing(false);
+});
 
 const map = useTemplateRef('map');
 

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -17,7 +17,7 @@ except according to the terms contained in the LICENSE file.
       @show="setShowing(true)" @shown="setShowing(false)"
       @selection-changed="selectionChanged"/>
     <submission-map-popup :project-id="projectId" :xml-form-id="xmlFormId"
-      :instance-id="selection?.id" :fieldpath="selection?.properties.fieldpath"
+      :instance-id="selection?.id" :fieldpath="selection?.properties?.fieldpath"
       @hide="map.deselect()"/>
   </div>
 </template>

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -101,8 +101,6 @@ watch(() => geojson.dataExists, (dataExists) => {
   if (!dataExists) setShowing(false);
 });
 
-const map = useTemplateRef('map');
-
 const el = useTemplateRef('el');
 // Stretches the map to the bottom of the screen.
 const sizeMap = () => {
@@ -118,6 +116,8 @@ const sizeMap = () => {
 
 const selection = shallowRef(null);
 const selectionChanged = (value) => { selection.value = value; };
+
+const map = useTemplateRef('map');
 
 defineExpose({ refresh });
 </script>

--- a/src/util/load-async.js
+++ b/src/util/load-async.js
@@ -123,6 +123,9 @@ const loaders = new Map()
     /* webpackChunkName: "component-form-submission" */
     '../components/form/submission.vue'
   )))
+  .set('GeojsonMap', loader(() => import(
+    '../components/geojson-map.vue'
+  )))
   .set('WebFormRenderer', loader(() => import(
     /* webpackChunkName: "component-web-form-renderer" */
     '../components/web-form-renderer.vue'

--- a/src/util/map-styles.js
+++ b/src/util/map-styles.js
@@ -1,0 +1,127 @@
+/*
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+*/
+import mapLocationIcon from '../assets/images/geojson-map/map-location.svg';
+
+const DEFAULT_POINT_STYLE = {
+  'icon-src': mapLocationIcon,
+  'icon-width': 40,
+  'icon-height': 40,
+};
+
+const DEFAULT_LINE_STYLE = {
+  'stroke-width': 6,
+  'stroke-color': '#3E9FCC',
+};
+
+const DEFAULT_POLYGON_STYLE = {
+  'fill-color': 'rgba(233, 248, 255, 0.8)',
+  'stroke-width': 6,
+  'stroke-color': '#3E9FCC',
+};
+
+const SCALE_POINT_STYLE = {
+  'icon-src': mapLocationIcon,
+  'icon-width': 50,
+  'icon-height': 50,
+};
+
+const SCALE_LINE_STYLE = {
+  'stroke-width': 10,
+  'stroke-color': '#3E9FCC',
+};
+
+const SCALE_POLYGON_STYLE = {
+  'stroke-width': 10,
+};
+
+const GLOW_POINT_STYLE = {
+  'circle-radius': 30,
+  'circle-fill-color': 'rgba(148, 224, 237, 0.7)',
+  'circle-displacement': [0, 0],
+};
+
+const GLOW_LINE_STYLE = {
+  'stroke-width': 20,
+  'stroke-color': 'rgba(148, 224, 237, 0.7)',
+};
+
+const GLOW_POLYGON_STYLE = {
+  'stroke-width': 20,
+  'stroke-color': 'rgba(148, 224, 237, 0.7)',
+  'fill-color': 'transparent',
+};
+
+export const getUnselectedStyles = () => {
+  const makeFilter = (type) => [
+    'all',
+    ['!', ['has', 'clusterSize']],
+    ['match', ['geometry-type'], type, true, false],
+    ['!=', ['get', 'id'], ['var', 'selectedId']],
+  ];
+
+  return [
+    {
+      filter: ['has', 'clusterSize'],
+      style: GLOW_POINT_STYLE,
+    },
+    {
+      filter: makeFilter('Point'),
+      style: DEFAULT_POINT_STYLE,
+    },
+    {
+      filter: makeFilter('LineString'),
+      style: DEFAULT_LINE_STYLE,
+    },
+    {
+      filter: makeFilter('Polygon'),
+      style: DEFAULT_POLYGON_STYLE,
+    },
+  ];
+};
+
+export const getSelectedStyles = () => {
+  const makeFilter = (type) => [
+    'all',
+    ['!', ['has', 'clusterSize']],
+    ['match', ['geometry-type'], type, true, false],
+    ['==', ['get', 'id'], ['var', 'selectedId']],
+  ];
+
+  return [
+    {
+      filter: makeFilter('Point'),
+      style: [GLOW_POINT_STYLE, DEFAULT_POINT_STYLE, SCALE_POINT_STYLE],
+    },
+    {
+      filter: makeFilter('LineString'),
+      style: [GLOW_LINE_STYLE, DEFAULT_LINE_STYLE, SCALE_LINE_STYLE],
+    },
+    {
+      filter: makeFilter('Polygon'),
+      style: [GLOW_POLYGON_STYLE, DEFAULT_POLYGON_STYLE, SCALE_POLYGON_STYLE],
+    },
+  ];
+};
+
+export const getClusterSizeStyles = () => {
+  const style = getComputedStyle(document.body);
+  return [
+    {
+      filter: ['has', 'clusterSize'],
+      style: {
+        'text-value': ['get', 'clusterSize'],
+        'text-font': `500 ${style.fontSize} ${style.fontFamily}`,
+        'text-fill-color': style.color,
+      },
+    },
+  ];
+};

--- a/test/components/submission/map-popup.spec.js
+++ b/test/components/submission/map-popup.spec.js
@@ -1,0 +1,140 @@
+import DateTime from '../../../src/components/date-time.vue';
+import DlData from '../../../src/components/dl-data.vue';
+import SubmissionMapPopup from '../../../src/components/submission/map-popup.vue';
+
+import useFields from '../../../src/request-data/fields';
+
+import testData from '../../data';
+import { mergeMountOptions } from '../../util/lifecycle';
+import { mockHttp } from '../../util/http';
+import { testRequestData } from '../../util/request-data';
+
+const mountOptions = (options = undefined) => {
+  const form = testData.extendedForms.last();
+  const { instanceId } = testData.extendedSubmissions.last();
+  return mergeMountOptions(options, {
+    props: {
+      projectId: form.projectId.toString(),
+      xmlFormId: form.xmlFormId,
+      instanceId,
+      fieldpath: '/p1'
+    },
+    container: {
+      requestData: testRequestData([useFields], { fields: form._fields })
+    }
+  });
+};
+
+describe('SubmissionMapPopup', () => {
+  beforeEach(() => {
+    testData.extendedUsers.createPast(1, { displayName: 'Allison' });
+    testData.extendedForms.createPast(1, {
+      xmlFormId: 'a b',
+      fields: [
+        testData.fields.group('/names'),
+        testData.fields.string('/names/first_name'),
+        testData.fields.geopoint('/p1'),
+        testData.fields.geopoint('/p2')
+      ],
+      submissions: 1
+    });
+    testData.extendedSubmissions.createPast(1, {
+      instanceId: 'c d',
+      names: { first_name: 'Someone' },
+      p1: 'POINT (1 1)',
+      p2: 'POINT (2 2)'
+    });
+  });
+
+  it('does nothing if instanceId is not defined', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions({
+        props: { instanceId: null }
+      }))
+      .testNoRequest()
+      .afterResponses(component => {
+        component.should.be.hidden();
+      }));
+
+  it('sends the correct request', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions())
+      .respondWithData(testData.submissionOData)
+      .testRequests([{
+        url: "/v1/projects/1/forms/a%20b.svc/Submissions('c%20d')?%24wkt=true"
+      }]));
+
+  it('shows submission metadata', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions())
+      .respondWithData(testData.submissionOData)
+      .afterResponse(async (component) => {
+        const dd = component.findAll('dd');
+        dd[0].text().should.equal('Allison');
+        await dd[0].should.have.textTooltip();
+
+        const { createdAt } = testData.extendedSubmissions.last();
+        dd[1].getComponent(DateTime).props().iso.should.equal(createdAt);
+      }));
+
+  it('shows form-field data, ordering the geo field first', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions())
+      .respondWithData(testData.submissionOData)
+      .afterResponse(async (component) => {
+        const pairs = component.findAllComponents(DlData);
+        const names = pairs.map(pair => pair.get('dt').text());
+        names.should.eql(['p1', 'first_name', 'p2']);
+
+        const values = pairs.map(pair => pair.props().value);
+        values.should.eql(['POINT (1 1)', 'Someone', 'POINT (2 2)']);
+      }));
+
+  it('shows fields in form order if the geo field is not present', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions({
+        props: { fieldpath: '/field_that_is_no_longer_in_form' }
+      }))
+      .respondWithData(testData.submissionOData)
+      .afterResponse(component => {
+        const names = component.findAllComponents(DlData)
+          .map(pair => pair.get('dt').text());
+        names.should.eql(['first_name', 'p1', 'p2']);
+      }));
+
+  it('shows tooltips for form-field data', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions())
+      .respondWithData(testData.submissionOData)
+      .afterResponse(async (component) => {
+        const pair = component.findAllComponents(DlData)[1];
+        const name = pair.get('dt span');
+        name.text().should.equal('first_name');
+        await name.should.have.tooltip('names-first_name');
+        pair.get('dd').should.have.textTooltip();
+      }));
+
+  it('updates after the instanceId changes', () =>
+    mockHttp()
+      .mount(SubmissionMapPopup, mountOptions())
+      .respondWithData(testData.submissionOData)
+      .complete()
+      .request(component => {
+        testData.extendedSubmissions.createNew({
+          instanceId: 'another',
+          p1: 'POINT (3 3)'
+        });
+        return component.setProps({ instanceId: 'another' });
+      })
+      .respondWithData(() => testData.submissionOData(1))
+      .testRequests([{
+        url: ({ pathname }) => {
+          pathname.should.contain('another');
+        }
+      }])
+      .afterResponse(component => {
+        const pair = component.getComponent(DlData);
+        pair.get('dt').text().should.equal('p1');
+        pair.props().value.should.equal('POINT (3 3)');
+      }));
+});

--- a/test/components/submission/map-popup.spec.js
+++ b/test/components/submission/map-popup.spec.js
@@ -49,7 +49,7 @@ describe('SubmissionMapPopup', () => {
   it('does nothing if instanceId is not defined', () =>
     mockHttp()
       .mount(SubmissionMapPopup, mountOptions({
-        props: { instanceId: null }
+        props: { instanceId: null, fieldpath: null }
       }))
       .testNoRequest()
       .afterResponses(component => {

--- a/test/components/submission/map-view.spec.js
+++ b/test/components/submission/map-view.spec.js
@@ -224,7 +224,7 @@ describe('SubmissionMapView', () => {
     it('updates the map', () => {
       testData.extendedSubmissions.createPast(1, { mypoint: 'POINT (1 2)' });
       const assertCount = (app, count) => {
-        const { features } = app.getComponent(GeojsonMap).props();
+        const { features } = app.getComponent(GeojsonMap).props().data;
         features.length.should.equal(count);
       };
       return load('/projects/1/forms/f/submissions?map=true')
@@ -309,7 +309,7 @@ describe('SubmissionMapView', () => {
       .createPast(1, { mypoint: 'POINT (1 2)' })
       .createPast(1, { mypoint: null });
     const app = await load('/projects/1/forms/f/submissions?map=true');
-    app.getComponent(GeojsonMap).props().features.length.should.equal(1);
+    app.getComponent(GeojsonMap).props().data.features.length.should.equal(1);
     // Even though there is only one submission in the GeoJSON, that should not
     // change the submission count in the tab badge.
     findTab(app, 'Submissions').get('.badge').text().should.equal('2');

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -3694,6 +3694,12 @@
         }
       }
     },
+    "GeojsonMap": {
+      "showing": {
+        "string": "Showing {count} of {total}",
+        "developer_comment": "{count} and {total} are both numbers."
+      }
+    },
     "Home": {
       "heading": {
         "0": {

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -5030,6 +5030,12 @@
         }
       }
     },
+    "SubmissionMapPopup": {
+      "missingField": {
+        "string": "This Submission was mapped using {field}, which isn’t in the published Form version.",
+        "developer_comment": "{field} is the name of a Form field."
+      }
+    },
     "SubmissionRestore": {
       "title": {
         "string": "Restore Submission",


### PR DESCRIPTION
This PR makes progress on submission mapping (getodk/central#1152). The biggest change is to the `GeojsonMap` component, which now renders an actual map using the OpenLayers library.

<details>
<summary>Here is a fuller list of what this PR does</summary>

- Render an OpenLayers map.
- Parse GeoJSON, adding the resulting geo features to the map.
- Initially fit the view so that the map shows all features.
- Show the number of features in view (e.g., "Showing 10 of 100").
- Update the map in place after a background refresh of the GeoJSON. The features on the map may change, but the center of the map and the zoom level will not.
- Hide the map when the GeoJSON is cleared.
  - This happens after filters are changed, but before the new response is received. During that time, the map is hidden, and a loading message is shown.
- Wait to show the map until conditions are met. The following two conditions are resolved async and can happen in either order:
  1. The GeoJSON response is received.
  2. All ancestor elements become visible. Much of `SubmissionList` is hidden until the `fields` response is received.
- Cluster features.
- Allow a feature or cluster to be selected.
- Style features based on whether they are selected or not.
- Show a popup after a feature is selected. The popup will send a request for OData.
- Deselect a feature
  1. After a click on an empty space on the map
  2. After the close button in the popup is clicked
</details>

---

This PR adapts the code in getodk/web-forms#491. It's been really helpful to be able to draw from that PR. In particular, the `GeojsonMap` component in this PR includes a lot of the code from the `useMapBlock()` composable in Web Forms. src/util/map-styles.js here closely matches map-styles.ts in Web Forms. There are some differences between the design/criteria for Central vs. Web Forms, some of which I mentioned in a [review](https://github.com/getodk/web-forms/pull/491#pullrequestreview-3270032257) I left on the Web Forms PR.

<details>
<summary>Here are some of the main differences between the two PRs</summary>

- Central fits the view to show all features. **UPDATE:** Actually, I think Web Forms does this now too.
- Central clusters features.
- Central shows the number of features in view.
- Central waits for ancestor elements to become visible before showing the map. As far as I know, that's not needed in Web Forms. Central also waits for the base layer to be loaded.
- Web Forms allows features to be saved, not just selected.
- Web Forms shows a button to center the map on the user's location. It shows an error message if the location is not available.
- Web Forms shows a button to make the map full-screen.
- Both Central and Web Forms load the OpenLayers dependency async. However, Web Forms seems to have more sophisticated logic around how that's done, surfacing the loading state. Central just uses `GeojsonMap` with `defineAsyncComponent()`, similar to other async components in Central. Nothing is shown until the async component is downloaded.
- Central and Web Forms both show popups, but they're different from one another and were implemented separately. For Central, the popup will be different from one page to another (i.e., for submissions vs. entities).
- I'm sure I'm missing other things that Web Forms does and other differences between the two PRs. I'll add things to this list as I think of them. Mostly I just wanted to give examples of how even though the two PRs are very similar in some ways, using OpenLayers similarly, they're also different in other ways.
</details>

---

This is an initial PR, and there's additional work that will need to be done. Most of that will probably come in follow-up PRs. I'm eager to get this PR merged sooner rather than later so that we can get it on staging and the QA team can begin testing it.

<details>
<summary>Here are some remaining to-dos</summary>

- Update the appearance of the count message.
- Add the buttons to the bottom of the popup.
- getodk/central#1391
- getodk/central#1392
- getodk/central#1383
- getodk/central#1384
- getodk/central#1389
</details>

---

#### What has been done to verify that this works as intended?

I've been trying it out locally. I've tested points, lines, and shapes. I also faked the Backend response to return 100,000 random points to see what the performance would be like. I was happy to see that the map was still plenty responsive given that amount of data.

I've updated existing Frontend tests, and everything is passing. However, as of the time of writing, I haven't added new tests yet. I'm hoping to at least write tests of the popup as part of this PR. For tests of the `GeojsonMap` component, those are more likely to come in a follow-up PR: see getodk/central#1381.

#### Why is this the best possible solution? Were any other approaches considered?

Especially in the `GeojsonMap` component, I tried to add code comments explaining the approach. In a review I left on the Web Forms PR, I left comments about places where I ended up doing things differently than Web Forms: https://github.com/getodk/web-forms/pull/491#pullrequestreview-3270032257

Outside `GeojsonMap`, the main change is the popup. The popup largely follows existing patterns:

- `MapPopup` is a generic component that contains the code that will be shared between submissions and entities. It's pretty similar to `HoverCard`. I originally thought I might be able just to modify `HoverCard` and reuse that. But there ended up being enough differences that I decided to create a new component.
- The `SubmissionMapPopup` component is specific to submissions. It renders a `MapPopup` component. It's similar in some ways to `SubmissionBasicDetails`.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced