### PR TITLE
fix(web-forms#824): reset dompurify config when validating link href attributes

### DIFF
--- a/.changeset/two-paws-wish.md
+++ b/.changeset/two-paws-wish.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+Fixed markdown sanitization to reliably work for links

--- a/packages/web-forms/src/lib/format/markdown.ts
+++ b/packages/web-forms/src/lib/format/markdown.ts
@@ -38,6 +38,8 @@ export const getStylePropertyMap = (node: ParentMarkdownNode): StyleValue | unde
 export const getUrl = (node: ParentMarkdownNode): string | undefined => {
   if (node.elementName === 'a') {
     const url = (node as AnchorMarkdownNode).url;
+    // validate that the URL isn't a javascript prompt
+    DOMPurify.setConfig({ ALLOWED_TAGS: ['a'], ALLOWED_ATTR: ['href'] });
     if (!DOMPurify.isValidAttribute('a', 'href', url)) {
       return 'about:blank';
     }

--- a/packages/web-forms/src/lib/format/markdown.ts
+++ b/packages/web-forms/src/lib/format/markdown.ts
@@ -48,5 +48,6 @@ export const getUrl = (node: ParentMarkdownNode): string | undefined => {
 };
 
 export const purify = (node: HtmlMarkdownNode): string => {
-  return DOMPurify.sanitize(node.unsafeHtml, DOM_PURIFY_SETTINGS);
+  DOMPurify.setConfig(DOM_PURIFY_SETTINGS);
+  return DOMPurify.sanitize(node.unsafeHtml);
 };


### PR DESCRIPTION
Closes getodk/web-forms#824

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

DOMPurify stores the config that you last used, and applies it future checks. So, if the link runs first, DOMPurify uses default settings. If it runs second, it uses our settings which disallow links.

The solution here is to use two configs and set the right one before calling DOMPurify.

#### Why is this the best possible solution? Were any other approaches considered?

We could allow links in the default config but that would also allow HTML links which we don't want to do for security reasons.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
