### PR TITLE
fix(#1815): install webForms on app instance for PrimeVue 4 compatibility  

### DIFF
--- a/src/components/web-form-renderer.vue
+++ b/src/components/web-form-renderer.vue
@@ -77,7 +77,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { computed, createApp, getCurrentInstance, inject, onMounted, onUnmounted, watch } from 'vue';
+import { computed, getCurrentInstance, inject, onMounted, onUnmounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 /* eslint-disable-next-line import/no-unresolved -- not sure why eslint is complaining about it */
 import { OdkWebForm, webFormsPlugin, POST_SUBMIT__NEW_INSTANCE } from '@getodk/web-forms';
@@ -114,14 +114,10 @@ const props = defineProps({
 
 const emit = defineEmits(['loaded']);
 
-// Install WebFormsPlugin in the component instead of installing it at the
-// application level so that @getodk/web-forms package is not loaded for every
-// page, thus increasing the initial bundle
-const app = createApp({});
-app.use(webFormsPlugin);
+// Install webFormsPlugin lazily here (not at app startup) to avoid loading @getodk/web-forms on every page.
+// This is safe because this component is already loaded asynchronously.
 const inst = getCurrentInstance();
-// webFormsPlugin just adds globalProperty ($primevue)
-Object.assign(inst.appContext.config.globalProperties, app._context.config.globalProperties);
+inst.appContext.app.use(webFormsPlugin);
 
 const { i18n } = inject('container');
 


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1815

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

 PrimeVue 4 registers itself via `app.provide()` (using a Symbol key) rather than `app.config.globalProperties` as PrimeVue 3 did. The previous approach was breaking PrimeVue 4 for our new use case with translations (PrimeLocale).                               
                                         
The fix installs `webFormsPlugin` directly on the real app instance via `inst.appContext.app.use(webFormsPlugin)`. I checked, and Web Forms bundles aren't in every Central page, and no global pollution from PrimeVue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced