### PR TITLE
ci/e2e-tests: bail after first failure

### DIFF
--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -11,6 +11,8 @@ export default defineConfig({
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
+  /* Bail after first test failure in CI */
+  maxFailures: process.env.CI ? 1 : undefined,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */


### PR DESCRIPTION
This should lead to quicker pipeline failure, and so faster feedback for developers.

Ref https://github.com/getodk/central/issues/1923

#### What has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

Flaky tests should be fixed, not glossed over.  Also currently there's no flake, so this should help prevent regressions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just the test suite.  But it should lead to more solid tests/product.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
