### PR TITLE
feat(#448): support encrypting submission payload

### DIFF
--- a/.changeset/curly-cups-camp.md
+++ b/.changeset/curly-cups-camp.md
@@ -1,0 +1,8 @@
+---
+'@getodk/xforms-engine': minor
+'@getodk/scenario': minor
+'@getodk/common': minor
+'@getodk/web-forms': minor
+---
+
+Added support for submission encryption

--- a/e2e-tests/backend-client.js
+++ b/e2e-tests/backend-client.js
@@ -120,7 +120,6 @@ export default class BackendClient {
 
   createFormAndChildren = async () => {
     const form = await this.createForm();
-    await this.setWebForms(form.xmlFormId, true); // this shouldn't be necessary - remove before pushing
     const submission = await this.createSubmission(form.xmlFormId);
     await this.editSubmission(form.xmlFormId, submission.instanceId);
     const formDraft = await this.createDraftVersion(form.xmlFormId);

--- a/e2e-tests/backend-client.js
+++ b/e2e-tests/backend-client.js
@@ -9,6 +9,10 @@ const user = process.env.ODK_USER;
 const password = process.env.ODK_PASSWORD;
 const credentials = Buffer.from(`${user}:${password}`, 'utf-8').toString('base64');
 const __dirname = import.meta.dirname;
+const FORM_TEMPLATES = {
+  'simple': path.join(__dirname, './data/form.template.xml'),
+  'attachment': path.join(__dirname, './data/form-with-attachment.template.xml'),
+};
 
 export default class BackendClient {
   #request;
@@ -34,8 +38,9 @@ export default class BackendClient {
     return this.#request;
   }
 
-  createForm = async () => {
-    const formTemplate = fs.readFileSync(path.join(__dirname, './data/form.template.xml'), 'utf8');
+  createForm = async (templateFile) => {
+    const template = templateFile || FORM_TEMPLATES.simple;
+    const formTemplate = fs.readFileSync(template, 'utf8');
     const request = await this.#getRequest();
 
     const response = await request.post(`/v1/projects/${this.#projectId}/forms?publish=true`, {
@@ -47,6 +52,10 @@ export default class BackendClient {
     });
     expect(response).toBeOK();
     return response.json();
+  };
+
+  createAttachmentForm = async () => {
+    return this.createForm(FORM_TEMPLATES.attachment);
   };
 
   createSubmission = async (xmlFormId) => {
@@ -144,6 +153,17 @@ export default class BackendClient {
   downloadCsv = async (xmlFormId, passphrase) => {
     const keyId = process.env.ENCRYPTION_KEY_ID;
     let downloadUrl = `/v1/projects/${this.#projectId}/forms/${xmlFormId}/submissions.csv`;
+    if (passphrase) {
+      downloadUrl += `?${keyId}=${passphrase}`;
+    }
+    const request = await this.#getRequest();
+    const response = await request.get(downloadUrl);
+    return response;
+  };
+
+  downloadZip = async (xmlFormId, passphrase) => {
+    const keyId = process.env.ENCRYPTION_KEY_ID;
+    let downloadUrl = `/v1/projects/${this.#projectId}/forms/${xmlFormId}/submissions.csv.zip`;
     if (passphrase) {
       downloadUrl += `?${keyId}=${passphrase}`;
     }

--- a/e2e-tests/backend-client.js
+++ b/e2e-tests/backend-client.js
@@ -8,17 +8,18 @@ const appUrl = process.env.ODK_URL;
 const user = process.env.ODK_USER;
 const password = process.env.ODK_PASSWORD;
 const credentials = Buffer.from(`${user}:${password}`, 'utf-8').toString('base64');
-const projectId = process.env.PROJECT_ID;
 const __dirname = import.meta.dirname;
 
 export default class BackendClient {
   #request;
   #playwright;
   #prefix;
+  #projectId;
 
-  constructor(playwright, prefix) {
+  constructor(playwright, prefix, projectId) {
     this.#playwright = playwright;
     this.#prefix = prefix;
+    this.#projectId = projectId || process.env.PROJECT_ID;
   }
 
   async #getRequest() {
@@ -37,7 +38,7 @@ export default class BackendClient {
     const formTemplate = fs.readFileSync(path.join(__dirname, './data/form.template.xml'), 'utf8');
     const request = await this.#getRequest();
 
-    const response = await request.post(`/v1/projects/${projectId}/forms?publish=true`, {
+    const response = await request.post(`/v1/projects/${this.#projectId}/forms?publish=true`, {
       headers: {
         'content-type': 'application/xml',
       },
@@ -51,7 +52,7 @@ export default class BackendClient {
   createSubmission = async (xmlFormId) => {
     const submissionTemplate = fs.readFileSync(path.join(__dirname, './data/submission.template.xml'), 'utf8');
     const request = await this.#getRequest();
-    const response = await request.post(`/v1/projects/${projectId}/forms/${xmlFormId}/submissions`, {
+    const response = await request.post(`/v1/projects/${this.#projectId}/forms/${xmlFormId}/submissions`, {
       headers: {
         'content-type': 'application/xml',
       },
@@ -66,14 +67,14 @@ export default class BackendClient {
 
   editSubmission = async (xmlFormId, instanceId) => {
     const request = await this.#getRequest();
-    const response = await request.get(`/v1/projects/${projectId}/forms/${xmlFormId}/submissions/${instanceId}/edit`);
+    const response = await request.get(`/v1/projects/${this.#projectId}/forms/${xmlFormId}/submissions/${instanceId}/edit`);
     expect(response).toBeOK();
   };
 
   createDraftVersion = async (xmlFormId, version = 'v2') => {
     const formTemplate = fs.readFileSync(path.join(__dirname, './data/form.template.xml'), 'utf8');
     const request = await this.#getRequest();
-    const response = await request.post(`/v1/projects/${projectId}/forms/${xmlFormId}/draft`, {
+    const response = await request.post(`/v1/projects/${this.#projectId}/forms/${xmlFormId}/draft`, {
       headers: {
         'content-type': 'application/xml',
       },
@@ -84,14 +85,14 @@ export default class BackendClient {
     });
     expect(response).toBeOK();
 
-    const getResponse = await request.get(`/v1/projects/${projectId}/forms/${xmlFormId}/draft`);
+    const getResponse = await request.get(`/v1/projects/${this.#projectId}/forms/${xmlFormId}/draft`);
     expect(getResponse).toBeOK();
     return getResponse.json();
   };
 
   createPublicLink = async (xmlFormId, once = false) => {
     const request = await this.#getRequest();
-    const response = await request.post(`/v1/projects/${projectId}/forms/${xmlFormId}/public-links`, {
+    const response = await request.post(`/v1/projects/${this.#projectId}/forms/${xmlFormId}/public-links`, {
       data: {
         displayName: faker.word.noun(),
         once
@@ -103,7 +104,7 @@ export default class BackendClient {
 
   setWebForms = async (xmlFormId, enable) => {
     const request = await this.#getRequest();
-    const response = await request.patch(`/v1/projects/${projectId}/forms/${xmlFormId}`, {
+    const response = await request.patch(`/v1/projects/${this.#projectId}/forms/${xmlFormId}`, {
       data: {
         webformsEnabled: enable
       }
@@ -113,12 +114,13 @@ export default class BackendClient {
 
   deleteForm = async (xmlFormId) => {
     const request = await this.#getRequest();
-    const response = await request.delete(`/v1/projects/${projectId}/forms/${xmlFormId}`);
+    const response = await request.delete(`/v1/projects/${this.#projectId}/forms/${xmlFormId}`);
     expect(response).toBeOK();
   };
 
   createFormAndChildren = async () => {
     const form = await this.createForm();
+    await this.setWebForms(form.xmlFormId, true); // this shouldn't be necessary - remove before pushing
     const submission = await this.createSubmission(form.xmlFormId);
     await this.editSubmission(form.xmlFormId, submission.instanceId);
     const formDraft = await this.createDraftVersion(form.xmlFormId);
@@ -138,6 +140,17 @@ export default class BackendClient {
       data: { propertyValue: '2100.1' } //  Fairly future-proof - modal will be dismissed if preference is not older than current version.
     });
     expect(response.ok()).toBeTruthy();
+  };
+
+  downloadCsv = async (xmlFormId, passphrase) => {
+    const keyId = process.env.ENCRYPTION_KEY_ID;
+    let downloadUrl = `/v1/projects/${this.#projectId}/forms/${xmlFormId}/submissions.csv`;
+    if (passphrase) {
+      downloadUrl += `?${keyId}=${passphrase}`;
+    }
+    const request = await this.#getRequest();
+    const response = await request.get(downloadUrl);
+    return response;
   };
 
   async dispose() {

--- a/e2e-tests/data/form-with-attachment.template.xml
+++ b/e2e-tests/data/form-with-attachment.template.xml
@@ -1,0 +1,27 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>{{ formId }}</h:title>
+        <model>
+            <instance>
+                <data id="{{ formId }}">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                    <first_name/>
+                    <text_file/>
+                </data>
+            </instance>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+            <bind nodeset="/data/first_name" type="string"/>
+            <bind nodeset="/data/text_file" type="binary"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/first_name">
+            <label>First Name</label>
+        </input>
+        <upload ref="/data/text_file">
+            <label>Upload</label>
+        </upload>
+    </h:body>
+</h:html>

--- a/e2e-tests/global.setup.js
+++ b/e2e-tests/global.setup.js
@@ -1,4 +1,5 @@
 import { test as setup, expect } from '@playwright/test';
+import { ENCRYPTION_SECRET } from './util';
 
 const appUrl = process.env.ODK_URL;
 const user = process.env.ODK_USER;
@@ -40,7 +41,7 @@ const createProject = async(request, encrypted) => {
           Authorization: `Basic ${credentials}`
         },
         data: {
-          passphrase: "encryptionsecret",
+          passphrase: ENCRYPTION_SECRET,
           hint: "it was a secret"
         }
       });

--- a/e2e-tests/global.setup.js
+++ b/e2e-tests/global.setup.js
@@ -5,7 +5,7 @@ const user = process.env.ODK_USER;
 const password = process.env.ODK_PASSWORD;
 const credentials = Buffer.from(`${user}:${password}`, 'utf-8').toString('base64');
 
-setup('create new project', async ({ request }) => {
+const createProject = async(request, encrypted) => {
   try {
     const createProjectResponse = await request.post(`${appUrl}/v1/projects`, {
       headers: {
@@ -32,7 +32,30 @@ setup('create new project', async ({ request }) => {
     const project = await createProjectResponse.json();
 
     expect(project.id).not.toBeFalsy();
-    process.env.PROJECT_ID = project.id;
+
+    if (encrypted) {
+      const encryptionResponse = await request.post(`${appUrl}/v1/projects/${project.id}/key`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${credentials}`
+        },
+        data: {
+          passphrase: "encryptionsecret",
+          hint: "it was a secret"
+        }
+      });
+      expect(encryptionResponse).toBeOK();
+      const getProjectResponse = await request.get(`${appUrl}/v1/projects/${project.id}`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${credentials}`
+        }
+      });
+      expect(getProjectResponse).toBeOK();
+      const getProjectBody = await getProjectResponse.json();
+      process.env.ENCRYPTION_KEY_ID = getProjectBody.keyId;
+    }
+    return project.id;
   } catch (err) {
     if (err.message.includes('ECONNREFUSED')) {
       // eslint-disable-next-line preserve-caught-error
@@ -48,4 +71,9 @@ setup('create new project', async ({ request }) => {
       throw err;
     }
   }
+};
+
+setup('create new project', async ({ request }) => {
+  process.env.PROJECT_ID = await createProject(request, false);
+  process.env.PROJECT_ID_ENCRYPTED = await createProject(request, true);
 });

--- a/e2e-tests/global.teardown.js
+++ b/e2e-tests/global.teardown.js
@@ -19,6 +19,6 @@ teardown('delete project', async () => {
       .then(res => res.json())
       .then(res => res.success);
   });
-  const results = await Promise.all(promises);
+  const results = await Promise.allSettled(promises);
   results.forEach(result => expect(result).toEqual(true));
 });

--- a/e2e-tests/global.teardown.js
+++ b/e2e-tests/global.teardown.js
@@ -8,10 +8,8 @@ const projectId = process.env.PROJECT_ID;
 const projectIdEncrypted = process.env.PROJECT_ID_ENCRYPTED;
 
 teardown('delete project', async () => {
-  for (const project of [ projectId, projectIdEncrypted ]) {
-    if (!project) return;
-
-    const result = await fetch(`${appUrl}/v1/projects/${project}`, {
+  const promises = [ projectId, projectIdEncrypted ].map((project) => {
+    return fetch(`${appUrl}/v1/projects/${project}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -19,8 +17,8 @@ teardown('delete project', async () => {
       }
     })
       .then(res => res.json())
-      .then(r => r.success);
-
-    expect(result).toEqual(true);
-  }
+      .then(res => res.success);
+  });
+  const results = await Promise.all(promises);
+  results.forEach(result => expect(result).toEqual(true));
 });

--- a/e2e-tests/global.teardown.js
+++ b/e2e-tests/global.teardown.js
@@ -20,5 +20,5 @@ teardown('delete project', async () => {
       .then(res => res.success);
   });
   const results = await Promise.allSettled(promises);
-  results.forEach(result => expect(result).toEqual(true));
+  results.forEach(result => expect(result.value).toEqual(true));
 });

--- a/e2e-tests/global.teardown.js
+++ b/e2e-tests/global.teardown.js
@@ -5,19 +5,22 @@ const user = process.env.ODK_USER;
 const password = process.env.ODK_PASSWORD;
 const credentials = Buffer.from(`${user}:${password}`, 'utf-8').toString('base64');
 const projectId = process.env.PROJECT_ID;
+const projectIdEncrypted = process.env.PROJECT_ID_ENCRYPTED;
 
 teardown('delete project', async () => {
-  if (!projectId) return;
+  for (const project of [ projectId, projectIdEncrypted ]) {
+    if (!project) return;
 
-  const result = await fetch(`${appUrl}/v1/projects/${projectId}`, {
-    method: 'DELETE',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Basic ${credentials}`
-    }
-  })
-    .then(res => res.json())
-    .then(r => r.success);
+    const result = await fetch(`${appUrl}/v1/projects/${project}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${credentials}`
+      }
+    })
+      .then(res => res.json())
+      .then(r => r.success);
 
-  expect(result).toEqual(true);
+    expect(result).toEqual(true);
+  }
 });

--- a/e2e-tests/tests/encrypted-submission.spec.js
+++ b/e2e-tests/tests/encrypted-submission.spec.js
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 import BackendClient from '../backend-client';
+import { login, ENCRYPTION_SECRET } from '../util';
 
 const appUrl = process.env.ODK_URL;
-const user = process.env.ODK_USER;
-const password = process.env.ODK_PASSWORD;
 const projectId = process.env.PROJECT_ID_ENCRYPTED;
 
 const FIRSTNAME_COLUMN_INDEX = 2;
@@ -16,33 +15,20 @@ test.beforeAll(async ({ playwright }, testInfo) => {
   backendClient = new BackendClient(playwright, `${testInfo.project.name}_wf`, projectId);
   await backendClient.alwaysHideModal();
   publishedForm = await backendClient.createForm();
-  await backendClient.setWebForms(publishedForm.xmlFormId, true); // this shouldn't be necessary - remove before pushing
+  await backendClient.setWebForms(publishedForm.xmlFormId, true);
 });
 
 test.afterAll(async () => {
   await backendClient.dispose();
 })
 
-const login = async (page) => {
-  await page.goto(appUrl);
-  await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
-
-  await page.getByPlaceholder('email address').fill(user);
-  await page.getByPlaceholder('password').fill(password);
-
-  await page.getByRole('button', { name: 'Log in' }).click();
-
-  await page.waitForURL(appUrl);
-};
-
-const checkResponse = async (response, column, values) => {
+const assertCsvResponse = async (response, column, expected) => {
   expect(response).toBeOK();
   const text = await response.text();
   const rows = text.split('\n');
-  for (let i = 0; i < values.length; i++) {
-    const actual = rows[i + 1].split(',')[column];
-    expect(actual).toBe(values[i]);
-  }
+  rows.shift(); // remove the header row
+  const actual = rows.map(r => r.split(',')[column]);
+  expect(actual).to.deep.equal(expected);
 };
 
 test.describe('ODK Web Forms Encrypted', () => {
@@ -63,15 +49,15 @@ test.describe('ODK Web Forms Encrypted', () => {
 
     // attempt to download the file with no key
     const unencryptedResponse = await backendClient.downloadCsv(publishedForm.xmlFormId);
-    await checkResponse(unencryptedResponse, STATUS_COLUMN_INDEX, ['not decrypted', 'not decrypted']);
+    await assertCsvResponse(unencryptedResponse, STATUS_COLUMN_INDEX, ['not decrypted', 'not decrypted']);
 
     // attempt to download the csv with wrong passphrase
     const wrongPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, 'hax');
     expect(wrongPassphraseResponse).not.toBeOK();
 
     // attempt to download the csv with correct passphrase
-    const rightPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, 'encryptionsecret');
-    await checkResponse(rightPassphraseResponse, FIRSTNAME_COLUMN_INDEX, ['Jane Doe', 'John Doe']); // csv is reverse date order
+    const rightPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, ENCRYPTION_SECRET);
+    await assertCsvResponse(rightPassphraseResponse, FIRSTNAME_COLUMN_INDEX, ['Jane Doe', 'John Doe']); // csv is reverse date order
   });
 
 });

--- a/e2e-tests/tests/encrypted-submission.spec.js
+++ b/e2e-tests/tests/encrypted-submission.spec.js
@@ -46,7 +46,7 @@ const checkResponse = async (response, column, values) => {
 };
 
 test.describe('ODK Web Forms Encrypted', () => {
-  test('allows multiple submission', async ({ page }) => {
+  test('requires passphrase to download content', async ({ page }) => {
     await login(page);
 
     await page.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);

--- a/e2e-tests/tests/encrypted-submission.spec.js
+++ b/e2e-tests/tests/encrypted-submission.spec.js
@@ -28,7 +28,7 @@ const assertCsvResponse = async (response, column, expected) => {
   const rows = text.split('\n');
   rows.shift(); // remove the header row
   const actual = rows.map(r => r.split(',')[column]);
-  expect(actual).to.deep.equal(expected);
+  expect(actual).toEqual(expected);
 };
 
 test.describe('ODK Web Forms Encrypted', () => {

--- a/e2e-tests/tests/encrypted-submission.spec.js
+++ b/e2e-tests/tests/encrypted-submission.spec.js
@@ -1,42 +1,72 @@
 import { test, expect } from '@playwright/test';
 import BackendClient from '../backend-client';
 import { login, ENCRYPTION_SECRET } from '../util';
+import Zip from 'adm-zip';
 
 const appUrl = process.env.ODK_URL;
 const projectId = process.env.PROJECT_ID_ENCRYPTED;
 
-const FIRSTNAME_COLUMN_INDEX = 2;
-const STATUS_COLUMN_INDEX = 8;
-
-let publishedForm;
+let simpleForm;
+let formWithAttachment;
 let backendClient;
 
 test.beforeAll(async ({ playwright }, testInfo) => {
   backendClient = new BackendClient(playwright, `${testInfo.project.name}_wf`, projectId);
   await backendClient.alwaysHideModal();
-  publishedForm = await backendClient.createForm();
-  await backendClient.setWebForms(publishedForm.xmlFormId, true);
+  simpleForm = await backendClient.createForm();
+  await backendClient.setWebForms(simpleForm.xmlFormId, true);
+  formWithAttachment = await backendClient.createAttachmentForm();
+  await backendClient.setWebForms(formWithAttachment.xmlFormId, true);
 });
 
 test.afterAll(async () => {
   await backendClient.dispose();
-})
+});
 
-const assertCsvResponse = async (response, column, expected) => {
-  expect(response).toBeOK();
-  const text = await response.text();
+const assertCsv = (text, column, expected) => {
   const rows = text.split('\n');
   rows.shift(); // remove the header row
   const actual = rows.map(r => r.split(',')[column]);
   expect(actual).toEqual(expected);
 };
 
+const assertCsvResponse = async (response, column, expected) => {
+  expect(response).toBeOK();
+  const text = await response.text();
+  assertCsv(text, column, expected);
+};
+
+const assertZipResponse = async (response, csvColumn, csvExpected, attachmentExpected) => {
+  expect(response).toBeOK();
+
+  const body = await response.body();
+  const zip = new Zip(body);
+  const entries = zip.getEntries();
+  let count = 0;
+  for (const entry of entries) {
+    const name = entry.entryName;
+    const text = zip.readAsText(entry);
+    if (name.endsWith('.csv')) {
+      assertCsv(text, csvColumn, csvExpected);
+    } else if (name.endsWith('.txt')) {
+      expect(text).toEqual(attachmentExpected[count++]);
+    } else {
+      throw new Error('unexpected entry: ' + name);
+    }
+  }
+};
+
 test.describe('ODK Web Forms Encrypted', () => {
+
   test('requires passphrase to download content', async ({ page }) => {
+
+    const firstNameColumnIndex = 2;
+    const statusColumnIndex = 8;
+
     await login(page);
 
-    await page.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);
-    await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+    await page.goto(`${appUrl}/projects/${projectId}/forms/${simpleForm.xmlFormId}/submissions/new`);
+    await expect(page.getByRole('heading', { name: simpleForm.name })).toBeVisible();
 
     await page.getByLabel('First Name').fill('John Doe');
     await page.getByRole('button', { name: 'send' }).click();
@@ -48,16 +78,58 @@ test.describe('ODK Web Forms Encrypted', () => {
     await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
 
     // attempt to download the file with no key
-    const unencryptedResponse = await backendClient.downloadCsv(publishedForm.xmlFormId);
-    await assertCsvResponse(unencryptedResponse, STATUS_COLUMN_INDEX, ['not decrypted', 'not decrypted']);
+    const unencryptedResponse = await backendClient.downloadCsv(simpleForm.xmlFormId);
+    await assertCsvResponse(unencryptedResponse, statusColumnIndex, ['not decrypted', 'not decrypted']);
 
     // attempt to download the csv with wrong passphrase
-    const wrongPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, 'hax');
+    const wrongPassphraseResponse = await backendClient.downloadCsv(simpleForm.xmlFormId, 'hax');
     expect(wrongPassphraseResponse).not.toBeOK();
 
     // attempt to download the csv with correct passphrase
-    const rightPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, ENCRYPTION_SECRET);
-    await assertCsvResponse(rightPassphraseResponse, FIRSTNAME_COLUMN_INDEX, ['Jane Doe', 'John Doe']); // csv is reverse date order
+    const rightPassphraseResponse = await backendClient.downloadCsv(simpleForm.xmlFormId, ENCRYPTION_SECRET);
+    await assertCsvResponse(rightPassphraseResponse, firstNameColumnIndex, ['Jane Doe', 'John Doe']); // csv is reverse date order
+  });
+
+  test('supports downloading attachments', async ({ page }) => {
+
+    const firstNameColumnIndex = 2;
+    const statusColumnIndex = 9;
+
+    await login(page);
+
+    await page.goto(`${appUrl}/projects/${projectId}/forms/${formWithAttachment.xmlFormId}/submissions/new`);
+    await expect(page.getByRole('heading', { name: formWithAttachment.name })).toBeVisible();
+
+    await page.getByLabel('First Name').fill('John Doe');
+    await page.locator('input[type=file]').setInputFiles({
+      name: 'john.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('info about john')
+    });
+    await page.getByRole('button', { name: 'send' }).click();
+    await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'fill out again' }).click();
+    await page.getByLabel('First Name').fill('Jane Doe');
+    await page.locator('input[type=file]').setInputFiles({
+      name: 'jane.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('info about jane')
+    });
+    await page.getByRole('button', { name: 'send' }).click();
+    await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
+
+    // attempt to download the file with no key
+    const unencryptedResponse = await backendClient.downloadZip(formWithAttachment.xmlFormId);
+    await assertZipResponse(unencryptedResponse, statusColumnIndex, ['not decrypted', 'not decrypted'], []);
+
+    // attempt to download the csv with wrong passphrase
+    const wrongPassphraseResponse = await backendClient.downloadZip(formWithAttachment.xmlFormId, 'hax');
+    expect(wrongPassphraseResponse).not.toBeOK();
+
+    // attempt to download the csv with correct passphrase
+    const rightPassphraseResponse = await backendClient.downloadZip(formWithAttachment.xmlFormId, ENCRYPTION_SECRET);
+    await assertZipResponse(rightPassphraseResponse, firstNameColumnIndex, ['Jane Doe', 'John Doe'], ['info about john', 'info about jane']); // csv is reverse date order, but attachments aren't
   });
 
 });

--- a/e2e-tests/tests/encrypted-submission.spec.js
+++ b/e2e-tests/tests/encrypted-submission.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import BackendClient from '../backend-client';
+
+const appUrl = process.env.ODK_URL;
+const user = process.env.ODK_USER;
+const password = process.env.ODK_PASSWORD;
+const projectId = process.env.PROJECT_ID_ENCRYPTED;
+
+const FIRSTNAME_COLUMN_INDEX = 2;
+const STATUS_COLUMN_INDEX = 8;
+
+let publishedForm;
+let backendClient;
+
+test.beforeAll(async ({ playwright }, testInfo) => {
+  backendClient = new BackendClient(playwright, `${testInfo.project.name}_wf`, projectId);
+  await backendClient.alwaysHideModal();
+  publishedForm = await backendClient.createForm();
+  await backendClient.setWebForms(publishedForm.xmlFormId, true); // this shouldn't be necessary - remove before pushing
+});
+
+test.afterAll(async () => {
+  await backendClient.dispose();
+})
+
+const login = async (page) => {
+  await page.goto(appUrl);
+  await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
+
+  await page.getByPlaceholder('email address').fill(user);
+  await page.getByPlaceholder('password').fill(password);
+
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  await page.waitForURL(appUrl);
+};
+
+const checkResponse = async (response, column, values) => {
+  expect(response).toBeOK();
+  const text = await response.text();
+  const rows = text.split('\n');
+  for (let i = 0; i < values.length; i++) {
+    const actual = rows[i + 1].split(',')[column];
+    expect(actual).toBe(values[i]);
+  }
+};
+
+test.describe('ODK Web Forms Encrypted', () => {
+  test.only('allows multiple submission', async ({ page }) => {
+    await login(page);
+
+    await page.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);
+    await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+
+    await page.getByLabel('First Name').fill('John Doe');
+    await page.getByRole('button', { name: 'send' }).click();
+    await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'fill out again' }).click();
+    await page.getByLabel('First Name').fill('Jane Doe');
+    await page.getByRole('button', { name: 'send' }).click();
+    await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
+
+    // attempt to download the file with no key
+    const unencryptedResponse = await backendClient.downloadCsv(publishedForm.xmlFormId);
+    await checkResponse(unencryptedResponse, STATUS_COLUMN_INDEX, ['not decrypted', 'not decrypted']);
+
+    // attempt to download the csv with wrong passphrase
+    const wrongPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, 'hax');
+    expect(wrongPassphraseResponse).not.toBeOK();
+
+    // attempt to download the csv with correct passphrase
+    const rightPassphraseResponse = await backendClient.downloadCsv(publishedForm.xmlFormId, 'encryptionsecret');
+    await checkResponse(rightPassphraseResponse, FIRSTNAME_COLUMN_INDEX, ['Jane Doe', 'John Doe']); // csv is reverse date order
+  });
+
+});

--- a/e2e-tests/tests/encrypted-submission.spec.js
+++ b/e2e-tests/tests/encrypted-submission.spec.js
@@ -46,7 +46,7 @@ const checkResponse = async (response, column, values) => {
 };
 
 test.describe('ODK Web Forms Encrypted', () => {
-  test.only('allows multiple submission', async ({ page }) => {
+  test('allows multiple submission', async ({ page }) => {
     await login(page);
 
     await page.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);

--- a/e2e-tests/tests/enketo.spec.js
+++ b/e2e-tests/tests/enketo.spec.js
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 import BackendClient from '../backend-client';
+import { login } from '../util';
 
 const appUrl = process.env.ODK_URL;
-const user = process.env.ODK_USER;
-const password = process.env.ODK_PASSWORD;
 const projectId = process.env.PROJECT_ID;
 
 let backendClient;
@@ -24,18 +23,6 @@ test.beforeAll(async ({ playwright }, testInfo) => {
 test.afterAll(async () => {
   await backendClient.dispose();
 });
-
-const login = async (page) => {
-  await page.goto(appUrl);
-  await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
-
-  await page.getByPlaceholder('email address').fill(user);
-  await page.getByPlaceholder('password').fill(password);
-
-  await page.getByRole('button', { name: 'Log in' }).click();
-
-  await page.waitForURL(appUrl);
-};
 
 test.describe('Enketo', () => {
   test.describe('all old URLs should be working', () => {

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 import BackendClient from '../backend-client';
+import { login } from '../util';
 
 const appUrl = process.env.ODK_URL;
-const user = process.env.ODK_USER;
-const password = process.env.ODK_PASSWORD;
 const projectId = process.env.PROJECT_ID;
 
 let publishedForm;
@@ -23,18 +22,6 @@ test.beforeAll(async ({ playwright }, testInfo) => {
   await backendClient.setWebForms(resources.form.xmlFormId, true);
   await backendClient.dispose();
 });
-
-const login = async (page) => {
-  await page.goto(appUrl);
-  await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
-
-  await page.getByPlaceholder('email address').fill(user);
-  await page.getByPlaceholder('password').fill(password);
-
-  await page.getByRole('button', { name: 'Log in' }).click();
-
-  await page.waitForURL(appUrl);
-};
 
 test.describe('ODK Web Forms', () => {
   test.describe('all old URLs should be working', () => {

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 const appUrl = process.env.ODK_URL;
 const user = process.env.ODK_USER;
 const password = process.env.ODK_PASSWORD;
+const ENCRYPTION_SECRET = 'encryptionsecret';
 
 const login = async (page) => {
   await page.goto(appUrl);
@@ -16,4 +17,7 @@ const login = async (page) => {
   await page.waitForURL(appUrl);
 };
 
-export { login };
+export {
+  login,
+  ENCRYPTION_SECRET
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@vue/eslint-config-typescript": "^14.7.0",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
+        "adm-zip": "^0.5.17",
         "eslint": "^10.0.3",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jsdoc": "^62.8.0",
@@ -6576,6 +6577,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
+    "adm-zip": "^0.5.17",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsdoc": "^62.8.0",

--- a/packages/common/src/constants/xmlns.ts
+++ b/packages/common/src/constants/xmlns.ts
@@ -24,6 +24,9 @@ export type JAVAROSA_NAMESPACE_URI = typeof JAVAROSA_NAMESPACE_URI;
 export const ODK_NAMESPACE_URI = 'http://www.opendatakit.org/xforms';
 export type ODK_NAMESPACE_URI = typeof ODK_NAMESPACE_URI;
 
+export const ODK_ENCRYPTED_NAMESPACE_URI = 'http://www.opendatakit.org/xforms/encrypted';
+export type ODK_ENCRYPTED_NAMESPACE_URI = typeof ODK_ENCRYPTED_NAMESPACE_URI;
+
 export const OPENROSA_XFORMS_NAMESPACE_URI = 'http://openrosa.org/xforms';
 export type OPENROSA_XFORMS_NAMESPACE_URI = typeof OPENROSA_XFORMS_NAMESPACE_URI;
 

--- a/packages/common/src/fixtures/encryption/encryption.xml
+++ b/packages/common/src/fixtures/encryption/encryption.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>encrypted</h:title>
+    <model>
+      <submission base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsrq8xrFswX/Ht1X4UVeLjupqz8hCMo+GR3hwqZdx7BQjvw9KBcCL+J6CI/2yyTqprVmeWZZu/i9qjuYcyWir3ZonZIDaVvClP8LN7e0+0SgQgEV+v9bjGVTDMQIKY2vq2ZNEbuy4UAHFLJCwGaUE370w76r/Da4YbAgfGVQn1sHarJ8Zp1o/6RE1IckxA8L2spo8oSU23KnttLIaR2qIS7mY+BkZPItyyNjulpJUZlxf4AgO7T8S4grmOC5TW4laB25vjbPw4KzB3L8bm+oK5JjlocazOiyUVDz8UwYMQke4ybEwSJbu3gl7DJzlwwQ1u3AbtjZk2T7LKUotrkVzAQIDAQAB"/>
+      <instance>
+        <encrypted id="encrypted">
+          <question/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </encrypted>
+      </instance>
+      <bind nodeset="/encrypted/question" type="string"/>
+      <bind jr:preload="uid" nodeset="/encrypted/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/encrypted/question">
+      <label>Question 1</label>
+    </input>
+  </h:body>
+</h:html>

--- a/packages/web-forms/feature-matrix.json
+++ b/packages/web-forms/feature-matrix.json
@@ -223,6 +223,6 @@
     "save as draft": "",
     "offline entities": "",
     "MBtiles / offline map layers": "",
-    "[submission encryption](https://github.com/getodk/web-forms/issues/448)": ""
+    "[submission encryption](https://github.com/getodk/web-forms/issues/448)": "✅"
   }
 }

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/prepareInstancePayload.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/prepareInstancePayload.ts
@@ -48,7 +48,7 @@ const collectInstanceAttachmentFiles = (attachments: InstanceAttachmentsState): 
 	return files.filter((file) => file != null);
 };
 
-class InstanceFile extends File implements ClientInstanceFile {
+export class InstanceFile extends File implements ClientInstanceFile {
 	override readonly name = INSTANCE_FILE_NAME;
 	override readonly type = INSTANCE_FILE_TYPE;
 
@@ -60,11 +60,11 @@ class InstanceFile extends File implements ClientInstanceFile {
 }
 
 export interface Submission {
-	readonly instanceXML: string;
+	readonly instanceFile: InstanceFile;
 	readonly attachments: readonly File[];
 }
 
-const collectInstanceFiles = async (
+const createSubmission = async (
 	instanceRoot: ClientReactiveSerializableInstance,
 	submissionMeta: SubmissionMeta
 ): Promise<Submission> => {
@@ -90,7 +90,8 @@ const collectInstanceFiles = async (
 			submissionMeta.encryptionKey
 		);
 	}
-	return { instanceXML, attachments };
+	const instanceFile = new InstanceFile(instanceXML);
+	return { instanceFile, attachments };
 };
 
 type AssertFile = (value: FormDataEntryValue) => asserts value is File;
@@ -265,8 +266,7 @@ export const prepareInstancePayload = async <PayloadType extends InstancePayload
 	const validation = validateInstance(instanceRoot);
 	const submissionMeta = instanceRoot.definition.submission;
 
-	const { instanceXML, attachments } = await collectInstanceFiles(instanceRoot, submissionMeta);
-	const instanceFile = new InstanceFile(instanceXML);
+	const { instanceFile, attachments } = await createSubmission(instanceRoot, submissionMeta);
 
 	switch (options.payloadType) {
 		case 'chunked':

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/prepareInstancePayload.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/prepareInstancePayload.ts
@@ -14,6 +14,21 @@ import type { DescendantNodeViolationReference } from '../../../client/validatio
 import { ErrorProductionDesignPendingError } from '../../../error/ErrorProductionDesignPendingError.ts';
 import type { InstanceAttachmentsState } from '../../../instance/attachments/InstanceAttachmentsState.ts';
 import type { ClientReactiveSerializableInstance } from '../../../instance/internal-api/serialization/ClientReactiveSerializableInstance.ts';
+import type { Root } from '../../../instance/Root.ts';
+import { encryptSubmission } from './quarantine/encryption.ts';
+
+const getAttribute = (root: Root, name: string) => {
+	const attribute = root.getAttributes().find((a) => a.definition.qualifiedName.localName === name);
+	return attribute?.definition.value;
+};
+
+const getInstanceID = (root: Root) => {
+	const meta = root.getChildren().find((c) => c.definition.qualifiedName.localName === 'meta');
+	const instanceID = meta
+		?.getChildren()
+		.find((c) => c.definition.qualifiedName.localName === 'instanceID');
+	return instanceID?.getXPathValue();
+};
 
 const collectInstanceAttachmentFiles = (attachments: InstanceAttachmentsState): readonly File[] => {
 	const files = Array.from(attachments.entries()).map(([context, attachment]) => {
@@ -37,14 +52,46 @@ class InstanceFile extends File implements ClientInstanceFile {
 	override readonly name = INSTANCE_FILE_NAME;
 	override readonly type = INSTANCE_FILE_TYPE;
 
-	constructor(instanceRoot: ClientReactiveSerializableInstance) {
-		const { instanceXML } = instanceRoot.instanceState;
-
+	constructor(instanceXML: string) {
 		super([instanceXML], INSTANCE_FILE_NAME, {
 			type: INSTANCE_FILE_TYPE,
 		});
 	}
 }
+
+export interface Submission {
+	readonly instanceXML: string;
+	readonly attachments: readonly File[];
+}
+
+const collectInstanceFiles = async (
+	instanceRoot: ClientReactiveSerializableInstance,
+	submissionMeta: SubmissionMeta
+): Promise<Submission> => {
+	const instanceXML = instanceRoot.instanceState.instanceXML;
+	const attachments = collectInstanceAttachmentFiles(instanceRoot.attachments);
+	if (submissionMeta.encryptionKey) {
+		const root = instanceRoot.root;
+		const formId = getAttribute(root, 'id');
+		const instanceId = getInstanceID(root);
+		const formVersion = getAttribute(root, 'version');
+		if (!formId) {
+			throw new Error('Encrypted submissions are required to have a form ID');
+		}
+		if (!instanceId) {
+			throw new Error('Encrypted submissions are required to have an instance ID');
+		}
+		return await encryptSubmission(
+			formId,
+			formVersion,
+			instanceId,
+			instanceXML,
+			attachments,
+			submissionMeta.encryptionKey
+		);
+	}
+	return { instanceXML, attachments };
+};
 
 type AssertFile = (value: FormDataEntryValue) => asserts value is File;
 
@@ -210,15 +257,16 @@ export interface PrepareInstancePayloadOptions<PayloadType extends InstancePaylo
 	readonly maxSize: number;
 }
 
-export const prepareInstancePayload = <PayloadType extends InstancePayloadType>(
+export const prepareInstancePayload = async <PayloadType extends InstancePayloadType>(
 	instanceRoot: ClientReactiveSerializableInstance,
 	options: PrepareInstancePayloadOptions<PayloadType>
-): InstancePayload<PayloadType> => {
+): Promise<InstancePayload<PayloadType>> => {
 	instanceRoot.root.parent.model.triggerXformsRevalidateListeners();
 	const validation = validateInstance(instanceRoot);
 	const submissionMeta = instanceRoot.definition.submission;
-	const instanceFile = new InstanceFile(instanceRoot);
-	const attachments = collectInstanceAttachmentFiles(instanceRoot.attachments);
+
+	const { instanceXML, attachments } = await collectInstanceFiles(instanceRoot, submissionMeta);
+	const instanceFile = new InstanceFile(instanceXML);
 
 	switch (options.payloadType) {
 		case 'chunked':

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/README.md
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/README.md
@@ -1,0 +1,15 @@
+# Encryption
+
+> [!CAUTION]
+> Custom encryption is a bad idea. Do not use this unless absolutely necessary.
+
+> [!CAUTION]
+> Modification of this code requires great care as a bug in the encryption algorithm will make submissions unrecoverable.
+
+The code in this directory implements the [ODK Spec](https://getodk.github.io/xforms-spec/encryption) which is very particular about how it's done so as to be compatible with other implementations.
+
+## Implementation
+
+The symmetric encryption parts of the spec are implemented using CryptoJS because the particular algorithm required by the spec is not supported by Subtle Crypto, and we use CryptoJS elsewhere.
+
+The asymmetric components of the spec are implemented using the [Subtle Crypto web spec](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) because CryptoJS doesn't implement asymmetric encryption.

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/asymmetric.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/asymmetric.ts
@@ -1,0 +1,44 @@
+/**
+ * WARNING: DO NOT USE
+ *
+ * More info: README.md
+ */
+const ASYMMETRIC_ALGORITHM = 'RSA-OAEP';
+const HASH_FUNCTION = 'SHA-256';
+const KEY_FORMAT = 'spki';
+
+// Equivalent to "RSA/NONE/OAEPWithSHA256AndMGF1Padding"
+const rsaEncrypt = async (symmetricKey: Uint8Array<ArrayBuffer>, publicKey: CryptoKey) => {
+	const encrypted = await crypto.subtle.encrypt(
+		{ name: ASYMMETRIC_ALGORITHM },
+		publicKey,
+		symmetricKey
+	);
+	return btoa(String.fromCharCode(...new Uint8Array(encrypted)));
+};
+
+const generatePublicKey = async (encryptionKey: string) => {
+	const binaryKey = atob(encryptionKey);
+	const data = new Uint8Array(binaryKey.length);
+	for (let i = 0; i < binaryKey.length; i++) {
+		data[i] = binaryKey.charCodeAt(i);
+	}
+	return await crypto.subtle.importKey(
+		KEY_FORMAT,
+		data,
+		{
+			name: ASYMMETRIC_ALGORITHM,
+			hash: HASH_FUNCTION,
+		},
+		false,
+		['encrypt']
+	);
+};
+
+export const getEncryptedSymmetricKey = async (
+	encryptionKey: string,
+	symmetricKey: Uint8Array<ArrayBuffer>
+): Promise<string> => {
+	const publicKey = await generatePublicKey(encryptionKey);
+	return await rsaEncrypt(symmetricKey, publicKey);
+};

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/encryption.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/encryption.ts
@@ -1,0 +1,51 @@
+/**
+ * WARNING: DO NOT USE
+ *
+ * More info: README.md
+ */
+
+import { EncryptedSubmissionManifestDefinition } from '../../../../parse/model/EncryptedSubmissionManifestDefinition';
+import { type Submission } from '../prepareInstancePayload';
+import { getEncryptedSymmetricKey } from './asymmetric';
+import { encryptAttachments } from './symmetric';
+
+export const ENCRYPTED_SUFFIX = '.enc';
+export const ENCRYPTED_SUBMISSION_ATTACHMENT_NAME = 'submission.xml.enc';
+
+const generateSymmetricKey = () => {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return bytes;
+};
+
+export const encryptSubmission = async (
+	formId: string,
+	formVersion: string | undefined,
+	instanceId: string,
+	instanceXML: string,
+	attachments: readonly File[],
+	encryptionKey: string
+): Promise<Submission> => {
+	const symmetricKey = generateSymmetricKey();
+	const encryptedSymmetricKey = await getEncryptedSymmetricKey(encryptionKey, symmetricKey);
+
+	const manifest = new EncryptedSubmissionManifestDefinition(
+		formId,
+		formVersion,
+		instanceId,
+		encryptedSymmetricKey,
+		attachments
+	);
+
+	const encryptedAttachments = await encryptAttachments(
+		instanceXML,
+		instanceId,
+		symmetricKey,
+		attachments
+	);
+
+	return {
+		instanceXML: manifest.serialize(),
+		attachments: encryptedAttachments,
+	};
+};

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/encryption.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/encryption.ts
@@ -5,7 +5,7 @@
  */
 
 import { EncryptedSubmissionManifestDefinition } from '../../../../parse/model/EncryptedSubmissionManifestDefinition';
-import { type Submission } from '../prepareInstancePayload';
+import { InstanceFile, type Submission } from '../prepareInstancePayload';
 import { getEncryptedSymmetricKey } from './asymmetric';
 import { encryptAttachments } from './symmetric';
 
@@ -44,8 +44,7 @@ export const encryptSubmission = async (
 		attachments
 	);
 
-	return {
-		instanceXML: manifest.serialize(),
-		attachments: encryptedAttachments,
-	};
+	const instanceFile = new InstanceFile(manifest.serialize());
+
+	return { instanceFile, attachments: encryptedAttachments };
 };

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/symmetric.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/symmetric.ts
@@ -1,0 +1,80 @@
+/**
+ * WARNING: DO NOT USE
+ *
+ * More info: README.md
+ */
+import { getBlobData } from '@getodk/common/lib/web-compat/blob.ts';
+import * as CryptoJS from 'crypto-js';
+import { ENCRYPTED_SUBMISSION_ATTACHMENT_NAME, ENCRYPTED_SUFFIX } from './encryption';
+import { arrayBufferToWordArray, wordArrayToArrayBuffer } from './wordArrayUtils';
+
+class Seed {
+	readonly ivSeedArray;
+	private counter = 0;
+
+	public constructor(
+		readonly instanceId: string,
+		readonly symmetricKey: CryptoJS.lib.WordArray
+	) {
+		const md = CryptoJS.algo.MD5.create();
+		md.update(instanceId);
+		md.update(symmetricKey);
+		this.ivSeedArray = wordArrayToArrayBuffer(md.finalize());
+	}
+
+	next(): string {
+		++this.ivSeedArray[this.counter % this.ivSeedArray.length]!;
+		++this.counter;
+		return String.fromCharCode(...new Uint8Array(this.ivSeedArray));
+	}
+}
+
+const encryptContent = (
+	content: CryptoJS.lib.WordArray | string,
+	symmetricKey: CryptoJS.lib.WordArray,
+	seed: Seed
+): Uint8Array<ArrayBuffer> => {
+	const ivString = seed.next();
+	const iv = CryptoJS.enc.Latin1.parse(ivString);
+	const encrypted = CryptoJS.AES.encrypt(content, symmetricKey, {
+		iv: iv,
+		mode: CryptoJS.mode.CFB,
+		padding: CryptoJS.pad.Pkcs7,
+	});
+	return wordArrayToArrayBuffer(encrypted.ciphertext);
+};
+
+const encryptAttachment = async (
+	attachment: File,
+	symmetricKey: CryptoJS.lib.WordArray,
+	seed: Seed
+): Promise<File> => {
+	const content = await getBlobData(attachment);
+	const wordArray = arrayBufferToWordArray(new Uint8Array(content));
+	const encrypted = encryptContent(wordArray, symmetricKey, seed);
+	return new File([encrypted], attachment.name + ENCRYPTED_SUFFIX, {
+		type: 'application/octet-stream',
+	});
+};
+
+export const encryptAttachments = async (
+	instanceXML: string,
+	instanceId: string,
+	symmetricKey: Uint8Array<ArrayBuffer>,
+	attachments: readonly File[]
+): Promise<readonly File[]> => {
+	const symmetricKeyWords = arrayBufferToWordArray(symmetricKey);
+	const seed = new Seed(instanceId, symmetricKeyWords);
+	const encryptedAttachments: File[] = [];
+	for (const attachment of attachments) {
+		const encrypted = await encryptAttachment(attachment, symmetricKeyWords, seed);
+		encryptedAttachments.push(encrypted);
+	}
+
+	const encrypted: Uint8Array<ArrayBuffer> = encryptContent(instanceXML, symmetricKeyWords, seed);
+	const submissionFile = new File([encrypted], ENCRYPTED_SUBMISSION_ATTACHMENT_NAME, {
+		type: 'application/octet-stream',
+	});
+	encryptedAttachments.push(submissionFile);
+	return encryptedAttachments;
+};

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/symmetric.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/symmetric.ts
@@ -9,6 +9,7 @@ import { ENCRYPTED_SUBMISSION_ATTACHMENT_NAME, ENCRYPTED_SUFFIX } from './encryp
 import { arrayBufferToWordArray, wordArrayToArrayBuffer } from './wordArrayUtils';
 
 class Seed {
+	private readonly SEED_ARRAY_LENGTH = 16; // guaranteed by the md5 algorithm
 	readonly ivSeedArray;
 	private counter = 0;
 
@@ -23,7 +24,7 @@ class Seed {
 	}
 
 	next(): string {
-		++this.ivSeedArray[this.counter % this.ivSeedArray.length]!;
+		++this.ivSeedArray[this.counter % this.SEED_ARRAY_LENGTH]!;
 		++this.counter;
 		return String.fromCharCode(...new Uint8Array(this.ivSeedArray));
 	}

--- a/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/wordArrayUtils.ts
+++ b/packages/xforms-engine/src/lib/client-reactivity/instance-state/quarantine/wordArrayUtils.ts
@@ -1,0 +1,24 @@
+import * as CryptoJS from 'crypto-js';
+
+export const arrayBufferToWordArray = (buffer: Uint8Array<ArrayBuffer>) => {
+	const words = [];
+	for (let i = 0; i < buffer.length; i += 4) {
+		words.push(
+			((buffer[i] ?? 0) << 24) |
+				((buffer[i + 1] ?? 0) << 16) |
+				((buffer[i + 2] ?? 0) << 8) |
+				(buffer[i + 3] ?? 0)
+		);
+	}
+	return CryptoJS.lib.WordArray.create(words, buffer.byteLength);
+};
+
+export const wordArrayToArrayBuffer = (
+	wordArray: CryptoJS.lib.WordArray
+): Uint8Array<ArrayBuffer> => {
+	const bytes = new Uint8Array(wordArray.sigBytes);
+	for (let j = 0; j < wordArray.sigBytes; j++) {
+		bytes[j] = (wordArray.words[j >>> 2]! >>> (24 - 8 * (j % 4))) & 0xff;
+	}
+	return bytes;
+};

--- a/packages/xforms-engine/src/parse/model/EncryptedSubmissionManifestDefinition.ts
+++ b/packages/xforms-engine/src/parse/model/EncryptedSubmissionManifestDefinition.ts
@@ -1,0 +1,55 @@
+import {
+	ODK_ENCRYPTED_NAMESPACE_URI,
+	OPENROSA_XFORMS_NAMESPACE_URI,
+} from '@getodk/common/constants/xmlns.ts';
+import {
+	ENCRYPTED_SUBMISSION_ATTACHMENT_NAME,
+	ENCRYPTED_SUFFIX,
+} from '../../lib/client-reactivity/instance-state/quarantine/encryption';
+
+export class EncryptedSubmissionManifestDefinition {
+	readonly attachments: string[];
+
+	constructor(
+		readonly formId: string,
+		readonly formVersion: string | undefined,
+		readonly instanceId: string,
+		readonly encryptedSymmetricKey: string,
+		attachments: readonly File[]
+	) {
+		this.attachments = attachments.map((attachment) => attachment.name + ENCRYPTED_SUFFIX);
+	}
+
+	serialize(): string {
+		const manifest = document.createElementNS(ODK_ENCRYPTED_NAMESPACE_URI, 'data');
+		manifest.setAttribute('encrypted', 'yes');
+		manifest.setAttribute('id', this.formId);
+		if (this.formVersion) {
+			manifest.setAttribute('version', this.formVersion);
+		}
+
+		const keyEl = document.createElementNS(ODK_ENCRYPTED_NAMESPACE_URI, 'base64EncryptedKey');
+		keyEl.textContent = this.encryptedSymmetricKey;
+		manifest.appendChild(keyEl);
+
+		const xmlFileEl = document.createElementNS(ODK_ENCRYPTED_NAMESPACE_URI, 'encryptedXmlFile');
+		xmlFileEl.textContent = ENCRYPTED_SUBMISSION_ATTACHMENT_NAME;
+		manifest.appendChild(xmlFileEl);
+
+		for (const attachment of this.attachments) {
+			const mediaEl = document.createElementNS(ODK_ENCRYPTED_NAMESPACE_URI, 'media');
+			const fileEl = document.createElementNS(ODK_ENCRYPTED_NAMESPACE_URI, 'file');
+			fileEl.textContent = attachment;
+			mediaEl.appendChild(fileEl);
+			manifest.appendChild(mediaEl);
+		}
+
+		const metaEl = document.createElementNS(OPENROSA_XFORMS_NAMESPACE_URI, 'meta');
+		const instanceIDEl = document.createElementNS(OPENROSA_XFORMS_NAMESPACE_URI, 'instanceID');
+		instanceIDEl.textContent = this.instanceId;
+		metaEl.appendChild(instanceIDEl);
+		manifest.appendChild(metaEl);
+
+		return new XMLSerializer().serializeToString(manifest);
+	}
+}

--- a/packages/xforms-engine/test/integration/submission-encryption.test.ts
+++ b/packages/xforms-engine/test/integration/submission-encryption.test.ts
@@ -49,7 +49,7 @@ describe('Form submission encryption', () => {
 		return scenario;
 	};
 
-	it('includes a form-specified `base64RsaPublicKey` as encryptionKey', async () => {
+	it('generates an encrypted submission with a submission metadata file and an encoded attachment', async () => {
 		const base64RsaPublicKey =
 			'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwkP+HQEqkyb4HPLOekvn6imYW6Ze2dF2sLCspnzimOnbiF7C1mcd01xiau+9WgU23kM35URhBQVbDHtbQMgZL/Ol+xdA0zdbcUW00Z7EkYmM4sGu4wwJA2eQ6yhBbY2np+kDTvmVHlhP8DDYsXJKqtm+8bXlI36qjVgkVPXjT9YNAA4vRxPReP5wuXHrMGjclPyU6SlFZZm8QLknYV9cmGh1CquKxK7/hIoGIZ3j+edh2GZg8XJo3ZkgAwOwNUqF9b4kXw+tnbpqLXfcETX3fp6iXqLqNMt3E1MXXMnePfDqsa9wrcykUMKfxLXF/EyhIZ+2+iBoyRKeIkExwJRMdQIDAQAB';
 		const scenario = await buildSubmissionPayloadScenario({

--- a/packages/xforms-engine/test/integration/submission-encryption.test.ts
+++ b/packages/xforms-engine/test/integration/submission-encryption.test.ts
@@ -30,23 +30,21 @@ describe('Form submission encryption', () => {
 	const buildSubmissionPayloadScenario = async (
 		options?: BuildSubmissionPayloadScenario
 	): Promise<Scenario> => {
-		const scenario = await Scenario.init(
-			'Encrypted',
+		return await Scenario.init(
+			'My secret form',
 			html(
 				head(
-					title('Encrypted'),
+					title('My secret form'),
 					model(
-						mainInstance(t('data id="encrypted"', t('inp', 'test'), t('meta', t('instanceID')))),
+						mainInstance(t('data id="my-secret-form"', t('inp', 'test'), t('meta', t('instanceID')))),
 						...(options?.submissionElements ?? []),
 						bind('/data/inp').required(),
 						bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
 					)
 				),
-				body(input('/data/rep/inp', label('inp')))
+				body(input('/data/inp', label('inp')))
 			)
 		);
-
-		return scenario;
 	};
 
 	it('generates an encrypted submission with a submission metadata file and an encoded attachment', async () => {
@@ -55,6 +53,8 @@ describe('Form submission encryption', () => {
 		const scenario = await buildSubmissionPayloadScenario({
 			submissionElements: [t(`submission base64RsaPublicKey="${base64RsaPublicKey}"`)],
 		});
+		const userEnteredValue = 'secret value';
+		scenario.answer('/data/inp', userEnteredValue)
 		const submissionResult = await scenario.prepareWebFormsInstancePayload();
 
 		expect(submissionResult.submissionMeta).toMatchObject({
@@ -68,14 +68,18 @@ describe('Form submission encryption', () => {
 		expect(submissionFilename).to.equal('xml_submission_file');
 		const submission = await getBlobText(file);
 		expect(submission).to.contain(
-			'<data xmlns="http://www.opendatakit.org/xforms/encrypted" encrypted="yes" id="encrypted">'
+			'<data xmlns="http://www.opendatakit.org/xforms/encrypted" encrypted="yes" id="my-secret-form">'
 		);
+		expect(submission).to.match(/<base64EncryptedKey>.*<\/base64EncryptedKey>/);
 		expect(submission).to.contain('<encryptedXmlFile>submission.xml.enc</encryptedXmlFile>');
 		expect(submission).to.contain(
 			'<meta xmlns="http://openrosa.org/xforms"><instanceID>uuid:TODO-mock-xpath-functions</instanceID></meta>'
 		);
 
-		const [encodedFilename] = entries.next().value!;
+		const [encodedFilename, attachedFile] = entries.next().value!;
 		expect(encodedFilename).to.equal('submission.xml.enc');
+		const attached = await getBlobText(attachedFile);
+		expect(attached.length).to.be.greaterThan(userEnteredValue.length);
+		expect(attached).to.not.contain(userEnteredValue);
 	});
 });

--- a/packages/xforms-engine/test/integration/submission-encryption.test.ts
+++ b/packages/xforms-engine/test/integration/submission-encryption.test.ts
@@ -36,7 +36,9 @@ describe('Form submission encryption', () => {
 				head(
 					title('My secret form'),
 					model(
-						mainInstance(t('data id="my-secret-form"', t('inp', 'test'), t('meta', t('instanceID')))),
+						mainInstance(
+							t('data id="my-secret-form"', t('inp', 'test'), t('meta', t('instanceID')))
+						),
 						...(options?.submissionElements ?? []),
 						bind('/data/inp').required(),
 						bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
@@ -54,7 +56,7 @@ describe('Form submission encryption', () => {
 			submissionElements: [t(`submission base64RsaPublicKey="${base64RsaPublicKey}"`)],
 		});
 		const userEnteredValue = 'secret value';
-		scenario.answer('/data/inp', userEnteredValue)
+		scenario.answer('/data/inp', userEnteredValue);
 		const submissionResult = await scenario.prepareWebFormsInstancePayload();
 
 		expect(submissionResult.submissionMeta).toMatchObject({

--- a/packages/xforms-engine/test/integration/submission-encryption.test.ts
+++ b/packages/xforms-engine/test/integration/submission-encryption.test.ts
@@ -11,25 +11,23 @@ import {
 	t,
 	title,
 } from '@getodk/common/test-utils/xform-dsl/index.ts';
-import type { XFormsElement } from '@getodk/common/test-utils/xform-dsl/XFormsElement.ts';
 import { describe, expect, it } from 'vitest';
 import { Scenario } from '../scenario/jr/Scenario.ts';
 
 describe('Form submission encryption', () => {
 	const DEFAULT_INSTANCE_ID = 'uuid:TODO-mock-xpath-functions';
-
-	// prettier-ignore
-	type SubmissionFixtureElements =
-		| readonly []
-		| readonly [XFormsElement];
+	const BASE64_RSA_PUBLIC_KEY =
+		'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwkP+HQEqkyb4HPLOekvn6imYW6Ze2dF2sLCspnzimOnbiF7C1mcd01xiau+9WgU23kM35URhBQVbDHtbQMgZL/Ol+xdA0zdbcUW00Z7EkYmM4sGu4wwJA2eQ6yhBbY2np+kDTvmVHlhP8DDYsXJKqtm+8bXlI36qjVgkVPXjT9YNAA4vRxPReP5wuXHrMGjclPyU6SlFZZm8QLknYV9cmGh1CquKxK7/hIoGIZ3j+edh2GZg8XJo3ZkgAwOwNUqF9b4kXw+tnbpqLXfcETX3fp6iXqLqNMt3E1MXXMnePfDqsa9wrcykUMKfxLXF/EyhIZ+2+iBoyRKeIkExwJRMdQIDAQAB';
 
 	interface BuildSubmissionPayloadScenario {
-		readonly submissionElements?: SubmissionFixtureElements;
+		readonly version: string | null;
 	}
 
 	const buildSubmissionPayloadScenario = async (
-		options?: BuildSubmissionPayloadScenario
+		options: BuildSubmissionPayloadScenario
 	): Promise<Scenario> => {
+		const { version } = options;
+		const versionAttribute = version ? ` version="${version}"` : '';
 		return await Scenario.init(
 			'My secret form',
 			html(
@@ -37,9 +35,13 @@ describe('Form submission encryption', () => {
 					title('My secret form'),
 					model(
 						mainInstance(
-							t('data id="my-secret-form"', t('inp', 'test'), t('meta', t('instanceID')))
+							t(
+								'data id="my-secret-form"' + versionAttribute,
+								t('inp', 'test'),
+								t('meta', t('instanceID'))
+							)
 						),
-						...(options?.submissionElements ?? []),
+						t(`submission base64RsaPublicKey="${BASE64_RSA_PUBLIC_KEY}"`),
 						bind('/data/inp').required(),
 						bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
 					)
@@ -49,39 +51,42 @@ describe('Form submission encryption', () => {
 		);
 	};
 
-	it('generates an encrypted submission with a submission metadata file and an encoded attachment', async () => {
-		const base64RsaPublicKey =
-			'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwkP+HQEqkyb4HPLOekvn6imYW6Ze2dF2sLCspnzimOnbiF7C1mcd01xiau+9WgU23kM35URhBQVbDHtbQMgZL/Ol+xdA0zdbcUW00Z7EkYmM4sGu4wwJA2eQ6yhBbY2np+kDTvmVHlhP8DDYsXJKqtm+8bXlI36qjVgkVPXjT9YNAA4vRxPReP5wuXHrMGjclPyU6SlFZZm8QLknYV9cmGh1CquKxK7/hIoGIZ3j+edh2GZg8XJo3ZkgAwOwNUqF9b4kXw+tnbpqLXfcETX3fp6iXqLqNMt3E1MXXMnePfDqsa9wrcykUMKfxLXF/EyhIZ+2+iBoyRKeIkExwJRMdQIDAQAB';
-		const scenario = await buildSubmissionPayloadScenario({
-			submissionElements: [t(`submission base64RsaPublicKey="${base64RsaPublicKey}"`)],
+	describe('generates an encrypted submission with a submission metadata file and an encoded attachment', () => {
+		it.each([
+			{ includeVersion: false, name: 'without a version' },
+			{ includeVersion: true, name: 'with a version' },
+		])('$name', async ({ includeVersion }) => {
+			const version = includeVersion ? '53148686512' : null;
+			const scenario = await buildSubmissionPayloadScenario({ version });
+			const userEnteredValue = 'secret value';
+			scenario.answer('/data/inp', userEnteredValue);
+			const submissionResult = await scenario.prepareWebFormsInstancePayload();
+
+			expect(submissionResult.submissionMeta).toMatchObject({
+				encryptionKey: BASE64_RSA_PUBLIC_KEY,
+			});
+
+			expect(submissionResult.data.length).to.equal(1);
+			const entries = submissionResult.data[0].entries();
+
+			const [submissionFilename, file] = entries.next().value!;
+			expect(submissionFilename).to.equal('xml_submission_file');
+			const submission = await getBlobText(file);
+			const expectedVersionAttribute = version ? ` version="${version}"` : '';
+			expect(submission).to.contain(
+				`<data xmlns="http://www.opendatakit.org/xforms/encrypted" encrypted="yes" id="my-secret-form"${expectedVersionAttribute}>`
+			);
+			expect(submission).to.match(/<base64EncryptedKey>.*<\/base64EncryptedKey>/);
+			expect(submission).to.contain('<encryptedXmlFile>submission.xml.enc</encryptedXmlFile>');
+			expect(submission).to.contain(
+				'<meta xmlns="http://openrosa.org/xforms"><instanceID>uuid:TODO-mock-xpath-functions</instanceID></meta>'
+			);
+
+			const [encodedFilename, attachedFile] = entries.next().value!;
+			expect(encodedFilename).to.equal('submission.xml.enc');
+			const attached = await getBlobText(attachedFile);
+			expect(attached.length).to.be.greaterThan(userEnteredValue.length);
+			expect(attached).to.not.contain(userEnteredValue);
 		});
-		const userEnteredValue = 'secret value';
-		scenario.answer('/data/inp', userEnteredValue);
-		const submissionResult = await scenario.prepareWebFormsInstancePayload();
-
-		expect(submissionResult.submissionMeta).toMatchObject({
-			encryptionKey: base64RsaPublicKey,
-		});
-
-		expect(submissionResult.data.length).to.equal(1);
-		const entries = submissionResult.data[0].entries();
-
-		const [submissionFilename, file] = entries.next().value!;
-		expect(submissionFilename).to.equal('xml_submission_file');
-		const submission = await getBlobText(file);
-		expect(submission).to.contain(
-			'<data xmlns="http://www.opendatakit.org/xforms/encrypted" encrypted="yes" id="my-secret-form">'
-		);
-		expect(submission).to.match(/<base64EncryptedKey>.*<\/base64EncryptedKey>/);
-		expect(submission).to.contain('<encryptedXmlFile>submission.xml.enc</encryptedXmlFile>');
-		expect(submission).to.contain(
-			'<meta xmlns="http://openrosa.org/xforms"><instanceID>uuid:TODO-mock-xpath-functions</instanceID></meta>'
-		);
-
-		const [encodedFilename, attachedFile] = entries.next().value!;
-		expect(encodedFilename).to.equal('submission.xml.enc');
-		const attached = await getBlobText(attachedFile);
-		expect(attached.length).to.be.greaterThan(userEnteredValue.length);
-		expect(attached).to.not.contain(userEnteredValue);
 	});
 });

--- a/packages/xforms-engine/test/integration/submission-encryption.test.ts
+++ b/packages/xforms-engine/test/integration/submission-encryption.test.ts
@@ -1,0 +1,81 @@
+import { getBlobText } from '@getodk/common/lib/web-compat/blob.ts';
+import {
+	bind,
+	body,
+	head,
+	html,
+	input,
+	label,
+	mainInstance,
+	model,
+	t,
+	title,
+} from '@getodk/common/test-utils/xform-dsl/index.ts';
+import type { XFormsElement } from '@getodk/common/test-utils/xform-dsl/XFormsElement.ts';
+import { describe, expect, it } from 'vitest';
+import { Scenario } from '../scenario/jr/Scenario.ts';
+
+describe('Form submission encryption', () => {
+	const DEFAULT_INSTANCE_ID = 'uuid:TODO-mock-xpath-functions';
+
+	// prettier-ignore
+	type SubmissionFixtureElements =
+		| readonly []
+		| readonly [XFormsElement];
+
+	interface BuildSubmissionPayloadScenario {
+		readonly submissionElements?: SubmissionFixtureElements;
+	}
+
+	const buildSubmissionPayloadScenario = async (
+		options?: BuildSubmissionPayloadScenario
+	): Promise<Scenario> => {
+		const scenario = await Scenario.init(
+			'Encrypted',
+			html(
+				head(
+					title('Encrypted'),
+					model(
+						mainInstance(t('data id="encrypted"', t('inp', 'test'), t('meta', t('instanceID')))),
+						...(options?.submissionElements ?? []),
+						bind('/data/inp').required(),
+						bind('/data/meta/instanceID').calculate(`'${DEFAULT_INSTANCE_ID}'`)
+					)
+				),
+				body(input('/data/rep/inp', label('inp')))
+			)
+		);
+
+		return scenario;
+	};
+
+	it('includes a form-specified `base64RsaPublicKey` as encryptionKey', async () => {
+		const base64RsaPublicKey =
+			'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwkP+HQEqkyb4HPLOekvn6imYW6Ze2dF2sLCspnzimOnbiF7C1mcd01xiau+9WgU23kM35URhBQVbDHtbQMgZL/Ol+xdA0zdbcUW00Z7EkYmM4sGu4wwJA2eQ6yhBbY2np+kDTvmVHlhP8DDYsXJKqtm+8bXlI36qjVgkVPXjT9YNAA4vRxPReP5wuXHrMGjclPyU6SlFZZm8QLknYV9cmGh1CquKxK7/hIoGIZ3j+edh2GZg8XJo3ZkgAwOwNUqF9b4kXw+tnbpqLXfcETX3fp6iXqLqNMt3E1MXXMnePfDqsa9wrcykUMKfxLXF/EyhIZ+2+iBoyRKeIkExwJRMdQIDAQAB';
+		const scenario = await buildSubmissionPayloadScenario({
+			submissionElements: [t(`submission base64RsaPublicKey="${base64RsaPublicKey}"`)],
+		});
+		const submissionResult = await scenario.prepareWebFormsInstancePayload();
+
+		expect(submissionResult.submissionMeta).toMatchObject({
+			encryptionKey: base64RsaPublicKey,
+		});
+
+		expect(submissionResult.data.length).to.equal(1);
+		const entries = submissionResult.data[0].entries();
+
+		const [submissionFilename, file] = entries.next().value!;
+		expect(submissionFilename).to.equal('xml_submission_file');
+		const submission = await getBlobText(file);
+		expect(submission).to.contain(
+			'<data xmlns="http://www.opendatakit.org/xforms/encrypted" encrypted="yes" id="encrypted">'
+		);
+		expect(submission).to.contain('<encryptedXmlFile>submission.xml.enc</encryptedXmlFile>');
+		expect(submission).to.contain(
+			'<meta xmlns="http://openrosa.org/xforms"><instanceID>uuid:TODO-mock-xpath-functions</instanceID></meta>'
+		);
+
+		const [encodedFilename] = entries.next().value!;
+		expect(encodedFilename).to.equal('submission.xml.enc');
+	});
+});

--- a/packages/xforms-engine/test/integration/submission.test.ts
+++ b/packages/xforms-engine/test/integration/submission.test.ts
@@ -19,9 +19,7 @@ import {
 	t,
 	title,
 } from '@getodk/common/test-utils/xform-dsl/index.ts';
-import { TagXFormsElement } from '@getodk/common/test-utils/xform-dsl/TagXFormsElement.ts';
 import type { XFormsElement } from '@getodk/common/test-utils/xform-dsl/XFormsElement.ts';
-import { createUniqueId } from 'solid-js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { Scenario } from '../scenario/jr/Scenario.ts';
 import { ANSWER_OK, ANSWER_REQUIRED_BUT_EMPTY } from '../scenario/jr/validation/ValidateOutcome.ts';
@@ -808,27 +806,6 @@ describe('Form submission', () => {
 					await expect(init).rejects.toThrow();
 				}
 			);
-
-			it('includes a form-specified `base64RsaPublicKey` as encryptionKey', async () => {
-				const base64RsaPublicKey = btoa(createUniqueId());
-				const scenario = await buildSubmissionPayloadScenario({
-					submissionElements: [
-						// Note: `t()` fails here, presumably because the ported JavaRosa
-						// `parseAttributes` doesn't expect equals signs as produced in
-						// the trailing base64 value.
-						new TagXFormsElement(
-							'submission',
-							new Map([['base64RsaPublicKey', base64RsaPublicKey]]),
-							[]
-						),
-					],
-				});
-				const submissionResult = await scenario.prepareWebFormsInstancePayload();
-
-				expect(submissionResult.submissionMeta).toMatchObject({
-					encryptionKey: base64RsaPublicKey,
-				});
-			});
 		});
 
 		describe('for a single (monolithic) request', () => {

--- a/packages/xforms-engine/test/lib/client-reactivity/instance-state/quarantine/asymmetric.test.ts
+++ b/packages/xforms-engine/test/lib/client-reactivity/instance-state/quarantine/asymmetric.test.ts
@@ -1,0 +1,57 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getEncryptedSymmetricKey } from '../../../../../src/lib/client-reactivity/instance-state/quarantine/asymmetric';
+
+describe('asymmetric encryption', () => {
+	let publicKeyBase64: string;
+	let privateKey: CryptoKey;
+
+	const symmetricKey = new Uint8Array([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+
+	beforeAll(async () => {
+		const keyPair = await crypto.subtle.generateKey(
+			{
+				name: 'RSA-OAEP',
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: 'SHA-256',
+			},
+			true,
+			['encrypt', 'decrypt']
+		);
+
+		const exported = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+		publicKeyBase64 = btoa(String.fromCharCode(...new Uint8Array(exported)));
+		privateKey = keyPair.privateKey;
+	});
+
+	it('should return a valid base64 encrypted string', async () => {
+		const actual = await getEncryptedSymmetricKey(publicKeyBase64, symmetricKey);
+
+		expect(typeof actual).toBe('string');
+		expect(actual.length).toBeGreaterThan(0);
+		expect(() => atob(actual)).not.toThrow();
+	});
+
+	// ensures attacker cannot figure out what the plaintext is by looking up known encrypted submissions
+	// See:
+	// - https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding
+	// - https://en.wikipedia.org/wiki/Probabilistic_encryption
+	it('should produce different ciphertexts for the same input', async () => {
+		const result1 = await getEncryptedSymmetricKey(publicKeyBase64, symmetricKey);
+		const result2 = await getEncryptedSymmetricKey(publicKeyBase64, symmetricKey);
+		expect(result1).not.toBe(result2);
+	});
+
+	it('should be decryptable by the corresponding private key', async () => {
+		const actual = await getEncryptedSymmetricKey(publicKeyBase64, symmetricKey);
+		const encryptedBuffer = Uint8Array.from(atob(actual), (c) => c.charCodeAt(0));
+
+		const decryptedBuffer = await crypto.subtle.decrypt(
+			{ name: 'RSA-OAEP' },
+			privateKey,
+			encryptedBuffer
+		);
+
+		expect(new Uint8Array(decryptedBuffer)).toEqual(symmetricKey);
+	});
+});

--- a/packages/xforms-engine/test/lib/client-reactivity/instance-state/quarantine/symmetric.test.ts
+++ b/packages/xforms-engine/test/lib/client-reactivity/instance-state/quarantine/symmetric.test.ts
@@ -1,0 +1,96 @@
+import * as CryptoJS from 'crypto-js';
+import { describe, expect, it } from 'vitest';
+import {
+	arrayBufferToWordArray,
+	wordArrayToArrayBuffer,
+} from '../../../../../src/lib/client-reactivity/instance-state/quarantine/wordArrayUtils';
+
+describe('symmetric encryption', () => {
+	// not unit tested, because it requires decryption so is better suited to an e2e test
+	// describe('encryptAttachment()', () => {});
+
+	describe('wordarray utils', () => {
+		describe('arrayBufferToWordArray', () => {
+			it('should correctly convert a Uint8Array to a WordArray', () => {
+				const data = new Uint8Array([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+
+				const wordArray = arrayBufferToWordArray(data);
+
+				expect(wordArray.words.length).toBe(2);
+				expect(wordArray.words[0]).toBe(0x11223344);
+				expect(wordArray.words[1]).toBe(0x55667788);
+				expect(wordArray.sigBytes).toBe(8);
+			});
+
+			it('should handle data that is not a multiple of 4 bytes (padding)', () => {
+				const data = new Uint8Array([0xaa, 0xbb, 0xcc]);
+
+				const wordArray = arrayBufferToWordArray(data);
+
+				expect(wordArray.words.length).toBe(1);
+				const unsignedWord = wordArray.words[0]! >>> 0;
+				expect(unsignedWord).toBe(0xaabbcc00);
+				expect(wordArray.sigBytes).toBe(3);
+			});
+
+			it('should handle empty buffer', () => {
+				const data = new Uint8Array([]);
+
+				const wordArray = arrayBufferToWordArray(data);
+
+				expect(wordArray.words.length).toBe(0);
+				expect(wordArray.sigBytes).toBe(0);
+			});
+		});
+
+		describe('wordArrayToArrayBuffer', () => {
+			it('should correctly convert a WordArray to a Uint8Array', () => {
+				const words = [0x11223344];
+				const wordArray = CryptoJS.lib.WordArray.create(words, 4);
+
+				const result = wordArrayToArrayBuffer(wordArray);
+
+				expect(result).toBeInstanceOf(Uint8Array);
+				expect(result.length).toBe(4);
+				expect(Array.from(result)).toEqual([0x11, 0x22, 0x33, 0x44]);
+			});
+
+			it('should respect sigBytes when the last word is partial', () => {
+				const words = [0x11223344, 0x55667788];
+				const wordArray = CryptoJS.lib.WordArray.create(words, 6);
+
+				const result = wordArrayToArrayBuffer(wordArray);
+
+				expect(result.length).toBe(6);
+				expect(Array.from(result)).toEqual([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+			});
+
+			it('should handle high-bit (negative) signed integers correctly', () => {
+				const words = [0xaabbccdd >>> 0];
+				const wordArray = CryptoJS.lib.WordArray.create(words, 4);
+				const result = wordArrayToArrayBuffer(wordArray);
+				expect(Array.from(result)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);
+			});
+
+			it('should return an empty Uint8Array for an empty WordArray', () => {
+				const wordArray = CryptoJS.lib.WordArray.create([], 0);
+				const result = wordArrayToArrayBuffer(wordArray);
+
+				expect(result.length).toBe(0);
+				expect(result).toBeInstanceOf(Uint8Array);
+			});
+		});
+
+		describe('functions are symmetrical', () => {
+			[[], [0], [0, 1], [0, 1, 2], [0, 1, 2, 3], [0x80], [0xff, 0xff, 0xff, 0xff]].forEach(
+				(input, idx) => {
+					it(`should not mangle example #${idx}`, () => {
+						const given = new Uint8Array(input);
+						const actual = wordArrayToArrayBuffer(arrayBufferToWordArray(given));
+						expect(actual).to.deep.equal(given);
+					});
+				}
+			);
+		});
+	});
+});

--- a/packages/xforms-engine/test/lib/client-reactivity/instance-state/quarantine/symmetric.test.ts
+++ b/packages/xforms-engine/test/lib/client-reactivity/instance-state/quarantine/symmetric.test.ts
@@ -28,7 +28,7 @@ describe('symmetric encryption', () => {
 				const wordArray = arrayBufferToWordArray(data);
 
 				expect(wordArray.words.length).toBe(1);
-				const unsignedWord = wordArray.words[0]! >>> 0;
+				const unsignedWord = wordArray.words[0]! >>> 0; // shift to convert to unsigned int
 				expect(unsignedWord).toBe(0xaabbcc00);
 				expect(wordArray.sigBytes).toBe(3);
 			});
@@ -66,7 +66,7 @@ describe('symmetric encryption', () => {
 			});
 
 			it('should handle high-bit (negative) signed integers correctly', () => {
-				const words = [0xaabbccdd >>> 0];
+				const words = [0xaabbccdd];
 				const wordArray = CryptoJS.lib.WordArray.create(words, 4);
 				const result = wordArrayToArrayBuffer(wordArray);
 				expect(Array.from(result)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);


### PR DESCRIPTION
Closes getodk/web-forms#448

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Various testing, manual and automatic

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Encryption which was previously ignored silently is now applied when filling out forms using web-forms

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced