### PR TITLE
DOMPurify: clear persistent config before sanitisation

### DIFF
--- a/apps/central/src/components/markdown/view.vue
+++ b/apps/central/src/components/markdown/view.vue
@@ -44,6 +44,7 @@ export default {
   computed: {
     renderedMarkdown() {
       const md = marked.parse(this.rawMarkdown, { gfm: true, breaks: true });
+      DOMPurify.clearConfig();
       const santized = DOMPurify.sanitize(md, {
         FORBID_ATTR: forbiddenAttributes,
         ALLOWED_TAGS: allowedTags,

--- a/apps/central/src/components/markdown/view.vue
+++ b/apps/central/src/components/markdown/view.vue
@@ -20,13 +20,6 @@ except according to the terms contained in the LICENSE file.
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if ('target' in node) {
-    node.setAttribute('target', '_blank');
-    node.setAttribute('rel', 'noreferrer noopener');
-  }
-});
-
 const forbiddenAttributes = ['style', 'class', 'id', 'data'];
 const allowedTags = ['a', 'b', 'br', 'code', 'em',
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
@@ -44,7 +37,17 @@ export default {
   computed: {
     renderedMarkdown() {
       const md = marked.parse(this.rawMarkdown, { gfm: true, breaks: true });
+
       DOMPurify.clearConfig();
+      DOMPurify.removeAllHooks();
+
+      DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+        if ('target' in node) {
+          node.setAttribute('target', '_blank');
+          node.setAttribute('rel', 'noreferrer noopener');
+        }
+      });
+
       const santized = DOMPurify.sanitize(md, {
         FORBID_ATTR: forbiddenAttributes,
         ALLOWED_TAGS: allowedTags,

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 import MarkdownView from '../../../src/components/markdown/view.vue';
 
 import { mount } from '../../util/lifecycle';
@@ -8,46 +10,55 @@ const mountComponent = (raw) => mount(MarkdownView, {
   }
 });
 
-describe('MarkdownView', () => {
-  it('renders basic text', () => {
-    const component = mountComponent('some text');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"><p>some text</p>\n</div>');
-  });
+describe.only('MarkdownView', () => {
+  [
+    [ 'clean slate',                () => DOMPurify.clearConfig() ],
+    [ 'polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] }) ],
+  ].forEach(([ description, setupFn ]) => {
+    describe(description, () => {
+      beforeEach(setupFn);
 
-  it('shows rendered markdown', () => {
-    const component = mountComponent('Some **bold** comment');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"><p>Some <strong>bold</strong> comment</p>\n</div>');
-  });
+      it('renders basic text', () => {
+        const component = mountComponent('some text');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"><p>some text</p>\n</div>');
+      });
 
-  it('shows a multi-line input rendered on multiple lines', () => {
-    const component = mountComponent('Line 1\nLine 2');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"><p>Line 1<br>Line 2</p>\n</div>');
-  });
+      it('shows rendered markdown', () => {
+        const component = mountComponent('Some **bold** comment');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"><p>Some <strong>bold</strong> comment</p>\n</div>');
+      });
 
-  it('augments links to add target=_blank and open in new tab', () => {
-    const component = mountComponent('[link](https://getodk.org)');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"><p><a href="https://getodk.org" target="_blank" rel="noreferrer noopener">link</a></p>\n</div>');
-  });
+      it('shows a multi-line input rendered on multiple lines', () => {
+        const component = mountComponent('Line 1\nLine 2');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"><p>Line 1<br>Line 2</p>\n</div>');
+      });
 
-  it('does allow raw html in markdown', () => {
-    const component = mountComponent('<b>bold</b>');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"><p><b>bold</b></p>\n</div>');
-  });
+      it('augments links to add target=_blank and open in new tab', () => {
+        const component = mountComponent('[link](https://getodk.org)');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"><p><a href="https://getodk.org" target="_blank" rel="noreferrer noopener">link</a></p>\n</div>');
+      });
 
-  it('removes script and svg tags and sanitizes html', () => {
-    const component = mountComponent('<script>foo</script><svg>bar</svg>');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"></div>');
-  });
+      it('does allow raw html in markdown', () => {
+        const component = mountComponent('<b>bold</b>');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"><p><b>bold</b></p>\n</div>');
+      });
 
-  it('removes unwanted attributes', () => {
-    const component = mountComponent('<b style="color: red;" class="c" data-foo="bar">foo</b>');
-    const { outerHTML } = component.get('div').element;
-    outerHTML.should.equal('<div class="markdown-view"><p><b>foo</b></p>\n</div>');
+      it('removes script and svg tags and sanitizes html', () => {
+        const component = mountComponent('<script>foo</script><svg>bar</svg>');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"></div>');
+      });
+
+      it('removes unwanted attributes', () => {
+        const component = mountComponent('<b style="color: red;" class="c" data-foo="bar">foo</b>');
+        const { outerHTML } = component.get('div').element;
+        outerHTML.should.equal('<div class="markdown-view"><p><b>foo</b></p>\n</div>');
+      });
+    });
   });
 });

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -14,7 +14,8 @@ describe('MarkdownView', () => {
   [
     ['clean slate',                () => { DOMPurify.clearConfig(); DOMPurify.removeAllHooks(); }], // eslint-disable-line no-multi-spaces
     ['polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] })],
-    ['stray hooks',                () => DOMPurify.addHook('uponSanitizeAttribute', (_, hookEvent) => { hookEvent.forceKeepAttr = true; })], // eslint-disable-line no-multi-spaces,no-param-reassign
+    ['stray hooks - meddling',     () => DOMPurify.addHook('uponSanitizeAttribute', (_, hookEvent) => { hookEvent.forceKeepAttr = true; })], // eslint-disable-line no-multi-spaces,no-param-reassign
+    ['stray hooks - breaking',     () => DOMPurify.addHook('uponSanitizeAttribute', () => { throw new Error('Unexpected!?'); })], // eslint-disable-line no-multi-spaces
   ].forEach(([description, setupFn]) => {
     describe(description, () => {
       beforeEach(setupFn);

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -14,7 +14,7 @@ describe('MarkdownView', () => {
   [
     ['clean slate',                () => { DOMPurify.clearConfig(); DOMPurify.removeAllHooks(); }], // eslint-disable-line no-multi-spaces
     ['polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] })],
-    ['stray hooks',                () => DOMPurify.addHook('uponSanitizeAttribute', (_, hookEvent) => hookEvent.forceKeepAttr = true)], // eslint-disable-line no-multi-spaces
+    ['stray hooks',                () => DOMPurify.addHook('uponSanitizeAttribute', (_, hookEvent) => { hookEvent.forceKeepAttr = true; })], // eslint-disable-line no-multi-spaces,no-param-reassign
   ].forEach(([description, setupFn]) => {
     describe(description, () => {
       beforeEach(setupFn);

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -12,9 +12,9 @@ const mountComponent = (raw) => mount(MarkdownView, {
 
 describe.only('MarkdownView', () => {
   [
-    [ 'clean slate',                () => DOMPurify.clearConfig() ],
-    [ 'polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] }) ],
-  ].forEach(([ description, setupFn ]) => {
+    ['clean slate',                () => DOMPurify.clearConfig()], // eslint-disable-line no-multi-spaces
+    ['polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] })],
+  ].forEach(([description, setupFn]) => {
     describe(description, () => {
       beforeEach(setupFn);
 

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -10,7 +10,7 @@ const mountComponent = (raw) => mount(MarkdownView, {
   }
 });
 
-describe.only('MarkdownView', () => {
+describe('MarkdownView', () => {
   [
     ['clean slate',                () => { DOMPurify.clearConfig(); DOMPurify.removeAllHooks(); }], // eslint-disable-line no-multi-spaces
     ['polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] })],

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -10,10 +10,11 @@ const mountComponent = (raw) => mount(MarkdownView, {
   }
 });
 
-describe('MarkdownView', () => {
+describe.only('MarkdownView', () => {
   [
-    ['clean slate',                () => DOMPurify.clearConfig()], // eslint-disable-line no-multi-spaces
+    ['clean slate',                () => { DOMPurify.clearConfig(); DOMPurify.removeAllHooks(); }], // eslint-disable-line no-multi-spaces
     ['polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] })],
+    ['stray hooks',                () => DOMPurify.addHook('uponSanitizeAttribute', (_, hookEvent) => hookEvent.forceKeepAttr = true)], // eslint-disable-line no-multi-spaces
   ].forEach(([description, setupFn]) => {
     describe(description, () => {
       beforeEach(setupFn);

--- a/apps/central/test/components/markdown/view.spec.js
+++ b/apps/central/test/components/markdown/view.spec.js
@@ -10,7 +10,7 @@ const mountComponent = (raw) => mount(MarkdownView, {
   }
 });
 
-describe.only('MarkdownView', () => {
+describe('MarkdownView', () => {
   [
     ['clean slate',                () => DOMPurify.clearConfig()], // eslint-disable-line no-multi-spaces
     ['polluted persistent config', () => DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] })],


### PR DESCRIPTION
By design, DOMPurify falls back to a global "persistent" configuration if set with `DOMPurify.setConfig(...)`.  This means that 3rd-party calls to `DOMPurify.setConfig()` can break expectations about content filtering.

See:

* https://github.com/cure53/DOMPurify#persistent-configuration
* https://github.com/cure53/DOMPurify/issues/1134

Related:

* https://github.com/getodk/central-frontend/pull/1643
* https://github.com/enketo/enketo/pull/1541

#### What has been done to verify that this works as intended?

Added a set of tests that fail without the change to application code, but pass with it.

#### Why is this the best possible solution? Were any other approaches considered?

This behvaiour is surprising, and the only sure approach to avoiding it seems to be the call to `clearConfig()`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No effect.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes