### PR TITLE
fix: output main js files to assets dir so they get cached

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -98,9 +98,9 @@ export default defineConfig(({ mode }) => ({
         entryFileNames: (chunkInfo) => {
           const moduleId = chunkInfo.facadeModuleId;
           if (moduleId && moduleId.includes('/apps/forms/')) {
-            return 'forms/[name]-[hash].js';
+            return 'assets/forms/[name]-[hash].js';
           }
-          return 'central/[name]-[hash].js';
+          return 'assets/central/[name]-[hash].js';
         }
       },
     },


### PR DESCRIPTION
Closes #

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Executed locally in a prod like environment and saw the cache headers were as expected.

#### Why is this the best possible solution? Were any other approaches considered?

One option was to change the nginx config to cache more paths, but it's complicated enough without additional changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Files are now cached as expected.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
