### PR TITLE
fix(#738): revokes media's object URL on Web Forms unmount

### DIFF
--- a/.changeset/eager-teeth-mate.md
+++ b/.changeset/eager-teeth-mate.md
@@ -1,0 +1,6 @@
+---
+"@getodk/central-frontend": patch
+"@getodk/web-forms": patch
+---
+
+Revoke media's object URLs on Web Forms unmount

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -196,7 +196,8 @@ const formOptions = readonly<FormOptions>({
 	attachmentMaxSize: props.attachmentMaxSize,
 });
 provide(FORM_OPTIONS, formOptions);
-provide(FORM_MEDIA_CACHE, new Map<JRResourceURLString, ObjectURL>());
+const mediaCache = new Map<JRResourceURLString, ObjectURL>();
+provide(FORM_MEDIA_CACHE, mediaCache);
 
 const state = initializeFormState();
 const submitPressed = ref(false);
@@ -271,6 +272,8 @@ watchEffect(() => {
 });
 
 onUnmounted(() => {
+	mediaCache.forEach((url) => URL.revokeObjectURL(url));
+	mediaCache.clear();
 	resetComponentState();
 });
 </script>


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/738

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

- Manually verified using a temporary button to simulate unmount: the hook ran and the cache was cleared.

#### Why is this the best possible solution? Were any other approaches considered?

 - The cache is intentionally not cleared on form submission because the same form definition (and its media attachments) is reused when the user fills the form again (avoiding unnecessary re-fetching of the same blobs). 
 - The cache stores form definition media, no user uploads. 
- Revoking on unmount covers all cases where the component is destroyed (e.g. navigating away, or a redirect), without interfering with the cache during a session.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
