### PR TITLE
fix(xforms-engine): preserve newlines in mixed-content label text chunks

### DIFF
--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -26,7 +26,7 @@ import {
 } from '../markdown/MarkdownNode.ts';
 
 const OUTPUT_STRING_REGEX = /`(--ODK-OUTPUT-STRING-[0-9]+--)`/g;
-const LEADING_WHITESPACE_REGEX = /^\s+/;
+const LEADING_SPACES_AND_TABS_REGEX = /^[ \t]+/;
 const STYLE_PROPERTY_REGEX = /style\s*=\s*(?:'|")(.+)(?:'|")/i;
 const HTML_TAG_MAP = {
   span: Span,
@@ -193,7 +193,10 @@ function mdastToOdkMarkdown(elements: RootContent[]): MarkdownNode[] {
 function escapeEditableChunks(chunks: readonly TextChunk[]) {
   return chunks
     .map((chunk, i) => {
-      const str = chunk.asString.replace(LEADING_WHITESPACE_REGEX, ' ') ?? '';
+      const str =
+        chunk.source === 'literal'
+          ? chunk.asString.replace(LEADING_SPACES_AND_TABS_REGEX, '')
+          : chunk.asString;
       if (chunk.source === 'output') {
         // we need to process this separately otherwise user entered markup will
         // interract with form markup in unexpected ways


### PR DESCRIPTION
Closes getodk/web-forms#819
Closes https://github.com/getodk/web-forms/issues/829

## Problem
In getodk/web-forms#819, when a form label contains newlines between `<output>` elements like this:

```xml
<label>Deliveries assigned: <output value="/data/packed_at"/>
Target weight: <output value="/data/target_weight"/>
Actual weight: <output value="/data/actual_weight"/></label>
```

Web Forms was collapsing everything into one line:

> Deliveries assigned: 2026-05-28T23:11:29.298974+00:00 Target weight: 10 Actual weight: 10

## Root Cause
In `escapeEditableChunks()` in `markdownFormat.ts`, the regex `LEADING_WHITESPACE_REGEX` (`/^\s+/`) was replacing ALL leading whitespace including `\n` with a single space. Since `\s` in JavaScript matches newlines too, every chunk starting with `\n` lost its line break.

## Fix
Renamed to `LEADING_SPACES_AND_TABS_REGEX` with updated regex (`/^[ \t]+/`) that only strips leading spaces and tabs from literal chunks, preserving `\n` characters so newlines render correctly as line breaks.

## Before
<img width="1618" height="134" alt="image" src="https://github.com/user-attachments/assets/9ace8467-760d-4bb1-acb6-009a939a4c81" />

## After
<img width="1092" height="106" alt="image" src="https://github.com/user-attachments/assets/2c6a6f8a-5d29-447e-8912-46a7b9fca057" />

## Testing
- All 357 unit tests passing
- All 719 integration tests passing
- Manually verified with a test XForm confirming multi-line labels now render on separate lines