### PR TITLE
feat(#785): add 'Select Answer' placeholder to select one minimal dropdown

### DIFF
--- a/packages/web-forms/locales/strings_en.json
+++ b/packages/web-forms/locales/strings_en.json
@@ -75,8 +75,8 @@
     "string": "Longitude: {longitude}.",
     "developer_comment": "Displays the GPS longitude coordinate. {longitude} is the numeric longitude value."
   },
-  "select.placeholder": {
-    "string": "Select Answer",
+  "searchable_dropdown.select.placeholder": {
+    "string": "Select answer",
     "developer_comment": "Placeholder text shown in a minimal select dropdown when no option has been selected yet."
   },
   "validation_message.required.error": {

--- a/packages/web-forms/locales/strings_en.json
+++ b/packages/web-forms/locales/strings_en.json
@@ -75,6 +75,10 @@
     "string": "Longitude: {longitude}.",
     "developer_comment": "Displays the GPS longitude coordinate. {longitude} is the numeric longitude value."
   },
+  "select.placeholder": {
+    "string": "Select Answer",
+    "developer_comment": "Placeholder text shown in a minimal select dropdown when no option has been selected yet."
+  },
   "validation_message.required.error": {
     "string": "This field is required.",
     "developer_comment": "Default error shown when a required field has no value and the form designer did not specify a custom message."

--- a/packages/web-forms/src/components/common/SearchableDropdown.i18n.json
+++ b/packages/web-forms/src/components/common/SearchableDropdown.i18n.json
@@ -1,6 +1,6 @@
 {
-  "select.placeholder": {
-    "string": "Select Answer",
+  "searchable_dropdown.select.placeholder": {
+    "string": "Select answer",
     "developer_comment": "Placeholder text shown in a minimal select dropdown when no option has been selected yet."
   }
 }

--- a/packages/web-forms/src/components/common/SearchableDropdown.i18n.json
+++ b/packages/web-forms/src/components/common/SearchableDropdown.i18n.json
@@ -1,0 +1,6 @@
+{
+  "select.placeholder": {
+    "string": "Select Answer",
+    "developer_comment": "Placeholder text shown in a minimal select dropdown when no option has been selected yet."
+  }
+}

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import type { SelectNode } from '@getodk/xforms-engine';
 import Select from 'primevue/select';
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
 import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
 import type { Translate } from '@/lib/locale/useLocale.ts';
-import { inject } from 'vue';
 
 interface SearchableDropdownProps {
 	readonly question: SelectNode;
@@ -66,10 +65,10 @@ const selectValue = (value: string) => {
 			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />
 		</template>
 		<template #value>
-				<span v-if="!selectedLabel.length" class="dropdown-placeholder">{{
-					t('select.placeholder')
-				}}</span>
-				<MarkdownBlock v-for="elem in selectedLabel" :key="elem.id" :elem="elem" />
+			<span v-if="!selectedLabel?.length" class="dropdown-placeholder">{{
+				t('searchable_dropdown.select.placeholder')
+			}}</span>
+			<MarkdownBlock v-for="elem in selectedLabel" :key="elem.id" :elem="elem" />
 		</template>
 	</Select>
 </template>
@@ -90,7 +89,7 @@ const selectValue = (value: string) => {
 		width: 50%;
 	}
 	.dropdown-placeholder {
-		color: var(--odk-placeholder-color, #6c757d);
+		color: var(--odk-muted-text-color);
 	}
 }
 </style>

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -3,12 +3,16 @@ import type { SelectNode } from '@getodk/xforms-engine';
 import Select from 'primevue/select';
 import { computed } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
+import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
+import type { Translate } from '@/lib/locale/useLocale.ts';
+import { inject } from 'vue';
 
 interface SearchableDropdownProps {
 	readonly question: SelectNode;
 	readonly style?: string;
 }
 
+const t: Translate = inject(TRANSLATE)!;
 const props = defineProps<SearchableDropdownProps>();
 
 defineEmits(['update:modelValue', 'change']);
@@ -62,7 +66,10 @@ const selectValue = (value: string) => {
 			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />
 		</template>
 		<template #value>
-			<MarkdownBlock v-for="elem in selectedLabel" :key="elem.id" :elem="elem" />
+				<span v-if="!selectedLabel.length" class="dropdown-placeholder">{{
+					t('select.placeholder')
+				}}</span>
+				<MarkdownBlock v-for="elem in selectedLabel" :key="elem.id" :elem="elem" />
 		</template>
 	</Select>
 </template>
@@ -81,6 +88,9 @@ const selectValue = (value: string) => {
 
 	@media screen and (min-width: #{pf.$md}) {
 		width: 50%;
+	}
+	.dropdown-placeholder {
+		color: var(--odk-placeholder-color, #6c757d);
 	}
 }
 </style>


### PR DESCRIPTION
## What this PR does

Adds a "Select Answer" placeholder to the select one minimal dropdown, matching the behavior of ODK Collect.

## Why

Fixes getodk/web-forms#785

Currently, the `SearchableDropdown` component shows a blank dropdown when no option is selected. ODK Collect shows "Select Answer" in this state. This PR aligns Web Forms behavior with Collect.

## Changes

- `SearchableDropdown.vue`: Inject the translation function and show placeholder text in the `#value` slot when no option is selected
- `SearchableDropdown.i18n.json`: Add new translation key `select.placeholder` with value "Select Answer"
- `locales/strings_en.json`: Auto-generated by running `npm run build:translations`

## Screenshots

### Before
As shown in the original issue (getodk/web-forms#785), the dropdown showed blank when no option was selected.

### After

**1. Before any selection — placeholder shown:**
<img width="744" height="217" alt="image" src="https://github.com/user-attachments/assets/237e599f-ff69-45fe-961b-6e0c03bc390f" />

**2. Dropdown opened — options visible:**
<img width="693" height="354" alt="image" src="https://github.com/user-attachments/assets/4a10c4c0-54b1-405d-89bf-bca27c6ef564" />

**3. After selection — placeholder replaced by selected value:**
<img width="645" height="197" alt="image" src="https://github.com/user-attachments/assets/28ae7074-9ea6-4365-800f-70ea3dbad597" />