### PR TITLE
Remove link leading slash

### DIFF
--- a/apps/central/src/components/form/edit/web-form.vue
+++ b/apps/central/src/components/form/edit/web-form.vue
@@ -4,7 +4,7 @@
     <template #body>
       <i18n-t tag="p" keypath="description.full" class="form-edit-web-form-description">
         <template #learnMore>
-          <doc-link to="/web-forms-intro#features-not-yet-supported">{{ $t('description.learnMore') }}</doc-link>
+          <doc-link to="web-forms-intro#features-not-yet-supported">{{ $t('description.learnMore') }}</doc-link>
         </template>
       </i18n-t>
       <radio-field v-model="webformsEnabled" :options="options"


### PR DESCRIPTION
Link is broken.

#### What has been done to verify that this works as intended?

Verified that other `<doc-link to>` links start without a leading slash.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
