### PR TITLE
e2e-tests: reduce log noise: enketo "default theme"

### DIFF
--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -23,9 +23,16 @@ const test = testBase.extend({
     async ({ browserName, page }, use) => {
       page.on('console', msg => {
         const { url, line, column } = msg.location();
+
+        const message = msg.text();
+
+        if(url.includes('/-/')) {
+          if(message === 'Keeping default theme.') return;
+        }
+
         console.log(
           `[${browserName}|console.${msg.type()}] ${url}:${line}:${column}` +
-          `\n    message:`, msg.text(),
+          `\n    message:`, message,
         );
       });
       await use();


### PR DESCRIPTION
Printed by enketo-express every time a form page loads.

See: packages/enketo-express/public/js/src/module/gui.js

Ref https://github.com/getodk/central/issues/1979

#### What has been done to verify that this works as intended?

CI: https://github.com/getodk/central-frontend/actions/runs/27543434669/job/81411864671?pr=1620:

```sh
$ cat job-logs.txt | cut -d'Z' -f2- | grep message: | sed -E 's/\(glyph [0-9]+\)/(glyph 000)/' | sort | uniq -c | sort -rn | grep 'Keeping default theme' | wc -l
0
```

#### Why is this the best possible solution? Were any other approaches considered?

Not interesting information.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just affects devs looking at test logs.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes