### PR TITLE
Form Draft Redesign Part 6: Miscellaneous

### DIFF
--- a/apps/central/src/components/form/edit.vue
+++ b/apps/central/src/components/form/edit.vue
@@ -14,14 +14,9 @@ except according to the terms contained in the LICENSE file.
     @dragenter="dragHandler" @dragleave="dragHandler" @drop="dragHandler">
     <loading :state="formDraft.initiallyLoading"/>
     <template v-if="formDraft.dataExists">
-      <div class="row">
-        <div v-if="formDraft.isEmpty()" class="col-xs-6">
-          <form-edit-create-draft @success="fetchDraft(true)"/>
-        </div>
-        <div v-if="form.dataExists && form.publishedAt != null" class="col-xs-6">
-          <form-edit-published-version/>
-        </div>
-      </div>
+      <form-edit-published-version v-if="form.dataExists && form.publishedAt != null"/>
+      <form-edit-create-draft v-if="formDraft.isEmpty()" @success="fetchDraft(true)"/>
+
       <template v-if="formDraft.isDefined()">
         <form-edit-def @after-upload="afterUpload"/>
         <form-edit-attachments/>

--- a/apps/central/src/components/form/edit.vue
+++ b/apps/central/src/components/form/edit.vue
@@ -15,9 +15,9 @@ except according to the terms contained in the LICENSE file.
     <loading :state="formDraft.initiallyLoading"/>
     <template v-if="formDraft.dataExists">
       <form-edit-published-version v-if="form.dataExists && form.publishedAt != null"/>
-      <form-edit-create-draft v-if="formDraft.isEmpty()" @success="fetchDraft(true)"/>
 
-      <template v-if="formDraft.isDefined()">
+      <form-edit-create-draft v-if="formDraft.isEmpty()" @success="fetchDraft(true)"/>
+      <template v-else>
         <form-edit-def @after-upload="afterUpload"/>
         <form-edit-attachments/>
         <form-edit-entities/>

--- a/apps/central/src/components/form/edit/draft-controls.vue
+++ b/apps/central/src/components/form/edit/draft-controls.vue
@@ -10,9 +10,9 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <form-edit-section id="form-edit-draft-controls">
-    <template #title>{{ $t('title') }}</template>
-    <template #body>
+  <div id="form-edit-draft-controls">
+    <div class="title">{{ $t('title') }}</div>
+    <div>
       <button id="form-edit-abandon-button" type="button" class="btn btn-danger-outlined"
         @click="$emit('abandon')">
         <span class="icon-trash"></span>{{ abandonText }}
@@ -21,15 +21,13 @@ except according to the terms contained in the LICENSE file.
         class="btn btn-primary" @click="$emit('publish')">
         <span class="icon-star"></span>{{ $t('action.publish') }}
       </button>
-    </template>
-  </form-edit-section>
+    </div>
+  </div>
 </template>
 
 <script setup>
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-
-import FormEditSection from './section.vue';
 
 import { useRequestData } from '../../../request-data';
 
@@ -47,7 +45,19 @@ const abandonText = computed(() => (!form.dataExists
 </script>
 
 <style lang="scss">
-#form-edit-publish-button { margin-left: 10px; }
+#form-edit-draft-controls {
+  text-align: center;
+  margin: 20px 0;
+
+  .title {
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1.2;
+    margin-bottom: 20px;
+  }
+
+  #form-edit-publish-button { margin-left: 10px; }
+}
 </style>
 
 <i18n lang="json5">
@@ -55,7 +65,7 @@ const abandonText = computed(() => (!form.dataExists
   "en": {
     // @transifexKey component.FormEditDraftControls.subtitle
     // This refers to the draft version of a Form.
-    "title": "Ready to publish",
+    "title": "Ready to publish?",
     "action": {
       "delete": "Delete Form",
       // @transifexKey component.FormDraftStatus.actions.action.abandon

--- a/apps/central/src/components/form/edit/section.vue
+++ b/apps/central/src/components/form/edit/section.vue
@@ -17,7 +17,7 @@ except according to the terms contained in the LICENSE file.
         <p class="form-edit-section-subtitle"><slot name="subtitle"></slot></p>
       </div>
       <div class="form-edit-section-tag">
-        <span><slot name="tag"></slot></span>
+        <slot name="tag"></slot>
       </div>
       <div class="form-edit-section-actions">
         <slot name="actions"></slot>
@@ -78,9 +78,8 @@ $heading-margin-bottom: 10px;
   color: $color-accent-primary;
   padding: 5px 9px;
 
-  // Hide the entire element if no tag slot is provided. We don't want the icon
-  // to be shown in that case.
-  &:has(> :nth-child(2):empty) { display: none; }
+  // Hide the entire element if no tag slot is provided.
+  &:empty { display: none; }
 }
 
 

--- a/apps/central/src/components/form/edit/section.vue
+++ b/apps/central/src/components/form/edit/section.vue
@@ -77,7 +77,12 @@ $heading-margin-bottom: 10px;
   border-radius: 6px;
   color: $color-accent-primary;
   padding: 5px 9px;
+
+  // Hide the entire element if no tag slot is provided. We don't want the icon
+  // to be shown in that case.
+  &:has(> :nth-child(2):empty) { display: none; }
 }
+
 
 .form-edit-section:has(.form-edit-section-subtitle:empty) .form-edit-section-body > p:first-of-type {
   margin-top: -$heading-margin-bottom;

--- a/apps/central/src/routes.js
+++ b/apps/central/src/routes.js
@@ -482,8 +482,7 @@ const routes = [
               'submission.read'
             ])
           },
-          title: () => [i18n.t('formHead.tab.editForm'), form.nameOrId],
-          fullWidth: true
+          title: () => [i18n.t('formHead.tab.editForm'), form.nameOrId]
         }
       })
     ]

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3478,7 +3478,7 @@
         }
       },
       "subtitle": {
-        "string": "Ready to publish",
+        "string": "Ready to publish?",
         "developer_comment": "This refers to the draft version of a Form."
       }
     },


### PR DESCRIPTION
- Brought back CSS to hide tag element if no slot is provided
- Removed fullWidth from the draft page
- Aligned sections on draft page vertically when there is no active draft
- Restyle FormEditControl

<img width="1151" height="845" alt="image" src="https://github.com/user-attachments/assets/51a16381-e2a4-4df8-b757-a219a7bbad2b" />


#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
