### PR TITLE
chore: updates the README with troubleshooting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Follow these instructions to run ODK Central Frontend in development. For deploy
 
 First, run ODK Central Backend.
 
-Next, run ODK Central Frontend in development by running `npm run dev`. This will start a Vite dev server. ODK Central Frontend will be available on port 8989. `npm run dev` will also start NGINX, which will forward requests to ODK Central Backend. If you see a "error code 500" on page load, check that host networking is enabled in your Docker settings — without it, `--network=host` does nothing and port 8686 will not bind. Alternatively, run `npm run dev-no-docker` to use a locally installed NGINX instead.
+Next, run ODK Central Frontend in development by running `npm run dev`. This will start a Vite dev server. ODK Central Frontend will be available on port 8989. `npm run dev` will also start NGINX on port 8686, which will forward requests to ODK Central Backend. If you see a "error code 500" on page load, check that host networking is enabled in your Docker settings — without it, `--network=host` does nothing and port 8686 will not bind. Alternatively, run `npm run dev-no-docker` to use a locally installed NGINX instead.
 
 ODK Central Frontend communicates with ODK Central Backend in part using a session cookie. The cookie is `Secure`, but will be sent over HTTP on localhost. ODK Central Frontend also interacts with data collection clients and with services:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Follow these steps to set up your development environment:
 - Install [Volta](https://volta.sh/)
 - Install dependencies by running `npm install`.
 - Install docker or NGINX.
+  - The `npm run dev` runs NGINX in a Docker container using `--network=host`, which requires host networking to be enabled in your Docker settings. If you'd rather skip that, install NGINX directly and use `npm run dev-no-docker` instead.
 - Set up [ODK Central Backend](https://github.com/getodk/central-backend).
   - You will need to create a user using an ODK Central Backend command line script.
   - You will probably also want to promote that user to a sitewide administrator.
@@ -44,7 +45,7 @@ Follow these instructions to run ODK Central Frontend in development. For deploy
 
 First, run ODK Central Backend.
 
-Next, run ODK Central Frontend in development by running `npm run dev`. This will start a Vite dev server. ODK Central Frontend will be available on port 8989. `npm run dev` will also start NGINX, which will forward requests to ODK Central Backend.
+Next, run ODK Central Frontend in development by running `npm run dev`. This will start a Vite dev server. ODK Central Frontend will be available on port 8989. `npm run dev` will also start NGINX, which will forward requests to ODK Central Backend. If you see a "error code 500" on page load, check that host networking is enabled in your Docker settings — without it, `--network=host` does nothing and port 8686 will not bind. Alternatively, run `npm run dev-no-docker` to use a locally installed NGINX instead.
 
 ODK Central Frontend communicates with ODK Central Backend in part using a session cookie. The cookie is `Secure`, but will be sent over HTTP on localhost. ODK Central Frontend also interacts with data collection clients and with services:
 


### PR DESCRIPTION
- Adds setup guidance to the README: Notes that `npm run dev` requires Docker host networking to be enabled (or to use `npm run dev-no-docker` instead), and adds a troubleshooting note for the "error code 500" when it's missing.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
