### PR TITLE
Project Custom Properties tab and ability to create properties

### DIFF
--- a/.changeset/mighty-experts-repair.md
+++ b/.changeset/mighty-experts-repair.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+Add Custom Properties tab in Project to manage App User/Public Link properties

--- a/apps/central/src/components/project/custom-properties/list.vue
+++ b/apps/central/src/components/project/custom-properties/list.vue
@@ -6,18 +6,17 @@
         <button v-if="project.dataExists && project.permits('project.update')"
           id="custom-properties-list-new-button" type="button" class="btn btn-primary"
           @click="createModal.show()">
-          <span class="icon-plus-circle"></span>{{ $t('new') }}
+          <span class="icon-plus-circle"></span>{{ $t('action.create') }}&hellip;
         </button>
       </template>
     </page-section>
     <div class="page-body-heading">
-      <p>{{ $t('heading[0]') }}</p>
       <p>
-        <span>{{ $t('heading[1]') }}</span>
+        <span>{{ $t('heading[0]') }}</span>
         <sentence-separator/>
         <i18n-t keypath="moreInfo.clickHere.full">
           <template #clickHere>
-            <doc-link to="TODO">{{ $t('moreInfo.clickHere.clickHere') }}</doc-link>
+            <doc-link to="central-projects/#managing-custom-properties">{{ $t('moreInfo.clickHere.clickHere') }}</doc-link>
           </template>
         </i18n-t>
       </p>
@@ -91,15 +90,14 @@ const afterCreate = (name) => {
   "en": {
     "heading": [
       // A brief introduction to Custom Properties shown for the current project
-      "Some helper intro text",
-      "Custom Properties are custom fields that can be attached to project app users and public links to store additional metadata."
+      "Custom Properties are custom fields that can be attached to App Users and Public Links to store additional metadata."
     ],
     "emptyTable": "No custom properties have been defined for this project.",
     // Shown after a custom property is successfully created.
     "created": "Custom property created successfully.",
-    // This is the text of a button that is used to create a new Custom Property for users.
-    // It is shown next to a heading whose text is "Custom Properties".
-    "new": "New"
+    "action": {
+      "create": "New"
+    }
   }
 }
 </i18n>

--- a/apps/central/src/components/project/custom-properties/list.vue
+++ b/apps/central/src/components/project/custom-properties/list.vue
@@ -1,0 +1,105 @@
+<template>
+  <div id="custom-properties-list">
+    <page-section>
+      <template #heading>
+        <span>{{ $t('projectShow.tab.customProperties') }}</span>
+        <button v-if="project.dataExists && project.permits('project.update')"
+          id="custom-properties-list-new-button" type="button" class="btn btn-primary"
+          @click="createModal.show()">
+          <span class="icon-plus-circle"></span>{{ $t('new') }}
+        </button>
+      </template>
+    </page-section>
+    <div class="page-body-heading">
+      <p>{{ $t('heading[0]') }}</p>
+      <p>
+        <span>{{ $t('heading[1]') }}</span>
+        <sentence-separator/>
+        <i18n-t keypath="moreInfo.clickHere.full">
+          <template #clickHere>
+            <doc-link to="TODO">{{ $t('moreInfo.clickHere.clickHere') }}</doc-link>
+          </template>
+        </i18n-t>
+      </p>
+    </div>
+    <table id="custom-properties-table" class="table">
+      <thead>
+        <tr>
+          <th>{{ $t('header.name') }}</th>
+        </tr>
+      </thead>
+      <tbody v-if="actorProperties.dataExists">
+        <tr v-for="property of actorProperties" :key="property.name">
+          <td>{{ property.name }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-if="actorProperties.dataExists && actorProperties.length === 0"
+      class="empty-table-message">
+      {{ $t('emptyTable') }}
+    </p>
+    <loading :state="actorProperties.initiallyLoading"/>
+    <custom-properties-new v-bind="createModal"
+      @hide="createModal.hide()" @success="afterCreate"/>
+  </div>
+</template>
+
+<script setup>
+import { inject } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import CustomPropertiesNew from './new.vue';
+import DocLink from '../../doc-link.vue';
+import Loading from '../../loading.vue';
+import PageSection from '../../page/section.vue';
+import SentenceSeparator from '../../sentence-separator.vue';
+
+import { modalData } from '../../../util/reactivity';
+import { useRequestData } from '../../../request-data';
+
+defineOptions({
+  name: 'CustomPropertyList'
+});
+
+defineProps({
+  projectId: {
+    type: String,
+    required: true
+  }
+});
+
+const emit = defineEmits(['fetch-actor-properties']);
+
+const alert = inject('alert');
+const { t } = useI18n();
+
+const { project, actorProperties } = useRequestData();
+
+const createModal = modalData();
+
+emit('fetch-actor-properties', false);
+
+const afterCreate = () => {
+  createModal.hide();
+  emit('fetch-actor-properties', true);
+  alert.success(t('created'));
+};
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    "heading": [
+      // A brief introduction to Custom Properties shown for the current project
+      "Some helper intro text",
+      "Custom Properties are custom fields that can be attached to project app users and public links to store additional metadata."
+    ],
+    "emptyTable": "No custom properties have been defined for this project.",
+    // Shown after a custom property is successfully created.
+    "created": "Custom property created successfully.",
+    // This is the text of a button that is used to create a new Custom Property for users.
+    // It is shown next to a heading whose text is "Custom Properties".
+    "new": "New"
+  }
+}
+</i18n>

--- a/apps/central/src/components/project/custom-properties/list.vue
+++ b/apps/central/src/components/project/custom-properties/list.vue
@@ -77,11 +77,11 @@ const { project, actorProperties } = useRequestData();
 
 const createModal = modalData();
 
-emit('fetch-actor-properties', false);
+emit('fetch-actor-properties');
 
-const afterCreate = () => {
+const afterCreate = (name) => {
   createModal.hide();
-  emit('fetch-actor-properties', true);
+  actorProperties.push({ name });
   alert.success(t('created'));
 };
 </script>

--- a/apps/central/src/components/project/custom-properties/new.vue
+++ b/apps/central/src/components/project/custom-properties/new.vue
@@ -1,0 +1,94 @@
+<template>
+  <modal id="custom-properties-new" :state="state" :hideable="!awaitingResponse" backdrop
+    @hide="$emit('hide')" @shown="nameGroup.focus()">
+    <template #title>{{ $t('title') }}</template>
+    <template #body>
+      <div class="modal-introduction">
+        <p>{{ $t('introduction') }}</p>
+      </div>
+      <form @submit.prevent="submit">
+        <form-group ref="nameGroup" v-model.trim="name"
+          :placeholder="$t('newPropertyName')" required autocomplete="off"/>
+        <div class="modal-actions">
+          <button type="button" class="btn btn-link"
+            :aria-disabled="awaitingResponse" @click="$emit('hide')">
+            {{ $t('action.cancel') }}
+          </button>
+          <button type="submit" class="btn btn-primary"
+            :aria-disabled="awaitingResponse">
+            {{ $t('action.create') }} <spinner :state="awaitingResponse"/>
+          </button>
+        </div>
+      </form>
+    </template>
+  </modal>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { equals } from 'ramda';
+
+import Modal from '../../modal.vue';
+import FormGroup from '../../form-group.vue';
+import Spinner from '../../spinner.vue';
+
+import useRequest from '../../../composables/request';
+import { apiPaths } from '../../../util/request';
+import { useRequestData } from '../../../request-data';
+import { noop } from '../../../util/util';
+
+defineOptions({
+  name: 'CustomPropertyNew'
+});
+
+const props = defineProps({
+  state: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const emit = defineEmits(['hide', 'success']);
+
+const { request, awaitingResponse } = useRequest();
+const { project } = useRequestData();
+const { t } = useI18n();
+
+const nameGroup = ref(null);
+const name = ref('');
+
+watch(() => props.state, (state) => {
+  if (!state) name.value = '';
+});
+
+const submit = () => {
+  request({
+    method: 'POST',
+    url: apiPaths.actorProperties(project.id),
+    data: { name: name.value },
+    problemToAlert: ({ code, details }) =>
+      (code === 409.3 && equals(details.fields, ['projectId', 'name'])
+        ? t('problem.409_3', { propertyName: details.values[1] })
+        : null)
+  })
+    .then(() => {
+      emit('success');
+    })
+    .catch(noop);
+};
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    // This is the title at the top of a pop-up.
+    "title": "Add Custom Property",
+    "introduction": "To add a custom property for this project, choose a unique property name below.",
+    "newPropertyName": "New property name",
+    "problem": {
+      "409_3": "A custom property already exists in this project with the name of \"{propertyName}\"."
+    }
+  }
+}
+</i18n>

--- a/apps/central/src/components/project/custom-properties/new.vue
+++ b/apps/central/src/components/project/custom-properties/new.vue
@@ -73,7 +73,7 @@ const submit = () => {
         : null)
   })
     .then(() => {
-      emit('success');
+      emit('success', name.value);
     })
     .catch(noop);
 };

--- a/apps/central/src/components/project/show.vue
+++ b/apps/central/src/components/project/show.vue
@@ -52,6 +52,12 @@ except according to the terms contained in the LICENSE file.
             {{ $t('resource.appUsers') }}
           </router-link>
         </li>
+        <li v-if="canRoute(tabPath('custom-properties'))"
+          :class="tabClass('custom-properties')" role="presentation">
+          <router-link :to="tabPath('custom-properties')">
+            {{ $t('projectShow.tab.customProperties') }}
+          </router-link>
+        </li>
         <li v-if="canRoute(tabPath('form-access'))"
           :class="tabClass('form-access')" role="presentation">
           <router-link :to="tabPath('form-access')">

--- a/apps/central/src/locales/en.json5
+++ b/apps/central/src/locales/en.json5
@@ -16,6 +16,7 @@
   "projectShow": {
     "tab": {
       "formAccess": "Form Access",
+      "customProperties": "Custom Properties",
     }
   },
   "formHead": {

--- a/apps/central/src/routes.js
+++ b/apps/central/src/routes.js
@@ -364,6 +364,18 @@ const routes = [
         }
       }),
       asyncRoute({
+        path: 'custom-properties',
+        component: 'CustomPropertyList',
+        props: true,
+        loading: 'tab',
+        meta: {
+          validateData: {
+            project: () => project.permits('project.update')
+          },
+          title: () => [i18n.t('projectShow.tab.customProperties'), project.name]
+        }
+      }),
+      asyncRoute({
         path: 'settings',
         component: 'ProjectSettings',
         loading: 'tab',
@@ -755,6 +767,7 @@ const routesByName = new Map();
     'ProjectOverview',
     'ProjectUserList',
     'FieldKeyList',
+    'CustomPropertyList',
     'ProjectFormAccess',
     'DatasetList',
     'ProjectSettings',

--- a/apps/central/src/util/load-async.js
+++ b/apps/central/src/util/load-async.js
@@ -180,6 +180,10 @@ const loaders = new Map()
     /* webpackChunkName: "component-project-user-list" */
     '../components/project/user/list.vue'
   )))
+  .set('CustomPropertyList', loader(() => import(
+    /* webpackChunkName: "component-custom-properties-list" */
+    '../components/project/custom-properties/list.vue'
+  )))
   .set('PublicLinkList', loader(() => import(
     /* webpackChunkName: "component-public-link-list" */
     '../components/public-link/list.vue'

--- a/apps/central/test/components/project/custom-properties/list.spec.js
+++ b/apps/central/test/components/project/custom-properties/list.spec.js
@@ -14,7 +14,7 @@ const mountComponent = () => mount(CustomPropertyList, {
   props: { projectId: '1' },
   container: {
     router: mockRouter('/'),
-    requestData: testRequestData([useProject], {
+    requestData: testRequestData([useProject, 'actorProperties'], {
       project: testData.extendedProjects.last(),
       actorProperties: testData.actorProperties.sorted()
     })

--- a/apps/central/test/components/project/custom-properties/list.spec.js
+++ b/apps/central/test/components/project/custom-properties/list.spec.js
@@ -1,0 +1,88 @@
+import CustomPropertyList from '../../../../src/components/project/custom-properties/list.vue';
+import CustomPropertiesNew from '../../../../src/components/project/custom-properties/new.vue';
+
+import useProject from '../../../../src/request-data/project';
+
+import testData from '../../../data';
+import { load } from '../../../util/http';
+import { mockLogin } from '../../../util/session';
+import { mockRouter } from '../../../util/router';
+import { mount } from '../../../util/lifecycle';
+import { testRequestData } from '../../../util/request-data';
+
+const mountComponent = () => mount(CustomPropertyList, {
+  props: { projectId: '1' },
+  container: {
+    router: mockRouter('/'),
+    requestData: testRequestData([useProject], {
+      project: testData.extendedProjects.last(),
+      actorProperties: testData.actorProperties.sorted()
+    })
+  }
+});
+
+describe('CustomPropertyList', () => {
+  beforeEach(mockLogin);
+
+  it('shows the properties', () => {
+    testData.extendedProjects.createPast(1);
+    testData.actorProperties.createPast(1, { name: 'region' });
+    testData.actorProperties.createPast(1, { name: 'department' });
+    const component = mountComponent();
+    const rows = component.findAll('tbody tr');
+    rows.length.should.equal(2);
+    rows[0].find('td').text().should.equal('region');
+    rows[1].find('td').text().should.equal('department');
+  });
+
+  it('shows empty message when there are no properties', () => {
+    testData.extendedProjects.createPast(1);
+    const component = mountComponent();
+    component.find('.empty-table-message').text().should.equal('No custom properties have been defined for this project.');
+  });
+
+  it('shows the new button for a user with project.update permission', () => {
+    testData.extendedProjects.createPast(1);
+    const component = mountComponent();
+    component.find('#custom-properties-list-new-button').exists().should.be.true;
+  });
+
+  it('toggles the new property modal', () => {
+    testData.extendedProjects.createPast(1);
+    return load('/projects/1/custom-properties').testModalToggles({
+      modal: CustomPropertiesNew,
+      show: '#custom-properties-list-new-button',
+      hide: '.btn-link'
+    });
+  });
+
+  it('shows success alert after successful creation', async () => {
+    testData.extendedProjects.createPast(1);
+    const app = await load('/projects/1/custom-properties')
+      .complete()
+      .request(async (c) => {
+        await c.get('#custom-properties-list-new-button').trigger('click');
+        await c.get('#custom-properties-new input').setValue('region');
+        return c.get('#custom-properties-new form').trigger('submit');
+      })
+      .respondWithSuccess();
+    app.should.alert('success', 'Custom property created successfully.');
+  });
+
+  it('sends the correct POST request when creating a property', () => {
+    testData.extendedProjects.createPast(1);
+    return load('/projects/1/custom-properties')
+      .complete()
+      .request(async (app) => {
+        await app.get('#custom-properties-list-new-button').trigger('click');
+        await app.get('#custom-properties-new input').setValue('region');
+        return app.get('#custom-properties-new form').trigger('submit');
+      })
+      .respondWithSuccess()
+      .testRequests([{
+        method: 'POST',
+        url: '/v1/projects/1/actor-properties',
+        data: { name: 'region' }
+      }]);
+  });
+});

--- a/apps/central/test/components/project/show.spec.js
+++ b/apps/central/test/components/project/show.spec.js
@@ -197,6 +197,7 @@ describe('ProjectShow', () => {
         'Entity Lists 1',
         'Project Roles',
         'App Users',
+        'Custom Properties',
         'Form Access',
         'Settings'
       ]);

--- a/apps/central/test/util/http/data.js
+++ b/apps/central/test/util/http/data.js
@@ -98,6 +98,7 @@ const responsesByComponent = {
     deletedDatasets: () => []
   }),
   ProjectSettings: [],
+  CustomPropertyList: componentResponses({ actorProperties: true }),
   FormNewPage: [],
   FormShow: componentResponses({
     project: true,

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -30,6 +30,10 @@
       "formAccess": {
         "string": "Form Access",
         "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
+      },
+      "customProperties": {
+        "string": "Custom Properties",
+        "developer_comment": "This is the text of a navigation tab, which may also be shown as the page title (browser tab)."
       }
     }
   },
@@ -4293,6 +4297,45 @@
             "string": "This action cannot be undone",
             "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {noUndo} is in the following text:\n\n{noUndo}, but the ability to unarchive a Project is planned for a future release."
           }
+        }
+      }
+    },
+    "ProjectCustomPropertiesList": {
+      "heading": {
+        "0": {
+          "string": "Some helper intro text",
+          "developer_comment": "A brief introduction to Custom Properties shown for the current project"
+        },
+        "1": {
+          "string": "Custom Properties are custom fields that can be attached to project app users and public links to store additional metadata."
+        }
+      },
+      "emptyTable": {
+        "string": "No custom properties have been defined for this project."
+      },
+      "created": {
+        "string": "Custom property created successfully.",
+        "developer_comment": "Shown after a custom property is successfully created."
+      },
+      "new": {
+        "string": "New",
+        "developer_comment": "This is the text of a button that is used to create a new Custom Property for users. It is shown next to a heading whose text is \"Custom Properties\"."
+      }
+    },
+    "ProjectCustomPropertiesNew": {
+      "title": {
+        "string": "Add Custom Property",
+        "developer_comment": "This is the title at the top of a pop-up."
+      },
+      "introduction": {
+        "string": "To add a custom property for this project, choose a unique property name below."
+      },
+      "newPropertyName": {
+        "string": "New property name"
+      },
+      "problem": {
+        "409_3": {
+          "string": "A custom property already exists in this project with the name of \"{propertyName}\"."
         }
       }
     },

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -4303,11 +4303,8 @@
     "ProjectCustomPropertiesList": {
       "heading": {
         "0": {
-          "string": "Some helper intro text",
+          "string": "Custom Properties are custom fields that can be attached to App Users and Public Links to store additional metadata.",
           "developer_comment": "A brief introduction to Custom Properties shown for the current project"
-        },
-        "1": {
-          "string": "Custom Properties are custom fields that can be attached to project app users and public links to store additional metadata."
         }
       },
       "emptyTable": {
@@ -4317,9 +4314,11 @@
         "string": "Custom property created successfully.",
         "developer_comment": "Shown after a custom property is successfully created."
       },
-      "new": {
-        "string": "New",
-        "developer_comment": "This is the text of a button that is used to create a new Custom Property for users. It is shown next to a heading whose text is \"Custom Properties\"."
+      "action": {
+        "create": {
+          "string": "New",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
       }
     },
     "ProjectCustomPropertiesNew": {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1870

<img width="834" height="604" alt="Screenshot 2026-05-13 at 4 02 28 PM" src="https://github.com/user-attachments/assets/6365ef7c-7919-4b01-99d5-d35c3cf20bc6" />

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I've used it along with the backend in https://github.com/getodk/central-backend/pull/1824 

#### Why is this the best possible solution? Were any other approaches considered?

We've discussed a lot of ways to show user properties, and this was the one we decided to start with!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is part of a larger effort to give more flexibility and enable entity segmentation.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

We will want to add user documentation about what these properties are and how to use them. 

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced