### PR TITLE
fix: aligns dev nginx config with production equivalent

### DIFF
--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -52,6 +52,20 @@ http {
     default "/new${is_args}${args}${qp_deliminator}single=true";
   }
 
+  # Note: using $request_uri here remains safe while percent-encodings are not
+  # normalised in frontend URLs.  Tracked at https://github.com/getodk/central/issues/1532
+  map $request_uri $spa_name {
+    # form routes: approximately /f/... and /projects/.../forms/...
+    ~^/(?:f/[^/]+(?:/.*)?|projects/\d+/forms/[^/]+/(?:(?:draft/)?(?:preview|submissions/new(?:/offline)?)|submissions/[^/]+/edit)(?:/)?)(?:\?.*)?$
+      form-wrapper;
+    default
+      root-app;
+  }
+  map $spa_name $spa_html {
+    form-wrapper "/apps/forms/index.html";
+    default      "/index.html";
+  }
+
   server {
     listen 8686;
     server_name localhost;
@@ -143,32 +157,10 @@ http {
       return 404;
     }
 
-    # Handle requests for the Forms app
-    # Only relevant for `npm run dev:build`, not `npm run dev`.
-    # The first part of the regex matches public link paths and Enketo style paths, eg:
-    #   - /f/sCTIfjC5LrUto4yVXRYJkNKzP7e53vo?st=8T2mGshoNDbmWCUV7yd6qsYeojHrJSxih6EO3tJq5zVbJFHOx6ZLhif!$RUdmCHT
-    # The second part matches the restful paths, eg:
-    #   - /projects/123/forms/abc
-    #   - /projects/123/forms/abc/draft
-    #   - /projects/123/forms/abc/preview
-    #   - /projects/123/forms/abc/submissions/new
-    #   - /projects/123/forms/abc/submissions/{id}/edit
-    location ~ ^/f/.+|/projects/\d+/forms/[^/]+(?:/draft)?(?:/preview|/submissions/new(?:/offline)?/?|/submissions/[^/]+/edit)/?$ {
-      root /dist;
-      try_files $uri $uri/ /apps/forms/index.html;
-
-      include ./common-headers.conf;
-      # We return this header for more files in development than we do in
-      # production. That's needed because in development, unlike production,
-      # many file names don't contain hashes.
-      add_header Cache-Control no-cache;
-    }
-
     # central-frontend
-    # Only relevant for `npm run dev:build`, not `npm run dev`.
     location / {
       root /dist;
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/ $spa_html;
 
       include ./common-headers.conf;
       # We return this header for more files in development than we do in


### PR DESCRIPTION
Closes #

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Executed `npm run dev:build` and ensured forms were accessible.

#### Why is this the best possible solution? Were any other approaches considered?

The best possible solution would be to use the same file in both as much as possible, but this is better than letting them get more out of sync than they already are.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
