### PR TITLE
fix(web-forms#832): preserve spaces after output

### DIFF
--- a/.changeset/swift-hats-attack.md
+++ b/.changeset/swift-hats-attack.md
@@ -1,0 +1,6 @@
+---
+"@getodk/xforms-engine": patch
+"@getodk/forms": patch
+---
+
+Preserve spaces after output elements in dynamic labels

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -195,7 +195,7 @@ function escapeEditableChunks(chunks: readonly TextChunk[]) {
     .map((chunk, i) => {
       const str =
         chunk.source === 'literal'
-          ? chunk.asString.replace(LEADING_SPACES_AND_TABS_REGEX, '')
+          ? chunk.asString.replace(LEADING_SPACES_AND_TABS_REGEX, ' ')
           : chunk.asString;
       if (chunk.source === 'output') {
         // we need to process this separately otherwise user entered markup will

--- a/packages/xforms-engine/test/integration/label-hint-text.test.ts
+++ b/packages/xforms-engine/test/integration/label-hint-text.test.ts
@@ -191,9 +191,7 @@ describe('`<label>` and/or `<hint>` text', () => {
             bind('/data/question').type('string')
           )
         ),
-        body(
-          input('/data/question', t('label', 'Parcel <output value="/data/field"/> not found'))
-        )
+        body(input('/data/question', t('label', 'Parcel <output value="/data/field"/> not found')))
       )
     );
     scenario.next('/data/question');

--- a/packages/xforms-engine/test/integration/label-hint-text.test.ts
+++ b/packages/xforms-engine/test/integration/label-hint-text.test.ts
@@ -178,4 +178,30 @@ describe('`<label>` and/or `<hint>` text', () => {
       { value: 'Line 2' },
     ]);
   });
+
+  it('preserves space between `<output>` element and following text', async () => {
+    const scenario = await Scenario.init(
+      'label-space-after-output',
+      html(
+        head(
+          title('label-space-after-output'),
+          model(
+            mainInstance(t('data id="label-space-after-output"', t('field'), t('question'))),
+            bind('/data/field').type('string').calculate("'value'"),
+            bind('/data/question').type('string')
+          )
+        ),
+        body(
+          input('/data/question', t('label', 'Parcel <output value="/data/field"/> not found'))
+        )
+      )
+    );
+    scenario.next('/data/question');
+    const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/question' }).formatted;
+    expect(label).toMatchObject([
+      { value: 'Parcel ' },
+      { elementName: 'span', children: [{ value: 'value' }] },
+      { value: ' not found' },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/832

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
