### PR TITLE
e2e-tests: reduce log noise: icomoon glyph bbox

### DIFF
--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -23,9 +23,17 @@ const test = testBase.extend({
     async ({ browserName, page }, use) => {
       page.on('console', msg => {
         const { url, line, column } = msg.location();
+
+        const message = msg.text();
+
+        if(browserName === 'firefox') {
+          // See: https://github.com/getodk/central/issues/1989
+          if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "icomoon"/)) return;
+        }
+
         console.log(
           `[${browserName}|console.${msg.type()}] ${url}:${line}:${column}` +
-          `\n    message:`, msg.text(),
+          `\n    message:`, message,
         );
       });
       await use();


### PR DESCRIPTION
Ignore warning about icomoon: it's been filed at https://github.com/getodk/central/issues/1989, so logging this message on every e2e test run isn't very interesting.

#### What has been done to verify that this works as intended?

- [x] test build at: https://github.com/getodk/central-frontend/actions/runs/27602217614/job/81607023116?pr=1621

```
$ cat job-logs.txt | cut -d'Z' -f2- | grep message: | sed -E 's/\(glyph [0-9]+\)/(glyph 000)/' | sort | uniq -c | sort -rn | grep Glyph
     42      message: [JavaScript Warning: "downloadable font: glyf: Glyph bbox was incorrect; adjusting (glyph 000) (font-family: "OpenSans" style:normal weight:700 stretch:100 src index:0) source: http://central-test.localhost/-/fonts/OpenSans-Bold-webfont.woff"]
     15      message: [JavaScript Warning: "downloadable font: glyf: Glyph bbox was incorrect; adjusting (glyph 000) (font-family: "OpenSans" style:normal weight:700 stretch:100 src index:0) source: http://central-test.localhost/-/x/fonts/OpenSans-Bold-webfont.woff"]
     14      message: [JavaScript Warning: "downloadable font: glyf: Glyph bbox was incorrect; adjusting (glyph 000) (font-family: "OpenSans" style:normal weight:400 stretch:100 src index:0) source: http://central-test.localhost/-/fonts/OpenSans-Regular-webfont.woff"]
      5      message: [JavaScript Warning: "downloadable font: glyf: Glyph bbox was incorrect; adjusting (glyph 000) (font-family: "OpenSans" style:normal weight:400 stretch:100 src index:0) source: http://central-test.localhost/-/x/fonts/OpenSans-Regular-webfont.woff"]
```

#### Why is this the best possible solution? Were any other approaches considered?

Continues work done in:

* https://github.com/getodk/central-frontend/pull/1618
* https://github.com/getodk/central-frontend/pull/1619
* https://github.com/getodk/central-frontend/pull/1620

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just test code.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
