### PR TITLE
transifex:lint: run transifex:destructure

### DIFF
--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -10,7 +10,7 @@
     "test": "./test/run.sh",
     "transifex:destructure": "node bin/transifex/destructure.js",
     "transifex:fix": "node bin/transifex/restructure.js > transifex/strings_en.json",
-    "transifex:lint": "bash -c 'diff transifex/strings_en.json <(node bin/transifex/restructure.js)'"
+    "transifex:lint": "bash -c 'diff transifex/strings_en.json <(node bin/transifex/restructure.js)' && node bin/transifex/destructure.js"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",


### PR DESCRIPTION
Closes getodk/central#1931

#### What has been done to verify that this works as intended?

- [ ] passes locally
- [ ] passes in CI

#### Why is this the best possible solution? Were any other approaches considered?

Running `transifex:destructure` as part of `transifex:lint` ensures certain structural issues with translations do not make it into `master`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
