### PR TITLE
transifex:destructure: improve plural error message

### DIFF
--- a/apps/central/bin/util/transifex.js
+++ b/apps/central/bin/util/transifex.js
@@ -100,7 +100,7 @@ class PluralForms {
   }
 
   // Transifex uses ICU plurals.
-  static fromTransifex(string, locale) {
+  static fromTransifex(key, string, locale) {
     const forms = [];
     const icuMatch = string.match(/^({count, plural,).+}$/s);
     if (icuMatch == null) {
@@ -129,7 +129,7 @@ class PluralForms {
       categories.sort();
       const expectedCategories = locales[locale].pluralCategories;
       if (!equals(categories, expectedCategories))
-        logThenThrow(string, `Expected the plural categories [${expectedCategories.join(', ')}], but found [${categories.join(', ')}]. Did you download the translations "to translate"?`);
+        logThenThrow(string, `.${key} in locale "${locale}" expected the plural categories [${expectedCategories.join(', ')}], but found [${categories.join(', ')}]. Did you download the translations "to translate"?`);
     }
 
     for (let i = 0; i < forms.length; i += 1)
@@ -522,10 +522,10 @@ const restructure = (messages) =>
 // message is a PluralForms object.
 const destructure = (json, locale) => JSON.parse(
   json,
-  (_, value) => {
+  (key, value) => {
     if (value != null && typeof value === 'object' &&
       typeof value.string === 'string')
-      return PluralForms.fromTransifex(value.string, locale);
+      return PluralForms.fromTransifex(key, value.string, locale);
     return value;
   }
 );


### PR DESCRIPTION
Previous:

	Error: Expected the plural categories [one, few, many, other], but found [few, many, one, other]. Did you download the translations "to translate"?

This branch:

	Error: .appUser in locale "cs" expected the plural categories [one, few, many, other], but found [few, many, one, other]. Did you download the translations "to translate"?

#### What has been done to verify that this works as intended?

Tested locally - `master` currently fails to destructure.

#### Why is this the best possible solution? Were any other approaches considered?

This should make it much clearer where the problematic JSON is - currently you have to divine it from a combination of log messages and grepping for the bad translation string.  Depending on how unique the translated text is, this might be more or less complicated.

Ideally the full key path would be supplied, but that would require rewriting the parsing/visiting code in `destructure()` as `JSON.parse()` doesn't provide full key context to the `reviver` function.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect for users.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
