### PR TITLE
Disable CSP for e2e tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,7 @@ jobs:
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/enketo/config.json.template
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/service/config.json.template
         sed -i 's/\$scheme/https/g' files/nginx/odk.conf.template
+        sed -i 's/\Content-Security-Policy/Content-Security-Report-Only/g' files/nginx/odk.conf.template
         sed 's/your.domain.com/central-test.localhost/; s/^SSL_TYPE=letsencrypt/SSL_TYPE=upstream/' .env.template > .env
     - name: Add domain
       run: echo '127.0.0.1 central-test.localhost' | sudo tee --append /etc/hosts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/enketo/config.json.template
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/service/config.json.template
         sed -i 's/\$scheme/https/g' files/nginx/odk.conf.template
-        sed -i 's/\Content-Security-Policy/Content-Security-Report-Only/g' files/nginx/odk.conf.template
+        sed -i 's/Content-Security-Policy/Content-Security-Report-Only/g' files/nginx/odk.conf.template
         sed 's/your.domain.com/central-test.localhost/; s/^SSL_TYPE=letsencrypt/SSL_TYPE=upstream/' .env.template > .env
     - name: Add domain
       run: echo '127.0.0.1 central-test.localhost' | sudo tee --append /etc/hosts


### PR DESCRIPTION
Disable CSP for e2e tests; it is a temporary workaround for https://github.com/getodk/central/issues/1920 so that we can unblock PR merges.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
