### PR TITLE
e2e-tests: reduce log noise: enketo EOL font

### DIFF
--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -28,7 +28,7 @@ const test = testBase.extend({
 
         // See: https://github.com/getodk/central/issues/1986
         if(browserName === 'firefox') {
-          if(message.match(/^downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "FontAwesome"/)) return;
+          if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "FontAwesome"/)) return;
         }
 
         console.log(

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -23,9 +23,17 @@ const test = testBase.extend({
     async ({ browserName, page }, use) => {
       page.on('console', msg => {
         const { url, line, column } = msg.location();
+
+        const message = msg.text();
+
+        // See: https://github.com/getodk/central/issues/1986
+        if(browserName === 'firefox') {
+          if(message.match(/^downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "FontAwesome"/)) return;
+        }
+
         console.log(
           `[${browserName}|console.${msg.type()}] ${url}:${line}:${column}` +
-          `\n    message:`, msg.text(),
+          `\n    message:`, message,
         );
       });
       await use();


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1986

#### What has been done to verify that this works as intended?

CI: https://github.com/getodk/central-frontend/actions/runs/27543042666/job/81410523733?pr=1618

```sh
$ cat job-logs.txt | cut -d'Z' -f2- | grep message: | sed -E 's/\(glyph [0-9]+\)/(glyph 000)/' | sort | uniq -c | sort -rn | head -n1
    288      message: [JavaScript Warning: "downloadable font: glyf: Glyph bbox was incorrect; adjusting (glyph 000) (font-family: "icomoon" style:normal weight:400 stretch:100 src index:0) source: http://central-test.localhost/fonts/icomoon.ttf?8wnuuu"]
```

#### Why is this the best possible solution? Were any other approaches considered?

The issue has been filed upstream, and it's not a very interesting issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just an update to the test logging.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes