### PR TITLE
Change the dropzone for attachments to the attachment section

### DIFF
--- a/.changeset/slimy-cups-burn.md
+++ b/.changeset/slimy-cups-burn.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": patch
+---
+
+Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.

--- a/apps/central/src/components/form-attachment/list.vue
+++ b/apps/central/src/components/form-attachment/list.vue
@@ -10,7 +10,8 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div id="form-attachment-list">
+  <file-drop-zone id="form-attachment-list" :disabled="uploading" :styled="false"
+    @dragenter="dragenter" @dragleave="dragleave" @drop="drop">
     <form-attachment-table
       :file-is-over-drop-zone="countOfFilesOverDropZone !== 0 && !uploading"
       :dragover-attachment="dragoverAttachment"
@@ -38,10 +39,11 @@ except according to the terms contained in the LICENSE file.
       @confirm="uploadFiles" @cancel="cancelUploads"/>
     <form-attachment-link-dataset v-bind="linkDatasetModal"
       @hide="linkDatasetModal.hide()" @success="afterLinkDataset"/>
-  </div>
+  </file-drop-zone>
 </template>
 
 <script>
+import FileDropZone from '../file-drop-zone.vue';
 import FormAttachmentLinkDataset from './link-dataset.vue';
 import FormAttachmentNameMismatch from './name-mismatch.vue';
 import FormAttachmentPopups from './popups.vue';
@@ -57,13 +59,14 @@ import { useRequestData } from '../../request-data';
 export default {
   name: 'FormAttachmentList',
   components: {
+    FileDropZone,
     FormAttachmentLinkDataset,
     FormAttachmentNameMismatch,
     FormAttachmentPopups,
     FormAttachmentTable,
     FormAttachmentUploadFiles
   },
-  inject: ['toast', 'redAlert', 'projectId', 'dragDisabled', 'dragHandler'],
+  inject: ['toast', 'redAlert', 'projectId'],
   setup() {
     const { project, form, draftAttachments, datasets } = useRequestData();
     const { request } = useRequest();
@@ -130,20 +133,7 @@ export default {
         if (dataExists && this.project.datasets > 0) this.fetchDatasets();
       },
       immediate: true
-    },
-    uploading(uploading) {
-      this.dragDisabled = uploading;
     }
-  },
-  created() {
-    this.dragHandler = (event, ...args) => {
-      // Delegate to one of the drag and drop methods below (e.g.,
-      // this.dragenter()).
-      this[event.type]?.(event, ...args);
-    };
-  },
-  beforeUnmount() {
-    this.dragHandler = noop;
   },
   methods: {
     ////////////////////////////////////////////////////////////////////////////
@@ -166,8 +156,6 @@ export default {
         if (items[i].kind === 'file') count += 1;
       return count;
     },
-    // this.dragenter(), this.dragleave(), and this.drop() are called via
-    // this.dragHandler.
     dragenter(event) {
       const { items } = event.dataTransfer;
       this.countOfFilesOverDropZone = this.fileItemCount(items);
@@ -335,7 +323,7 @@ export default {
       "upload": "Choose files"
     },
     // This text is shown next to a button with the text "Choose files".
-    "orDrag": "or drag files onto this page to upload",
+    "orDrag": "or drag files onto this section to upload",
     "problem": {
       // {message} is an error message from the server.
       "noneUploaded": "{message} No files were successfully uploaded.",

--- a/apps/central/src/components/form/edit.vue
+++ b/apps/central/src/components/form/edit.vue
@@ -10,8 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <file-drop-zone id="form-edit" :disabled="dragDisabled" :styled="false"
-    @dragenter="dragHandler" @dragleave="dragHandler" @drop="dragHandler">
+  <div id="form-edit">
     <loading :state="formDraft.initiallyLoading"/>
     <template v-if="formDraft.dataExists">
       <form-edit-published-version v-if="form.dataExists && form.publishedAt != null"/>
@@ -32,14 +31,13 @@ except according to the terms contained in the LICENSE file.
       @success="afterPublish"/>
     <form-draft-abandon v-bind="abandonModal" @hide="abandonModal.hide()"
       @success="afterAbandon"/>
-  </file-drop-zone>
+  </div>
 </template>
 
 <script setup>
-import { inject, provide, ref, watchEffect } from 'vue';
+import { inject, provide, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import FileDropZone from '../file-drop-zone.vue';
 import FormDraftAbandon from '../form-draft/abandon.vue';
 import FormDraftPublish from '../form-draft/publish.vue';
 import FormDraftTesting from '../form-draft/testing.vue';
@@ -108,18 +106,6 @@ watchEffect(() => {
     }).catch(noop);
   }
 });
-
-/* We allow form attachments to be dragged and dropped anywhere in FormEdit.
-That's why FileDropZone is in this component. But it's FormAttachmentList that
-actually knows how to handle drag events. FormAttachmentList is a few layers
-away from FormEdit, so the two communicate using refs. FormEdit provides the
-refs, then FormAttachmentList sets their values. That approach allows the two
-components to interact directly without getting intermediate components
-involved. */
-const dragDisabled = ref(false);
-provide('dragDisabled', dragDisabled);
-const dragHandler = ref(noop);
-provide('dragHandler', dragHandler);
 
 const { router, alert } = inject('container');
 const { t } = useI18n();

--- a/apps/central/test/components/form/edit.spec.js
+++ b/apps/central/test/components/form/edit.spec.js
@@ -1,6 +1,5 @@
 import Property from '../../util/ds-property-enum';
 import testData from '../../data';
-import { dragAndDrop } from '../../util/trigger';
 import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 
@@ -44,31 +43,5 @@ describe('FormEdit', () => {
         url: '/v1/projects/1/forms/f/draft/dataset-diff'
       }]);
     });
-  });
-
-  it('does not error for file drop after attachments section is removed', () => {
-    testData.extendedForms.createPast(1, { draft: true });
-    testData.standardFormAttachments.createPast(1, { name: 'foo' });
-    return load('/projects/1/forms/f/draft')
-      .afterResponses(app => {
-        app.find('#form-edit-attachments').exists().should.be.true;
-      })
-      .request(async (app) => {
-        await app.get('#form-edit-publish-button').trigger('click');
-        return app.get('#form-draft-publish form').trigger('submit');
-      })
-      .respondWithData(() => {
-        testData.extendedFormDrafts.publish(-1);
-        return { success: true };
-      })
-      .respondWithData(() => testData.extendedProjects.last())
-      .respondWithData(() => testData.extendedForms.last())
-      .respondWithData(() => testData.standardFormAttachments.sorted()) // publishedAttachments
-      .respondWithData(() => testData.formDatasetDiffs.sorted())
-      .afterResponses(async (app) => {
-        app.find('#form-edit-attachments').exists().should.be.false;
-        // As long as this doesn't result in an error, we're in the clear.
-        await dragAndDrop(app.get('#form-edit'), [new File([''], 'foo')]);
-      });
   });
 });

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3036,7 +3036,7 @@
         }
       },
       "orDrag": {
-        "string": "or drag files onto this page to upload",
+        "string": "or drag files onto this section to upload",
         "developer_comment": "This text is shown next to a button with the text \"Choose files\"."
       },
       "problem": {


### PR DESCRIPTION
Closes getodk/central#1944

#### What has been done to verify that this works as intended?

Manually verified it

#### Why is this the best possible solution? Were any other approaches considered?

Drop event from file upload component was bubbling up to the draft form page which had drop zone for the attachments. Moving the drop zone for the attachments from the page to the attachment section resolved the issue and made the UX predictable. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
