### PR TITLE
e2e-tests: ignore expected 401 errors

### DIFF
--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -43,6 +43,13 @@ const test = testBase.extend({
         if(browserName === 'chromium') {
           // See: https://github.com/getodk/central/issues/1997
           if(url.endsWith('/v1/config/analytics') && message.includes('404 (Not Found)')) return;
+
+          if(message.includes('Failed to load resource: the server responded with a status of 401 (Unauthorized)')) {
+            if(url.endsWith('/v1/sessions/restore')) return;
+
+            // See: https://github.com/getodk/central/issues/1686
+            if(url.includes('/-/submission/max-size/')) return;
+          }
         }
 
         if(url.includes('/-/')) {


### PR DESCRIPTION
* enketo max-size requests (https://github.com/getodk/central/issues/1686)
* central-backend session restore requests (should fail pre-login)

Ref https://github.com/getodk/central/issues/1979

#### What has been done to verify that this works as intended?

CI run: https://github.com/getodk/central-frontend/actions/runs/27675411707/job/81850543526?pr=1637
Logs:

```
$ cat job-logs-master.txt | grep 'Failed to load resource: the server responded with a status of 401 (Unauthorized)' | wc -l
30
$ cat job-logs.txt | grep 'Failed to load resource: the server responded with a status of 401 (Unauthorized)' | wc -l
0
```

#### Why is this the best possible solution? Were any other approaches considered?

These are chromium `fetch()` errors, and can't be disabled.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect - just test code.  These messages will still be logged in prod.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
