### PR TITLE
e2e-tests: fix firefox logging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,85 @@ on:
   pull_request:
 
 jobs:
+  static-checks:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - run: sudo apt-get install shellcheck
+    - run: ./bin/check-scripts.sh
+    - run: ./bin/check-for-large-files.sh
+    - run: ./bin/check-images.sh
+  unit-tests:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: npm run lint
+    - uses: browser-actions/setup-chrome@v2
+    - run: npm run test -w=@getodk/central-frontend
+    - run: npx playwright install chromium --with-deps
+    - run: npm run test -w=@getodk/forms
+  build:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: ./bin/check-bundle-size.js
+    - name: Upload Release Artefact
+      if: github.ref_type == 'tag'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        tar -cvzf dist-${{ github.ref_name }}.tar.gz dist/
+        echo "Uploading dist bundle..."
+        gh release upload ${{ github.ref_name }} dist-${{ github.ref_name }}.tar.gz
+        echo "Upload complete."
+  build-wf:
+    name: 'Build Web Forms'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['24.14.1']
+    steps:
+      - uses: 'actions/checkout@v6'
+      - uses: 'volta-cli/action@v5'
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - uses: 'actions/cache@v5'
+        id: cache-install
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: install-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
+      - uses: 'actions/cache@v5'
+        id: cache-build
+        with:
+          path: |
+            packages/*/dist
+            packages/web-forms/dist-demo
+          key: build-${{ matrix.node-version }}-${{ github.sha }}
+      - run: 'npm ci'
+      - run: 'npm run build'
   e2e-tests:
+    needs:
+    - build
+    - static-checks
+    - unit-tests
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +120,7 @@ jobs:
       run: echo '127.0.0.1 central-test.localhost' | sudo tee --append /etc/hosts
     - name: Start services
       working-directory: central
-      run: touch ./files/allow-postgres14-upgrade && docker compose build --build-arg VITE_SOURCE_MAPS=true && docker compose up -d
+      run: touch ./files/allow-postgres14-upgrade && docker compose build && docker compose up -d
     - name: Set node version
       uses: actions/setup-node@v6
       with:
@@ -58,3 +136,13 @@ jobs:
       with:
         name: Playwright Artifacts
         path: central/client/test-results
+  wf-tests:
+    name: 'Run Web Forms Tests'
+    needs:
+    - build-wf
+    uses: ./.github/workflows/wf-ci.yml
+  wf-e2e-tests:
+    name: 'Run Web Forms E2E Tests'
+    needs:
+    - wf-tests
+    uses: ./.github/workflows/wf-ci-e2e.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,85 @@ on:
   pull_request:
 
 jobs:
+  static-checks:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - run: sudo apt-get install shellcheck
+    - run: ./bin/check-scripts.sh
+    - run: ./bin/check-for-large-files.sh
+    - run: ./bin/check-images.sh
+  unit-tests:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: npm run lint
+    - uses: browser-actions/setup-chrome@v2
+    - run: npm run test -w=@getodk/central-frontend
+    - run: npx playwright install chromium --with-deps
+    - run: npm run test -w=@getodk/forms
+  build:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: ./bin/check-bundle-size.js
+    - name: Upload Release Artefact
+      if: github.ref_type == 'tag'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        tar -cvzf dist-${{ github.ref_name }}.tar.gz dist/
+        echo "Uploading dist bundle..."
+        gh release upload ${{ github.ref_name }} dist-${{ github.ref_name }}.tar.gz
+        echo "Upload complete."
+  build-wf:
+    name: 'Build Web Forms'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['24.14.1']
+    steps:
+      - uses: 'actions/checkout@v6'
+      - uses: 'volta-cli/action@v5'
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - uses: 'actions/cache@v5'
+        id: cache-install
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: install-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
+      - uses: 'actions/cache@v5'
+        id: cache-build
+        with:
+          path: |
+            packages/*/dist
+            packages/web-forms/dist-demo
+          key: build-${{ matrix.node-version }}-${{ github.sha }}
+      - run: 'npm ci'
+      - run: 'npm run build'
   e2e-tests:
+    needs:
+    - build
+    - static-checks
+    - unit-tests
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -58,3 +136,13 @@ jobs:
       with:
         name: Playwright Artifacts
         path: central/client/test-results
+  wf-tests:
+    name: 'Run Web Forms Tests'
+    needs:
+    - build-wf
+    uses: ./.github/workflows/wf-ci.yml
+  wf-e2e-tests:
+    name: 'Run Web Forms E2E Tests'
+    needs:
+    - wf-tests
+    uses: ./.github/workflows/wf-ci-e2e.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,85 +9,7 @@ on:
   pull_request:
 
 jobs:
-  static-checks:
-    timeout-minutes: 2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - run: sudo apt-get install shellcheck
-    - run: ./bin/check-scripts.sh
-    - run: ./bin/check-for-large-files.sh
-    - run: ./bin/check-images.sh
-  unit-tests:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: package.json
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build
-    - run: npm run lint
-    - uses: browser-actions/setup-chrome@v2
-    - run: npm run test -w=@getodk/central-frontend
-    - run: npx playwright install chromium --with-deps
-    - run: npm run test -w=@getodk/forms
-  build:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: package.json
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build
-    - run: ./bin/check-bundle-size.js
-    - name: Upload Release Artefact
-      if: github.ref_type == 'tag'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        tar -cvzf dist-${{ github.ref_name }}.tar.gz dist/
-        echo "Uploading dist bundle..."
-        gh release upload ${{ github.ref_name }} dist-${{ github.ref_name }}.tar.gz
-        echo "Upload complete."
-  build-wf:
-    name: 'Build Web Forms'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: ['24.14.1']
-    steps:
-      - uses: 'actions/checkout@v6'
-      - uses: 'volta-cli/action@v5'
-        with:
-          node-version: '${{ matrix.node-version }}'
-      - uses: 'actions/cache@v5'
-        id: cache-install
-        with:
-          path: |
-            node_modules
-            **/node_modules
-          key: install-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
-        id: cache-build
-        with:
-          path: |
-            packages/*/dist
-            packages/web-forms/dist-demo
-          key: build-${{ matrix.node-version }}-${{ github.sha }}
-      - run: 'npm ci'
-      - run: 'npm run build'
   e2e-tests:
-    needs:
-    - build
-    - static-checks
-    - unit-tests
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -120,7 +42,7 @@ jobs:
       run: echo '127.0.0.1 central-test.localhost' | sudo tee --append /etc/hosts
     - name: Start services
       working-directory: central
-      run: touch ./files/allow-postgres14-upgrade && docker compose build && docker compose up -d
+      run: touch ./files/allow-postgres14-upgrade && docker compose build --build-arg VITE_SOURCE_MAPS=true && docker compose up -d
     - name: Set node version
       uses: actions/setup-node@v6
       with:
@@ -136,13 +58,3 @@ jobs:
       with:
         name: Playwright Artifacts
         path: central/client/test-results
-  wf-tests:
-    name: 'Run Web Forms Tests'
-    needs:
-    - build-wf
-    uses: ./.github/workflows/wf-ci.yml
-  wf-e2e-tests:
-    name: 'Run Web Forms E2E Tests'
-    needs:
-    - wf-tests
-    uses: ./.github/workflows/wf-ci-e2e.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,85 +9,7 @@ on:
   pull_request:
 
 jobs:
-  static-checks:
-    timeout-minutes: 2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - run: sudo apt-get install shellcheck
-    - run: ./bin/check-scripts.sh
-    - run: ./bin/check-for-large-files.sh
-    - run: ./bin/check-images.sh
-  unit-tests:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: package.json
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build
-    - run: npm run lint
-    - uses: browser-actions/setup-chrome@v2
-    - run: npm run test -w=@getodk/central-frontend
-    - run: npx playwright install chromium --with-deps
-    - run: npm run test -w=@getodk/forms
-  build:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: package.json
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build
-    - run: ./bin/check-bundle-size.js
-    - name: Upload Release Artefact
-      if: github.ref_type == 'tag'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        tar -cvzf dist-${{ github.ref_name }}.tar.gz dist/
-        echo "Uploading dist bundle..."
-        gh release upload ${{ github.ref_name }} dist-${{ github.ref_name }}.tar.gz
-        echo "Upload complete."
-  build-wf:
-    name: 'Build Web Forms'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: ['24.14.1']
-    steps:
-      - uses: 'actions/checkout@v6'
-      - uses: 'volta-cli/action@v5'
-        with:
-          node-version: '${{ matrix.node-version }}'
-      - uses: 'actions/cache@v5'
-        id: cache-install
-        with:
-          path: |
-            node_modules
-            **/node_modules
-          key: install-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
-        id: cache-build
-        with:
-          path: |
-            packages/*/dist
-            packages/web-forms/dist-demo
-          key: build-${{ matrix.node-version }}-${{ github.sha }}
-      - run: 'npm ci'
-      - run: 'npm run build'
   e2e-tests:
-    needs:
-    - build
-    - static-checks
-    - unit-tests
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -136,13 +58,3 @@ jobs:
       with:
         name: Playwright Artifacts
         path: central/client/test-results
-  wf-tests:
-    name: 'Run Web Forms Tests'
-    needs:
-    - build-wf
-    uses: ./.github/workflows/wf-ci.yml
-  wf-e2e-tests:
-    name: 'Run Web Forms E2E Tests'
-    needs:
-    - wf-tests
-    uses: ./.github/workflows/wf-ci-e2e.yml

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,24 +24,7 @@ const test = testBase.extend({
       page.on('console', async msg => {
         const { url, line, column } = msg.location();
 
-        let message = msg.text();
-        if(browserName === 'firefox') {
-          try {
-            const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
-              try {
-                if(a instanceof Error) return `${a}\n${a.stack}`;
-                if(a && typeof a === 'object') return JSON.stringify(a);
-                return String(a);
-              } catch(err) {
-                return `Failed to deserialise JSHandle: ${err}`;
-              }
-            })));
-            message = args.join(' ');
-          } catch(err) {
-            // Handle race condition: `Error: jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation`
-            message = `Failed async deserialisation: ${err}; msg.text(): ${message}`;
-          }
-        }
+        const message = asText(msg);
 
         // See: /apps/central/src/composables/feature-flags.js
         if(message.includes('ODK Central Alpha Features:')) return;
@@ -81,6 +64,44 @@ const test = testBase.extend({
     { auto:true },
   ],
 });
+
+function asText(msg) {
+  if(browserName !== 'firefox') return msg.text();
+
+  const basicMessage = msg.text();
+  try {
+    const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
+      try {
+        if(a instanceof Error) return `${a}\n${filteredStack(a)}`;
+        if(a && typeof a === 'object') return JSON.stringify(a);
+        return String(a);
+      } catch(err) {
+        return `Failed to deserialise JSHandle: ${err}`;
+      }
+    })));
+    return args.join(' ');
+  } catch(err) {
+    // Handle race condition: `Error: jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation`
+    return `Failed async deserialisation: ${err}; msg.text(): ${basicMessage}`;
+  }
+
+  function filteredStack({ stack }) {
+    return stack
+        .split('\n')
+        .reduce((acc, line, idx) => {
+          const prev = acc.at(-1);
+
+          if(line.match(/@http:\/\/central-test\.localhost\/assets\/runtime-core\.esm-bundler-\w+\.js:\d+:\d+$/)) {
+            if(prev?.count) ++prev.count;
+            else acc.push({ count:1 });
+          } else acc.push(line);
+
+          return acc;
+        }, [])
+        .map(it => typeof it === 'string' ? it : `<${it.count} references to runtime-core.esm-bundler omitted>`)
+        .join('\n');
+  }
+}
 
 export {
   test,

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,18 +24,16 @@ const test = testBase.extend({
       page.on('console', async msg => {
         const { url, line, column } = msg.location();
 
-        let message = msg.text();
-
-        if(browserName === 'firefox') {
+        const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
           try {
-            const args = await Promise.all(msg.args().map(a => a.jsonValue()));
-            message = 'standard: ' + message +
-                '\n' +
-                'special-handling: ' + args.join(' '); // FIXME remove special-handling string - just a placeholder to confirm this code is running
+            if(a instanceof Error) return `${a}\n${a.stack}`;
+            if(a && typeof a === 'object') return JSON.stringify(a);
+            return String(a);
           } catch(err) {
-            message = `Failed to deserialise args: ${err.message}\n    stack: ${err.stack}`;
+            return `Failed to deserialise JSHandle: ${err}`;
           }
-        }
+        })));
+        const message = args.join(' ');
 
         if(browserName === 'firefox') {
           // See: https://github.com/getodk/central/issues/1986

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -76,28 +76,28 @@ async function asText(msg) {
       } catch(err) {
         return `Failed to deserialise JSHandle: ${err}`;
       }
+
+      function filteredStack({ stack }) {
+        return stack
+            .split('\n')
+            .reduce((acc, line) => {
+              const prev = acc.at(-1);
+
+              if(line.match(/@http:\/\/central-test\.localhost\/assets\/runtime-core\.esm-bundler-\w+\.js:\d+:\d+$/)) {
+                if(prev?.count) ++prev.count;
+                else acc.push({ count:1 });
+              } else acc.push(line);
+
+              return acc;
+            }, [])
+            .map(it => typeof it === 'string' ? it : `<${it.count} references to runtime-core.esm-bundler omitted>`)
+            .join('\n');
+      }
     })));
     return args.join(' ');
   } catch(err) {
     // Handle race condition: `Error: jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation`
     return `Failed async deserialisation: ${err}; msg.text(): ${basicMessage}`;
-  }
-
-  function filteredStack({ stack }) {
-    return stack
-        .split('\n')
-        .reduce((acc, line) => {
-          const prev = acc.at(-1);
-
-          if(line.match(/@http:\/\/central-test\.localhost\/assets\/runtime-core\.esm-bundler-\w+\.js:\d+:\d+$/)) {
-            if(prev?.count) ++prev.count;
-            else acc.push({ count:1 });
-          } else acc.push(line);
-
-          return acc;
-        }, [])
-        .map(it => typeof it === 'string' ? it : `<${it.count} references to runtime-core.esm-bundler omitted>`)
-        .join('\n');
   }
 }
 

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,7 +24,7 @@ const test = testBase.extend({
       page.on('console', async msg => {
         const { url, line, column } = msg.location();
 
-        const message = await asText(msg);
+        const message = browserName === 'firefox' ? await asText(msg) : msg.text();
 
         // See: /apps/central/src/composables/feature-flags.js
         if(message.includes('ODK Central Alpha Features:')) return;
@@ -66,8 +66,6 @@ const test = testBase.extend({
 });
 
 async function asText(msg) {
-  if(browserName !== 'firefox') return msg.text();
-
   const basicMessage = msg.text();
   try {
     const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
@@ -88,7 +86,7 @@ async function asText(msg) {
   function filteredStack({ stack }) {
     return stack
         .split('\n')
-        .reduce((acc, line, idx) => {
+        .reduce((acc, line) => {
           const prev = acc.at(-1);
 
           if(line.match(/@http:\/\/central-test\.localhost\/assets\/runtime-core\.esm-bundler-\w+\.js:\d+:\d+$/)) {

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,7 +24,16 @@ const test = testBase.extend({
       page.on('console', msg => {
         const { url, line, column } = msg.location();
 
-        const message = msg.text();
+        let message = msg.text();
+
+        if(message === 'JSHandle@object') {
+          try {
+            const args = msg.args();
+            message = args.join(' ');
+          } catch(err) {
+            message = `Failed to deserialise args: ${err.message}\n    stack: ${err.stack}`;
+          }
+        }
 
         if(browserName === 'firefox') {
           // See: https://github.com/getodk/central/issues/1986

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -26,16 +26,21 @@ const test = testBase.extend({
 
         let message = msg.text();
         if(browserName === 'firefox') {
-          const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
-            try {
-              if(a instanceof Error) return `${a}\n${a.stack}`;
-              if(a && typeof a === 'object') return JSON.stringify(a);
-              return String(a);
-            } catch(err) {
-              return `Failed to deserialise JSHandle: ${err}`;
-            }
-          })));
-          message = args.join(' ');
+          try {
+            const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
+              try {
+                if(a instanceof Error) return `${a}\n${a.stack}`;
+                if(a && typeof a === 'object') return JSON.stringify(a);
+                return String(a);
+              } catch(err) {
+                return `Failed to deserialise JSHandle: ${err}`;
+              }
+            })));
+            message = args.join(' ');
+          } catch(err) {
+            // Handle race condition: `Error: jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation`
+            message = `Failed async deserialisation: ${err}; msg.text(): ${message}`;
+          }
         }
 
         // See: /apps/central/src/composables/feature-flags.js

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,17 +24,17 @@ const test = testBase.extend({
       page.on('console', msg => {
         const { url, line, column } = msg.location();
 
-        let message;
+        let message = msg.text();
 
         if(browserName === 'firefox') {
           try {
-            const args = msg.args();
-            message = 'special-handling' + args.map(a => a.jsonValue()).join(' '); // FIXME remove special-handling string - just a placeholder to confirm this code is running
+            const args = await Promise.all(msg.args().map(a => a.jsonValue()));
+            message = 'standard: ' + message +
+                '\n' +
+                'special-handling: ' + args.join(' '); // FIXME remove special-handling string - just a placeholder to confirm this code is running
           } catch(err) {
             message = `Failed to deserialise args: ${err.message}\n    stack: ${err.stack}`;
           }
-        } else {
-          message = msg.text();
         }
 
         if(browserName === 'firefox') {

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -29,7 +29,7 @@ const test = testBase.extend({
         if(browserName === 'firefox') {
           try {
             const args = msg.args();
-            message = args.join(' ');
+            message = 'special-handling' + args.map(a => a.jsonValue()).join(' ');
           } catch(err) {
             message = `Failed to deserialise args: ${err.message}\n    stack: ${err.stack}`;
           }

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,16 +24,22 @@ const test = testBase.extend({
       page.on('console', async msg => {
         const { url, line, column } = msg.location();
 
-        const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
-          try {
-            if(a instanceof Error) return `${a}\n${a.stack}`;
-            if(a && typeof a === 'object') return JSON.stringify(a);
-            return String(a);
-          } catch(err) {
-            return `Failed to deserialise JSHandle: ${err}`;
-          }
-        })));
-        const message = args.join(' ');
+        let message = msg.text();
+        try {
+          const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
+            try {
+              if(a instanceof Error) return `${a}\n${a.stack}`;
+              if(a && typeof a === 'object') return JSON.stringify(a);
+              return String(a);
+            } catch(err) {
+              return `Failed to deserialise JSHandle: ${err}`;
+            }
+          })));
+          message = args.join(' ');
+        } catch(err) {
+          // Handle race condition: `Error: jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation`
+          message = `Failed async deserialisation: ${err}; msg.text(): ${message}`;
+        }
 
         // See: /apps/central/src/composables/feature-flags.js
         if(message.includes('ODK Central Alpha Features:')) return;

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,15 +24,17 @@ const test = testBase.extend({
       page.on('console', msg => {
         const { url, line, column } = msg.location();
 
-        let message = msg.text();
+        let message;
 
-        if(message === 'JSHandle@object') {
+        if(browserName === 'firefox') {
           try {
             const args = msg.args();
             message = args.join(' ');
           } catch(err) {
             message = `Failed to deserialise args: ${err.message}\n    stack: ${err.stack}`;
           }
+        } else {
+          message = msg.text();
         }
 
         if(browserName === 'firefox') {

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -29,7 +29,7 @@ const test = testBase.extend({
         if(browserName === 'firefox') {
           try {
             const args = msg.args();
-            message = 'special-handling' + args.map(a => a.jsonValue()).join(' ');
+            message = 'special-handling' + args.map(a => a.jsonValue()).join(' '); // FIXME remove special-handling string - just a placeholder to confirm this code is running
           } catch(err) {
             message = `Failed to deserialise args: ${err.message}\n    stack: ${err.stack}`;
           }

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -25,7 +25,7 @@ const test = testBase.extend({
         const { url, line, column } = msg.location();
 
         let message = msg.text();
-        try {
+        if(browserName === 'firefox') {
           const args = await Promise.all(msg.args().map(arg => arg.evaluate(a => {
             try {
               if(a instanceof Error) return `${a}\n${a.stack}`;
@@ -36,9 +36,6 @@ const test = testBase.extend({
             }
           })));
           message = args.join(' ');
-        } catch(err) {
-          // Handle race condition: `Error: jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation`
-          message = `Failed async deserialisation: ${err}; msg.text(): ${message}`;
         }
 
         // See: /apps/central/src/composables/feature-flags.js

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -21,7 +21,7 @@ const test = testBase.extend({
   // See: https://playwright.dev/docs/test-fixtures#adding-global-beforeeachaftereach-hooks
   browserConsoleToTestStdout: [
     async ({ browserName, page }, use) => {
-      page.on('console', msg => {
+      page.on('console', async msg => {
         const { url, line, column } = msg.location();
 
         let message = msg.text();

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -24,7 +24,7 @@ const test = testBase.extend({
       page.on('console', async msg => {
         const { url, line, column } = msg.location();
 
-        const message = asText(msg);
+        const message = await asText(msg);
 
         // See: /apps/central/src/composables/feature-flags.js
         if(message.includes('ODK Central Alpha Features:')) return;
@@ -65,7 +65,7 @@ const test = testBase.extend({
   ],
 });
 
-function asText(msg) {
+async function asText(msg) {
   if(browserName !== 'firefox') return msg.text();
 
   const basicMessage = msg.text();


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1988

#### What has been done to verify that this works as intended?

```
$ grep message: job-logs-master.txt | wc -l
488
$ grep message: job-logs-master.txt | grep JSHandle | wc -l
70
```

vs

CI run: https://github.com/getodk/central-frontend/actions/runs/27676942186/job/81854457384?pr=1628
Logs:

```
$ grep message: job-logs.txt | wc -l
550
$ grep message: job-logs.txt | grep JSHandle | wc -l
22
```

Messages inspected to confirm that existing filters are not affected.

#### Why is this the best possible solution? Were any other approaches considered?

* chromium logging works best with `msg.text()`
* firefox logging works best with `msg.args()`
* if/when webkit tests are introduced, best approach for that browser can be decided

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just test code.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
