### PR TITLE
fix(#823): Adds placeholder text to multiselect dropdown

### DIFF
--- a/.changeset/brave-wolves-dance.md
+++ b/.changeset/brave-wolves-dance.md
@@ -1,0 +1,6 @@
+---
+'@getodk/central-frontend': minor
+'@getodk/web-forms': minor
+---
+
+Added 'Select answer' placeholder to select one and select multiple with dropdowns when no option has been selected yet.

--- a/packages/web-forms/src/assets/styles/primevue.scss
+++ b/packages/web-forms/src/assets/styles/primevue.scss
@@ -1,6 +1,13 @@
 @use './style' as odk;
 
 .odk-form {
+  // MultiSelect hides the label when empty, but we render a placeholder
+  // in a slot, so must stay visible.
+  .p-multiselect-label-empty {
+    visibility: visible;
+    overflow: visible;
+  }
+
   .p-datepicker-input:disabled,
   .p-datepicker-input:disabled + .p-datepicker-input-icon-container,
   .p-inputtext:disabled,

--- a/packages/web-forms/src/assets/styles/select-options.scss
+++ b/packages/web-forms/src/assets/styles/select-options.scss
@@ -112,6 +112,10 @@
   }
 }
 
+.dropdown-placeholder {
+  color: var(--odk-muted-text-color);
+}
+
 @media screen and (max-width: #{pf.$sm}) {
   :not(.select-with-images) .value-option {
     flex-wrap: wrap;

--- a/packages/web-forms/src/components/common/MultiselectDropdown.vue
+++ b/packages/web-forms/src/components/common/MultiselectDropdown.vue
@@ -1,14 +1,17 @@
 <script lang="ts" setup>
 import type { SelectNode } from '@getodk/xforms-engine';
 import MultiSelect from 'primevue/multiselect';
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
+import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
+import type { Translate } from '@/lib/locale/useLocale.ts';
 
 interface MultiselectDropdownProps {
 	readonly question: SelectNode;
 	readonly style?: string;
 }
 
+const t: Translate = inject(TRANSLATE)!;
 const props = defineProps<MultiselectDropdownProps>();
 
 defineEmits(['update:modelValue', 'change']);
@@ -72,6 +75,9 @@ const selectedLabels = computed(() => {
 			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />
 		</template>
 		<template #value>
+			<span v-if="!selectedLabels?.length" class="dropdown-placeholder">
+				{{ t('searchable_dropdown.select.placeholder') }}
+			</span>
 			<template v-for="(markdown, index) in selectedLabels" :key="index">
 				<!-- eslint-disable-next-line -->
 				<template v-if="index > 0">, </template>
@@ -83,6 +89,7 @@ const selectedLabels = computed(() => {
 
 <style scoped lang="scss">
 @use 'primeflex/core/_variables.scss' as pf;
+@use '../../assets/styles/select-options';
 
 .multi-select-dropdown {
 	width: 100%;

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -65,9 +65,9 @@ const selectValue = (value: string) => {
 			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />
 		</template>
 		<template #value>
-			<span v-if="!selectedLabel?.length" class="dropdown-placeholder">{{
-				t('searchable_dropdown.select.placeholder')
-			}}</span>
+			<span v-if="!selectedLabel?.length" class="dropdown-placeholder">
+				{{ t('searchable_dropdown.select.placeholder') }}
+			</span>
 			<MarkdownBlock v-for="elem in selectedLabel" :key="elem.id" :elem="elem" />
 		</template>
 	</Select>
@@ -75,6 +75,7 @@ const selectValue = (value: string) => {
 
 <style scoped lang="scss">
 @use 'primeflex/core/_variables.scss' as pf;
+@use '../../assets/styles/select-options';
 
 .dropdown {
 	width: 100%;
@@ -87,9 +88,6 @@ const selectValue = (value: string) => {
 
 	@media screen and (min-width: #{pf.$md}) {
 		width: 50%;
-	}
-	.dropdown-placeholder {
-		color: var(--odk-muted-text-color);
 	}
 }
 </style>


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/823

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested with the All-questions form and checked the edit submission as well. 

#### Why is this the best possible solution? Were any other approaches considered?

Follow up of https://github.com/getodk/web-forms/issues/785 for consistency 

Because we use a template slot for the dropdown value, we need to use our own placeholder instead of PrimeVue's built-in one. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
