### PR TITLE
fix: transifex:destructure

### DIFF
--- a/apps/central/bin/transifex/destructure.js
+++ b/apps/central/bin/transifex/destructure.js
@@ -8,7 +8,7 @@ const { logThenThrow, mapComponentsToFiles } = require('../util/util');
 
 const filenamesByComponent = mapComponentsToFiles('src/components');
 const { messages: sourceMessages, transifexPaths } = readSourceMessages(
-  'apps/central/src/locales',
+  'src/locales',
   filenamesByComponent
 );
 for (const basename of fs.readdirSync('transifex')) {

--- a/apps/central/docs/CONTRIBUTING.md
+++ b/apps/central/docs/CONTRIBUTING.md
@@ -193,7 +193,7 @@ Before each release, we download all translations from Transifex and save them i
 tx pull --mode translator --force
 ```
 
-Once they are downloaded, we convert the Structured JSON files to Vue I18n JSON by running [`/apps/central/bin/transifex/destructure.js`](/apps/central/bin/transifex/destructure.js). `destructure.js` generates all locale files in `/apps/central/src/locales/` other than `en.json5`.
+Once they are downloaded, we convert the Structured JSON files to Vue I18n JSON by running `npm run transifex:destructure`.  This generates all locale files in `/apps/central/src/locales/` other than `en.json5`.
 
 To summarize the workflow:
 

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -8,6 +8,7 @@
     "lint": "npm run eslint && npm run transifex:lint",
     "lint:fix": "npm run eslint:fix && npm run transifex:fix",
     "test": "./test/run.sh",
+    "transifex:destructure": "node bin/transifex/destructure.js",
     "transifex:fix": "node bin/transifex/restructure.js > transifex/strings_en.json",
     "transifex:lint": "bash -c 'diff transifex/strings_en.json <(node bin/transifex/restructure.js)'"
   },


### PR DESCRIPTION
Broken when repo merged with web-forms.

Changes:

1. move from running `npm node/bin/transifex/destructure.js` to `npm run transifex:destructure`

This is in line with other transifex commands, including `restructure.js` which is executed by `npm run transifex:fix`.

2. revert path to locale files - remove `apps/central/` prefix

3. update CONTRIBUTING.md

Closes getodk/central#1921

#### What has been done to verify that this works as intended?

Tried to run it, and it certainly fails later than previously:

```sh
$ npm run transifex:destructure

> @getodk/central-frontend@0.1.0 transifex:destructure
> node bin/transifex/destructure.js

destructuring cs
{count, plural, one {Uživatel aplikace} few {Uživatelé aplikace} many {Uživatelů aplikace} other {Uživatelé aplikace}}
/home/user/workspaces/odk/frontend/apps/central/bin/util/util.js:13
  throw new Error(errorMessage);
  ^

Error: Expected the plural categories [one, few, many, other], but found [few, many, one, other]. Did you download the translations "to translate"?
    at logThenThrow (/odk/frontend/apps/central/bin/util/util.js:13:9)
    at PluralForms.fromTransifex (/odk/frontend/apps/central/bin/util/transifex.js:132:9)
    at Object.<anonymous> (/odk/frontend/apps/central/bin/util/transifex.js:528:26)
    at JSON.parse (<anonymous>)
    at destructure (/odk/frontend/apps/central/bin/util/transifex.js:523:44)
    at Object.<anonymous> (/odk/frontend/apps/central/bin/transifex/destructure.js:23:22)
    at Module._compile (node:internal/modules/cjs/loader:1761:14)
    at Object..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1481:32)
    at Module._load (node:internal/modules/cjs/loader:1300:12)
```

`CONTRIBUTING.md` suggests:

> ```
> tx pull --mode translator --force
> ```

But the source of `tx` is not explained.

#### Why is this the best possible solution? Were any other approaches considered?

Keeps the code agnostic of how the repo is structured.  It can also be now run with `npm run -w apps/central transifex:destructure`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - this is a dev-only script.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
