### PR TITLE
Form Draft Redesign Part 5: Hide upload and cancel button by default

### DIFF
--- a/apps/central/src/components/form/new-page.vue
+++ b/apps/central/src/components/form/new-page.vue
@@ -5,7 +5,7 @@
         <span>{{ $t('title') }}</span>
       </template>
       <template #body>
-        <form-upload @success="afterCreate" @cancel="afterCancel"/>
+        <form-upload @success="afterCreate"/>
       </template>
     </page-section>
   </div>
@@ -28,7 +28,7 @@ defineOptions({
 
 const router = useRouter();
 const { t } = useI18n();
-const { formPath, projectPath } = useRoutes();
+const { formPath } = useRoutes();
 const alert = inject('alert');
 const { project } = useRequestData();
 
@@ -39,10 +39,6 @@ const afterCreate = async (form) => {
   project.forms += 1;
   await router.push(formPath(form.projectId, form.xmlFormId, 'draft'));
   alert.success(message);
-};
-
-const afterCancel = async () => {
-  await router.push(projectPath());
 };
 
 </script>

--- a/apps/central/src/components/form/upload.vue
+++ b/apps/central/src/components/form/upload.vue
@@ -103,9 +103,9 @@ definition for an existing form -->
         {{ file != null ? file.name : '' }}
       </div>
     </file-drop-zone>
-    <div class="actions">
+    <div v-if="file != null" class="actions">
       <button type="button" class="btn btn-link" :aria-disabled="awaitingResponse"
-        @click="$emit('cancel')">
+        @click="clear()">
         {{ $t('action.cancel') }}
       </button>
       <button id="upload-button" type="button"

--- a/apps/central/src/components/form/upload.vue
+++ b/apps/central/src/components/form/upload.vue
@@ -130,7 +130,7 @@ export default {
   name: 'FormUpload',
   components: { DocLink, FileDropZone, SentenceSeparator, Spinner },
   inject: ['redAlert'],
-  emits: ['cancel', 'success'],
+  emits: ['success'],
   setup() {
     const { request, awaitingResponse } = useRequest();
     return { request, awaitingResponse };
@@ -178,10 +178,6 @@ export default {
       this.$refs.input.value = '';
     },
     upload(ignoreWarnings) {
-      if (this.file == null) {
-        this.redAlert.show(this.$t('alert.fileRequired'));
-        return;
-      }
       // Try to read the file, error means file is modified or deleted or moved
       const reader = new FileReader();
       reader.onload = () => this.postFile(ignoreWarnings);
@@ -321,7 +317,6 @@ export default {
       "uploadAnyway": "Upload anyway"
     },
     "alert": {
-      "fileRequired": "Please choose a file.",
       "fileNotReadable": "The file could not be read. It may have been modified or deleted. Please choose the file again."
     },
     "problem": {

--- a/apps/central/test/components/form/upload.spec.js
+++ b/apps/central/test/components/form/upload.spec.js
@@ -96,6 +96,28 @@ describe('FormUpload', () => {
       await dragAndDrop(component.getComponent(FileDropZone), [xlsForm()]);
       component.get('#form-upload-filename').text().should.equal('my_form.xlsx');
     });
+
+    it('does not render actions initially', () => {
+      const component = mount(FormUpload, mountOptions());
+      component.find('.actions').exists().should.be.false;
+    });
+
+    it('renders actions after a file is selected', async () => {
+      const component = mount(FormUpload, mountOptions());
+      component.find('.actions').exists().should.be.false;
+      await setFiles(component.get('input'), [xlsForm()]);
+      component.find('.actions').exists().should.be.true;
+    });
+
+    it('clears the file when cancel button is clicked', async () => {
+      const component = mount(FormUpload, mountOptions());
+      await setFiles(component.get('input'), [xlsForm()]);
+      component.find('.actions').exists().should.be.true;
+      component.get('#form-upload-filename').text().should.equal('my_form.xlsx');
+      await component.get('.actions .btn-link').trigger('click');
+      component.find('.actions').exists().should.be.false;
+      component.get('#form-upload-filename').text().should.equal('');
+    });
   });
 
   describe('request', () => {
@@ -185,7 +207,6 @@ describe('FormUpload', () => {
   it('implements some standard button things for the upload button', () => {
     mockLogin();
     testData.extendedProjects.createPast(1);
-    // await setFiles(component.get('input'), [xlsForm()]);
     return mockHttp()
       .mount(FormUpload, mountOptions())
       .request(component => setFiles(component.get('input'), [xlsForm()]))

--- a/apps/central/test/components/form/upload.spec.js
+++ b/apps/central/test/components/form/upload.spec.js
@@ -77,19 +77,6 @@ describe('FormUpload', () => {
       testData.extendedProjects.createPast(1);
     });
 
-    it('shows an alert if no file is selected', async () => {
-      const component = mount(FormUpload, mountOptions());
-      await component.get('#upload-button').trigger('click');
-      component.should.alert('danger');
-    });
-
-    it('hides the alert after a file is selected', async () => {
-      const component = mount(FormUpload, mountOptions());
-      await component.get('#upload-button').trigger('click');
-      await setFiles(component.get('input'), [xlsForm()]);
-      component.should.not.alert();
-    });
-
     describe('after a file is selected using the file input', () => {
       it('shows the filename', async () => {
         const component = mount(FormUpload, mountOptions());
@@ -198,8 +185,11 @@ describe('FormUpload', () => {
   it('implements some standard button things for the upload button', () => {
     mockLogin();
     testData.extendedProjects.createPast(1);
+    // await setFiles(component.get('input'), [xlsForm()]);
     return mockHttp()
       .mount(FormUpload, mountOptions())
+      .request(component => setFiles(component.get('input'), [xlsForm()]))
+      .complete()
       .testStandardButton({
         button: '#upload-button',
         request: upload,
@@ -258,20 +248,6 @@ describe('FormUpload', () => {
           // updated form list is received.
           app.get('#page-head-tabs li.active .badge').text().should.equal('2');
         }));
-  });
-
-  describe('after cancelling form creation', () => {
-    it('redirects to the project overview', () => {
-      mockLogin();
-      testData.extendedProjects.createPast(1);
-      return load('/projects/1/new-form')
-        .complete()
-        .request(app => app.get('#form-upload .btn-link').trigger('click'))
-        .respondFor('/projects/1', { project: false })
-        .afterResponses(app => {
-          app.vm.$route.path.should.equal('/projects/1');
-        });
-    });
   });
 
   // TODO: to be updated in https://github.com/getodk/central/issues/1831

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3636,9 +3636,6 @@
         }
       },
       "alert": {
-        "fileRequired": {
-          "string": "Please choose a file."
-        },
         "fileNotReadable": {
           "string": "The file could not be read. It may have been modified or deleted. Please choose the file again."
         }


### PR DESCRIPTION

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
