### PR TITLE
fix: e2e tests should not check for new version message on first load

### DIFF
--- a/e2e-tests/tests/enketo.spec.js
+++ b/e2e-tests/tests/enketo.spec.js
@@ -124,8 +124,6 @@ test.describe('Enketo', () => {
         await page.waitForURL(appUrl + t.newUrl({ enketoId, enketoOnceId, draftEnketoId, xmlFormId, instanceId, st }));
 
         await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
-
-        await expect(page.getByText('A new version of this application has been downloaded. Refresh this page to load the updated version.')).toBeVisible();
       });
     });
 
@@ -149,8 +147,6 @@ test.describe('Enketo', () => {
       await page.goto(`${appUrl}/-/x/${enketoId}`);
 
       await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
-
-      await expect(page.getByText('A new version of this application has been downloaded. Refresh this page to load the updated version.')).toBeVisible();
 
       await page.reload();
 


### PR DESCRIPTION
Enketo e2e tests started failing after the [central enketo upgrade](https://github.com/getodk/central/pull/1965), probably due to changes in the way Enketo registers service workers.