### PR TITLE
e2e-tests: ignore expected XML parse error

### DIFF
--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -37,7 +37,7 @@ const test = testBase.extend({
           if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "OpenSans"/)) return;
 
           // See: https://github.com/getodk/central/issues/1696
-          if(message === 'XML Parsing Error: unclosed token') return;
+          if(message.includes('XML Parsing Error: unclosed token')) return;
         }
 
         if(url.includes('/-/')) {

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -35,6 +35,9 @@ const test = testBase.extend({
 
           // See: https://github.com/enketo/enketo/issues/1540
           if(message.match(/"downloadable font: glyf: Glyph bbox was incorrect;.*font-family: "OpenSans"/)) return;
+
+          // See: https://github.com/getodk/central/issues/1696
+          if(message === 'XML Parsing Error: unclosed token') return;
         }
 
         if(url.includes('/-/')) {


### PR DESCRIPTION
Related: https://github.com/getodk/central/issues/1979

See: https://github.com/getodk/central/issues/1696

#### What has been done to verify that this works as intended?

CI run: https://github.com/getodk/central-frontend/actions/runs/27610293921/job/81633949061?pr=1630
Logs:
```
$ cat job-logs.txt | grep message: | wc -l
752
$ cat job-logs.txt | grep message: | grep XML | wc -l
0
```

#### Why is this the best possible solution? Were any other approaches considered?

Not a useful message to include.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just test code.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
