### PR TITLE
fix(web-forms#827): Fix map not loading on first load in iOS Safari

### DIFF
--- a/.changeset/sour-houses-wink.md
+++ b/.changeset/sour-houses-wink.md
@@ -1,0 +1,6 @@
+---
+"@getodk/web-forms": patch
+"@getodk/forms": patch
+---
+
+Serialise MapBlock dynamic import to fix map not loading on first load in iOS Safari

--- a/packages/web-forms/src/components/common/map/AsyncMap.vue
+++ b/packages/web-forms/src/components/common/map/AsyncMap.vue
@@ -6,21 +6,12 @@
  */
 import { createFeatureCollectionAndProps } from '@/components/common/map/geojson-parsers.ts';
 import type { Mode, SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
+import { loadMapBlock, type MapBlockComponent } from '@/components/common/map/loadMapBlock.ts';
 import AsyncLoader from '@/components/common/AsyncLoader.vue';
 import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
 import type { Translate } from '@/lib/locale/useLocale.ts';
 import type { SelectItem } from '@getodk/xforms-engine';
-import type { Feature } from 'geojson';
-import { computed, type DefineComponent, inject, shallowRef } from 'vue';
-
-type MapBlockComponent = DefineComponent<{
-	featureCollection: { type: string; features: Feature[] };
-	disabled: boolean;
-	singleFeatureType?: SingleFeatureType;
-	mode: Mode;
-	orderedExtraProps: Map<string, Array<[key: string, value: string]>>;
-	savedFeatureValue: Feature | undefined;
-}>;
+import { computed, inject, shallowRef } from 'vue';
 
 interface AsyncMapProps {
 	features?: readonly SelectItem[];
@@ -46,11 +37,7 @@ const savedFeatureValue = computed(() => {
 });
 
 const loadMap = async () => {
-	mapComponent.value = (
-		(await import('./MapBlock.vue')) as {
-			default: MapBlockComponent;
-		}
-	).default;
+	mapComponent.value = await loadMapBlock();
 };
 
 const save = (value: string | undefined) => emit('save', value);

--- a/packages/web-forms/src/components/common/map/loadMapBlock.ts
+++ b/packages/web-forms/src/components/common/map/loadMapBlock.ts
@@ -1,0 +1,27 @@
+/**
+ * IMPORTANT: The dynamic import here keeps MapBlock (and its OpenLayers dependency) in a separate lazy chunk.
+ * Do not replace it with a static import.
+ *
+ * The module-level cache serialises concurrent imports. Safari throws "Cannot access 'default' before initialization"
+ * when multiple "import('./MapBlock.vue')" calls are in-flight simultaneously.
+ */
+import type { DefineComponent } from 'vue';
+import type { Mode, SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
+import type { Feature } from 'geojson';
+
+export type MapBlockComponent = DefineComponent<{
+  featureCollection: { type: string; features: Feature[] };
+  disabled: boolean;
+  singleFeatureType?: SingleFeatureType;
+  mode: Mode;
+  orderedExtraProps: Map<string, Array<[key: string, value: string]>>;
+  savedFeatureValue: Feature | undefined;
+}>;
+
+const cache = { promise: null as Promise<MapBlockComponent> | null };
+
+export const loadMapBlock = (): Promise<MapBlockComponent> => {
+  cache.promise ??= (async () =>
+    ((await import('./MapBlock.vue')) as { default: MapBlockComponent }).default)();
+  return cache.promise;
+};


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/827

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
iOS Safari throws on multiple dynamic imports

Issue before fix: only one map loads:
 
https://github.com/user-attachments/assets/b03083a2-6466-42f0-b220-9c6409a3fa3b

After the fix: 

https://github.com/user-attachments/assets/16c845c6-3eff-48aa-b35b-b91fe61f09fd


#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
