### PR TITLE
e2e-tests: reduce log noise: OpenSans glyph bbox

### DIFF
--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -32,6 +32,9 @@ const test = testBase.extend({
 
           // See: https://github.com/getodk/central/issues/1989
           if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "icomoon"/)) return;
+
+          // See: https://github.com/enketo/enketo/issues/1540
+          if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "OpenSans"/)) return;
         }
 
         if(url.includes('/-/')) {


### PR DESCRIPTION
Ignore warning about enketo's OpenSans: it's been filed at https://github.com/enketo/enketo/issues/1540, so logging this message on every e2e test run isn't very interesting.

Ref https://github.com/getodk/central/issues/1979

#### What has been done to verify that this works as intended?

CI test run: https://github.com/getodk/central-frontend/actions/runs/27605715791/job/81618401545?pr=1626
Logs:
```
$ cat job-logs.txt | cut -d'Z' -f2- | grep message: | sed -E 's/\(glyph [0-9]+\)/(glyph 000)/' | sort | uniq -c | sort -rn | grep font | wc -l
0
```

#### Why is this the best possible solution? Were any other approaches considered?

It's been filed upstream, and has no impact, so removing noise from the e2e test logs is helpful.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
