### PR TITLE
Fixes : handle concurrent refresh and bulk delete gracefully

### DIFF
--- a/src/components/dataset/entities.vue
+++ b/src/components/dataset/entities.vue
@@ -147,6 +147,7 @@ export default {
             $filter: '__system/deletedAt ne null',
           }
         ),
+        clear: false,
       }).catch(noop);
     },
     toggleDeleted() {

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -575,6 +575,7 @@ export default {
       this.allSelected = false;
     },
     cancelBackgroundRefresh() {
+      if (!this.refreshing) return;
       this.odataEntities.cancelRequest();
       this.deletedEntityCount.cancelRequest();
     },

--- a/src/components/entity/list.vue
+++ b/src/components/entity/list.vue
@@ -18,7 +18,7 @@ except according to the terms contained in the LICENSE file.
         :disabled="deleted" :disabled-message="deleted ? $t('filterDisabledMessage') : null"/>
       </form>
       <button id="entity-list-refresh-button" type="button"
-        class="btn btn-outlined" :aria-disabled="refreshing"
+        class="btn btn-outlined" :aria-disabled="refreshing || bulkOperationInProgress"
         @click="fetchChunk(false, true)">
         <span class="icon-refresh"></span>{{ $t('action.refresh') }}
         <spinner :state="refreshing"/>
@@ -341,6 +341,8 @@ export default {
 
       const $search = this.searchTerm ? this.searchTerm : undefined;
 
+      this.clearSelectedEntities();
+
       this.odataEntities.request({
         url: apiPaths.odataEntities(
           this.projectId,
@@ -572,12 +574,17 @@ export default {
       this.odataEntities.value?.forEach(e => { e.__system.selected = false; });
       this.allSelected = false;
     },
+    cancelBackgroundRefresh() {
+      this.odataEntities.cancelRequest();
+      this.deletedEntityCount.cancelRequest();
+    },
     requestBulkDelete() {
       const uuids = Array.from(this.selectedEntities).map(e => e.__id);
       // TODO: disable the whole table
 
       const bulkDelete = () => {
         this.bulkOperationInProgress = true;
+        this.cancelBackgroundRefresh();
         return this.request({
           method: 'POST',
           url: apiPaths.entities(this.projectId, this.datasetName, '/bulk-delete'),
@@ -618,6 +625,8 @@ export default {
       const uuids = this.bulkDeletedEntities.map(e => e.__id);
       const bulkRestore = () => {
         this.bulkOperationInProgress = true;
+        this.cancelBackgroundRefresh();
+
         return this.request({
           method: 'POST',
           url: apiPaths.entities(this.projectId, this.datasetName, '/bulk-restore'),

--- a/src/components/form/submissions.vue
+++ b/src/components/form/submissions.vue
@@ -162,6 +162,7 @@ export default {
             $filter: '__system/deletedAt ne null',
           }
         ),
+        clear: false,
       }).catch(noop);
     },
     toggleDeleted() {

--- a/test/components/entity/list.spec.js
+++ b/test/components/entity/list.spec.js
@@ -1560,10 +1560,14 @@ describe('EntityList', () => {
         await checkboxes[1].setValue(true);
         return component.find('.action-bar-container .btn-primary').trigger('click');
       })
+      .beforeAnyResponse(component => {
+        const refreshButton = component.find('#entity-list-refresh-button');
+        refreshButton.attributes('aria-disabled').should.equal('true');
+      })
       .respondWithSuccess()
       .afterResponse(component => {
         const refreshButton = component.find('#entity-list-refresh-button');
-        should.not.exist(refreshButton.attributes('disabled'));
+        refreshButton.attributes('aria-disabled').should.equal('false');
       });
   });
 });

--- a/test/components/entity/list.spec.js
+++ b/test/components/entity/list.spec.js
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { nextTick } from 'vue';
+import sinon from 'sinon';
 import DateTime from '../../../src/components/date-time.vue';
 import EntityDataRow from '../../../src/components/entity/data-row.vue';
 import EntityDelete from '../../../src/components/entity/delete.vue';
@@ -1456,6 +1457,49 @@ describe('EntityList', () => {
       checkboxes[0].element.checked.should.be.false;
       checkboxes[1].element.checked.should.be.false;
     });
+
+    it('clears selected entities when refresh completes', async () => {
+      const component = await loadEntityList()
+        .complete()
+        .request(async c => {
+          const checkboxes = c.findAll('.entity-metadata-row input[type="checkbox"]');
+          await checkboxes[0].setValue(true);
+          await checkboxes[1].setValue(true);
+
+          checkboxes[0].element.checked.should.be.true;
+          checkboxes[1].element.checked.should.be.true;
+
+          const actionBar = c.findComponent({ name: 'ActionBar' });
+          actionBar.props().state.should.be.true;
+          return c.get('#entity-list-refresh-button').trigger('click');
+        })
+        .respondWithData(testData.entityOData)
+        .complete();
+
+      const checkboxes = component.findAll('.entity-metadata-row input[type="checkbox"]');
+      checkboxes[0].element.checked.should.be.false;
+      checkboxes[1].element.checked.should.be.false;
+
+      const actionBar = component.findComponent({ name: 'ActionBar' });
+      actionBar.props().state.should.be.false;
+    });
+
+    it('aborts refresh request when bulk delete is initiated during refresh', () =>
+      loadEntityList()
+        .complete()
+        .request(async component => {
+          sinon.spy(component.vm.$container.requestData.localResources.odataEntities, 'cancelRequest');
+          component.get('#entity-list-refresh-button').trigger('click');
+          const checkboxes = component.findAll('.entity-metadata-row input[type="checkbox"]');
+          await checkboxes[0].setValue(true);
+          await checkboxes[1].setValue(true);
+          return component.find('.action-bar-container .btn-primary').trigger('click');
+        })
+        .respondWithData(testData.entityOData)
+        .respondWithSuccess()
+        .afterResponses((component) => {
+          component.vm.$container.requestData.localResources.odataEntities.cancelRequest.called.should.be.true;
+        }));
   });
 
   it('sets allSelected to false when all entities on current page are deleted and user navigates to next page', () => {
@@ -1504,5 +1548,22 @@ describe('EntityList', () => {
     await actionBar.find('.close').trigger('click');
 
     headerCheckbox.element.checked.should.be.false;
+  });
+
+  it('disables refresh button when bulk delete is in progress', () => {
+    createEntities(3);
+    return load('/projects/1/entity-lists/trees/entities')
+      .complete()
+      .request(async component => {
+        const checkboxes = component.findAll('.entity-metadata-row input[type="checkbox"]');
+        await checkboxes[0].setValue(true);
+        await checkboxes[1].setValue(true);
+        return component.find('.action-bar-container .btn-primary').trigger('click');
+      })
+      .respondWithSuccess()
+      .afterResponse(component => {
+        const refreshButton = component.find('#entity-list-refresh-button');
+        should.not.exist(refreshButton.attributes('disabled'));
+      });
   });
 });


### PR DESCRIPTION
Closes getodk/central#1334

- Disable refresh button while bulk request is in progress
- Clear selection when refresh request is completed (was happening already because of watcher on odataEntities, added test)
- Abort refresh request on bulk request

#### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Implemented all suggestions in original comment https://github.com/getodk/central-frontend/pull/1316/files#r2286984706

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

NA

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

NA 

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced