### PR TITLE
Change passphrase to encryption password

### DIFF
--- a/apps/central/src/components/project/enable-encryption.vue
+++ b/apps/central/src/components/project/enable-encryption.vue
@@ -307,9 +307,9 @@ export default {
       },
       {
         "introduction": [
-          "First, you will need to choose a passphrase. This passphrase will be required to decrypt your Submissions. For your privacy, the server will not remember this passphrase: only people with the passphrase will be able to decrypt and read your Submission data.",
+          "First, choose an encryption password. The server does not store this password. Only people who know it can decrypt and read your Submission data.",
           {
-            "full": "If you lose the passphrase, there is {no} way to recover it or your data!",
+            "full": "If you lose this encryption password, there is {no} way to recover it or your data.",
             "no": "no"
           }
         ]
@@ -319,10 +319,10 @@ export default {
       "Encryption has been configured for this Project. Any mobile devices will have to fetch or refetch the latest Forms for encryption to take place."
     ],
     "field": {
-      "hint": "Passphrase hint (optional)"
+      "hint": "Encryption password hint (optional)"
     },
     "alert": {
-      "passphraseTooShort": "Please input a passphrase at least 10 characters long."
+      "passphraseTooShort": "Encryption password must be at least 10 characters long."
     }
   }
 }

--- a/apps/central/src/components/submission/download.vue
+++ b/apps/central/src/components/submission/download.vue
@@ -398,10 +398,10 @@ $actions-padding-left: $label-icon-max-width + $margin-right-icon;
     "encryptedForm": "Encrypted Forms cannot be processed in this way.",
     "deletedFieldsDisabledForDraft": "Draft Forms cannot be processed in this way.",
     "introduction": [
-      "In order to download this data, you will need to provide your passphrase. Your passphrase will be used only to decrypt your data for download, after which the server will forget it again."
+      "Enter your encryption password to download this data. Your encryption password will be used only to decrypt the data for download and will not be stored by the server."
     ],
-    // This text is shown if there is a passphrase hint. {hint} is the
-    // passphrase hint.
+    // This text is shown if there is an encryption password hint. {hint} is the
+    // encryption password hint.
     "hint": "Hint: {hint}",
     // "Repeats" refers to repeat groups.
     "noRepeat": "This Form does not have repeats.",

--- a/apps/central/src/components/submission/download.vue
+++ b/apps/central/src/components/submission/download.vue
@@ -398,7 +398,7 @@ $actions-padding-left: $label-icon-max-width + $margin-right-icon;
     "encryptedForm": "Encrypted Forms cannot be processed in this way.",
     "deletedFieldsDisabledForDraft": "Draft Forms cannot be processed in this way.",
     "introduction": [
-      "Enter your encryption password to download this data. Your encryption password will be used only to decrypt the data for download and will not be stored by the server."
+      "Your encryption password is needed to download this data."
     ],
     // This text is shown if there is an encryption password hint. {hint} is the
     // encryption password hint.

--- a/apps/central/test/components/project/enable-encryption.spec.js
+++ b/apps/central/test/components/project/enable-encryption.spec.js
@@ -62,7 +62,7 @@ describe('ProjectEnableEncryption', () => {
     await modal.get('.btn-primary').trigger('click');
     await modal.get('input[placeholder="Passphrase *"]').setValue('x');
     await modal.get('form').trigger('submit');
-    modal.should.alert('danger', 'Please input a passphrase at least 10 characters long.');
+    modal.should.alert('danger', 'Encryption password must be at least 10 characters long.');
   });
 
   it('resets the modal after it is hidden', async () => {
@@ -103,7 +103,7 @@ describe('ProjectEnableEncryption', () => {
         .request(async (modal) => {
           await modal.get('.btn-primary').trigger('click');
           await modal.get('input[placeholder="Passphrase *"]').setValue('supersecret');
-          const hint = modal.get('input[placeholder="Passphrase hint (optional)"]');
+          const hint = modal.get('input[placeholder="Encryption password hint (optional)"]');
           await hint.setValue('bar');
           return modal.get('form').trigger('submit');
         })

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -4296,16 +4296,16 @@
         "1": {
           "introduction": {
             "0": {
-              "string": "First, you will need to choose a passphrase. This passphrase will be required to decrypt your Submissions. For your privacy, the server will not remember this passphrase: only people with the passphrase will be able to decrypt and read your Submission data."
+              "string": "First, choose an encryption password. The server does not store this password. Only people who know it can decrypt and read your Submission data."
             },
             "1": {
               "full": {
-                "string": "If you lose the passphrase, there is {no} way to recover it or your data!",
+                "string": "If you lose this encryption password, there is {no} way to recover it or your data.",
                 "developer_comment": "{no} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. Its text is:\n\nno"
               },
               "no": {
                 "string": "no",
-                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {no} is in the following text:\n\nIf you lose the passphrase, there is {no} way to recover it or your data!"
+                "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {no} is in the following text:\n\nIf you lose this encryption password, there is {no} way to recover it or your data."
               }
             }
           }
@@ -4318,13 +4318,13 @@
       },
       "field": {
         "hint": {
-          "string": "Passphrase hint (optional)",
+          "string": "Encryption password hint (optional)",
           "developer_comment": "This is the text of a form field."
         }
       },
       "alert": {
         "passphraseTooShort": {
-          "string": "Please input a passphrase at least 10 characters long."
+          "string": "Encryption password must be at least 10 characters long."
         }
       }
     },
@@ -4946,12 +4946,12 @@
       },
       "introduction": {
         "0": {
-          "string": "In order to download this data, you will need to provide your passphrase. Your passphrase will be used only to decrypt your data for download, after which the server will forget it again."
+          "string": "Enter your encryption password to download this data. Your encryption password will be used only to decrypt the data for download and will not be stored by the server."
         }
       },
       "hint": {
         "string": "Hint: {hint}",
-        "developer_comment": "This text is shown if there is a passphrase hint. {hint} is the passphrase hint."
+        "developer_comment": "This text is shown if there is an encryption password hint. {hint} is the encryption password hint."
       },
       "noRepeat": {
         "string": "This Form does not have repeats.",

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -4946,7 +4946,7 @@
       },
       "introduction": {
         "0": {
-          "string": "Enter your encryption password to download this data. Your encryption password will be used only to decrypt the data for download and will not be stored by the server."
+          "string": "Your encryption password is needed to download this data."
         }
       },
       "hint": {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1079

#### What has been done to verify that this works as intended?
Updated and ran tests. Search for "passphrase" and made sure it doesn't show up in code files. Compared with https://github.com/getodk/central/issues/1079#issuecomment-2956733110 and tried to simplify even further.

#### Why is this the best possible solution? Were any other approaches considered?

I considered also changing variable names and test names but I think they are fine as-is and that we can change the user-facing text independently.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is to text only. Probably the biggest risks are that users might re-use their login password and that I may have forgotten some places, leading to inconsistencies.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

https://github.com/getodk/docs/issues/2070


#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
    I don't think this requires a changeset because it's a text-only change that most users won't notice.