### PR TITLE
chore: add test for dynamic labels with line breaks

### DIFF
--- a/.changeset/solid-lies-chew.md
+++ b/.changeset/solid-lies-chew.md
@@ -1,0 +1,6 @@
+---
+"@getodk/forms": minor
+"@getodk/xforms-engine": minor
+---
+
+Preserved newlines in mixed-content label text

--- a/packages/xforms-engine/test/integration/label-hint-text.test.ts
+++ b/packages/xforms-engine/test/integration/label-hint-text.test.ts
@@ -161,23 +161,12 @@ describe('`<label>` and/or `<hint>` text', () => {
         head(
           title('label-newline-after-output'),
           model(
-            mainInstance(
-              t(
-                'data id="label-newline-after-output"',
-                t('field'),
-                t('question')
-              )
-            ),
+            mainInstance(t('data id="label-newline-after-output"', t('field'), t('question'))),
             bind('/data/field').type('string').calculate("'value'"),
             bind('/data/question').type('string')
           )
         ),
-        body(
-          input(
-            '/data/question',
-            t('label', 'Line 1 <output value="/data/field"/>\nLine 2')
-          )
-        )
+        body(input('/data/question', t('label', 'Line 1 <output value="/data/field"/>\nLine 2')))
       )
     );
     scenario.next('/data/question');

--- a/packages/xforms-engine/test/integration/label-hint-text.test.ts
+++ b/packages/xforms-engine/test/integration/label-hint-text.test.ts
@@ -153,4 +153,41 @@ describe('`<label>` and/or `<hint>` text', () => {
       }
     );
   });
+
+  it('newline following `<output>` element renders as line break', async () => {
+    const scenario = await Scenario.init(
+      'label-newline-after-output',
+      html(
+        head(
+          title('label-newline-after-output'),
+          model(
+            mainInstance(
+              t(
+                'data id="label-newline-after-output"',
+                t('field'),
+                t('question')
+              )
+            ),
+            bind('/data/field').type('string').calculate("'value'"),
+            bind('/data/question').type('string')
+          )
+        ),
+        body(
+          input(
+            '/data/question',
+            t('label', 'Line 1 <output value="/data/field"/>\nLine 2')
+          )
+        )
+      )
+    );
+    scenario.next('/data/question');
+    const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/question' }).formatted;
+    expect(label).toMatchObject([
+      { value: 'Line 1 ' },
+      { elementName: 'span', children: [{ value: 'value' }] },
+      { elementName: 'br' },
+      { value: 'Line 2' },
+    ]);
+    expect(label.length).toEqual(4);
+  });
 });

--- a/packages/xforms-engine/test/integration/label-hint-text.test.ts
+++ b/packages/xforms-engine/test/integration/label-hint-text.test.ts
@@ -177,6 +177,5 @@ describe('`<label>` and/or `<hint>` text', () => {
       { elementName: 'br' },
       { value: 'Line 2' },
     ]);
-    expect(label.length).toEqual(4);
   });
 });


### PR DESCRIPTION
Follow-up of https://github.com/getodk/central-frontend/pull/1613

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
