### PR TITLE
Improve OdataLoadingMessage

### DIFF
--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -41,11 +41,10 @@ except according to the terms contained in the LICENSE file.
     <p v-show="emptyTableMessage" class="empty-table-message">
       {{ emptyTableMessage }}
     </p>
-    <odata-loading-message type="entity"
+    <odata-loading-message :state="odataEntities.initiallyLoading"
+      type="entity"
       :top="pagination.size"
-      :odata="odataEntities"
       :filter="odataFilter != null || !!searchTerm"
-      :refreshing="refreshing"
       :total-count="dataset.dataExists ? dataset.entities : 0"/>
 
     <!-- @update:page is emitted on size change as well -->

--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -24,9 +24,6 @@ import Spinner from './spinner.vue';
 
 import { useI18nUtils } from '../util/i18n';
 
-const { t } = useI18n();
-const { tn } = useI18nUtils();
-
 defineOptions({
   name: 'OdataLoadingMessage'
 });
@@ -41,6 +38,9 @@ const props = defineProps({
   totalCount: Number,
   top: Number
 });
+
+const { t } = useI18n();
+const { tn } = useI18nUtils();
 
 const message = computed(() => {
   if (!props.state) return null;

--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -11,10 +11,8 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div v-show="state" id="odata-loading-message">
-    <div id="odata-loading-spinner-container">
-      <spinner :state="state"/>
-    </div>
-    <div id="odata-loading-message-text">{{ message }}</div>
+    <spinner :state="state" inline/>
+    <span id="odata-loading-message-text">{{ message }}</span>
   </div>
 </template>
 
@@ -72,23 +70,13 @@ const message = computed(() => {
 @import '../assets/scss/variables';
 
 #odata-loading-message {
-  margin-left: 28px;
-  margin-top: 20px;
-  padding-bottom: 38px;
-  position: relative;
+  font-size: 12px;
+  padding: 20px 0 38px 28px;
+}
 
-  #odata-loading-spinner-container {
-    margin-right: 8px;
-    position: absolute;
-    top: 8px;
-    width: 16px; // eventually probably better not to default spinner to center.
-  }
-
-  #odata-loading-message-text {
-    color: #555;
-    font-size: 12px;
-    padding-left: 24px;
-  }
+#odata-loading-message-text {
+  color: #555;
+  margin-left: 9px;
 }
 </style>
 

--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -10,9 +10,9 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div v-show="message != null" id="odata-loading-message">
+  <div v-show="state" id="odata-loading-message">
     <div id="odata-loading-spinner-container">
-      <spinner :state="message != null"/>
+      <spinner :state="state"/>
     </div>
     <div id="odata-loading-message-text">{{ message }}</div>
   </div>
@@ -23,6 +23,7 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import Spinner from './spinner.vue';
+
 import { useI18nUtils } from '../util/i18n';
 
 const { t } = useI18n();
@@ -33,22 +34,12 @@ defineOptions({
 });
 
 const props = defineProps({
-  odata: {
-    type: Object,
-    required: true
-  },
+  state: Boolean,
   type: {
     type: String,
     required: true
   },
-  refreshing: {
-    type: Boolean,
-    required: true
-  },
-  filter: {
-    type: Boolean,
-    default: false
-  },
+  filter: Boolean,
   totalCount: {
     type: Number,
     required: true
@@ -59,28 +50,22 @@ const props = defineProps({
   }
 });
 
-
-
 const message = computed(() => {
-  if (!props.odata.awaitingResponse || props.refreshing) return null;
+  if (!props.state) return null;
 
-  if (!props.odata.dataExists) {
-    if (props.filter)
-      return t(`${props.type}.filtered.withoutCount`);
+  if (props.filter)
+    return t(`${props.type}.filtered.withoutCount`);
 
-    if (props.totalCount === 0)
-      return t(`${props.type}.withoutCount`);
+  if (props.totalCount === 0)
+    return t(`${props.type}.withoutCount`);
 
-    if (props.totalCount <= props.top)
-      return tn(`${props.type}.all`, props.totalCount);
+  if (props.totalCount <= props.top)
+    return tn(`${props.type}.all`, props.totalCount);
 
-    return tn(`${props.type}.first`, props.totalCount, {
-      top: props.top
-    });
-  }
-  return null;
+  return tn(`${props.type}.first`, props.totalCount, {
+    top: props.top
+  });
 });
-
 </script>
 
 <style lang="scss">

--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -38,14 +38,8 @@ const props = defineProps({
     required: true
   },
   filter: Boolean,
-  totalCount: {
-    type: Number,
-    required: true
-  },
-  top: {
-    type: Number,
-    required: true
-  }
+  totalCount: Number,
+  top: Number
 });
 
 const message = computed(() => {
@@ -54,10 +48,10 @@ const message = computed(() => {
   if (props.filter)
     return t(`${props.type}.filtered.withoutCount`);
 
-  if (props.totalCount === 0)
+  if (props.totalCount == null || props.totalCount === 0)
     return t(`${props.type}.withoutCount`);
 
-  if (props.totalCount <= props.top)
+  if (props.top == null || props.totalCount <= props.top)
     return tn(`${props.type}.all`, props.totalCount);
 
   return tn(`${props.type}.first`, props.totalCount, {

--- a/src/components/odata-loading-message.vue
+++ b/src/components/odata-loading-message.vue
@@ -61,8 +61,6 @@ const message = computed(() => {
 </script>
 
 <style lang="scss">
-@import '../assets/scss/variables';
-
 #odata-loading-message {
   font-size: 12px;
   padding: 20px 0 38px 28px;
@@ -70,7 +68,7 @@ const message = computed(() => {
 
 #odata-loading-message-text {
   color: #555;
-  margin-left: 9px;
+  margin-left: 8px;
 }
 </style>
 

--- a/src/components/submission/list.vue
+++ b/src/components/submission/list.vue
@@ -59,14 +59,14 @@ except according to the terms contained in the LICENSE file.
       <submission-table-view v-if="dataView === 'table'" ref="view"
         :project-id="projectId" :xml-form-id="xmlFormId" :draft="draft" :deleted="deleted"
         :filter="odataFilter" :fields="selectedFields"
-        :refreshing="refreshing" :total-count="formVersion.submissions"
+        :total-count="formVersion.submissions"
         :awaiting-responses="awaitingResponses"
         @review="reviewModal.show({ submission: $event })"
         @delete="showDelete"
         @restore="showRestore"/>
       <submission-map-view v-else ref="view"
         :project-id="projectId" :xml-form-id="xmlFormId" :deleted="deleted"
-        :filter="geojsonFilter" :refreshing="refreshing"/>
+        :filter="geojsonFilter"/>
       <p v-show="emptyTableMessage" class="empty-table-message">
         {{ emptyTableMessage }}
       </p>

--- a/src/components/submission/map-view.vue
+++ b/src/components/submission/map-view.vue
@@ -12,9 +12,8 @@ except according to the terms contained in the LICENSE file.
 <template>
   <geojson-map v-if="geojson.dataExists && geojson.features.length !== 0"
     :features="geojson.features"/>
-  <odata-loading-message type="submission" :odata="geojson"
-    :filter="filter != null" :refreshing="refreshing" :total-count="0"
-    :top="0"/>
+  <odata-loading-message :state="geojson.initiallyLoading" type="submission"
+    :filter="filter != null" :total-count="0" :top="0"/>
 </template>
 
 <script setup>
@@ -43,10 +42,7 @@ const props = defineProps({
   deleted: Boolean,
 
   // Table actions
-  filter: Object,
-
-  // Loading message
-  refreshing: Boolean
+  filter: Object
 });
 
 const { odata, createResource } = useRequestData();

--- a/src/components/submission/table-view.vue
+++ b/src/components/submission/table-view.vue
@@ -16,11 +16,10 @@ except according to the terms contained in the LICENSE file.
     @review="$emit('review', $event)"
     @delete="$emit('delete', $event)"
     @restore="$emit('restore', $event)"/>
-  <odata-loading-message type="submission"
+  <odata-loading-message :state="odata.initiallyLoading"
+    type="submission"
     :top="pagination.size"
-    :odata="odata"
     :filter="!!filter"
-    :refreshing="refreshing"
     :total-count="totalCount"/>
   <!-- @update:page is emitted on size change as well -->
   <Pagination v-if="pagination.count > 0"
@@ -61,13 +60,10 @@ const props = defineProps({
   filter: String,
   fields: Array,
 
-  // Loading message
   totalCount: {
     type: Number,
     default: 0
   },
-  refreshing: Boolean,
-
   awaitingResponses: {
     type: Set,
     required: true

--- a/test/components/entity/upload.spec.js
+++ b/test/components/entity/upload.spec.js
@@ -406,8 +406,7 @@ describe('EntityUpload', () => {
         if (i === 0) return;
         component.get('#entity-table').should.be.hidden();
         const props = component.getComponent(OdataLoadingMessage).props();
-        props.odata.awaitingResponse.should.be.true;
-        props.refreshing.should.be.false;
+        props.state.should.be.true;
         props.totalCount.should.equal(1);
       }));
 

--- a/test/components/odata-loading-message.spec.js
+++ b/test/components/odata-loading-message.spec.js
@@ -9,7 +9,7 @@ describe('OdataLoadingMessage', () => {
     ['Loading Submissions…',                                  { state: true }],
     ['Loading 10 Submissions…',                               { state: true, top: 250, totalCount: 10 }],
     ['Loading the first 10 of 100 Submissions…',              { state: true, top: 10, totalCount: 100 }],
-    // totalCount is 0
+    // totalCount is 0.
     ['Loading Submissions…',                                  { state: true, top: 250, totalCount: 0 }],
     // No `top`
     ['Loading 10 Submissions…',                               { state: true, totalCount: 10 }],

--- a/test/components/odata-loading-message.spec.js
+++ b/test/components/odata-loading-message.spec.js
@@ -1,38 +1,29 @@
-import { mount } from '../util/lifecycle';
-
 import OdataLoadingMessage from '../../src/components/odata-loading-message.vue';
+
+import { mount } from '../util/lifecycle';
 
 describe('OdataLoadingMessage', () => {
   /* eslint-disable no-multi-spaces */
   const cases = [
-    ['',                                                      { dataExists: false, awaitingResponse: false, top: 0, refreshing: false, filter: false, totalCount: 0 }],
-    ['Loading matching Submissions…',                         { dataExists: false, awaitingResponse: true, top: 0, refreshing: false, filter: true, totalCount: 0 }],
-    ['Loading Submissions…',                                  { dataExists: false, awaitingResponse: true, top: 0, refreshing: false, filter: false, totalCount: 0 }],
-    ['Loading 10 Submissions…',                               { dataExists: false, awaitingResponse: true, top: 250, refreshing: false, filter: false, totalCount: 10 }],
-    ['Loading the first 10 of 100 Submissions…',              { dataExists: false, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 100 }],
-    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 100, originalCount: 100, dataLength: 10 }],
-    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 15, originalCount: 15, dataLength: 10 }],
-    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: false, totalCount: 11, originalCount: 11, dataLength: 10 }],
-    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 100, originalCount: 100, dataLength: 10 }],
-    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 15, originalCount: 15, dataLength: 10 }],
-    ['',                                                      { dataExists: true, awaitingResponse: true, top: 10, refreshing: false, filter: true, totalCount: 11, originalCount: 11, dataLength: 10 }],
+    ['',                                                      { state: false }],
+    ['Loading Submissions…',                                  { state: true }],
+    ['Loading 10 Submissions…',                               { state: true, top: 250, totalCount: 10 }],
+    ['Loading the first 10 of 100 Submissions…',              { state: true, top: 10, totalCount: 100 }],
+    // totalCount is 0
+    ['Loading Submissions…',                                  { state: true, top: 250, totalCount: 0 }],
+    // No `top`
+    ['Loading 10 Submissions…',                               { state: true, totalCount: 10 }],
+    ['Loading matching Submissions…',                         { state: true, filter: true }],
 
-    ['Loading Entities…',                                     { dataExists: false, awaitingResponse: true, type: 'entity', top: 0, refreshing: false, filter: false, totalCount: 0 }],
-    ['Loading matching Entities…',                            { dataExists: false, awaitingResponse: true, type: 'entity', top: 0, refreshing: false, filter: true, totalCount: 0 }]
+    ['Loading Entities…',                                     { state: true, type: 'entity' }],
+    ['Loading matching Entities…',                            { state: true, type: 'entity', filter: true }]
   ];
   /* eslint-enable no-multi-spaces */
 
-  for (const [expectedMessage, data] of cases) {
+  for (const [expectedMessage, props] of cases) {
     it(`should say "${expectedMessage}"`, () => {
       const component = mount(OdataLoadingMessage, {
-        props: {
-          odata: { dataExists: data.dataExists, awaitingResponse: data.awaitingResponse, originalCount: data.originalCount, value: new Array(data.dataLength) },
-          top: data.top,
-          refreshing: data.refreshing,
-          filter: data.filter,
-          totalCount: data.totalCount,
-          type: data.type ?? 'submission'
-        }
+        props: { type: 'submission', ...props }
       });
       component.text().should.be.eql(expectedMessage);
     });


### PR DESCRIPTION
This PR makes a few changes to the `OdataLoadingMessage` component. Most of the changes are to facilitate mapping (getodk/central#1152).

- Replace the `odata` and `refreshing` props with a single `state` prop
  - The main impetus for this is that there will now be times when we show the loading message even after the response has been received. In `SubmissionMapView`, it takes a moment for the map to render after the response is received. Instead of leaving things completely blank during that time, I want to continue showing the loading message.
  - Even without that impetus, I think it's overall a simplifying change. It means that we don't need to pass a `refreshing` prop to `SubmissionMapView` or `SubmissionTableView`. There was also awkwardness in that `SubmissionMapView` was passing the `geojson` resource for the `odata` prop.
- Replace margin with padding
  - For mapping, I need to measure the `top` pixel of `SubmissionMapView` in order to correctly size the map. However, the top margin on `OdataLoadingMessage` was affecting where `SubmissionMapView` thought its `top` was.
- Make the `totalCount` and `top` props optional
  - `SubmissionMapView` doesn't have access to these values. Right now, it's passing `0` for both, but it'd be nice if it could just omit them.
- Other minor changes
  - One change that I'm happy about is that we can remove the `#odata-loading-spinner-container`. That's because the `Spinner` component now has an `inline` prop that we can use instead.

#### What has been done to verify that this works as intended?

I've tried it out locally in the context of #1351. I've also updated tests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced