### PR TITLE
ci/e2e: reduce timeout to 20 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
     - build
     - static-checks
     - unit-tests
-    timeout-minutes: 120
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Normally a successful job might be under 6 minutes, and a failed job might take a few minutes more.

Closes getodk/central#1924

#### What has been done to verify that this works as intended?

Nothing in particular.

#### Why is this the best possible solution? Were any other approaches considered?

Normally a successful job might be under 6 minutes, and a failed job might take a few minutes more.  Doubling the expected maximum seems like a reasonable timeout value to allow for weird github or network issues slowing things down.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No risk.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
