### PR TITLE
feature-flags: handle synthetic events cleanly

### DIFF
--- a/src/composables/feature-flags.js
+++ b/src/composables/feature-flags.js
@@ -24,6 +24,8 @@ export default function useFeatureFlags() {
   };
 
   function updateCheatKeys(event, isKeydownEvent) {
+    if (!event.key) return;
+
     if (event.key.toLowerCase() === 'w') {
       cheatKeys.w = isKeydownEvent;
     }

--- a/test/composables/feature-flags.spec.js
+++ b/test/composables/feature-flags.spec.js
@@ -35,7 +35,9 @@ describe('useFeatureFlags()', () => {
   });
 
   // Occasionally synthetic events can be fired without a .key prop, e.g.
-  // Chrome password manager filling form fields.
+  // Chrome password manager filling form fields.  Note that this *cannot*
+  // be recreated with `component.trigger()`, as that sends a `KeyEvent`,
+  // which _always_ has .key defined as a String.
   // See: https://github.com/getodk/central/issues/1280
   it('should not throw when a synthetic key event is fired', async () => {
     mountComponent();

--- a/test/composables/feature-flags.spec.js
+++ b/test/composables/feature-flags.spec.js
@@ -33,4 +33,13 @@ describe('useFeatureFlags()', () => {
 
     component.classes().should.be.empty;
   });
+
+  // Occasionally synthetic events can be fired without a .key prop, e.g.
+  // Chrome password manager filling form fields.
+  // See: https://github.com/getodk/central/issues/1280
+  it('should not throw when a synthetic key event is fired', async () => {
+    mountComponent();
+
+    document.dispatchEvent(new Event('keydown'));
+  });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1280

#### What has been done to verify that this works as intended?

A new test, which fails before the code change.

#### Why is this the best possible solution? Were any other approaches considered?

The test is a bit different to others, but it has to avoid VueJS `test-utils`'s `component.trigger()`, as that function creates a KeyEvent, which seems to _always_ define `.key` as a `string`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect expected.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced