### PR TITLE
e2e-tests/teardown: use request()

### DIFF
--- a/e2e-tests/global.teardown.js
+++ b/e2e-tests/global.teardown.js
@@ -7,10 +7,9 @@ const credentials = Buffer.from(`${user}:${password}`, 'utf-8').toString('base64
 const projectId = process.env.PROJECT_ID;
 const projectIdEncrypted = process.env.PROJECT_ID_ENCRYPTED;
 
-teardown('delete project', async () => {
+teardown('delete project', async ({ request }) => {
   const promises = [ projectId, projectIdEncrypted ].map((project) => {
-    return fetch(`${appUrl}/v1/projects/${project}`, {
-      method: 'DELETE',
+    return request.delete(`${appUrl}/v1/projects/${project}`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Basic ${credentials}`


### PR DESCRIPTION
This brings `global.teardown` in line with `global.setup` and ensures that HTTP requests made in teardown are caught by standard playwright logging etc.

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

* no obvious reason to avoid `request.delete()`
* noted while debugging HTTP requests in e2e tests

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just for testing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
