### PR TITLE
fix(web-forms#538): handle errors loading forms

### DIFF
--- a/.changeset/brave-poets-sin.md
+++ b/.changeset/brave-poets-sin.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Display errors encountered while loading the forms app

--- a/apps/forms/eslint.config.js
+++ b/apps/forms/eslint.config.js
@@ -57,7 +57,7 @@ export default defineConfig(
 			'web-forms/dist-demo/**/*',
 			'web-forms/bin/**/*',
 			'xforms-engine/api-docs/**/*',
-			'**/vendor'
+			'**/vendor',
 		],
 	},
 

--- a/apps/forms/eslint.config.js
+++ b/apps/forms/eslint.config.js
@@ -58,6 +58,7 @@ export default defineConfig(
 			'web-forms/bin/**/*',
 			'xforms-engine/api-docs/**/*',
 			'**/vendor',
+			'src/init.js'
 		],
 	},
 

--- a/apps/forms/eslint.config.js
+++ b/apps/forms/eslint.config.js
@@ -57,8 +57,7 @@ export default defineConfig(
 			'web-forms/dist-demo/**/*',
 			'web-forms/bin/**/*',
 			'xforms-engine/api-docs/**/*',
-			'**/vendor',
-			'src/init.js'
+			'**/vendor'
 		],
 	},
 
@@ -250,6 +249,8 @@ export default defineConfig(
 			reportUnusedDisableDirectives: true,
 		},
 
+		ignores: ['src/init.js'],
+
 		plugins: {
 			'no-only-tests': noOnlyTestsPlugin, // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 		},
@@ -377,6 +378,22 @@ export default defineConfig(
 		rules: {
 			'@typescript-eslint/triple-slash-reference': 'off',
 		},
+	},
+
+
+	{
+		files: ['src/init.js'],
+		rules: eslint.configs.recommended.rules,
+		languageOptions: {
+			ecmaVersion: 5,
+			sourceType: 'script',
+			globals: {
+				document: 'readonly',
+				window: 'readonly',
+				console: 'readonly',
+				globalThis: 'readonly'
+			}
+		}
 	},
 
 	{

--- a/apps/forms/index.html
+++ b/apps/forms/index.html
@@ -43,22 +43,26 @@
       }
     </style>
     <script>
-      const handle = (message) => {
+      // NB use legacy JavaScript to support older browsers
+      var __handleInitializationErrors = function(event) {
         if (!document.getElementById('loading')) {
           // do not intercept errors after the app has loaded
           return;
         }
-        console.error('FATAL ERROR: loading forms app');
+        var message = event.message
+          || event.reason && event.reason.message
+          || 'An unknown error occurred.';
+        console.error('FATAL ERROR while loading forms app:', message);
         document.getElementById('loading').style.display = 'none';
         document.getElementById('loading-error').style.display = 'block';
-        document.getElementById('error-message').innerText = message ?? 'An unknown error occurred';
+        document.getElementById('error-message').innerText = message;
       };
-      window.addEventListener('error', event => {
-        handle(event.message);
-      });
-      window.addEventListener('unhandledrejection', event => {
-        handle(event.reason && event.reason.message);
-      });
+      var __deregisterInitializationErrorHandling = function() {
+        window.removeEventListener('error', __handleInitializationErrors, { capture: true, once: true });
+        window.removeEventListener('unhandledrejection', __handleInitializationErrors, { once: true });
+      };
+      window.addEventListener('error', __handleInitializationErrors, { capture: true, once: true });
+      window.addEventListener('unhandledrejection', __handleInitializationErrors, { once: true });
     </script>
   </head>
   <body>
@@ -72,7 +76,7 @@
     <div id="forms-app">
       <div id="loading-error">
         <h1>Error loading forms application</h1>
-        <p>Please try updating to the latest version of your browser or contact support.</p>
+        <p>Please try reloading the page, updating your browser to the latest version, or contacting support.</p>
         <p id="error-message"></p>
         <p>Powered by <a href="https://getodk.org">ODK</a>.</p>
       </div>

--- a/apps/forms/index.html
+++ b/apps/forms/index.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"/>
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"/>
     <link rel="manifest" href="/site.webmanifest"/>
+    <script src="/apps/forms/src/init.js"></script>
     <style>
       .loading-container {
         text-align: center;
@@ -42,28 +43,6 @@
         font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
       }
     </style>
-    <script>
-      // NB use legacy JavaScript to support older browsers
-      var __handleInitializationErrors = function(event) {
-        if (!document.getElementById('loading')) {
-          // do not intercept errors after the app has loaded
-          return;
-        }
-        var message = event.message
-          || event.reason && event.reason.message
-          || 'An unknown error occurred.';
-        console.error('FATAL ERROR while loading forms app:', message);
-        document.getElementById('loading').style.display = 'none';
-        document.getElementById('loading-error').style.display = 'block';
-        document.getElementById('error-message').innerText = message;
-      };
-      var __deregisterInitializationErrorHandling = function() {
-        window.removeEventListener('error', __handleInitializationErrors, { capture: true, once: true });
-        window.removeEventListener('unhandledrejection', __handleInitializationErrors, { once: true });
-      };
-      window.addEventListener('error', __handleInitializationErrors, { capture: true, once: true });
-      window.addEventListener('unhandledrejection', __handleInitializationErrors, { once: true });
-    </script>
   </head>
   <body>
     <noscript>

--- a/apps/forms/index.html
+++ b/apps/forms/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"/>
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"/>
     <link rel="manifest" href="/site.webmanifest"/>
-    <script src="/apps/forms/src/init.js"></script>
+    <script src="/apps/forms/src/init.js" defer></script>
     <style>
       .loading-container {
         text-align: center;

--- a/apps/forms/index.html
+++ b/apps/forms/index.html
@@ -34,7 +34,32 @@
           transform: rotate(360deg);
         }
       }
+      #loading-error {
+        display: none;
+        margin: 20px auto;
+        max-width: 800px;
+        padding: 1rem;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
     </style>
+    <script>
+      const handle = (message) => {
+        if (!document.getElementById('loading')) {
+          // do not intercept errors after the app has loaded
+          return;
+        }
+        console.error('FATAL ERROR: loading forms app');
+        document.getElementById('loading').style.display = 'none';
+        document.getElementById('loading-error').style.display = 'block';
+        document.getElementById('error-message').innerText = message;
+      };
+      window.addEventListener('error', event => {
+        handle(event.message);
+      });
+      window.addEventListener('unhandledrejection', event => {
+        handle(event.reason && event.reason.message);
+      });
+    </script>
   </head>
   <body>
     <noscript>
@@ -45,6 +70,12 @@
       <span class="spinner"></span>
     </div>
     <div id="forms-app">
+      <div id="loading-error">
+        <h1>Error loading forms application</h1>
+        <p>Please try updating to the latest version of your browser or contact support.</p>
+        <p id="error-message"></p>
+        <p>Powered by <a href="https://getodk.org">ODK</a>.</p>
+      </div>
     </div>
     <script type="module" src="/apps/forms/src/main.ts"></script>
   </body>

--- a/apps/forms/index.html
+++ b/apps/forms/index.html
@@ -51,7 +51,7 @@
         console.error('FATAL ERROR: loading forms app');
         document.getElementById('loading').style.display = 'none';
         document.getElementById('loading-error').style.display = 'block';
-        document.getElementById('error-message').innerText = message;
+        document.getElementById('error-message').innerText = message ?? 'An unknown error occurred';
       };
       window.addEventListener('error', event => {
         handle(event.message);

--- a/apps/forms/src/Forms.vue
+++ b/apps/forms/src/Forms.vue
@@ -3,7 +3,9 @@ import { onMounted } from 'vue';
 import { RouterView } from 'vue-router';
 
 onMounted(() => {
-  globalThis.__deregisterInitializationErrorHandling();
+  if (globalThis.__deregisterInitializationErrorHandling) {
+    globalThis.__deregisterInitializationErrorHandling();
+  }
 });
 </script>
 

--- a/apps/forms/src/Forms.vue
+++ b/apps/forms/src/Forms.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
+import { onMounted } from 'vue';
 import { RouterView } from 'vue-router';
+
+onMounted(() => {
+  globalThis.__deregisterInitializationErrorHandling();
+});
 </script>
 
 <template>

--- a/apps/forms/src/init.js
+++ b/apps/forms/src/init.js
@@ -1,0 +1,18 @@
+// NB use legacy JavaScript to support older browsers
+var __handle = function(e) {
+  var spinner = document.getElementById('loading-spinner');
+  if (!spinner) return;
+  var error = document.getElementById('loading-error');
+  var message = document.getElementById('error-message');
+  var msg = e.message || (e.reason && e.reason.message) || 'An unknown error occurred.';
+  console.error('FATAL ERROR while loading forms app:', msg);
+  spinner.style.display = 'none';
+  if (error) error.style.display = 'block';
+  if (message) message.innerText = msg;
+};
+globalThis.__deregisterInitializationErrorHandling = function() {
+  window.removeEventListener('error', __handle, { capture: true });
+  window.removeEventListener('unhandledrejection', __handle);
+};
+window.addEventListener('error', __handle, { capture: true, once: true });
+window.addEventListener('unhandledrejection', __handle, { once: true });

--- a/apps/forms/src/init.js
+++ b/apps/forms/src/init.js
@@ -10,9 +10,11 @@ var __handle = function(e) {
   if (error) error.style.display = 'block';
   if (message) message.innerText = msg;
 };
-globalThis.__deregisterInitializationErrorHandling = function() {
-  window.removeEventListener('error', __handle, { capture: true });
-  window.removeEventListener('unhandledrejection', __handle);
-};
+if (globalThis) {
+  globalThis.__deregisterInitializationErrorHandling = function() {
+    window.removeEventListener('error', __handle, { capture: true });
+    window.removeEventListener('unhandledrejection', __handle);
+  };
+}
 window.addEventListener('error', __handle, { capture: true, once: true });
 window.addEventListener('unhandledrejection', __handle, { once: true });

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -68,7 +68,7 @@ function isTooBig({ path, size }) {
   const type = extname(path).substr(1);
   switch (type) {
     case 'css':         return size > 220_000;
-    case 'html':        return size >   2_500;
+    case 'html':        return size >   3_000;
     case 'ico':         return size >  16_000;
     case 'js':          return size > 200_000;
     case 'png':         return size > 700_000;

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -68,7 +68,7 @@ function isTooBig({ path, size }) {
   const type = extname(path).substr(1);
   switch (type) {
     case 'css':         return size > 220_000;
-    case 'html':        return size >   3_500;
+    case 'html':        return size >   4_000;
     case 'ico':         return size >  16_000;
     case 'js':          return size > 200_000;
     case 'png':         return size > 700_000;

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -68,7 +68,7 @@ function isTooBig({ path, size }) {
   const type = extname(path).substr(1);
   switch (type) {
     case 'css':         return size > 220_000;
-    case 'html':        return size >   4_000;
+    case 'html':        return size >   2_500;
     case 'ico':         return size >  16_000;
     case 'js':          return size > 200_000;
     case 'png':         return size > 700_000;

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -68,7 +68,7 @@ function isTooBig({ path, size }) {
   const type = extname(path).substr(1);
   switch (type) {
     case 'css':         return size > 220_000;
-    case 'html':        return size >   2_500;
+    case 'html':        return size >   3_500;
     case 'ico':         return size >  16_000;
     case 'js':          return size > 200_000;
     case 'png':         return size > 700_000;


### PR DESCRIPTION
Closes getodk/web-forms#538

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manually tested in multiple browsers with wasm disabled. I tried to find other features that would fail but I think I need an older browser.

#### Why is this the best possible solution? Were any other approaches considered?

This has to be handled outside of the main JS bundle because it happens when the bundle fails to load for whatever reason.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

When errors occur the loading spinner disappears and the error is shown. It should not impact users who haven't encountered errors.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
