### PR TITLE
fix(web-forms#815): catch uncaught errors

### DIFF
--- a/.changeset/frank-wings-attend.md
+++ b/.changeset/frank-wings-attend.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+Catch undefined errors and show a user facing dialog

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -37,6 +37,7 @@ import Message from 'primevue/message';
 import {
 	computed,
 	getCurrentInstance,
+	onErrorCaptured,
 	onUnmounted,
 	provide,
 	readonly,
@@ -44,6 +45,7 @@ import {
 	watch,
 	watchEffect,
 } from 'vue';
+import { FormInitializationError } from '@/lib/error/FormInitializationError';
 
 const webFormsVersion = __WEB_FORMS_VERSION__;
 type ObjectURL = `blob:${string}`;
@@ -200,6 +202,7 @@ const mediaCache = new Map<JRResourceURLString, ObjectURL>();
 provide(FORM_MEDIA_CACHE, mediaCache);
 
 const state = initializeFormState();
+const runtimeError = ref<FormInitializationError | null>(null);
 const submitPressed = ref(false);
 const floatingErrorActive = ref(false);
 const showValidationError = ref(false);
@@ -208,6 +211,10 @@ const isFormEditMode = ref(false);
 provide(IS_FORM_EDIT_MODE, readonly(isFormEditMode));
 const { setLanguage, t } = useLocale(computed(() => state.value.root));
 provide(TRANSLATE, t);
+
+onErrorCaptured(err => {
+	runtimeError.value = FormInitializationError.from(err);
+});
 
 watch(
 	() => state.value,
@@ -296,6 +303,10 @@ onUnmounted(() => {
 
 	<template v-if="state.status === 'FORM_STATE_FAILURE'">
 		<FormLoadFailureDialog severity="error" :error="state.error" />
+	</template>
+
+	<template v-else-if="runtimeError">
+		<FormLoadFailureDialog severity="error" :error="runtimeError" />
 	</template>
 
 	<div


### PR DESCRIPTION
Closes getodk/web-forms#815

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Catch any errors that propagate up to the web-forms vue component and display an undismisable dialog just like a form loading error. The error continues to propagate so sentry and console still get the error.

#### Why is this the best possible solution? Were any other approaches considered?

Over time it would be good to catch specific errors and handle in a more user friendly way, however we still need a catch all so errors are silently ignored.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Forms that previously failed silently will now block user access. If this causes too many disruptions for users we should reconsider but at least this will shine a light on the issue!

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
