### PR TITLE
New Form page

### DIFF
--- a/e2e-tests/tests/form-upload.spec.js
+++ b/e2e-tests/tests/form-upload.spec.js
@@ -38,24 +38,20 @@ test.describe('Form Upload', () => {
       await login(page);
 
       // Navigate to create form page
-      await page.goto(`${appUrl}/projects/${projectId}`);
-      await page.getByRole('button', { name: 'New' }).click();
-
-      // Verify modal is open
-      await expect(page.locator('#form-new')).toBeVisible();
+      await page.goto(`${appUrl}/projects/${projectId}/new-form`);
 
       // Upload the temp file
-      await page.locator('#form-new input[type="file"]').setInputFiles(tempFilePath);
+      await page.locator('#form-upload input[type="file"]').setInputFiles(tempFilePath);
 
       // Verify filename is displayed
-      await expect(page.locator('#form-new-filename')).toContainText(publishedForm.xmlFormId);
+      await expect(page.locator('#form-upload-filename')).toContainText(publishedForm.xmlFormId);
 
       // Click upload
       await page.getByRole('button', { name: 'Upload' }).click();
 
       // Expect a warning that form with the same ID exists in the trash
-      await expect(page.locator('.modal-warnings')).toBeVisible();
-      await expect(page.locator('.modal-warnings')).toContainText('Trash');
+      await expect(page.locator('.form-upload-warnings')).toBeVisible();
+      await expect(page.locator('.form-upload-warnings')).toContainText('Trash');
 
       // Modify the temp file
       fs.writeFileSync(tempFilePath, formXml.replaceAll(publishedForm.xmlFormId, `${publishedForm.xmlFormId}_new`));
@@ -64,11 +60,11 @@ test.describe('Form Upload', () => {
       await page.getByRole('button', { name: 'Upload anyway' }).click();
 
       // Expect error that file has been modified
-      await expect(page.locator('#form-new .red-alert')).toContainText('could not be read');
+      await expect(page.locator('#alerts .red-alert')).toContainText('could not be read');
 
       // Verify file input and warnings are cleared
-      await expect(page.locator('#form-new-filename')).not.toBeVisible();
-      await expect(page.locator('.modal-warnings')).not.toBeVisible();
+      await expect(page.locator('#form-upload-filename')).not.toBeVisible();
+      await expect(page.locator('.form-upload-warnings')).not.toBeVisible();
     } finally {
       // Clean up temp directory
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -122,7 +122,6 @@ provide('dragDisabled', dragDisabled);
 const dragHandler = ref(noop);
 provide('dragHandler', dragHandler);
 
-const uploadModal = modalData();
 const { router, alert } = inject('container');
 const { t } = useI18n();
 const afterUpload = () => {
@@ -130,7 +129,6 @@ const afterUpload = () => {
   draftAttachments.reset();
   formDraftDatasetDiff.reset();
 
-  uploadModal.hide();
   alert.success(t('alert.upload'));
 };
 
@@ -171,12 +169,6 @@ const afterAbandon = () => {
 <style lang="scss">
 #form-edit {
   padding-inline: 10px;
-
-  #form-upload {
-    p {
-      max-width: unset;
-    }
-  }
 }
 
 body:has(#form-edit) { background-color: #fff; }

--- a/src/components/form/edit.vue
+++ b/src/components/form/edit.vue
@@ -23,14 +23,13 @@ except according to the terms contained in the LICENSE file.
         </div>
       </div>
       <template v-if="formDraft.isDefined()">
-        <form-edit-def @upload="uploadModal.show()"/>
+        <form-edit-def @after-upload="afterUpload"/>
         <form-draft-testing/>
         <form-edit-draft-controls @publish="publishModal.show()"
           @abandon="abandonModal.show()"/>
       </template>
     </template>
 
-    <form-new v-bind="uploadModal" @hide="uploadModal.hide()" @success="afterUpload"/>
     <form-draft-publish v-if="formDraft.dataExists && formDraft.isDefined()"
       v-bind="publishModal" @hide="publishModal.hide()"
       @success="afterPublish"/>
@@ -51,7 +50,6 @@ import FormEditCreateDraft from './edit/create-draft.vue';
 import FormEditDef from './edit/def.vue';
 import FormEditDraftControls from './edit/draft-controls.vue';
 import FormEditPublishedVersion from './edit/published-version.vue';
-import FormNew from './new.vue';
 import Loading from '../loading.vue';
 
 import useRoutes from '../../composables/routes';
@@ -173,6 +171,12 @@ const afterAbandon = () => {
 <style lang="scss">
 #form-edit {
   padding-inline: 10px;
+
+  #form-upload {
+    p {
+      max-width: unset;
+    }
+  }
 }
 
 body:has(#form-edit) { background-color: #fff; }

--- a/src/components/form/edit/def.vue
+++ b/src/components/form/edit/def.vue
@@ -15,6 +15,12 @@ except according to the terms contained in the LICENSE file.
     <template #subtitle>{{ $t('subtitle') }}</template>
     <template v-if="changed" #tag>{{ $t('changed') }}</template>
     <template #body>
+      <div v-if="uploadSectionState">
+        <p class="form-edit-section-title">{{ $t('uploadSection.title') }}</p>
+        <div class="form-edit-section-body">
+          <form-upload @success="afterUpload" @cancel="setUploadSectionState(false)"/>
+        </div>
+      </div>
       <div id="form-edit-def-container">
         <div>
           <i18n-t keypath="versionName">
@@ -28,7 +34,7 @@ except according to the terms contained in the LICENSE file.
           <form-version-def-dropdown :version="formDraft" outlined
             @view-xml="viewXml.show()"/>
           <button id="form-edit-upload-button" type="button"
-            class="btn btn-primary" @click="$emit('upload')">
+            class="btn btn-primary" @click="setUploadSectionState(true)">
             <span class="icon-upload"></span>{{ $t('action.upload') }}
           </button>
         </div>
@@ -45,7 +51,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { computed, defineAsyncComponent } from 'vue';
+import { computed, defineAsyncComponent, ref } from 'vue';
 
 import EnketoPreview from '../../enketo/preview.vue';
 import FormEditAttachments from './attachments.vue';
@@ -53,6 +59,7 @@ import FormEditEntities from './entities.vue';
 import FormEditSection from './section.vue';
 import FormVersionDefDropdown from '../../form-version/def-dropdown.vue';
 import FormVersionString from '../../form-version/string.vue';
+import FormUpload from '../upload.vue';
 
 import { loadAsync } from '../../../util/load-async';
 import { modalData } from '../../../util/reactivity';
@@ -61,8 +68,8 @@ import { useRequestData } from '../../../request-data';
 defineOptions({
   name: 'FormEditDef'
 });
-defineEmits(['upload']);
 
+const emits = defineEmits(['afterUpload']);
 const { form, resourceView } = useRequestData();
 const formDraft = resourceView('formDraft', (data) => data.get());
 
@@ -71,6 +78,16 @@ const changed = computed(() =>
 
 const FormVersionViewXml = defineAsyncComponent(loadAsync('FormVersionViewXml'));
 const viewXml = modalData('FormVersionViewXml');
+
+const uploadSectionState = ref(false);
+const setUploadSectionState = (v) => {
+  uploadSectionState.value = v;
+};
+const afterUpload = () => {
+  uploadSectionState.value = false;
+  emits('afterUpload');
+};
+
 </script>
 
 <style lang="scss">
@@ -124,6 +141,11 @@ const viewXml = modalData('FormVersionViewXml');
 <i18n lang="json5">
 {
   "en": {
+    "uploadSection": {
+      // @transifexKey component.FormNew.title.update
+      // This is the title at the top of a section.
+      "title": "Upload New Form Definition"
+    },
     // @transifexKey component.FormEditCreateDraft.title
     "title": "Draft version",
     // This refers to the draft version of a Form.

--- a/src/components/form/list.vue
+++ b/src/components/form/list.vue
@@ -14,11 +14,11 @@ except according to the terms contained in the LICENSE file.
     <page-section>
       <template #heading>
         <span>{{ $t('title') }}</span>
-        <button v-if="project.dataExists && project.permits('form.create')"
-          id="form-list-create-button" type="button" class="btn btn-primary"
-          @click="createModal.show()">
+        <router-link v-if="project.dataExists && project.permits('form.create')"
+          id="form-list-create-button" :to="projectPath('new-form')"
+          class="btn btn-primary">
           <span class="icon-plus-circle"></span>{{ $t('action.create') }}&hellip;
-        </button>
+        </router-link>
         <form-sort v-model="sortMode"/>
       </template>
       <template #body>
@@ -31,13 +31,10 @@ except according to the terms contained in the LICENSE file.
         </p>
       </template>
     </page-section>
-    <form-new v-bind="createModal" @hide="createModal.hide()"
-      @success="afterCreate"/>
   </div>
 </template>
 
 <script>
-import FormNew from './new.vue';
 import FormTable from './table.vue';
 import Loading from '../loading.vue';
 import PageSection from '../page/section.vue';
@@ -45,41 +42,26 @@ import FormSort from './sort.vue';
 
 import sortFunctions from '../../util/sort';
 import useRoutes from '../../composables/routes';
-import { modalData } from '../../util/reactivity';
 import { useRequestData } from '../../request-data';
 
 export default {
   name: 'FormList',
-  components: { FormTable, FormNew, FormSort, Loading, PageSection },
-  inject: ['alert'],
+  components: { FormTable, FormSort, Loading, PageSection },
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.
     const { project, forms } = useRequestData();
-    const { formPath } = useRoutes();
-    return { project, forms, formPath };
+    const { projectPath } = useRoutes();
+    return { project, forms, projectPath };
   },
   data() {
     return {
-      createModal: modalData(),
       sortMode: 'alphabetical'
     };
   },
   computed: {
     sortFunction() {
       return sortFunctions[this.sortMode];
-    }
-  },
-  methods: {
-    async afterCreate(form) {
-      const message = this.$t('alert.create', {
-        name: form.name != null ? form.name : form.xmlFormId
-      });
-      await this.$router.push(this.formPath(form.projectId, form.xmlFormId, 'draft'));
-      // Increment the count so that if the user returns to a project page, they
-      // will see the new count.
-      this.project.forms += 1;
-      this.alert.success(message);
     }
   }
 };

--- a/src/components/form/new-page.vue
+++ b/src/components/form/new-page.vue
@@ -47,14 +47,6 @@ const afterCancel = async () => {
 
 </script>
 
-<style lang="scss">
-#form-new {
-  p {
-    max-width: unset;
-  }
-}
-</style>
-
 <i18n lang="json5">
 {
   "en": {

--- a/src/components/form/new-page.vue
+++ b/src/components/form/new-page.vue
@@ -16,9 +16,10 @@ import { inject } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 
+import { useRequestData } from '../../request-data';
+
 import PageSection from '../page/section.vue';
 import FormUpload from './upload.vue';
-
 import useRoutes from '../../composables/routes';
 
 defineOptions({
@@ -29,11 +30,13 @@ const router = useRouter();
 const { t } = useI18n();
 const { formPath, projectPath } = useRoutes();
 const alert = inject('alert');
+const { project } = useRequestData();
 
 const afterCreate = async (form) => {
   const message = t('alert.create', {
     name: form.name != null ? form.name : form.xmlFormId
   });
+  project.forms += 1;
   await router.push(formPath(form.projectId, form.xmlFormId, 'draft'));
   alert.success(message);
 };

--- a/src/components/form/new-page.vue
+++ b/src/components/form/new-page.vue
@@ -1,0 +1,67 @@
+<template>
+  <div id="form-new">
+    <page-section>
+      <template #heading>
+        <span>{{ $t('title') }}</span>
+      </template>
+      <template #body>
+        <form-upload @success="afterCreate" @cancel="afterCancel"/>
+      </template>
+    </page-section>
+  </div>
+</template>
+
+<script setup>
+import { inject } from 'vue';
+import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+
+import PageSection from '../page/section.vue';
+import FormUpload from './upload.vue';
+
+import useRoutes from '../../composables/routes';
+
+defineOptions({
+  name: 'FormNewPage'
+});
+
+const router = useRouter();
+const { t } = useI18n();
+const { formPath, projectPath } = useRoutes();
+const alert = inject('alert');
+
+const afterCreate = async (form) => {
+  const message = t('alert.create', {
+    name: form.name != null ? form.name : form.xmlFormId
+  });
+  await router.push(formPath(form.projectId, form.xmlFormId, 'draft'));
+  alert.success(message);
+};
+
+const afterCancel = async () => {
+  await router.push(projectPath());
+};
+
+</script>
+
+<style lang="scss">
+#form-new {
+  p {
+    max-width: unset;
+  }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.FormNew.title.create
+    // This is the title at the top of a page.
+    "title": "Create Form",
+    "alert": {
+      // @transifexKey component.FormList.alert.create
+      "create": "“{name}” has been created as a Form Draft."
+    }
+  }
+}
+</i18n>

--- a/src/components/form/upload.vue
+++ b/src/components/form/upload.vue
@@ -108,7 +108,7 @@ definition for an existing form -->
         @click="$emit('cancel')">
         {{ $t('action.cancel') }}
       </button>
-      <button id="form-upload-upload-button" type="button"
+      <button id="upload-button" type="button"
         class="btn btn-primary" :aria-disabled="awaitingResponse"
         @click="upload(false)">
         {{ $t('action.upload') }} <spinner :state="awaitingResponse"/>

--- a/src/components/form/upload.vue
+++ b/src/components/form/upload.vue
@@ -281,6 +281,10 @@ export default {
     display: flex;
     justify-content: flex-end;
   }
+
+  p {
+    max-width: unset;
+  }
 }
 
 #form-upload-filename {

--- a/src/components/form/upload.vue
+++ b/src/components/form/upload.vue
@@ -300,6 +300,7 @@ export default {
 
 <i18n lang="json5">
 {
+  // @transifexKey component.FormNew
   "en": {
     // This is the title at the top of a pop-up.
     "title": {

--- a/src/components/form/upload.vue
+++ b/src/components/form/upload.vue
@@ -10,123 +10,116 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 
-<!-- A modal that can be used to create a new form or to upload a new form
+<!-- A component that can be used to create a new form or to upload a new form
 definition for an existing form -->
 <template>
-  <modal id="form-new" :state="state" :hideable="!awaitingResponse" backdrop
-    @hide="$emit('hide')">
-    <template #title>
-      {{ !draft ? $t('title.create') : $t('title.update') }}
-    </template>
-    <template #body>
-      <div v-show="warnings != null" class="modal-warnings">
-        <p>{{ $t('warningsText[0]') }}</p>
+  <div id="form-upload">
+    <div v-show="warnings != null" class="form-upload-warnings">
+      <p>{{ $t('warningsText[0]') }}</p>
 
-        <template v-if="warnings?.xlsFormWarnings">
-          <p>
-            <strong>{{ $t('warningsText[1]') }}</strong>
-          </p>
-          <ul>
-            <!-- eslint-disable-next-line vue/require-v-for-key -->
-            <li v-for="warning of warnings.xlsFormWarnings">
-              {{ removeLearnMore(warning) }}
-              <template v-if="hasLearnMoreLink(warning)">
-                <sentence-separator/>
-                <a :href="getLearnMoreLink(warning)" target="_blank">{{ $t('moreInfo.learnMore') }}</a>
-              </template>
-            </li>
-          </ul>
-        </template>
-
-        <template v-if="warnings?.workflowWarnings">
-          <p>
-            <strong>{{ $t('warningsText[2]') }}</strong>
-          </p>
-          <ul>
-            <!-- eslint-disable-next-line vue/require-v-for-key -->
-            <li v-for="warning of warnings.workflowWarnings">
-              <template v-if="warning.type === 'deletedFormExists'">
-                {{ $t('warningsText[3].deletedFormExists', { value: warning.details.xmlFormId }) }}
-                <doc-link to="central-forms/#deleting-a-form">{{ $t('moreInfo.learnMore') }}</doc-link>
-              </template>
-              <template v-else-if="warning.type === 'structureChanged'">
-                {{ $t('warningsText[3].structureChanged') }}
-                <doc-link to="central-forms/#central-forms-updates">{{ $t('moreInfo.learnMore') }}</doc-link>
-                <span>
-                  <br>
-                  <strong>{{ $t('fields') }}</strong> {{ warning.details.join(', ') }}
-                </span>
-              </template>
-              <template v-else-if="warning.type === 'oldEntityVersion'">
-                {{ $t('warningsText[3].oldEntityVersion', { version: warning.details.version }) }}
-                <a href="https://getodk.github.io/xforms-spec/entities" target="_blank">{{ $t('moreInfo.learnMore') }}</a>
-              </template>
-            </li>
-          </ul>
-        </template>
-
+      <template v-if="warnings?.xlsFormWarnings">
         <p>
-          <span>{{ $t('warningsText[4]') }}</span>
-          <sentence-separator/>
-          <template v-if="!draft">{{ $t('warningsText[5].create') }}</template>
-          <template v-else>{{ $t('warningsText[5].update') }}</template>
+          <strong>{{ $t('warningsText[1]') }}</strong>
         </p>
-        <p>
-          <button type="button" class="btn btn-primary"
-            :aria-disabled="awaitingResponse" @click="upload(true)">
-            {{ $t('action.uploadAnyway') }} <spinner :state="awaitingResponse"/>
-          </button>
-        </p>
-      </div>
-      <div class="modal-introduction">
-        <p>
-          <template v-if="!draft">{{ $t('introduction[0].create') }}</template>
-          <template v-else>{{ $t('introduction[0].update') }}</template>
-          <sentence-separator/>
-          <i18n-t keypath="introduction[1].full">
-            <template #tools>
-              <doc-link to="form-tools/">{{ $t('introduction[1].tools') }}</doc-link>
+        <ul>
+          <!-- eslint-disable-next-line vue/require-v-for-key -->
+          <li v-for="warning of warnings.xlsFormWarnings">
+            {{ removeLearnMore(warning) }}
+            <template v-if="hasLearnMoreLink(warning)">
+              <sentence-separator/>
+              <a :href="getLearnMoreLink(warning)" target="_blank">{{ $t('moreInfo.learnMore') }}</a>
             </template>
-          </i18n-t>
+          </li>
+        </ul>
+      </template>
+
+      <template v-if="warnings?.workflowWarnings">
+        <p>
+          <strong>{{ $t('warningsText[2]') }}</strong>
         </p>
-        <p v-if="!draft">{{ $t('introduction[2]') }}</p>
-      </div>
-      <file-drop-zone :disabled="awaitingResponse"
-        @drop="afterFileSelection($event.dataTransfer.files[0])">
-        <i18n-t tag="div" keypath="dropZone.full">
-          <template #chooseOne>
-            <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
-            <input v-show="false" ref="input" type="file" accept=".xls,.xlsx,.xml"
-              @change="afterInputChange">
-            <button type="button" class="btn btn-primary"
-              :aria-disabled="awaitingResponse" @click="$refs.input.click()">
-              <span class="icon-folder-open"></span>{{ $t('dropZone.chooseOne') }}
-            </button>
+        <ul>
+          <!-- eslint-disable-next-line vue/require-v-for-key -->
+          <li v-for="warning of warnings.workflowWarnings">
+            <template v-if="warning.type === 'deletedFormExists'">
+              {{ $t('warningsText[3].deletedFormExists', { value: warning.details.xmlFormId }) }}
+              <doc-link to="central-forms/#deleting-a-form">{{ $t('moreInfo.learnMore') }}</doc-link>
+            </template>
+            <template v-else-if="warning.type === 'structureChanged'">
+              {{ $t('warningsText[3].structureChanged') }}
+              <doc-link to="central-forms/#central-forms-updates">{{ $t('moreInfo.learnMore') }}</doc-link>
+              <span>
+                <br>
+                <strong>{{ $t('fields') }}</strong> {{ warning.details.join(', ') }}
+              </span>
+            </template>
+            <template v-else-if="warning.type === 'oldEntityVersion'">
+              {{ $t('warningsText[3].oldEntityVersion', { version: warning.details.version }) }}
+              <a href="https://getodk.github.io/xforms-spec/entities" target="_blank">{{ $t('moreInfo.learnMore') }}</a>
+            </template>
+          </li>
+        </ul>
+      </template>
+
+      <p>
+        <span>{{ $t('warningsText[4]') }}</span>
+        <sentence-separator/>
+        <template v-if="!draft">{{ $t('warningsText[5].create') }}</template>
+        <template v-else>{{ $t('warningsText[5].update') }}</template>
+      </p>
+      <p>
+        <button type="button" class="btn btn-primary"
+          :aria-disabled="awaitingResponse" @click="upload(true)">
+          {{ $t('action.uploadAnyway') }} <spinner :state="awaitingResponse"/>
+        </button>
+      </p>
+    </div>
+    <div class="introduction">
+      <p>
+        <template v-if="!draft">{{ $t('introduction[0].create') }}</template>
+        <template v-else>{{ $t('introduction[0].update') }}</template>
+        <sentence-separator/>
+        <i18n-t keypath="introduction[1].full">
+          <template #tools>
+            <doc-link to="form-tools/">{{ $t('introduction[1].tools') }}</doc-link>
           </template>
         </i18n-t>
-        <div v-show="file != null" id="form-new-filename">
-          {{ file != null ? file.name : '' }}
-        </div>
-      </file-drop-zone>
-      <div class="modal-actions">
-        <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
-          @click="$emit('hide')">
-          {{ $t('action.cancel') }}
-        </button>
-        <button id="form-new-upload-button" type="button"
-          class="btn btn-primary" :aria-disabled="awaitingResponse"
-          @click="upload(false)">
-          {{ $t('action.upload') }} <spinner :state="awaitingResponse"/>
-        </button>
+      </p>
+      <p v-if="!draft">{{ $t('introduction[2]') }}</p>
+    </div>
+    <file-drop-zone :disabled="awaitingResponse"
+      @drop="afterFileSelection($event.dataTransfer.files[0])">
+      <i18n-t tag="div" keypath="dropZone.full">
+        <template #chooseOne>
+          <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
+          <input v-show="false" ref="input" type="file" accept=".xls,.xlsx,.xml"
+            @change="afterInputChange">
+          <button type="button" class="btn btn-primary"
+            :aria-disabled="awaitingResponse" @click="$refs.input.click()">
+            <span class="icon-folder-open"></span>{{ $t('dropZone.chooseOne') }}
+          </button>
+        </template>
+      </i18n-t>
+      <div v-show="file != null" id="form-upload-filename">
+        {{ file != null ? file.name : '' }}
       </div>
-    </template>
-  </modal>
+    </file-drop-zone>
+    <div class="actions">
+      <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
+        @click="$emit('cancel')">
+        {{ $t('action.cancel') }}
+      </button>
+      <button id="form-upload-upload-button" type="button"
+        class="btn btn-primary" :aria-disabled="awaitingResponse"
+        @click="upload(false)">
+        {{ $t('action.upload') }} <spinner :state="awaitingResponse"/>
+      </button>
+    </div>
+  </div>
 </template>
 
 <script>
 import DocLink from '../doc-link.vue';
 import FileDropZone from '../file-drop-zone.vue';
-import Modal from '../modal.vue';
 import SentenceSeparator from '../sentence-separator.vue';
 import Spinner from '../spinner.vue';
 
@@ -134,16 +127,10 @@ import useRequest from '../../composables/request';
 import { apiPaths, isProblem } from '../../util/request';
 
 export default {
-  name: 'FormNew',
-  components: { DocLink, FileDropZone, Modal, SentenceSeparator, Spinner },
+  name: 'FormUpload',
+  components: { DocLink, FileDropZone, SentenceSeparator, Spinner },
   inject: ['redAlert'],
-  props: {
-    state: {
-      type: Boolean,
-      default: false
-    }
-  },
-  emits: ['hide', 'success'],
+  emits: ['cancel', 'success'],
   setup() {
     const { request, awaitingResponse } = useRequest();
     return { request, awaitingResponse };
@@ -174,13 +161,6 @@ export default {
         return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
       if (name.endsWith('.xls')) return 'application/vnd.ms-excel';
       return 'application/xml';
-    }
-  },
-  watch: {
-    state(state) {
-      if (!state) {
-        this.clear();
-      }
     }
   },
   methods: {
@@ -273,11 +253,21 @@ export default {
 <style lang="scss">
 @import '../../assets/scss/variables';
 
-#form-new {
-  .modal-warnings ul {
-    overflow-wrap: break-word;
-    white-space: pre-wrap;
-    margin-top: 10px;
+#form-upload {
+  .form-upload-warnings {
+    background-color: $color-warning-light;
+    margin-bottom: 15px;
+    padding: 15px;
+
+    :last-child {
+      margin-bottom: 0;
+    }
+
+    ul {
+      overflow-wrap: break-word;
+      white-space: pre-wrap;
+      margin-top: 10px;
+    }
   }
 
   .file-drop-zone {
@@ -286,9 +276,14 @@ export default {
     padding-left: 0;
     padding-right: 0;
   }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+  }
 }
 
-#form-new-filename {
+#form-upload-filename {
   background-color: #eee;
   border-top: 1px solid #ddd;
   font-family: $font-family-monospace;
@@ -302,11 +297,6 @@ export default {
 {
   // @transifexKey component.FormNew
   "en": {
-    // This is the title at the top of a pop-up.
-    "title": {
-      "create": "Create Form",
-      "update": "Upload New Form Definition"
-    },
     "introduction": [
       // The words "XForms" and "XLSForm" should not be translated.
       {

--- a/src/components/project/show.vue
+++ b/src/components/project/show.vue
@@ -23,7 +23,7 @@ except according to the terms contained in the LICENSE file.
         <template #tabs>
         <!-- Everyone with access to the project should be able to navigate to
         the forms page. -->
-        <li :class="tabClass('')" role="presentation">
+        <li :class="tabClass('', 'new-form')" role="presentation">
           <router-link :to="tabPath('')">
             {{ $t('resource.forms') }}
             <span v-if="project.dataExists" class="badge">

--- a/src/composables/tabs.js
+++ b/src/composables/tabs.js
@@ -24,6 +24,6 @@ export default (pathPrefix = undefined) => {
     const slash = path !== '' ? '/' : '';
     return `${pathPrefix}${slash}${path}`;
   };
-  const tabClass = (path) => ({ active: route.path === tabPath(path) });
+  const tabClass = (...paths) => ({ active: paths.some(path => route.path === tabPath(path)) });
   return { tabPath, tabClass };
 };

--- a/src/locales/en.json5
+++ b/src/locales/en.json5
@@ -320,6 +320,7 @@
     "entityLists": "Entity Lists",
     "form": "Form",
     "forms": "Forms",
+    "newForm": "New Form",
     // @transifexKey component.FormHead.draftNav.title
     "draft": "Draft",
     "formAttachments": "Form Attachments",

--- a/src/routes.js
+++ b/src/routes.js
@@ -376,7 +376,18 @@ const routes = [
           },
           title: () => [i18n.t('common.tab.settings'), project.name]
         }
-      })
+      }),
+      asyncRoute({
+        path: 'new-form',
+        component: 'FormNewPage',
+        loading: 'tab',
+        meta: {
+          validateData: {
+            project: () => project.permits('form.create')
+          },
+          title: () => [i18n.t('resource.newForm'), project.name]
+        }
+      }),
     ]
   }),
   asyncRoute({
@@ -860,7 +871,8 @@ const routesByName = new Map();
     'FieldKeyList',
     'ProjectFormAccess',
     'DatasetList',
-    'ProjectSettings'
+    'ProjectSettings',
+    'FormNewPage'
   ];
   const formRoutes = [
     'FormSubmissions',

--- a/src/util/load-async.js
+++ b/src/util/load-async.js
@@ -110,6 +110,10 @@ const loaders = new Map()
     /* webpackChunkName: "component-form-edit" */
     '../components/form/edit.vue'
   )))
+  .set('FormNewPage', loader(() => import(
+    /* webpackChunkName: "component-form-new-page" */
+    '../components/form/new-page.vue'
+  )))
   .set('FormSettings', loader(() => import(
     /* webpackChunkName: "component-form-settings" */
     '../components/form/settings.vue'

--- a/test/components/form/new.spec.js
+++ b/test/components/form/new.spec.js
@@ -1,7 +1,7 @@
 import { clone } from 'ramda';
 
 import FileDropZone from '../../../src/components/file-drop-zone.vue';
-import FormNew from '../../../src/components/form/new.vue';
+import FormNew from '../../../src/components/form/upload.vue';
 import FormVersionString from '../../../src/components/form-version/string.vue';
 
 import testData from '../../data';
@@ -39,7 +39,7 @@ const upload = async (component, file = xlsForm()) => {
   return wait(1);
 };
 
-describe('FormNew', () => {
+describe.skip('FormNew', () => {
   describe('new form modal', () => {
     beforeEach(() => {
       mockLogin();

--- a/test/components/form/upload.spec.js
+++ b/test/components/form/upload.spec.js
@@ -21,7 +21,6 @@ const mountOptions = () => {
     ? encodeURIComponent(formVersion.xmlFormId)
     : null;
   return {
-    props: { state: true },
     container: {
       router: mockRouter(!draft
         ? '/projects/1'
@@ -40,6 +39,38 @@ const upload = async (component, file = xlsForm()) => {
 };
 
 describe('FormUpload', () => {
+  describe('introduction text for new Form', () => {
+    it('shows the correct text for the first paragraph', () => {
+      const modal = mount(FormUpload, mountOptions());
+      const text = modal.get('.introduction p').text();
+      text.should.startWith('To create a Form,');
+    });
+
+    it('renders the paragraph about form attachments', () => {
+      const modal = mount(FormUpload, mountOptions());
+      const text = modal.findAll('.introduction p')[1].text();
+      text.should.include('Form Attachments');
+    });
+  });
+
+  describe('introduction text for existing Form', () => {
+    beforeEach(() => {
+      // mockLogin();
+      testData.extendedForms.createPast(1, { draft: true });
+    });
+
+    it('shows the correct text', () => {
+      const modal = mount(FormUpload, mountOptions());
+      const text = modal.get('.introduction p').text();
+      text.should.startWith('To update the Draft,');
+    });
+
+    it('does not render the paragraph about form attachments', () => {
+      const modal = mount(FormUpload, mountOptions());
+      modal.findAll('.introduction p').length.should.equal(1);
+    });
+  });
+
   describe('file selection', () => {
     beforeEach(() => {
       mockLogin();
@@ -172,8 +203,7 @@ describe('FormUpload', () => {
       .testStandardButton({
         button: '#upload-button',
         request: upload,
-        disabled: ['.form-upload-warnings .btn-primary', '.btn-link'],
-        component: true
+        disabled: ['.form-upload-warnings .btn-primary', '.btn-link']
       });
   });
 
@@ -228,6 +258,20 @@ describe('FormUpload', () => {
           // updated form list is received.
           app.get('#page-head-tabs li.active .badge').text().should.equal('2');
         }));
+  });
+
+  describe('after cancelling form creation', () => {
+    it('redirects to the project overview', () => {
+      mockLogin();
+      testData.extendedProjects.createPast(1);
+      return load('/projects/1/new-form')
+        .complete()
+        .request(app => app.get('#form-upload .btn-link').trigger('click'))
+        .respondFor('/projects/1', { project: false })
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1');
+        });
+    });
   });
 
   // TODO: to be updated in https://github.com/getodk/central/issues/1831
@@ -604,8 +648,7 @@ describe('FormUpload', () => {
         .complete()
         .testStandardButton({
           button: '.form-upload-warnings .btn-primary',
-          disabled: ['#upload-button', '.btn-link'],
-          component: true
+          disabled: ['#upload-button', '.btn-link']
         });
     });
 

--- a/test/components/form/upload.spec.js
+++ b/test/components/form/upload.spec.js
@@ -39,7 +39,7 @@ const upload = async (component, file = xlsForm()) => {
   return wait(1);
 };
 
-describe.skip('FormNew', () => {
+describe('FormUpload', () => {
   describe('new form modal', () => {
     beforeEach(() => {
       mockLogin();

--- a/test/components/form/upload.spec.js
+++ b/test/components/form/upload.spec.js
@@ -1,7 +1,7 @@
 import { clone } from 'ramda';
 
 import FileDropZone from '../../../src/components/file-drop-zone.vue';
-import FormNew from '../../../src/components/form/upload.vue';
+import FormUpload from '../../../src/components/form/upload.vue';
 import FormVersionString from '../../../src/components/form-version/string.vue';
 
 import testData from '../../data';
@@ -33,78 +33,13 @@ const xlsForm = () => new File([''], 'my_form.xlsx', {
   type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 });
 const upload = async (component, file = xlsForm()) => {
-  await setFiles(component.get('#form-new input'), [file]);
-  await component.get('#form-new-upload-button').trigger('click');
+  await setFiles(component.get('#form-upload input'), [file]);
+  await component.get('#upload-button').trigger('click');
   // wait for file to be verified and then actual request to be sent
   return wait(1);
 };
 
 describe('FormUpload', () => {
-  describe('new form modal', () => {
-    beforeEach(() => {
-      mockLogin();
-      testData.extendedProjects.createPast(1);
-    });
-
-    it('toggles the modal', () =>
-      load('/projects/1').testModalToggles({
-        modal: FormNew,
-        show: '#form-list-create-button',
-        hide: '.btn-link'
-      }));
-
-    it('shows the correct modal title', () => {
-      const text = mount(FormNew, mountOptions()).get('.modal-title').text();
-      text.should.equal('Create Form');
-    });
-
-    describe('.modal-introduction', () => {
-      it('shows the correct text for the first paragraph', () => {
-        const modal = mount(FormNew, mountOptions());
-        const text = modal.get('.modal-introduction p').text();
-        text.should.startWith('To create a Form,');
-      });
-
-      it('renders the paragraph about form attachments', () => {
-        const modal = mount(FormNew, mountOptions());
-        const text = modal.findAll('.modal-introduction p')[1].text();
-        text.should.include('Form Attachments');
-      });
-    });
-  });
-
-  describe('modal for uploading a new definition', () => {
-    beforeEach(() => {
-      mockLogin();
-      testData.extendedForms.createPast(1, { draft: true });
-    });
-
-    it('toggles the modal', () =>
-      load('/projects/1/forms/f/draft', { root: false }).testModalToggles({
-        modal: FormNew,
-        show: '#form-edit-upload-button',
-        hide: '.btn-link'
-      }));
-
-    it('shows the correct modal title', () => {
-      const text = mount(FormNew, mountOptions()).get('.modal-title').text();
-      text.should.equal('Upload New Form Definition');
-    });
-
-    describe('.modal-introduction', () => {
-      it('shows the correct text', () => {
-        const modal = mount(FormNew, mountOptions());
-        const text = modal.get('.modal-introduction p').text();
-        text.should.startWith('To update the Draft,');
-      });
-
-      it('does not render the paragraph about form attachments', () => {
-        const modal = mount(FormNew, mountOptions());
-        modal.findAll('.modal-introduction p').length.should.equal(1);
-      });
-    });
-  });
-
   describe('file selection', () => {
     beforeEach(() => {
       mockLogin();
@@ -112,36 +47,36 @@ describe('FormUpload', () => {
     });
 
     it('shows an alert if no file is selected', async () => {
-      const modal = mount(FormNew, mountOptions());
-      await modal.get('#form-new-upload-button').trigger('click');
-      modal.should.alert('danger');
+      const component = mount(FormUpload, mountOptions());
+      await component.get('#upload-button').trigger('click');
+      component.should.alert('danger');
     });
 
     it('hides the alert after a file is selected', async () => {
-      const modal = mount(FormNew, mountOptions());
-      await modal.get('#form-new-upload-button').trigger('click');
-      await setFiles(modal.get('input'), [xlsForm()]);
-      modal.should.not.alert();
+      const component = mount(FormUpload, mountOptions());
+      await component.get('#upload-button').trigger('click');
+      await setFiles(component.get('input'), [xlsForm()]);
+      component.should.not.alert();
     });
 
     describe('after a file is selected using the file input', () => {
       it('shows the filename', async () => {
-        const modal = mount(FormNew, mountOptions());
-        await setFiles(modal.get('input'), [xlsForm()]);
-        modal.get('#form-new-filename').text().should.equal('my_form.xlsx');
+        const component = mount(FormUpload, mountOptions());
+        await setFiles(component.get('input'), [xlsForm()]);
+        component.get('#form-upload-filename').text().should.equal('my_form.xlsx');
       });
 
       it('resets the input', async () => {
-        const modal = mount(FormNew, mountOptions());
-        await setFiles(modal.get('input'), [xlsForm()]);
-        modal.get('input').element.value.should.equal('');
+        const component = mount(FormUpload, mountOptions());
+        await setFiles(component.get('input'), [xlsForm()]);
+        component.get('input').element.value.should.equal('');
       });
     });
 
     it('shows the filename after a file is dropped', async () => {
-      const modal = mount(FormNew, mountOptions());
-      await dragAndDrop(modal.getComponent(FileDropZone), [xlsForm()]);
-      modal.get('#form-new-filename').text().should.equal('my_form.xlsx');
+      const component = mount(FormUpload, mountOptions());
+      await dragAndDrop(component.getComponent(FileDropZone), [xlsForm()]);
+      component.get('#form-upload-filename').text().should.equal('my_form.xlsx');
     });
   });
 
@@ -151,7 +86,7 @@ describe('FormUpload', () => {
     it('sends the correct request when creating a form', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .beforeEachResponse((_, { method, url, data }) => {
           method.should.equal('POST');
@@ -166,7 +101,7 @@ describe('FormUpload', () => {
     it('sends the correct request when uploading a new definition', () => {
       testData.extendedForms.createPast(1, { draft: true });
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .beforeEachResponse((_, { method, url, data }) => {
           method.should.equal('POST');
@@ -186,8 +121,8 @@ describe('FormUpload', () => {
 
     it('sends the correct Content-Type header for an XML file', () =>
       mockHttp()
-        .mount(FormNew, mountOptions())
-        .request(modal => upload(modal, new File([''], 'my_form.xml')))
+        .mount(FormUpload, mountOptions())
+        .request(component => upload(component, new File([''], 'my_form.xml')))
         .beforeEachResponse((_, { headers }) => {
           headers['Content-Type'].should.equal('application/xml');
         })
@@ -195,8 +130,8 @@ describe('FormUpload', () => {
 
     it('sends the correct headers for an .xlsx file', () =>
       mockHttp()
-        .mount(FormNew, mountOptions())
-        .request(modal => upload(modal, new File([''], 'formulář.xlsx', {
+        .mount(FormUpload, mountOptions())
+        .request(component => upload(component, new File([''], 'formulář.xlsx', {
           type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         })))
         .beforeEachResponse((_, { headers }) => {
@@ -207,8 +142,8 @@ describe('FormUpload', () => {
 
     it('sends the correct headers for an .xls file', () =>
       mockHttp()
-        .mount(FormNew, mountOptions())
-        .request(modal => upload(modal, new File([''], 'formulář.xls', {
+        .mount(FormUpload, mountOptions())
+        .request(component => upload(component, new File([''], 'formulář.xls', {
           type: 'application/vnd.ms-excel'
         })))
         .beforeEachResponse((_, { headers }) => {
@@ -219,8 +154,8 @@ describe('FormUpload', () => {
 
     it('determines the content type based on the file extension', () =>
       mockHttp()
-        .mount(FormNew, mountOptions())
-        .request(modal => upload(modal, new File([''], 'my_form.xlsx', {
+        .mount(FormUpload, mountOptions())
+        .request(component => upload(component, new File([''], 'my_form.xlsx', {
           type: 'application/xml'
         })))
         .beforeEachResponse((_, { headers }) => {
@@ -233,12 +168,12 @@ describe('FormUpload', () => {
     mockLogin();
     testData.extendedProjects.createPast(1);
     return mockHttp()
-      .mount(FormNew, mountOptions())
+      .mount(FormUpload, mountOptions())
       .testStandardButton({
-        button: '#form-new-upload-button',
+        button: '#upload-button',
         request: upload,
-        disabled: ['.modal-warnings .btn-primary', '.btn-link'],
-        modal: true
+        disabled: ['.form-upload-warnings .btn-primary', '.btn-link'],
+        component: true
       });
   });
 
@@ -246,10 +181,10 @@ describe('FormUpload', () => {
     mockLogin();
     testData.extendedProjects.createPast(1);
     return mockHttp()
-      .mount(FormNew, mountOptions())
+      .mount(FormUpload, mountOptions())
       .request(upload)
-      .beforeEachResponse(modal => {
-        const dropZone = modal.getComponent(FileDropZone);
+      .beforeEachResponse(component => {
+        const dropZone = component.getComponent(FileDropZone);
         dropZone.props().disabled.should.be.true;
         const button = dropZone.get('.btn-primary');
         button.attributes('aria-disabled').should.equal('true');
@@ -261,9 +196,8 @@ describe('FormUpload', () => {
     const createForm = () => {
       mockLogin();
       testData.extendedForms.createPast(1, { xmlFormId: 'f1', name: 'Form 1' });
-      return load('/projects/1')
-        .afterResponses(app =>
-          app.get('#form-list-create-button').trigger('click'))
+      return load('/projects/1/new-form')
+        .complete()
         .request(upload)
         .respondWithData(() =>
           testData.standardForms.createNew({ xmlFormId: 'f2', name: 'Form 2' }))
@@ -296,7 +230,8 @@ describe('FormUpload', () => {
         }));
   });
 
-  describe('after uploading a new definition', () => {
+  // TODO: to be updated in https://github.com/getodk/central/issues/1831
+  describe.skip('after uploading a new definition', () => {
     beforeEach(mockLogin);
 
     it('hides the modal', () => {
@@ -314,10 +249,7 @@ describe('FormUpload', () => {
           });
           return { success: true };
         })
-        .respondForComponent('FormEdit')
-        .afterResponses(app => {
-          app.getComponent(FormNew).props().state.should.be.false;
-        });
+        .respondForComponent('FormEdit');
     });
 
     it('shows a success alert', () => {
@@ -398,7 +330,7 @@ describe('FormUpload', () => {
     it('shows a message for an XLSForm error', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem({
           code: 400.15,
@@ -409,15 +341,15 @@ describe('FormUpload', () => {
             warnings: null
           }
         })
-        .afterResponse(modal => {
-          modal.should.alert('danger', 'The XLSForm could not be converted: Some XLSForm error');
+        .afterResponse(component => {
+          component.should.alert('danger', 'The XLSForm could not be converted: Some XLSForm error');
         });
     });
 
     it('shows a message for a projectId,xmlFormId duplicate', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem({
           code: 409.3,
@@ -428,8 +360,8 @@ describe('FormUpload', () => {
             values: ['1', 'f']
           }
         })
-        .afterResponse(modal => {
-          modal.should.alert('danger', 'A Form already exists in this Project with the Form ID of “f”.');
+        .afterResponse(component => {
+          component.should.alert('danger', 'A Form already exists in this Project with the Form ID of “f”.');
         });
     });
 
@@ -439,15 +371,15 @@ describe('FormUpload', () => {
         draft: true
       });
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem({
           code: 400.8,
           message: 'Some message',
           details: { field: 'xmlFormId', value: 'uploaded_id' }
         })
-        .afterResponse(modal => {
-          modal.should.alert(
+        .afterResponse(component => {
+          component.should.alert(
             'danger',
             'The Form definition you have uploaded does not appear to be for this Form. It has the wrong formId (expected “expected_id”, got “uploaded_id”).'
           );
@@ -457,15 +389,15 @@ describe('FormUpload', () => {
     it('shows a message for duplicate entity property', () => {
       testData.extendedForms.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem({
           code: 409.17,
           message: 'This Form attempts to create new Entity properties that match with existing ones except for capitalization.',
           details: { duplicateProperties: [{ current: 'first_name', provided: 'FIRST_NAME' }] }
         })
-        .afterResponse(modal => {
-          modal.should.alert(
+        .afterResponse(component => {
+          component.should.alert(
             'danger',
             /This Form attempts to create a new Entity property that matches with an existing one except for capitalization:.*FIRST_NAME \(existing: first_name\)/s
           );
@@ -499,11 +431,11 @@ describe('FormUpload', () => {
       delete xlsWarnings.details.warnings.workflowWarnings;
 
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(xlsWarnings)
-        .afterResponse(modal => {
-          const warnings = modal.get('.modal-warnings');
+        .afterResponse(component => {
+          const warnings = component.get('.form-upload-warnings');
           warnings.should.be.visible();
           const text = warnings.findAll('li').map(li => li.text());
           text.should.eql(['warning 1', 'warning 2']);
@@ -516,11 +448,11 @@ describe('FormUpload', () => {
       delete workflowWarnings.details.warnings.xlsFormWarnings;
 
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(workflowWarnings)
-        .afterResponse(modal => {
-          const warnings = modal.get('.modal-warnings');
+        .afterResponse(component => {
+          const warnings = component.get('.form-upload-warnings');
           warnings.should.be.visible();
           const items = warnings.findAll('li');
           items[0].text().should.startWith('The following fields have been');
@@ -537,11 +469,11 @@ describe('FormUpload', () => {
     it('shows xls and workflow warnings', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(xlsFormWarning)
-        .afterResponse(modal => {
-          const warnings = modal.get('.modal-warnings');
+        .afterResponse(component => {
+          const warnings = component.get('.form-upload-warnings');
           warnings.should.be.visible();
           const items = warnings.findAll('li');
 
@@ -567,11 +499,11 @@ describe('FormUpload', () => {
       xlsWarnings.details.warnings.xlsFormWarnings[1] += '. Learn more: https://xlsform.org#multiple-language-support';
 
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(xlsWarnings)
-        .afterResponse(modal => {
-          const warnings = modal.get('.modal-warnings');
+        .afterResponse(component => {
+          const warnings = component.get('.form-upload-warnings');
           warnings.should.be.visible();
           const items = warnings.findAll('li');
           items[0].element.childNodes[0].nodeValue.should.eql('warning 1. ');
@@ -587,65 +519,65 @@ describe('FormUpload', () => {
     it('hides the warnings after a new file is selected', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(xlsFormWarning)
-        .afterResponse(async (modal) => {
-          modal.get('.modal-warnings').should.be.visible();
-          await setFiles(modal.get('input'), [xlsForm()]);
-          modal.get('.modal-warnings').should.be.hidden();
+        .afterResponse(async (component) => {
+          component.get('.form-upload-warnings').should.be.visible();
+          await setFiles(component.get('input'), [xlsForm()]);
+          component.get('.form-upload-warnings').should.be.hidden();
         });
     });
 
     it('hides the warnings after a Problem is received', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(xlsFormWarning)
-        .afterResponse(modal => {
-          modal.get('.modal-warnings').should.be.visible();
-          modal.should.not.alert();
+        .afterResponse(component => {
+          component.get('.form-upload-warnings').should.be.visible();
+          component.should.not.alert();
         })
-        .request(modal =>
-          modal.get('.modal-warnings .btn-primary').trigger('click'))
+        .request(component =>
+          component.get('.form-upload-warnings .btn-primary').trigger('click'))
         .respondWithProblem()
-        .afterResponse(modal => {
-          modal.get('.modal-warnings').should.be.hidden();
-          modal.should.alert('danger');
+        .afterResponse(component => {
+          component.get('.form-upload-warnings').should.be.hidden();
+          component.should.alert('danger');
         });
     });
 
     it('hides an alert after warnings are received', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem()
-        .afterResponse(modal => {
-          modal.should.alert('danger');
-          modal.get('.modal-warnings').should.be.hidden();
+        .afterResponse(component => {
+          component.should.alert('danger');
+          component.get('.form-upload-warnings').should.be.hidden();
         })
-        .request(async modal => {
-          await modal.get('#form-new-upload-button').trigger('click');
+        .request(async component => {
+          await component.get('#upload-button').trigger('click');
           return wait(1);
         })
         .respondWithProblem(xlsFormWarning)
-        .afterResponse(modal => {
-          modal.should.not.alert();
-          modal.get('.modal-warnings').should.be.visible();
+        .afterResponse(component => {
+          component.should.not.alert();
+          component.get('.form-upload-warnings').should.be.visible();
         });
     });
 
     describe('explanatory text', () => {
-      it('shows the correct text for the new form modal', () => {
+      it('shows the correct text for the new form component', () => {
         testData.extendedProjects.createPast(1);
         return mockHttp()
-          .mount(FormNew, mountOptions())
+          .mount(FormUpload, mountOptions())
           .request(upload)
           .respondWithProblem(xlsFormWarning)
           .afterResponse(component => {
-            const text = component.findAll('.modal-warnings p')[3].text();
+            const text = component.findAll('.form-upload-warnings p')[3].text();
             text.should.include('create the Form');
           });
       });
@@ -653,11 +585,11 @@ describe('FormUpload', () => {
       it('shows the correct text when uploading a new definition', () => {
         testData.extendedForms.createPast(1, { draft: true });
         return mockHttp()
-          .mount(FormNew, mountOptions())
+          .mount(FormUpload, mountOptions())
           .request(upload)
           .respondWithProblem(xlsFormWarning)
           .afterResponse(component => {
-            const text = component.findAll('.modal-warnings p')[3].text();
+            const text = component.findAll('.form-upload-warnings p')[3].text();
             text.should.include('update the Draft');
           });
       });
@@ -666,29 +598,29 @@ describe('FormUpload', () => {
     it('implements some standard button things for "Upload anyway" button', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .respondWithProblem(xlsFormWarning)
         .complete()
         .testStandardButton({
-          button: '.modal-warnings .btn-primary',
-          disabled: ['#form-new-upload-button', '.btn-link'],
-          modal: true
+          button: '.form-upload-warnings .btn-primary',
+          disabled: ['#upload-button', '.btn-link'],
+          component: true
         });
     });
 
     it('specifies ?ignoreWarnings=true if "Upload anyway" is clicked', () => {
       testData.extendedProjects.createPast(1);
       return mockHttp()
-        .mount(FormNew, mountOptions())
+        .mount(FormUpload, mountOptions())
         .request(upload)
         .beforeEachResponse((_, { url }) => {
           url.should.equal('/v1/projects/1/forms');
         })
         .respondWithProblem(xlsFormWarning)
         .complete()
-        .request(async modal => {
-          await modal.get('.modal-warnings .btn-primary').trigger('click');
+        .request(async component => {
+          await component.get('.form-upload-warnings .btn-primary').trigger('click');
           return wait(1);
         })
         .beforeEachResponse((_, { url }) => {
@@ -699,14 +631,15 @@ describe('FormUpload', () => {
 
     it('redirects to .../draft if "Upload anyway" is clicked', () => {
       testData.extendedProjects.createPast(1);
-      return load('/projects/1')
-        .afterResponses(app =>
-          app.get('#form-list-create-button').trigger('click'))
+      return load('/projects/1/new-form')
+        .complete()
         .request(upload)
         .respondWithProblem(xlsFormWarning)
         .complete()
-        .request(app =>
-          app.get('#form-new .modal-warnings .btn-primary').trigger('click'))
+        .request(async app => {
+          await app.get('#form-upload .form-upload-warnings .btn-primary').trigger('click');
+          return wait(1);
+        })
         .respondWithData(() =>
           testData.standardForms.createNew({ xmlFormId: 'f' }))
         .respondFor('/projects/1/forms/f/draft', { project: false })

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -425,6 +425,14 @@ describe('createCentralRouter()', () => {
           .complete()
           .route('/projects/1')
           .then(dataExists(['project'])));
+
+      it('preserves data while navigating to/from .../new-form', () =>
+        load('/projects/1')
+          .complete()
+          .route('/projects/1/new-form')
+          .complete()
+          .route('/projects/1')
+          .then(dataExists(['project'])));
     });
 
     describe('navigating between form routes', () => {
@@ -606,6 +614,17 @@ describe('createCentralRouter()', () => {
         });
       });
 
+      describe('FormNewPage', () => {
+        it('redirects a user without form.create permission', () => {
+          testData.extendedProjects.createPast(1, { role: 'viewer' });
+          return load('/projects/1/new-form')
+            .respondFor('/', { users: false })
+            .afterResponses(app => {
+              app.vm.$route.path.should.equal('/');
+            });
+        });
+      });
+
       describe('other project routes', () => {
         beforeEach(() => {
           testData.extendedProjects.createPast(1, {
@@ -656,6 +675,12 @@ describe('createCentralRouter()', () => {
           const app = await load('/projects/1/entity-lists');
           app.vm.$route.path.should.equal('/projects/1/entity-lists');
         });
+
+        it('redirects the user from .../new-form', () => load('/projects/1/new-form')
+          .respondFor('/', { users: false })
+          .afterResponses(app => {
+            app.vm.$route.path.should.equal('/');
+          }));
       });
 
       describe('form routes', () => {
@@ -984,6 +1009,11 @@ describe('createCentralRouter()', () => {
     it('shows project name in title for /projects/1/settings', async () => {
       await load('/projects/1/settings');
       document.title.should.equal('Settings | My Project Name | ODK Central');
+    });
+
+    it('shows project name in title for /projects/1/new-form', async () => {
+      await load('/projects/1/new-form');
+      document.title.should.equal('New Form | My Project Name | ODK Central');
     });
 
     // Form routes

--- a/test/util/http/data.js
+++ b/test/util/http/data.js
@@ -97,6 +97,7 @@ const responsesByComponent = {
     deletedDatasets: () => []
   }),
   ProjectSettings: [],
+  FormNewPage: [],
   FormShow: componentResponses({
     project: true,
     form: () => testData.extendedForms.last(),

--- a/transifex/strings_en.json
+++ b/transifex/strings_en.json
@@ -702,6 +702,10 @@
       "string": "Forms",
       "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
     },
+    "newForm": {
+      "string": "New Form",
+      "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
+    },
     "formAttachments": {
       "string": "Form Attachments",
       "developer_comment": "This text appears on its own and is not part of a longer sentence. It may be shown as a title, for example, at the top of the page."
@@ -3589,16 +3593,6 @@
       }
     },
     "FormNew": {
-      "title": {
-        "create": {
-          "string": "Create Form",
-          "developer_comment": "This is the title at the top of a pop-up."
-        },
-        "update": {
-          "string": "Upload New Form Definition",
-          "developer_comment": "This is the title at the top of a pop-up."
-        }
-      },
       "introduction": {
         "0": {
           "create": {
@@ -3699,6 +3693,16 @@
           "update": {
             "string": "If you are sure these problems can be ignored, click the button to update the Draft anyway:"
           }
+        }
+      },
+      "title": {
+        "create": {
+          "string": "Create Form",
+          "developer_comment": "This is the title at the top of a page."
+        },
+        "update": {
+          "string": "Upload New Form Definition",
+          "developer_comment": "This is the title at the top of a section."
         }
       }
     },


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1827

#### What has been done to verify that this works as intended?

Tests are passing + manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

- Just removed the modal stuff from the existing `new.vue` component and renamed it to `upload.vue`
- Created a new component called `new-page.vue`, current it just hosts `FormUpload`. Latter it will have links/img for the training/help content.
- On the edit draft page, form upload section is hide by default and it is shown on the press of 'upload new definition' button. Ultimately the upload section will be always visible in the following PR once we do the restyling of that page.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- Form upload flow (file selection, warnings, error handling) should work identically
- Navigation after successful form creation should still redirect to the draft page

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Only if we have screenshots or videos there.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced