### PR TITLE
e2e-tests: ignore feature-flags console messages

### DIFF
--- a/apps/central/src/composables/feature-flags.js
+++ b/apps/central/src/composables/feature-flags.js
@@ -58,6 +58,7 @@ export default function useFeatureFlags() {
   const { buildMode } = inject('container');
   onMounted(() => {
     if (buildMode !== 'test') {
+      // If this logging is removed, the corresponding filtering should be removed from e2e-tests/util.js
       // eslint-disable-next-line no-console
       console.log(
         '%c ODK Central Alpha Features: \n\n%c- Press and hold the %cW and F %ckeyboard keys on a screen with a form preview button to access the new %cWeb Forms%c preview.\n\n',

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -26,6 +26,9 @@ const test = testBase.extend({
 
         const message = msg.text();
 
+        // See: /apps/central/src/composables/feature-flags.js
+        if(message.includes('ODK Central Alpha Features:')) return;
+
         if(browserName === 'firefox') {
           // See: https://github.com/getodk/central/issues/1986
           if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "FontAwesome"/)) return;


### PR DESCRIPTION
Ref getodk/central#1979

#### What has been done to verify that this works as intended?

Test run: https://github.com/getodk/central-frontend/actions/runs/27607386471/job/81623957207?pr=1627
Logs:
```
$ cat job-logs.txt | grep Alpha | wc -l
0
```

#### Why is this the best possible solution? Were any other approaches considered?

This message is deliberate, so seeing it in test output is 100% noise, 0% signal.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
