### PR TITLE
Update text of SubmissionFeedEntry related to dataset deletion

### DIFF
--- a/src/components/submission/feed-entry.vue
+++ b/src/components/submission/feed-entry.vue
@@ -70,7 +70,7 @@ except according to the terms contained in the LICENSE file.
           </template>
           <template #dataset>
             <dataset-link v-if="entityDetails.entityAvailable" :project-id="projectId" :name="entityDetails.dataset"/>
-            <span v-else>{{ $t('title.entity.deletedDataset', { dataset: entityDetails.dataset }) }}</span>
+            <span v-else>{{ entityDetails.dataset }}</span>
           </template>
         </i18n-t>
       </template>
@@ -388,7 +388,7 @@ export default {
         "reprocess": "Previous Submission in offline update chain was received"
       }
     },
-    // Shown in the Submission feed when dataset or entity has been deleted.
+    // This text is shown next to an Entity when the Entity has been deleted.
     "deleted": "(deleted)"
   }
 }

--- a/test/components/submission/feed-entry.spec.js
+++ b/test/components/submission/feed-entry.spec.js
@@ -258,7 +258,8 @@ describe('SubmissionFeedEntry', () => {
           }
         });
         const component = mountComponent();
-        component.get('.feed-entry-title').text().should.match(/deleted/);
+        const title = component.get('.feed-entry-title').text();
+        title.should.equal('Created Entity (deleted)\u00a0xyz in DatasetName Entity List');
         component.findComponent(EntityLink).exists().should.be.false;
         component.findComponent(DatasetLink).exists().should.be.false;
       });
@@ -333,7 +334,8 @@ describe('SubmissionFeedEntry', () => {
           }
         });
         const component = mountComponent();
-        component.get('.feed-entry-title').text().should.match(/deleted/);
+        const title = component.get('.feed-entry-title').text();
+        title.should.equal('Updated Entity (deleted)\u00a0xyz in DatasetName Entity List');
         component.findComponent(EntityLink).exists().should.be.false;
         component.findComponent(DatasetLink).exists().should.be.false;
       });

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -5164,7 +5164,7 @@
       },
       "deleted": {
         "string": "(deleted)",
-        "developer_comment": "Shown in the Submission feed when dataset or entity has been deleted."
+        "developer_comment": "This text is shown next to an Entity when the Entity has been deleted."
       }
     },
     "SubmissionFieldDropdown": {


### PR DESCRIPTION
This PR is a follow-up to #1487. It makes some small changes to the text of `SubmissionFeedEntry`. I'll leave some line comments with additional details.

#### What has been done to verify that this works as intended?

Updated tests.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced