### PR TITLE
dev/nginx: fix central-backend hostname

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 vite: vite dev
 build: vite build --mode development --watch
-nginx: docker run --rm --publish 127.0.0.1:8686:8686 -v "$PWD/nginx-conf":/etc/nginx/ -v "$PWD/.nginx":/etc/nginx/.nginx -v "$PWD/dist":/dist nginx:1.27.4
+nginx: docker run --rm --publish 127.0.0.1:8686:8686 --add-host=host.docker.internal:host-gateway -v "$PWD/nginx-conf":/etc/nginx/ -v "$PWD/.nginx":/etc/nginx/.nginx -v "$PWD/dist":/dist nginx:1.27.4

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -109,7 +109,7 @@ http {
 
 
     location ~ ^/v\d {
-      proxy_pass http://localhost:8383;
+      proxy_pass http://host.docker.internal:8383;
       proxy_redirect off;
 
       # buffer requests, but not responses, so streaming out works.


### PR DESCRIPTION
Due to a50d496ee24f02cee090de2d3abb2d969246370e, central-backend is no longer available on `localhost`, so it must be accessed via the explicit `host.docker.internal` hostname.

Note:

* this approach may fail if `backend` is also run via Docker.  If that's a use-case we need to support then we may need to revert to --network=host until a more universal approach is implemented
* a similar fix may be required for `enketo`

#### What has been done to verify that this works as intended?

- [x] tested locally on linux
- [x] tested locally on macos

#### Why is this the best possible solution? Were any other approaches considered?

See above.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect for end users.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
