### PR TITLE
Feature: add access filter options on dataset settings page

### DIFF
--- a/.changeset/loud-spoons-tickle.md
+++ b/.changeset/loud-spoons-tickle.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": patch
+---
+
+Feature: add access filter options on dataset settings page

--- a/apps/central/src/components/dataset/owner-only.vue
+++ b/apps/central/src/components/dataset/owner-only.vue
@@ -10,15 +10,15 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div class="panel panel-simple">
+  <div id="dataset-owner-only" class="panel panel-simple">
     <div class="panel-heading">
       <h1 class="panel-title">{{ $t('panel.title') }}</h1>
     </div>
     <div class="panel-body">
-      <form @change="confirmationModal.show()" @submit.prevent>
+      <form v-if="!actorProperties.initiallyLoading" @change="openModal" @submit.prevent>
         <div class="radio">
           <label>
-            <input v-model="ownerOnly" type="radio" :value="false"
+            <input v-model="accessType" type="radio" value="all"
               aria-describedby="dataset-owner-only-false-help"
               :disabled="awaitingResponse">
             <strong>{{ $t('accessAllDefault') }}</strong>
@@ -29,7 +29,7 @@ except according to the terms contained in the LICENSE file.
         </div>
         <div class="radio">
           <label>
-            <input v-model="ownerOnly" type="radio" :value="true"
+            <input v-model="accessType" type="radio" value="ownerOnly"
               aria-describedby="dataset-owner-only-true-help"
               :disabled="awaitingResponse">
             <strong>{{ $t('ownerOnly') }}</strong>
@@ -38,16 +38,88 @@ except according to the terms contained in the LICENSE file.
             {{ $t('radio.true') }}
           </p>
         </div>
+        <div class="radio" :class="{ disabled: filterByPropertyDisabled }"
+          v-tooltip.no-aria="filterByPropertyDisabled ? disabledReason : null">
+          <label>
+            <input v-model="accessType" type="radio" value="property"
+              aria-describedby="dataset-filter-by-property-help"
+              :disabled="awaitingResponse || filterByPropertyDisabled">
+            <strong>{{ $t('filterByProperty.label') }}</strong>
+          </label>
+          <p id="dataset-filter-by-property-help" class="help-block">
+            {{ $t('filterByProperty.description') }}
+          </p>
+          <p v-if="dataset.accessFilter?.type === 'property'" class="current-filter-rule">
+            <i18n-t keypath="filterByProperty.currentRule">
+              <template #entityProperty>
+                <strong>{{ dataset.accessFilter.rules[0].datasetProperty }}</strong>
+              </template>
+              <template #userProperty>
+                <strong>{{ dataset.accessFilter.rules[0].actorProperty }}</strong>
+              </template>
+            </i18n-t>
+            <button type="button" class="btn btn-link" @click="openModal">
+              {{ $t('filterByProperty.action.change') }}
+            </button>
+          </p>
+        </div>
       </form>
+      <loading :state="actorProperties.initiallyLoading"/>
     </div>
   </div>
   <modal v-bind="confirmationModal" :hideable="!awaitingResponse" backdrop
     @hide="cancel">
-    <template #title>{{ ownerOnly ? $t('ownerOnly') : $t('accessAll') }}</template>
+    <template #title>
+      <template v-if="accessType === 'all'">
+        {{ $t('accessAll') }}
+      </template>
+      <template v-else-if="accessType === 'ownerOnly'">
+        {{ $t('ownerOnly') }}
+      </template>
+      <template v-else>
+        {{ $t('accessByFilterRule.title') }}
+      </template>
+    </template>
     <template #body>
       <p class="modal-introduction">
-        {{ ownerOnly ? $t('trueModal.introduction') : $t('falseModal.introduction') }}
+        <template v-if="accessType === 'all'">
+          {{ $t('falseModal.introduction') }}
+        </template>
+        <template v-else-if="accessType === 'ownerOnly'">
+          {{ $t('trueModal.introduction') }}
+        </template>
+        <template v-else>
+          {{ $t('accessByFilterRule.introduction') }}
+        </template>
       </p>
+      <div v-if="accessType === 'property'" ref="ruleSelector" class="filter-by-property-selects">
+        <label class="filter-select-label">
+          {{ $t('filterByProperty.entityPropertyLabel') }}
+          <select v-model="selectedEntityProperty"
+            class="form-control" :disabled="awaitingResponse" required>
+            <option value="" disabled>
+              {{ $t('filterByProperty.entityPropertyPlaceholder') }}
+            </option>
+            <option v-for="property of dataset.properties" :key="property.name"
+              :value="property.name">
+              {{ property.name }}
+            </option>
+          </select>
+        </label>
+        <label class="filter-select-label">
+          {{ $t('filterByProperty.userPropertyLabel') }}
+          <select v-model="selectedUserProperty"
+            class="form-control" :disabled="awaitingResponse" required>
+            <option value="" disabled>
+              {{ $t('filterByProperty.userPropertyPlaceholder') }}
+            </option>
+            <option v-for="property of actorProperties" :key="property.name"
+              :value="property.name">
+              {{ property.name }}
+            </option>
+          </select>
+        </label>
+      </div>
       <div class="modal-actions">
         <button type="button" class="btn btn-link"
           :aria-disabled="awaitingResponse" @click="cancel">
@@ -55,7 +127,15 @@ except according to the terms contained in the LICENSE file.
         </button>
         <button type="button" class="btn btn-primary"
           :aria-disabled="awaitingResponse" @click="confirm">
-          {{ ownerOnly ? $t('trueModal.action.confirm') : $t('accessAll') }}
+          <template v-if="accessType === 'all'">
+            {{ $t('accessAll') }}
+          </template>
+          <template v-else-if="accessType === 'ownerOnly'">
+            {{ $t('trueModal.action.confirm') }}
+          </template>
+          <template v-else>
+            {{ $t('accessByFilterRule.action.save') }}
+          </template>
           <spinner :state="awaitingResponse"/>
         </button>
       </div>
@@ -64,7 +144,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
-import { inject, ref, watch } from 'vue';
+import { computed, inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import Modal from '../modal.vue';
@@ -75,6 +155,7 @@ import { apiPaths } from '../../util/request';
 import { modalData } from '../../util/reactivity';
 import { noop } from '../../util/util';
 import { useRequestData } from '../../request-data';
+import Loading from '../loading.vue';
 
 defineOptions({
   name: 'DatasetOwnerOnly'
@@ -85,46 +166,147 @@ const { alert } = inject('container');
 
 // The component assumes that this data will exist when the component is
 // created.
-const { dataset } = useRequestData();
+const { dataset, createResource } = useRequestData();
+const { request, awaitingResponse } = useRequest();
 
-const ownerOnly = ref(false);
-watch(
-  () => dataset.dataExists,
-  (dataExists) => { if (dataExists) ownerOnly.value = dataset.ownerOnly; },
-  { immediate: true }
-);
+// Create and fetch actorProperties for this component
+const actorProperties = createResource('actorProperties');
+actorProperties.request({
+  url: apiPaths.actorProperties(dataset.projectId),
+  resend: false
+}).catch(noop);
+
+const hasDatasetProperties = computed(() => dataset.properties.length > 0);
+const hasActorProperties = computed(() => actorProperties.length > 0);
+
+const filterByPropertyDisabled = computed(() =>
+  !hasDatasetProperties.value || !hasActorProperties.value);
+
+const disabledReason = computed(() => {
+  if (!hasDatasetProperties.value && !hasActorProperties.value)
+    return t('filterByProperty.disabled.both');
+  if (!hasDatasetProperties.value)
+    return t('filterByProperty.disabled.datasetProperties');
+  if (!hasActorProperties.value)
+    return t('filterByProperty.disabled.userProperties');
+  return null;
+});
+
+const accessType = ref(dataset.accessFilter?.type ?? 'all');
+
+const selectedEntityProperty = ref('');
+const selectedUserProperty = ref('');
+const ruleSelector = ref(null);
 
 const confirmationModal = modalData();
+const populateDropdowns = () => {
+  const [rule] = dataset.accessFilter?.rules ?? [];
+  if (rule != null) {
+    selectedEntityProperty.value = rule.datasetProperty;
+    selectedUserProperty.value = rule.actorProperty;
+  } else {
+    selectedEntityProperty.value = '';
+    selectedUserProperty.value = '';
+  }
+};
+const openModal = () => {
+  populateDropdowns();
+  confirmationModal.show();
+};
 const cancel = () => {
   confirmationModal.hide();
-  ownerOnly.value = !ownerOnly.value;
+  accessType.value = dataset.accessFilter?.type ?? 'all';
 };
 
-const { request, awaitingResponse } = useRequest();
-const update = async (value) => {
-  const { data } = await request({
+let previousAccessFilter = null;
+
+const update = async (accessFilter) => {
+  const resp = await request({
     method: 'PATCH',
     url: apiPaths.dataset(dataset.projectId, dataset.name),
-    data: { ownerOnly: value }
-  });
-  dataset.ownerOnly = data.ownerOnly;
-};
-const undo = () => update(!ownerOnly.value)
-  .then(() => {
-    ownerOnly.value = !ownerOnly.value;
+    data: { accessFilter }
+  }).catch(noop);
+
+  if (resp?.data) {
+    previousAccessFilter = dataset.accessFilter ? { ...dataset.accessFilter } : null;
+
+    dataset.ownerOnly = resp.data.ownerOnly;
+    dataset.accessFilter = resp.data.accessFilter;
     return true;
-  })
-  .catch(noop);
-const confirm = () => update(ownerOnly.value)
-  .then(() => {
+  }
+
+  return false;
+};
+
+const undo = () => {
+  const newAccessType = previousAccessFilter?.type ?? 'all';
+  return update(previousAccessFilter)
+    .then((result) => {
+      if (result) {
+        accessType.value = newAccessType;
+      }
+      return result;
+    });
+};
+
+const confirm = async () => {
+  if (accessType.value === 'property') {
+    const selects = ruleSelector.value.querySelectorAll('select');
+    for (const select of selects) {
+      if (!select.reportValidity()) return;
+    }
+  }
+  const accessFilter = accessType.value === 'all' ? null : { type: accessType.value };
+  if (accessType.value === 'property') {
+    accessFilter.rules = [{
+      datasetProperty: selectedEntityProperty.value,
+      actorProperty: selectedUserProperty.value
+    }];
+  }
+
+  const result = await update(accessFilter);
+
+  if (result) {
     confirmationModal.hide();
-    const message = dataset.ownerOnly
-      ? t('alert.changeToTrue')
-      : t('alert.changeToFalse');
+    let message;
+    if (dataset.accessFilter?.type === 'property') {
+      message = t('alert.changeToProperty');
+    } else if (dataset.ownerOnly) {
+      message = t('alert.changeToTrue');
+    } else {
+      message = t('alert.changeToFalse');
+    }
     alert.success(message).cta(t('action.undo'), undo);
-  })
-  .catch(noop);
+  }
+};
 </script>
+
+<style lang="scss">
+@import '../../assets/scss/variables';
+
+#dataset-owner-only {
+  .current-filter-rule {
+    margin-top: -10px;
+    margin-left: 20px;
+  }
+}
+
+.filter-by-property-selects {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+}
+
+.filter-select-label {
+  flex-grow: 1;
+  font-size: 12px;
+
+  .form-control {
+    margin-top: 5px;
+    font-weight: normal;
+  }
+}
+</style>
 
 <i18n lang="json5">
 {
@@ -140,6 +322,24 @@ const confirm = () => update(ownerOnly.value)
       "false": "App Users and Data Collectors within this Project will have access to all Entities within their assigned Forms.",
       "true": "App Users and Data Collectors within this Project will only have access to the Entities they create, promoting privacy and limiting data transfers."
     },
+    "filterByProperty": {
+      "label": "Filter by Property",
+      "description": "Define rules for which Entities are visible to App Users and Data Collectors by comparing their properties.",
+      "entityPropertyLabel": "Only see Entities where",
+      "entityPropertyPlaceholder": "Entity property",
+      "userPropertyLabel": "is equal to the user’s",
+      "userPropertyPlaceholder": "User property",
+      "disabled": {
+        "datasetProperties": "There are no dataset properties defined.",
+        "userProperties": "There are no user properties defined.",
+        "both": "There are no dataset and user properties defined."
+      },
+      "action": {
+        "change": "Change"
+      },
+      // {entityProperty} is the name of an Entity property. {userProperty} is the name of a User property.
+      "currentRule": "Rule: {entityProperty} (Entity property) = {userProperty} (User property)"
+    },
     "falseModal": {
       "introduction": "App Users and Data Collectors will have access to all Entities, including ones they did not create."
     },
@@ -151,7 +351,15 @@ const confirm = () => update(ownerOnly.value)
     },
     "alert": {
       "changeToFalse": "App Users and Data Collectors will now have access to all Entities.",
-      "changeToTrue": "App Users and Data Collectors will now only have access to Entities they create."
+      "changeToTrue": "App Users and Data Collectors will now only have access to Entities they create.",
+      "changeToProperty": "App Users and Data Collectors will now only have access to Entities matching the filter rule."
+    },
+    "accessByFilterRule": {
+      "title": "Filter by Property",
+      "introduction": "App Users and Data Collectors will only have access to Entities where the selected property matches their user property.",
+      "action": {
+        "save": "Save Filter Rule"
+      }
     }
   }
 }

--- a/apps/central/src/components/dataset/owner-only.vue
+++ b/apps/central/src/components/dataset/owner-only.vue
@@ -218,16 +218,14 @@ const cancel = () => {
 let previousAccessFilter = null;
 
 const update = async (accessFilter) => {
-  const resp = await request({
+  const { data } = await request({
     method: 'PATCH',
     url: apiPaths.dataset(dataset.projectId, dataset.name),
     data: { accessFilter }
   });
 
-  if (resp?.data) {
-    previousAccessFilter = dataset.accessFilter;
-    Object.assign(dataset.data, { accessFilter: null }, resp.data);
-  }
+  previousAccessFilter = dataset.accessFilter;
+  Object.assign(dataset.data, { accessFilter: null }, data);
 };
 
 const undo = () => {

--- a/apps/central/src/components/dataset/owner-only.vue
+++ b/apps/central/src/components/dataset/owner-only.vue
@@ -15,7 +15,7 @@ except according to the terms contained in the LICENSE file.
       <h1 class="panel-title">{{ $t('panel.title') }}</h1>
     </div>
     <div class="panel-body">
-      <form v-if="!actorProperties.initiallyLoading" @change="openModal" @submit.prevent>
+      <form v-if="actorProperties.dataExists" @change="openModal" @submit.prevent>
         <div class="radio">
           <label>
             <input v-model="accessType" type="radio" value="all"
@@ -59,7 +59,7 @@ except according to the terms contained in the LICENSE file.
               </template>
             </i18n-t>
             <button type="button" class="btn btn-link" @click="openModal">
-              {{ $t('filterByProperty.action.change') }}
+              {{ $t('action.change') }}
             </button>
           </p>
         </div>
@@ -92,7 +92,8 @@ except according to the terms contained in the LICENSE file.
           {{ $t('accessByFilterRule.introduction') }}
         </template>
       </p>
-      <div v-if="accessType === 'property'" ref="ruleSelector" class="filter-by-property-selects">
+      <form v-if="accessType === 'property'" id="property-filter-form"
+        class="filter-by-property-selects" @submit.prevent="confirm">
         <label class="filter-select-label">
           {{ $t('filterByProperty.entityPropertyLabel') }}
           <select v-model="selectedEntityProperty"
@@ -119,23 +120,21 @@ except according to the terms contained in the LICENSE file.
             </option>
           </select>
         </label>
-      </div>
+      </form>
       <div class="modal-actions">
         <button type="button" class="btn btn-link"
           :aria-disabled="awaitingResponse" @click="cancel">
           {{ $t('action.cancel') }}
         </button>
-        <button type="button" class="btn btn-primary"
+        <button v-if="accessType === 'property'" type="submit"
+          form="property-filter-form" class="btn btn-primary"
+          :aria-disabled="awaitingResponse">
+          {{ $t('accessByFilterRule.action.save') }}
+          <spinner :state="awaitingResponse"/>
+        </button>
+        <button v-else type="button" class="btn btn-primary"
           :aria-disabled="awaitingResponse" @click="confirm">
-          <template v-if="accessType === 'all'">
-            {{ $t('accessAll') }}
-          </template>
-          <template v-else-if="accessType === 'ownerOnly'">
-            {{ $t('trueModal.action.confirm') }}
-          </template>
-          <template v-else>
-            {{ $t('accessByFilterRule.action.save') }}
-          </template>
+          {{ accessType === 'all' ? $t('accessAll') : $t('trueModal.action.confirm') }}
           <spinner :state="awaitingResponse"/>
         </button>
       </div>
@@ -166,11 +165,10 @@ const { alert } = inject('container');
 
 // The component assumes that this data will exist when the component is
 // created.
-const { dataset, createResource } = useRequestData();
+const { dataset, actorProperties } = useRequestData();
 const { request, awaitingResponse } = useRequest();
 
 // Create and fetch actorProperties for this component
-const actorProperties = createResource('actorProperties');
 actorProperties.request({
   url: apiPaths.actorProperties(dataset.projectId),
   resend: false
@@ -196,7 +194,6 @@ const accessType = ref(dataset.accessFilter?.type ?? 'all');
 
 const selectedEntityProperty = ref('');
 const selectedUserProperty = ref('');
-const ruleSelector = ref(null);
 
 const confirmationModal = modalData();
 const populateDropdowns = () => {
@@ -225,37 +222,25 @@ const update = async (accessFilter) => {
     method: 'PATCH',
     url: apiPaths.dataset(dataset.projectId, dataset.name),
     data: { accessFilter }
-  }).catch(noop);
+  });
 
   if (resp?.data) {
-    previousAccessFilter = dataset.accessFilter ? { ...dataset.accessFilter } : null;
-
-    dataset.ownerOnly = resp.data.ownerOnly;
-    dataset.accessFilter = resp.data.accessFilter;
-    return true;
+    previousAccessFilter = dataset.accessFilter;
+    Object.assign(dataset.data, { accessFilter: null }, resp.data);
   }
-
-  return false;
 };
 
 const undo = () => {
   const newAccessType = previousAccessFilter?.type ?? 'all';
   return update(previousAccessFilter)
-    .then((result) => {
-      if (result) {
-        accessType.value = newAccessType;
-      }
-      return result;
-    });
+    .then(() => {
+      accessType.value = newAccessType;
+      return true;
+    })
+    .catch(noop);
 };
 
-const confirm = async () => {
-  if (accessType.value === 'property') {
-    const selects = ruleSelector.value.querySelectorAll('select');
-    for (const select of selects) {
-      if (!select.reportValidity()) return;
-    }
-  }
+const confirm = () => {
   const accessFilter = accessType.value === 'all' ? null : { type: accessType.value };
   if (accessType.value === 'property') {
     accessFilter.rules = [{
@@ -264,20 +249,20 @@ const confirm = async () => {
     }];
   }
 
-  const result = await update(accessFilter);
-
-  if (result) {
-    confirmationModal.hide();
-    let message;
-    if (dataset.accessFilter?.type === 'property') {
-      message = t('alert.changeToProperty');
-    } else if (dataset.ownerOnly) {
-      message = t('alert.changeToTrue');
-    } else {
-      message = t('alert.changeToFalse');
-    }
-    alert.success(message).cta(t('action.undo'), undo);
-  }
+  return update(accessFilter)
+    .then(() => {
+      confirmationModal.hide();
+      let message;
+      if (dataset.accessFilter?.type === 'property') {
+        message = t('alert.changeToProperty');
+      } else if (dataset.accessFilter?.type === 'ownerOnly') {
+        message = t('alert.changeToTrue');
+      } else {
+        message = t('alert.changeToFalse');
+      }
+      alert.success(message).cta(t('action.undo'), undo);
+    })
+    .catch(noop);
 };
 </script>
 
@@ -313,7 +298,7 @@ const confirm = async () => {
   "en": {
     "panel": {
       // This is a title shown above a section of the page.
-      "title": "App User and Data Collector Entity Access"
+      "title": "Entity List Access"
     },
     "accessAll": "Access all Entities",
     "accessAllDefault": "Access all Entities (default)",
@@ -325,17 +310,18 @@ const confirm = async () => {
     "filterByProperty": {
       "label": "Filter by Property",
       "description": "Define rules for which Entities are visible to App Users and Data Collectors by comparing their properties.",
+      // This text is shown above the access rule filter dropdown. Translators are free not to translate this literally
       "entityPropertyLabel": "Only see Entities where",
+      // Placeholder text shown on a access rule filter dropdown.
       "entityPropertyPlaceholder": "Entity property",
+      // This text is shown above the access rule filter dropdown. Translators are free not to translate this literally
       "userPropertyLabel": "is equal to the user’s",
+      // Placeholder text shown on a access rule filter dropdown
       "userPropertyPlaceholder": "User property",
       "disabled": {
-        "datasetProperties": "There are no dataset properties defined.",
+        "datasetProperties": "There are no Entity properties defined.",
         "userProperties": "There are no user properties defined.",
-        "both": "There are no dataset and user properties defined."
-      },
-      "action": {
-        "change": "Change"
+        "both": "There are no Entity or user properties defined."
       },
       // {entityProperty} is the name of an Entity property. {userProperty} is the name of a User property.
       "currentRule": "Rule: {entityProperty} (Entity property) = {userProperty} (User property)"
@@ -352,11 +338,11 @@ const confirm = async () => {
     "alert": {
       "changeToFalse": "App Users and Data Collectors will now have access to all Entities.",
       "changeToTrue": "App Users and Data Collectors will now only have access to Entities they create.",
-      "changeToProperty": "App Users and Data Collectors will now only have access to Entities matching the filter rule."
+      "changeToProperty": "App Users and Public Links will now only have access to Entities matching the filter rule."
     },
     "accessByFilterRule": {
       "title": "Filter by Property",
-      "introduction": "App Users and Data Collectors will only have access to Entities where the selected property matches their user property.",
+      "introduction": "App Users and Public Links will only have access to Entities where the selected property matches their user property.",
       "action": {
         "save": "Save Filter Rule"
       }

--- a/apps/central/src/components/dataset/show.vue
+++ b/apps/central/src/components/dataset/show.vue
@@ -107,7 +107,8 @@ export default {
   setup() {
     // The component does not assume that this data will exist when the
     // component is created.
-    const { project, dataset, resourceStates } = useRequestData();
+    const { project, dataset, resourceStates, createResource } = useRequestData();
+    createResource('actorProperties');
 
     const { projectPath, datasetPath, canRoute, publishedFormPath } = useRoutes();
     const { tabPath, tabClass } = useTabs(datasetPath());

--- a/apps/central/src/locales/en.json5
+++ b/apps/central/src/locales/en.json5
@@ -235,7 +235,8 @@
     "restore": "Restore",
     "selectRow": "Select row",
     // This text is shown on a button that resets the data filters
-    "reset": "Reset"
+    "reset": "Reset",
+    "change": "Change"
   },
   "field": {
     "comment": "Leave a comment…",

--- a/apps/central/test/components/dataset/owner-only.spec.js
+++ b/apps/central/test/components/dataset/owner-only.spec.js
@@ -5,20 +5,25 @@ import testData from '../../data';
 import { load, mockHttp } from '../../util/http';
 import { mockLogin } from '../../util/session';
 import { mount } from '../../util/lifecycle';
+import { testRequestData } from '../../util/request-data';
 
 const mountOptions = () => ({
   container: {
-    requestData: { dataset: testData.extendedDatasets.last() }
+    requestData: testRequestData(['actorProperties'], {
+      dataset: testData.extendedDatasets.last(),
+      actorProperties: testData.actorProperties.sorted()
+    })
   }
 });
+
 const mountComponent = () => mount(DatasetOwnerOnly, mountOptions());
 
 describe('DatasetOwnerOnly', () => {
   describe('modal text', () => {
-    it('shows the correct modal after false is selected', async () => {
-      testData.extendedDatasets.createPast(1, { ownerOnly: true });
+    it('shows the correct modal after "Access all" is selected', async () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
       const component = mountComponent();
-      await component.get('input').setChecked();
+      await component.get('input[value="all"]').setChecked();
       component.getComponent(Modal).props().state.should.be.true;
       component.get('.modal-title').text().should.equal('Access all Entities');
       const introduction = component.get('.modal-introduction').text();
@@ -27,10 +32,10 @@ describe('DatasetOwnerOnly', () => {
       buttonText.should.equal('Access all Entities');
     });
 
-    it('shows the correct modal after true is selected', async () => {
-      testData.extendedDatasets.createPast(1, { ownerOnly: false });
+    it('shows the correct modal after "Only access own" is selected', async () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: null });
       const component = mountComponent();
-      await component.get('.radio + .radio input').setChecked();
+      await component.get('input[value="ownerOnly"]').setChecked();
       component.getComponent(Modal).props().state.should.be.true;
       const title = component.get('.modal-title').text();
       title.should.equal('Only access own Entities');
@@ -39,54 +44,119 @@ describe('DatasetOwnerOnly', () => {
       const buttonText = component.get('.modal-actions .btn-primary').text();
       buttonText.should.equal('Access own Entities');
     });
+
+    it('shows the correct modal after "Filter by Property" is selected', async () => {
+      testData.actorProperties.createPast(1, { name: 'region' });
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: null,
+        properties: [{ name: 'city' }]
+      });
+      const component = mountComponent();
+      await component.get('input[value="property"]').setChecked();
+      component.getComponent(Modal).props().state.should.be.true;
+      const title = component.get('.modal-title').text();
+      title.should.equal('Filter by Property');
+      const introduction = component.get('.modal-introduction').text();
+      introduction.should.include('will only have access to Entities where the selected property matches');
+      const buttonText = component.get('.modal-actions .btn-primary').text();
+      buttonText.should.equal('Save Filter Rule');
+    });
   });
 
   describe('canceling', () => {
     for (const selector of ['.close', '.btn-link']) {
       it(`it cancels after ${selector} is clicked`, async () => {
-        testData.extendedDatasets.createPast(1, { ownerOnly: true });
+        testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
         const component = mountComponent();
-        const inputs = component.findAll('input');
+        const inputs = component.findAll('input[type="radio"]');
         const checked = () => inputs.map(input => input.element.checked);
 
         // Initial state
         component.getComponent(Modal).props().state.should.be.false;
-        checked().should.eql([false, true]);
+        checked().should.eql([false, true, false]);
 
         // Changing the selection
         await inputs[0].setChecked();
         component.getComponent(Modal).props().state.should.be.true;
-        checked().should.eql([true, false]);
+        checked().should.eql([true, false, false]);
 
         // Canceling
         await component.getComponent(Modal).get(selector).trigger('click');
         component.getComponent(Modal).props().state.should.be.false;
-        checked().should.eql([false, true]);
+        checked().should.eql([false, true, false]);
       });
     }
   });
 
-  it('sends the correct request', () => {
-    testData.extendedDatasets.createPast(1, { ownerOnly: true });
-    return mockHttp()
-      .mount(DatasetOwnerOnly, mountOptions())
-      .request(async (component) => {
-        await component.get('input').setChecked();
-        await component.get('.modal-actions .btn-primary').trigger('click');
-      })
-      .respondWithProblem()
-      .testRequests([{
-        method: 'PATCH',
-        url: '/v1/projects/1/datasets/trees',
-        data: { ownerOnly: false }
-      }]);
+  describe('sends the correct request', () => {
+    it('sends correct request when changing to "Access all"', () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
+      return mockHttp()
+        .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
+        .request(async (component) => {
+          await component.get('input[value="all"]').setChecked();
+          await component.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .respondWithProblem()
+        .testRequests([{
+          method: 'PATCH',
+          url: '/v1/projects/1/datasets/trees',
+          data: { accessFilter: null }
+        }]);
+    });
+
+    it('sends correct request when changing to "Only access own"', () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: null });
+      return mockHttp()
+        .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
+        .request(async (component) => {
+          await component.get('input[value="ownerOnly"]').setChecked();
+          await component.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .respondWithProblem()
+        .testRequests([{
+          method: 'PATCH',
+          url: '/v1/projects/1/datasets/trees',
+          data: { accessFilter: { type: 'ownerOnly' } }
+        }]);
+    });
+
+    it('sends correct request when changing to "Filter by Property"', () => {
+      testData.actorProperties.createPast(1, { name: 'region' });
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: null,
+        properties: [{ name: 'city' }]
+      });
+      return mockHttp()
+        .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
+        .request(async (component) => {
+          await component.get('input[value="property"]').setChecked();
+          await component.get('select').findAll('option')[1].setSelected();
+          await component.findAll('select')[1].findAll('option')[1].setSelected();
+          await component.get('#property-filter-form').trigger('submit');
+        })
+        .respondWithProblem()
+        .testRequests([{
+          method: 'PATCH',
+          url: '/v1/projects/1/datasets/trees',
+          data: {
+            accessFilter: {
+              type: 'property',
+              rules: [{ datasetProperty: 'city', actorProperty: 'region' }]
+            }
+          }
+        }]);
+    });
   });
 
-  it('implements some standard button things', async () => {
-    testData.extendedDatasets.createPast(1, { ownerOnly: true });
+  it('implements some standard button things', () => {
+    testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
     return mockHttp()
       .mount(DatasetOwnerOnly, mountOptions())
-      .afterResponses(component => component.get('input').setChecked())
+      .afterResponses(component => component.get('input[value="all"]').setChecked())
       .testStandardButton({
         button: '.modal-actions .btn-primary',
         disabled: ['.modal-actions .btn-link'],
@@ -95,16 +165,21 @@ describe('DatasetOwnerOnly', () => {
   });
 
   describe('alert', () => {
-    it('shows the correct text once ownerOnly has been changed to false', () => {
-      testData.extendedDatasets.createPast(1, { ownerOnly: true });
+    it('shows the correct text once accessFilter has been changed to null', () => {
+      testData.actorProperties.createPast(1, { name: 'region' });
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: { type: 'ownerOnly' },
+        properties: [{ name: 'city' }]
+      });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
         .request(async (component) => {
-          await component.get('input').setChecked();
+          await component.get('input[value="all"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
         })
         .respondWithData(() =>
-          testData.extendedDatasets.update(-1, { ownerOnly: false }))
+          testData.extendedDatasets.update(-1, { accessFilter: null }))
         .afterResponse(component => {
           component.should.alert('success', (message) => {
             message.should.endWith('will now have access to all Entities.');
@@ -112,16 +187,17 @@ describe('DatasetOwnerOnly', () => {
         });
     });
 
-    it('shows the correct text once ownerOnly has been changed to true', () => {
-      testData.extendedDatasets.createPast(1, { ownerOnly: false });
+    it('shows the correct text once accessFilter has been changed to ownerOnly', () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: null });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
         .request(async (component) => {
-          await component.get('.radio + .radio input').setChecked();
+          await component.get('input[value="ownerOnly"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
         })
         .respondWithData(() =>
-          testData.extendedDatasets.update(-1, { ownerOnly: true }))
+          testData.extendedDatasets.update(-1, { accessFilter: { type: 'ownerOnly' } }))
         .afterResponse(component => {
           component.should.alert('success', (message) => {
             message.should.endWith('will now only have access to Entities they create.');
@@ -129,16 +205,50 @@ describe('DatasetOwnerOnly', () => {
         });
     });
 
-    it('shows a CTA to undo', () => {
-      testData.extendedDatasets.createPast(1, { ownerOnly: true });
+    it('shows the correct text once accessFilter has been changed to property', () => {
+      testData.actorProperties.createPast(1, { name: 'region' });
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: null,
+        properties: [{ name: 'city' }]
+      });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
         .request(async (component) => {
-          await component.get('input').setChecked();
+          await component.get('input[value="property"]').setChecked();
+          await component.get('select').findAll('option')[1].setSelected();
+          await component.findAll('select')[1].findAll('option')[1].setSelected();
+          await component.get('#property-filter-form').trigger('submit');
+        })
+        .respondWithData(() =>
+          testData.extendedDatasets.update(-1, {
+            accessFilter: {
+              type: 'property',
+              rules: [{ datasetProperty: 'city', actorProperty: 'region' }]
+            }
+          }))
+        .afterResponse(component => {
+          component.should.alert('success', (message) => {
+            message.should.endWith('will now only have access to Entities matching the filter rule.');
+          });
+        });
+    });
+
+    it('shows a CTA to undo', () => {
+      testData.actorProperties.createPast(1, { name: 'region' });
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: { type: 'ownerOnly' },
+        properties: [{ name: 'city' }]
+      });
+      return mockHttp()
+        .mount(DatasetOwnerOnly, mountOptions())
+        .complete()
+        .request(async (component) => {
+          await component.get('input[value="all"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
         })
         .respondWithData(() =>
-          testData.extendedDatasets.update(-1, { ownerOnly: false }))
+          testData.extendedDatasets.update(-1, { accessFilter: null }))
         .complete()
         .request(component => {
           const { alert } = component.vm.$container;
@@ -146,44 +256,76 @@ describe('DatasetOwnerOnly', () => {
           return alert.cta.handler();
         })
         .beforeAnyResponse(component => {
-          const inputs = component.findAll('input');
+          const inputs = component.findAll('input[type="radio"]');
           for (const input of inputs) input.element.disabled.should.be.true;
-          inputs.map(input => input.element.checked).should.eql([true, false]);
+          inputs.map(input => input.element.checked).should.eql([true, false, false]);
         })
         .respondWithData(() =>
-          testData.extendedDatasets.update(-1, { ownerOnly: true }))
+          testData.extendedDatasets.update(-1, { accessFilter: { type: 'ownerOnly' } }))
         .testRequests([{
           method: 'PATCH',
           url: '/v1/projects/1/datasets/trees',
-          data: { ownerOnly: true }
+          data: { accessFilter: { type: 'ownerOnly' } }
         }])
         .afterResponse(component => {
-          const inputs = component.findAll('input');
+          const inputs = component.findAll('input[type="radio"]');
           for (const input of inputs) input.element.disabled.should.be.false;
-          inputs.map(input => input.element.checked).should.eql([false, true]);
+          inputs.map(input => input.element.checked).should.eql([false, true, false]);
         });
     });
   });
 
+  describe('Filter by Property disabled state', () => {
+    it('disables "Filter by Property" when no dataset properties exist', async () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: null, properties: [] });
+      const component = await mountComponent();
+      const propertyInput = component.get('input[value="property"]');
+      propertyInput.element.disabled.should.be.true;
+    });
+
+    it('disables "Filter by Property" when no actor properties exist', async () => {
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: null,
+        properties: [{ name: 'city' }]
+      });
+      const component = mountComponent();
+      const propertyInput = component.get('input[value="property"]');
+      propertyInput.element.disabled.should.be.true;
+    });
+  });
+
+  it('displays the current filter rule when accessFilter type is property', async () => {
+    testData.extendedDatasets.createPast(1, {
+      accessFilter: {
+        type: 'property',
+        rules: [{ datasetProperty: 'city', actorProperty: 'region' }]
+      },
+      properties: [{ name: 'city' }]
+    });
+    const component = await mountComponent();
+    const ruleText = component.get('.current-filter-rule').text();
+    ruleText.should.startWith('Rule: city (Entity property) = region (User property)');
+  });
+
   it('remembers the new setting', () => {
     mockLogin();
-    testData.extendedDatasets.createPast(1, { ownerOnly: true });
+    testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
     return load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (app) => {
         const component = app.getComponent(DatasetOwnerOnly);
-        await component.get('input').setChecked();
+        await component.get('input[value="all"]').setChecked();
         await component.get('.btn-primary').trigger('click');
       })
       .respondWithData(() =>
-        testData.extendedDatasets.update(-1, { ownerOnly: false }))
+        testData.extendedDatasets.update(-1, { accessFilter: null }))
       .complete()
       .route('/projects/1/entity-lists/trees/properties')
       .complete()
       .route('/projects/1/entity-lists/trees/settings')
       .then(app => {
         const component = app.getComponent(DatasetOwnerOnly);
-        component.get('input').element.checked.should.be.true;
+        component.get('input[value="all"]').element.checked.should.be.true;
       });
   });
 });

--- a/apps/central/test/components/dataset/owner-only.spec.js
+++ b/apps/central/test/components/dataset/owner-only.spec.js
@@ -89,11 +89,27 @@ describe('DatasetOwnerOnly', () => {
   });
 
   describe('sends the correct request', () => {
+    it('sends correct initial request', () => {
+      testData.extendedDatasets.createPast(1);
+      return mockHttp()
+        .mount(DatasetOwnerOnly, {
+          container: {
+            requestData: testRequestData(['actorProperties'], {
+              dataset: testData.extendedDatasets.last()
+            })
+          }
+        })
+        .respondWithData(() => testData.actorProperties.sorted())
+        .testRequests([{
+          method: 'GET',
+          url: '/v1/projects/1/actor-properties'
+        }]);
+    });
+
     it('sends correct request when changing to "Access all"', () => {
       testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="all"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
@@ -110,7 +126,6 @@ describe('DatasetOwnerOnly', () => {
       testData.extendedDatasets.createPast(1, { accessFilter: null });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="ownerOnly"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
@@ -131,7 +146,6 @@ describe('DatasetOwnerOnly', () => {
       });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="property"]').setChecked();
           await component.get('select').findAll('option')[1].setSelected();
@@ -166,14 +180,11 @@ describe('DatasetOwnerOnly', () => {
 
   describe('alert', () => {
     it('shows the correct text once accessFilter has been changed to null', () => {
-      testData.actorProperties.createPast(1, { name: 'region' });
       testData.extendedDatasets.createPast(1, {
-        accessFilter: { type: 'ownerOnly' },
-        properties: [{ name: 'city' }]
+        accessFilter: { type: 'ownerOnly' }
       });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="all"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
@@ -191,7 +202,6 @@ describe('DatasetOwnerOnly', () => {
       testData.extendedDatasets.createPast(1, { accessFilter: null });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="ownerOnly"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
@@ -213,7 +223,6 @@ describe('DatasetOwnerOnly', () => {
       });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="property"]').setChecked();
           await component.get('select').findAll('option')[1].setSelected();
@@ -242,7 +251,6 @@ describe('DatasetOwnerOnly', () => {
       });
       return mockHttp()
         .mount(DatasetOwnerOnly, mountOptions())
-        .complete()
         .request(async (component) => {
           await component.get('input[value="all"]').setChecked();
           await component.get('.modal-actions .btn-primary').trigger('click');
@@ -271,6 +279,60 @@ describe('DatasetOwnerOnly', () => {
           const inputs = component.findAll('input[type="radio"]');
           for (const input of inputs) input.element.disabled.should.be.false;
           inputs.map(input => input.element.checked).should.eql([false, true, false]);
+        });
+    });
+
+    it('shows a CTA to undo when changing filter by property rule', () => {
+      testData.actorProperties.createPast(1, { name: 'region' });
+      testData.actorProperties.createPast(1, { name: 'country' });
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: {
+          type: 'property',
+          rules: [{ datasetProperty: 'city', actorProperty: 'region' }]
+        },
+        properties: [{ name: 'city' }, { name: 'state' }]
+      });
+      return mockHttp()
+        .mount(DatasetOwnerOnly, mountOptions())
+        .request(async (component) => {
+          await component.get('.current-filter-rule .btn-link').trigger('click');
+          await component.get('select').findAll('option')[2].setSelected();
+          await component.findAll('select')[1].findAll('option')[2].setSelected();
+          await component.get('#property-filter-form').trigger('submit');
+        })
+        .respondWithData(() =>
+          testData.extendedDatasets.update(-1, {
+            accessFilter: {
+              type: 'property',
+              rules: [{ datasetProperty: 'state', actorProperty: 'country' }]
+            }
+          }))
+        .complete()
+        .request(component => {
+          const { alert } = component.vm.$container;
+          alert.cta.text.should.equal('Undo');
+          return alert.cta.handler();
+        })
+        .respondWithData(() =>
+          testData.extendedDatasets.update(-1, {
+            accessFilter: {
+              type: 'property',
+              rules: [{ datasetProperty: 'city', actorProperty: 'region' }]
+            }
+          }))
+        .testRequests([{
+          method: 'PATCH',
+          url: '/v1/projects/1/datasets/trees',
+          data: {
+            accessFilter: {
+              type: 'property',
+              rules: [{ datasetProperty: 'city', actorProperty: 'region' }]
+            }
+          }
+        }])
+        .afterResponse(component => {
+          const ruleText = component.get('.current-filter-rule').text();
+          ruleText.should.startWith('Rule: city (Entity property) = region (User property)');
         });
     });
   });

--- a/apps/central/test/components/dataset/settings.spec.js
+++ b/apps/central/test/components/dataset/settings.spec.js
@@ -6,9 +6,7 @@ import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 
 describe('DatasetSettings', () => {
-  beforeEach(() => {
-    mockLogin();
-  });
+  beforeEach(mockLogin);
 
   it('should have onReceipt selected', async () => {
     testData.extendedDatasets.createPast(1);

--- a/apps/central/test/components/dataset/settings.spec.js
+++ b/apps/central/test/components/dataset/settings.spec.js
@@ -6,7 +6,9 @@ import { load } from '../../util/http';
 import { mockLogin } from '../../util/session';
 
 describe('DatasetSettings', () => {
-  beforeEach(mockLogin);
+  beforeEach(() => {
+    mockLogin();
+  });
 
   it('should have onReceipt selected', async () => {
     testData.extendedDatasets.createPast(1);
@@ -24,7 +26,7 @@ describe('DatasetSettings', () => {
 
   it('should sends the correct request - true', async () => {
     testData.extendedDatasets.createPast(1);
-    await load('/projects/1/entity-lists/trees/settings', { root: false })
+    await load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (component) => component.get('input[value="true"]').setValue(true))
       .beforeEachResponse((_, { method, url, data }) => {
@@ -37,7 +39,7 @@ describe('DatasetSettings', () => {
 
   it('should sends the correct request - false', async () => {
     testData.extendedDatasets.createPast(1, { approvalRequired: true });
-    await load('/projects/1/entity-lists/trees/settings', { root: false })
+    await load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (component) => component.get('input[value="false"]').setValue(true))
       .beforeEachResponse((_, { method, url, data }) => {
@@ -50,7 +52,7 @@ describe('DatasetSettings', () => {
 
   it('should change approvalRequired to true', async () => {
     testData.extendedDatasets.createPast(1);
-    await load('/projects/1/entity-lists/trees/settings', { root: false })
+    await load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (component) => component.get('input[value="true"]').setValue(true))
       .respondWithData(() => testData.extendedDatasets.last())
@@ -63,7 +65,7 @@ describe('DatasetSettings', () => {
 
   it('should revert approvalRequired flag if modal is cancelled', async () => {
     testData.extendedDatasets.createPast(1, { approvalRequired: true });
-    await load('/projects/1/entity-lists/trees/settings', { root: false })
+    await load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (component) => component.get('input[value="false"]').setValue(true))
       .respondWithProblem({
@@ -82,7 +84,7 @@ describe('DatasetSettings', () => {
 
   it('should revert approvalRequired flag there is an error', async () => {
     testData.extendedDatasets.createPast(1, { approvalRequired: true });
-    await load('/projects/1/entity-lists/trees/settings', { root: false })
+    await load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (component) => component.get('input[value="false"]').setValue(true))
       .respondWithProblem(500)
@@ -94,7 +96,7 @@ describe('DatasetSettings', () => {
 
   it('should send correct convert query param', async () => {
     testData.extendedDatasets.createPast(1, { approvalRequired: true });
-    await load('/projects/1/entity-lists/trees/settings', { root: false })
+    await load('/projects/1/entity-lists/trees/settings')
       .complete()
       .request(async (component) => component.get('input[value="false"]').setValue(true))
       .respondWithProblem({
@@ -125,7 +127,7 @@ describe('DatasetSettings', () => {
   describe('DatasetDelete', () => {
     it('toggles the modal', () => {
       testData.extendedDatasets.createPast(1);
-      return load('/projects/1/entity-lists/trees/settings', { root: false })
+      return load('/projects/1/entity-lists/trees/settings')
         .testModalToggles({
           modal: DatasetDelete,
           show: '#dataset-settings .panel-simple-danger .btn-danger',

--- a/apps/central/test/data/datasets.js
+++ b/apps/central/test/data/datasets.js
@@ -33,7 +33,7 @@ export const extendedDatasets = dataStore({
     name = 'trees',
     properties = [],
     approvalRequired = false,
-    ownerOnly = false,
+    accessFilter = null,
     entities = undefined,
     lastEntity = undefined,
     lastUpdate = undefined,
@@ -51,7 +51,8 @@ export const extendedDatasets = dataStore({
       name,
       properties: properties.map(normalizeProperty),
       approvalRequired,
-      ownerOnly,
+      ownerOnly: accessFilter?.type === 'ownerOnly',
+      accessFilter,
       ...entityStats,
       linkedForms,
       sourceForms

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -488,7 +488,7 @@ describe('createCentralRouter()', () => {
       it('preserves actorProperties while navigating between dataset tabs', () =>
         load('/projects/1/entity-lists/trees/settings')
           .complete()
-          .load('/projects/1/entity-lists/trees/properties', { project: false, dataset: false, actorProperties: false })
+          .load('/projects/1/entity-lists/trees/properties', { project: false, dataset: false })
           .complete()
           .load('/projects/1/entity-lists/trees/settings', { project: false, dataset: false, actorProperties: false })
           .afterResponses(dataExists(['actorProperties'])));

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -484,6 +484,14 @@ describe('createCentralRouter()', () => {
           .complete()
           .load('/projects/1/entity-lists/trees/properties', { project: false, dataset: false })
           .afterResponses(dataExists(['project', 'dataset'])));
+
+      it('preserves actorProperties while navigating between dataset tabs', () =>
+        load('/projects/1/entity-lists/trees/settings')
+          .complete()
+          .load('/projects/1/entity-lists/trees/properties', { project: false, dataset: false, actorProperties: false })
+          .complete()
+          .load('/projects/1/entity-lists/trees/settings', { project: false, dataset: false, actorProperties: false })
+          .afterResponses(dataExists(['actorProperties'])));
     });
 
     it('preserves project while navigating from entity list to project', () => {

--- a/apps/central/test/util/http/data.js
+++ b/apps/central/test/util/http/data.js
@@ -255,7 +255,9 @@ const responsesByComponent = {
       () => testData.entityGeojson(entity => entity.deletedAt == null)
     ]
   }),
-  DatasetSettings: [],
+  DatasetSettings: componentResponses({
+    actorProperties: true,
+  }),
   EntityShow: componentResponses({
     entity: () => testData.extendedEntities.last(),
     project: true,

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -494,6 +494,10 @@
     "reset": {
       "string": "Reset",
       "developer_comment": "This text is shown on a button that resets the data filters"
+    },
+    "change": {
+      "string": "Change",
+      "developer_comment": "This is the text for an action, for example, the text of a button."
     }
   },
   "field": {
@@ -1927,7 +1931,7 @@
     "DatasetOwnerOnly": {
       "panel": {
         "title": {
-          "string": "App User and Data Collector Entity Access",
+          "string": "Entity List Access",
           "developer_comment": "This is a title shown above a section of the page."
         }
       },
@@ -1956,32 +1960,30 @@
           "string": "Define rules for which Entities are visible to App Users and Data Collectors by comparing their properties."
         },
         "entityPropertyLabel": {
-          "string": "Only see Entities where"
+          "string": "Only see Entities where",
+          "developer_comment": "This text is shown above the access rule filter dropdown. Translators are free not to translate this literally"
         },
         "entityPropertyPlaceholder": {
-          "string": "Entity property"
+          "string": "Entity property",
+          "developer_comment": "Placeholder text shown on a access rule filter dropdown."
         },
         "userPropertyLabel": {
-          "string": "is equal to the user’s"
+          "string": "is equal to the user’s",
+          "developer_comment": "This text is shown above the access rule filter dropdown. Translators are free not to translate this literally"
         },
         "userPropertyPlaceholder": {
-          "string": "User property"
+          "string": "User property",
+          "developer_comment": "Placeholder text shown on a access rule filter dropdown"
         },
         "disabled": {
           "datasetProperties": {
-            "string": "There are no dataset properties defined."
+            "string": "There are no Entity properties defined."
           },
           "userProperties": {
             "string": "There are no user properties defined."
           },
           "both": {
-            "string": "There are no dataset and user properties defined."
-          }
-        },
-        "action": {
-          "change": {
-            "string": "Change",
-            "developer_comment": "This is the text for an action, for example, the text of a button."
+            "string": "There are no Entity or user properties defined."
           }
         },
         "currentRule": {
@@ -2013,7 +2015,7 @@
           "string": "App Users and Data Collectors will now only have access to Entities they create."
         },
         "changeToProperty": {
-          "string": "App Users and Data Collectors will now only have access to Entities matching the filter rule."
+          "string": "App Users and Public Links will now only have access to Entities matching the filter rule."
         }
       },
       "accessByFilterRule": {
@@ -2021,7 +2023,7 @@
           "string": "Filter by Property"
         },
         "introduction": {
-          "string": "App Users and Data Collectors will only have access to Entities where the selected property matches their user property."
+          "string": "App Users and Public Links will only have access to Entities where the selected property matches their user property."
         },
         "action": {
           "save": {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -1948,6 +1948,47 @@
           "string": "App Users and Data Collectors within this Project will only have access to the Entities they create, promoting privacy and limiting data transfers."
         }
       },
+      "filterByProperty": {
+        "label": {
+          "string": "Filter by Property"
+        },
+        "description": {
+          "string": "Define rules for which Entities are visible to App Users and Data Collectors by comparing their properties."
+        },
+        "entityPropertyLabel": {
+          "string": "Only see Entities where"
+        },
+        "entityPropertyPlaceholder": {
+          "string": "Entity property"
+        },
+        "userPropertyLabel": {
+          "string": "is equal to the user’s"
+        },
+        "userPropertyPlaceholder": {
+          "string": "User property"
+        },
+        "disabled": {
+          "datasetProperties": {
+            "string": "There are no dataset properties defined."
+          },
+          "userProperties": {
+            "string": "There are no user properties defined."
+          },
+          "both": {
+            "string": "There are no dataset and user properties defined."
+          }
+        },
+        "action": {
+          "change": {
+            "string": "Change",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
+        },
+        "currentRule": {
+          "string": "Rule: {entityProperty} (Entity property) = {userProperty} (User property)",
+          "developer_comment": "{entityProperty} is the name of an Entity property. {userProperty} is the name of a User property."
+        }
+      },
       "falseModal": {
         "introduction": {
           "string": "App Users and Data Collectors will have access to all Entities, including ones they did not create."
@@ -1970,6 +2011,23 @@
         },
         "changeToTrue": {
           "string": "App Users and Data Collectors will now only have access to Entities they create."
+        },
+        "changeToProperty": {
+          "string": "App Users and Data Collectors will now only have access to Entities matching the filter rule."
+        }
+      },
+      "accessByFilterRule": {
+        "title": {
+          "string": "Filter by Property"
+        },
+        "introduction": {
+          "string": "App Users and Data Collectors will only have access to Entities where the selected property matches their user property."
+        },
+        "action": {
+          "save": {
+            "string": "Save Filter Rule",
+            "developer_comment": "This is the text for an action, for example, the text of a button."
+          }
         }
       }
     },


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1791

#### What has been done to verify that this works as intended?

Added tests and verified the functionality manually

#### Why is this the best possible solution? Were any other approaches considered?

Discussed in the team meeting to add property dropdowns in the confirm modal and add change button that allows user to modify filter rules

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

Will be added as part of https://github.com/getodk/central/issues/1866

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
