### PR TITLE
e2e-tests: enforce CSP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,6 @@ jobs:
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/enketo/config.json.template
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/service/config.json.template
         sed -i 's/\$scheme/https/g' files/nginx/odk.conf.template
-        sed -i 's/Content-Security-Policy/Content-Security-Report-Only/g' files/nginx/odk.conf.template
         sed 's/your.domain.com/central-test.localhost/; s/^SSL_TYPE=letsencrypt/SSL_TYPE=upstream/' .env.template > .env
     - name: Add domain
       run: echo '127.0.0.1 central-test.localhost' | sudo tee --append /etc/hosts


### PR DESCRIPTION
The Content-Security-Policy should not prevent e2e-tests from passing after https://github.com/getodk/central/pull/1960 has been merged.

Closes https://github.com/getodk/central/issues/1920

#### What has been done to verify that this works as intended?

- [x] CI is still passing after `-Report-Only` has been un-added

#### Why is this the best possible solution? Were any other approaches considered?

Brings e2e test environment closer to production.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just test code.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
