### PR TITLE
feat(web-forms#752): send deviceID param with submission

### DIFF
--- a/.changeset/calm-pugs-cheat.md
+++ b/.changeset/calm-pugs-cheat.md
@@ -1,0 +1,6 @@
+---
+"@getodk/web-forms": minor
+"@getodk/forms": minor
+---
+
+Changed the vue component parameter from track-device to device-id which now expects the app to provide the id rather than autogenerating one

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -31,7 +31,7 @@ interface SubmissionData {
 
 interface PostPrimaryInstanceParams {
   st: string | undefined;
-  deviceId?: string | undefined;
+  deviceID?: string | undefined;
 }
 
 let clearForm:Function;
@@ -40,7 +40,7 @@ let submissionData: SubmissionData;
 const submissionResult:any = {};
 const isEdit = computed(() => props.actionType === 'edit');
 const isPublicLink = computed(() => props.actionType === 'public-link');
-const deviceId = computed(() => getDeviceId());
+const deviceID = computed(() => getDeviceId());
 
 const visibleModal = ref();
 
@@ -64,7 +64,7 @@ const postPrimaryInstance = async (file:File) => {
     method = 'PUT';
   } else {
     const draftPath = props.form.draft ? '/draft' : '';
-    params.deviceId = deviceId.value;
+    params.deviceID = deviceID.value;
     url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath}/submissions`;
     method = 'POST';
   }
@@ -292,7 +292,7 @@ const closeWindow = () => {
     :form-xml="props.xform"
     :edit-instance="editInstanceOptions"
     :fetch-form-attachment="getAttachment"
-    :device-id="deviceId"
+    :device-id="deviceID"
     @submit="handleSubmit"/>
 
   <Dialog modal :visible="!!visibleModal" :draggable="false" :closable="visibleModal?.hideable" @update:visible="visibleModal = null">

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -40,7 +40,8 @@ let submissionData: SubmissionData;
 const submissionResult:any = {};
 const isEdit = computed(() => props.actionType === 'edit');
 const isPublicLink = computed(() => props.actionType === 'public-link');
-const deviceID = computed(() => getDeviceId());
+
+const deviceID = getDeviceId();
 
 const visibleModal = ref();
 
@@ -64,7 +65,7 @@ const postPrimaryInstance = async (file:File) => {
     method = 'PUT';
   } else {
     const draftPath = props.form.draft ? '/draft' : '';
-    params.deviceID = deviceID.value;
+    params.deviceID = deviceID;
     url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath}/submissions`;
     method = 'POST';
   }

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -8,6 +8,7 @@ import Dialog from 'primevue/dialog';
 import Button from 'primevue/button';
 import { Translation } from 'vue-i18n'
 import Location from '../utils/location';
+import { getDeviceId } from '../utils/device-id';
 defineOptions({
   name: 'WebFormRenderer'
 });
@@ -28,12 +29,18 @@ interface SubmissionData {
   attachments: File[];
 }
 
+interface PostPrimaryInstanceParams {
+  st: string | undefined;
+  deviceID?: string | undefined;
+}
+
 let clearForm:Function;
 let submissionData: SubmissionData;
 
 const submissionResult:any = {};
 const isEdit = computed(() => props.actionType === 'edit');
 const isPublicLink = computed(() => props.actionType === 'public-link');
+const deviceID = computed(() => getDeviceId());
 
 const visibleModal = ref();
 
@@ -47,17 +54,21 @@ const getAttachment = (requestUrl: URL) => {
 };
 
 const postPrimaryInstance = async (file:File) => {
-  const draftPath = props.form.draft ? '/draft' : '';
-  let url;
-  let method;
+  let url:string;
+  let method:string;
+  let params: PostPrimaryInstanceParams = {
+    st: props.st ?? undefined
+  }
   if (isEdit.value) {
     url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}/submissions/${props.instanceId}`;
     method = 'PUT';
   } else {
+    const draftPath = props.form.draft ? '/draft' : '';
+    params.deviceID = deviceID.value;
     url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath}/submissions`;
     method = 'POST';
   }
-  url = withToken(url);
+  url += queryString(params);
   const headers = {
     'Content-Type': 'text/xml',
     'odk-client': `odk-web-forms/${__WEB_FORMS_VERSION__}`,
@@ -281,7 +292,7 @@ const closeWindow = () => {
     :form-xml="props.xform"
     :edit-instance="editInstanceOptions"
     :fetch-form-attachment="getAttachment"
-    :track-device="true"
+    :device-id="deviceID"
     @submit="handleSubmit"/>
 
   <Dialog modal :visible="!!visibleModal" :draggable="false" :closable="visibleModal?.hideable" @update:visible="visibleModal = null">

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -31,7 +31,7 @@ interface SubmissionData {
 
 interface PostPrimaryInstanceParams {
   st: string | undefined;
-  deviceID?: string | undefined;
+  deviceId?: string | undefined;
 }
 
 let clearForm:Function;
@@ -40,7 +40,7 @@ let submissionData: SubmissionData;
 const submissionResult:any = {};
 const isEdit = computed(() => props.actionType === 'edit');
 const isPublicLink = computed(() => props.actionType === 'public-link');
-const deviceID = computed(() => getDeviceId());
+const deviceId = computed(() => getDeviceId());
 
 const visibleModal = ref();
 
@@ -54,8 +54,8 @@ const getAttachment = (requestUrl: URL) => {
 };
 
 const postPrimaryInstance = async (file:File) => {
-  let url:string;
-  let method:string;
+  let url: string;
+  let method: string;
   let params: PostPrimaryInstanceParams = {
     st: props.st ?? undefined
   }
@@ -64,7 +64,7 @@ const postPrimaryInstance = async (file:File) => {
     method = 'PUT';
   } else {
     const draftPath = props.form.draft ? '/draft' : '';
-    params.deviceID = deviceID.value;
+    params.deviceId = deviceId.value;
     url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath}/submissions`;
     method = 'POST';
   }
@@ -292,7 +292,7 @@ const closeWindow = () => {
     :form-xml="props.xform"
     :edit-instance="editInstanceOptions"
     :fetch-form-attachment="getAttachment"
-    :device-id="deviceID"
+    :device-id="deviceId"
     @submit="handleSubmit"/>
 
   <Dialog modal :visible="!!visibleModal" :draggable="false" :closable="visibleModal?.hideable" @update:visible="visibleModal = null">

--- a/apps/forms/src/utils/device-id.ts
+++ b/apps/forms/src/utils/device-id.ts
@@ -1,0 +1,24 @@
+const DEVICE_ID_KEY = 'odk-deviceid';
+const DEVICE_ID_PREFIX = 'wf';
+const DEVICE_ID_LENGTH = 16;
+const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+const getRandomId = () => {
+  const bytes = new Uint8Array(DEVICE_ID_LENGTH);
+  crypto.getRandomValues(bytes);
+  const chars: string[] = [];
+  for (const byte of bytes) {
+    chars.push(ALPHABET[byte % ALPHABET.length]!);
+  }
+  return chars.join('');
+};
+
+export const getDeviceId = () => {
+  const existingDeviceId = localStorage.getItem(DEVICE_ID_KEY);
+  if (existingDeviceId) {
+    return existingDeviceId;
+  }
+  const deviceId = `${DEVICE_ID_PREFIX}:${getRandomId()}`;
+  localStorage.setItem(DEVICE_ID_KEY, deviceId);
+  return deviceId;
+};

--- a/apps/forms/test/components/web-form-renderer.spec.ts
+++ b/apps/forms/test/components/web-form-renderer.spec.ts
@@ -65,6 +65,7 @@ describe('WebFormRenderer', () => {
     vi.resetAllMocks();
   });
 
+  let deviceId;
 
   const mountComponent = async (testProps: Partial<WebFormsRendererProps>) => {
 
@@ -143,9 +144,14 @@ describe('WebFormRenderer', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls.length).to.equal(1);
     const firstCall = fetchSpy.mock.calls[0]!;
-    const url = firstCall[0];
+    const url: string = firstCall[0] as string;
     const args = firstCall[1]!;
-    expect(url).to.equal(`/v1/projects/1/forms/simple/submissions`);
+    expect(deviceId).toBeUndefined(); // this is the first time we're setting it
+    const deviceIdMatch = /\?deviceID=(wf%3A.{16})/.exec(url);
+    expect(deviceIdMatch).not.toBeNull();
+    expect(deviceIdMatch!.length).to.equal(2);
+    deviceId = deviceIdMatch![1];
+    expect(url).to.equal(`/v1/projects/1/forms/simple/submissions?deviceID=${deviceId}`);
     expect(args.method).to.equal('POST');
     expect(args.headers!['Content-Type']).to.equal('text/xml');
     expect((args.body as File).name).to.equal('xml_submission_file');
@@ -180,7 +186,7 @@ describe('WebFormRenderer', () => {
     const firstCall = fetchSpy.mock.calls[0]!;
     const url = firstCall[0];
     const args = firstCall[1]!;
-    expect(url).to.equal(`/v1/projects/1/forms/simple/submissions?st=sometoken`);
+    expect(url).to.equal(`/v1/projects/1/forms/simple/submissions?st=sometoken&deviceID=${deviceId}`);
     expect(args.method).to.equal('POST');
     const title = document.querySelector('.p-dialog-header span')!;
     const intro = document.querySelector('.p-dialog-content span')!;

--- a/packages/web-forms/README.md
+++ b/packages/web-forms/README.md
@@ -374,7 +374,7 @@ The `<OdkWebForm>` component accepts the following props:
 - `attachmentMaxSize` (`number`, optional, defaults to 100MB): Maximum size for submission attachments in bytes.
 - `editInstance` (`EditInstanceOptions`, optional): Options to resolve and load instance and attachment resources for editing.
 - `preloadProperties` (`PreloadProperties`, optional): Properties to make available for binding in the form using jr:preload.
-- `deviceId` (`string`, optional): If provided XXXXX. Ignored if `preloadProperties.deviceID` is given.
+- `deviceId` (`string`, optional): If provided is available for binding into the form using preload attributes. Ignored if `preloadProperties.deviceID` is given.
 
 ### Events (`OdkWebFormEmits`)
 

--- a/packages/web-forms/README.md
+++ b/packages/web-forms/README.md
@@ -348,7 +348,7 @@ To use this library in a Vue.js application:
     :submission-max-size="5242880"  <!-- 5MB -->
     :edit-instance="editOptions"
     :preload-properties="preloadProperties"
-    :track-device="true"
+    :device-id="abc123"
     @submit="handleSubmit"
     @submit-chunked="handleChunkedSubmit"
 />
@@ -374,7 +374,7 @@ The `<OdkWebForm>` component accepts the following props:
 - `attachmentMaxSize` (`number`, optional, defaults to 100MB): Maximum size for submission attachments in bytes.
 - `editInstance` (`EditInstanceOptions`, optional): Options to resolve and load instance and attachment resources for editing.
 - `preloadProperties` (`PreloadProperties`, optional): Properties to make available for binding in the form using jr:preload.
-- `trackDevice` (`boolean`, optional, defaults to `false`): If `true`, generates a unique identifier for this device and stores it in `localstorage` for use in subsequent submissions. Ignored if `preloadProperties.deviceID` is given.
+- `deviceId` (`string`, optional): If provided XXXXX. Ignored if `preloadProperties.deviceID` is given.
 
 ### Events (`OdkWebFormEmits`)
 

--- a/packages/web-forms/e2e/test-cases/functional/jr-preload.test.ts
+++ b/packages/web-forms/e2e/test-cases/functional/jr-preload.test.ts
@@ -39,8 +39,8 @@ test.describe('jr:preload', () => {
 
     await formPage.note.expectValueToBeEmpty('end'); // end isn't populated on load
 
-    const deviceID = await formPage.note.getValue('deviceid');
-    expect(deviceID).toMatch(DEVICE_ID_REGEX);
+    const deviceId = await formPage.note.getValue('deviceid');
+    expect(deviceId).toMatch(DEVICE_ID_REGEX);
 
     const instanceID = await formPage.note.getValue('instanceID');
     expect(instanceID).toMatch(INSTANCE_ID_REGEX);
@@ -53,7 +53,7 @@ test.describe('jr:preload', () => {
     await formPage.reload();
 
     // assert the deviceid hasn't changed - should be loaded from localstorage
-    await formPage.note.expectValue('deviceid', deviceID);
+    await formPage.note.expectValue('deviceid', deviceId);
 
     // assert the instanceID HAS changed
     const newInstanceID = await formPage.note.getValue('instanceID');

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -51,7 +51,7 @@ type ObjectURL = `blob:${string}`;
 export interface OdkWebFormsProps {
 	readonly formXml: string;
 	readonly fetchFormAttachment: FetchFormAttachment;
-	readonly trackDevice?: boolean;
+	readonly deviceId?: string;
 	readonly preloadProperties?: PreloadProperties;
 	readonly missingResourceBehavior?: MissingResourceBehavior;
 	readonly attachmentMaxSize?: number;
@@ -81,7 +81,7 @@ const hostSubmissionResultCallbackFactory = (
 		const options = {
 			form: formOptions,
 			preloadProperties: props.preloadProperties,
-			trackDevice: props.trackDevice,
+			deviceId: props.deviceId,
 		};
 		state.value = updateSubmittedFormState(submissionResult, currentState, options);
 		if (submissionResult?.next === POST_SUBMIT__NEW_INSTANCE) {
@@ -230,7 +230,7 @@ const init = async () => {
 		form: formOptions,
 		editInstance: props.editInstance ?? null,
 		preloadProperties: props.preloadProperties,
-		trackDevice: props.trackDevice,
+		deviceId: props.deviceId,
 	});
 };
 

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -51,7 +51,7 @@ type ObjectURL = `blob:${string}`;
 export interface OdkWebFormsProps {
 	readonly formXml: string;
 	readonly fetchFormAttachment: FetchFormAttachment;
-	readonly deviceId?: string;
+	readonly deviceId?: string; // different case to make it easier to bind
 	readonly preloadProperties?: PreloadProperties;
 	readonly missingResourceBehavior?: MissingResourceBehavior;
 	readonly attachmentMaxSize?: number;
@@ -81,7 +81,7 @@ const hostSubmissionResultCallbackFactory = (
 		const options = {
 			form: formOptions,
 			preloadProperties: props.preloadProperties,
-			deviceId: props.deviceId,
+			deviceID: props.deviceId,
 		};
 		state.value = updateSubmittedFormState(submissionResult, currentState, options);
 		if (submissionResult?.next === POST_SUBMIT__NEW_INSTANCE) {
@@ -230,7 +230,7 @@ const init = async () => {
 		form: formOptions,
 		editInstance: props.editInstance ?? null,
 		preloadProperties: props.preloadProperties,
-		deviceId: props.deviceId,
+		deviceID: props.deviceId,
 	});
 };
 

--- a/packages/web-forms/src/demo/FormPreview.vue
+++ b/packages/web-forms/src/demo/FormPreview.vue
@@ -86,6 +86,8 @@ const preloadProperties: PreloadProperties = {
 	phoneNumber: '+1235556789',
 	username: 'nousername',
 };
+
+const deviceId = 'wf-jhuS0ic9lFGT6ZOW';
 </script>
 <template>
 	<template v-if="formPreviewState">
@@ -95,7 +97,7 @@ const preloadProperties: PreloadProperties = {
 			:missing-resource-behavior="formPreviewState.missingResourceBehavior"
 			:submission-max-size="Infinity"
 			:preload-properties="preloadProperties"
-			:track-device="true"
+			:device-id="deviceId"
 			@submit="handleSubmit"
 			@submit-chunked="handleSubmitChunked"
 		/>

--- a/packages/web-forms/src/demo/FormPreview.vue
+++ b/packages/web-forms/src/demo/FormPreview.vue
@@ -87,6 +87,8 @@ const preloadProperties: PreloadProperties = {
 	username: 'nousername',
 };
 
+// hardcoded deviceId used for testing
+// because demo forms never get submitted anywhere it's never read elsewhere
 const deviceId = 'wf:jhuS0ic9lFGT6ZOW';
 </script>
 <template>

--- a/packages/web-forms/src/demo/FormPreview.vue
+++ b/packages/web-forms/src/demo/FormPreview.vue
@@ -87,7 +87,7 @@ const preloadProperties: PreloadProperties = {
 	username: 'nousername',
 };
 
-const deviceId = 'wf-jhuS0ic9lFGT6ZOW';
+const deviceId = 'wf:jhuS0ic9lFGT6ZOW';
 </script>
 <template>
 	<template v-if="formPreviewState">

--- a/packages/web-forms/src/lib/init/engine-config.ts
+++ b/packages/web-forms/src/lib/init/engine-config.ts
@@ -7,14 +7,9 @@ import type {
 } from '@getodk/xforms-engine';
 import { reactive } from 'vue';
 
-const DEVICE_ID_KEY = 'odk-deviceid';
-const DEVICE_ID_PREFIX = 'wf';
-const DEVICE_ID_LENGTH = 16;
-const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-
 interface GetFormInstanceConfigOptions {
   readonly form: FormOptions;
-  readonly trackDevice?: boolean;
+  readonly deviceId?: string;
   readonly preloadProperties?: PreloadProperties;
 }
 
@@ -44,33 +39,13 @@ const INSTANCE_ATTACHMENTS_CONFIG: InstanceAttachmentsConfig = {
   },
 };
 
-const getRandomId = () => {
-  const bytes = new Uint8Array(DEVICE_ID_LENGTH);
-  crypto.getRandomValues(bytes);
-  const chars = [];
-  for (const byte of bytes) {
-    chars.push(ALPHABET[byte % ALPHABET.length]);
-  }
-  return chars.join('');
-};
-
-const getDeviceId = () => {
-  const id = localStorage.getItem(DEVICE_ID_KEY);
-  if (id) {
-    return id;
-  }
-  const deviceId = `${DEVICE_ID_PREFIX}:${getRandomId()}`;
-  localStorage.setItem(DEVICE_ID_KEY, deviceId);
-  return deviceId;
-};
-
 const getPreloadProperties = (options: GetFormInstanceConfigOptions) => {
-  if (!options.trackDevice || options.preloadProperties?.deviceID) {
+  if (!options.deviceId || options.preloadProperties?.deviceId) {
     return options.preloadProperties;
   }
   return {
     ...options.preloadProperties,
-    deviceID: getDeviceId(),
+    deviceId: options.deviceId,
   };
 };
 

--- a/packages/web-forms/src/lib/init/engine-config.ts
+++ b/packages/web-forms/src/lib/init/engine-config.ts
@@ -9,7 +9,7 @@ import { reactive } from 'vue';
 
 interface GetFormInstanceConfigOptions {
   readonly form: FormOptions;
-  readonly deviceId?: string;
+  readonly deviceID?: string;
   readonly preloadProperties?: PreloadProperties;
 }
 
@@ -40,12 +40,12 @@ const INSTANCE_ATTACHMENTS_CONFIG: InstanceAttachmentsConfig = {
 };
 
 const getPreloadProperties = (options: GetFormInstanceConfigOptions) => {
-  if (!options.deviceId || options.preloadProperties?.deviceID) {
+  if (!options.deviceID || options.preloadProperties?.deviceID) {
     return options.preloadProperties;
   }
   return {
     ...options.preloadProperties,
-    deviceId: options.deviceId,
+    deviceID: options.deviceID,
   };
 };
 

--- a/packages/web-forms/src/lib/init/engine-config.ts
+++ b/packages/web-forms/src/lib/init/engine-config.ts
@@ -40,7 +40,7 @@ const INSTANCE_ATTACHMENTS_CONFIG: InstanceAttachmentsConfig = {
 };
 
 const getPreloadProperties = (options: GetFormInstanceConfigOptions) => {
-  if (!options.deviceId || options.preloadProperties?.deviceId) {
+  if (!options.deviceId || options.preloadProperties?.deviceID) {
     return options.preloadProperties;
   }
   return {

--- a/packages/web-forms/src/lib/init/load-form-state.ts
+++ b/packages/web-forms/src/lib/init/load-form-state.ts
@@ -70,7 +70,7 @@ const resolvableFormInstanceInput = (options: EditInstanceOptions): ResolvableFo
 interface LoadFormStateOptions {
   readonly form: FormOptions;
   readonly editInstance?: EditInstanceOptions | null;
-  readonly trackDevice?: boolean;
+  readonly deviceId?: string;
   readonly preloadProperties?: PreloadProperties;
 }
 

--- a/packages/web-forms/src/lib/init/load-form-state.ts
+++ b/packages/web-forms/src/lib/init/load-form-state.ts
@@ -70,7 +70,7 @@ const resolvableFormInstanceInput = (options: EditInstanceOptions): ResolvableFo
 interface LoadFormStateOptions {
   readonly form: FormOptions;
   readonly editInstance?: EditInstanceOptions | null;
-  readonly deviceId?: string;
+  readonly deviceID?: string;
   readonly preloadProperties?: PreloadProperties;
 }
 

--- a/packages/web-forms/src/lib/init/update-submitted-form-state.ts
+++ b/packages/web-forms/src/lib/init/update-submitted-form-state.ts
@@ -7,7 +7,7 @@ import type { FormStateSuccessResult } from './form-state.ts';
 
 interface ResetFormStateOptions {
   readonly form: FormOptions;
-  readonly deviceId?: string;
+  readonly deviceID?: string;
   readonly preloadProperties?: PreloadProperties;
 }
 

--- a/packages/web-forms/src/lib/init/update-submitted-form-state.ts
+++ b/packages/web-forms/src/lib/init/update-submitted-form-state.ts
@@ -7,7 +7,7 @@ import type { FormStateSuccessResult } from './form-state.ts';
 
 interface ResetFormStateOptions {
   readonly form: FormOptions;
-  readonly trackDevice?: boolean;
+  readonly deviceId?: string;
   readonly preloadProperties?: PreloadProperties;
 }
 


### PR DESCRIPTION
Closes getodk/web-forms#752

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added testing
Verified manually

#### Why is this the best possible solution? Were any other approaches considered?

I chose to move the deviceID generation code to the central-frontend forms app so that the vue component is stateless. This is a breaking change so getting it in before 1.0.0 felt important.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It should be transparent to users.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Readme updated.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
