### PR TITLE
fix(web-forms#828): preserve map state during user edits

### DIFF
--- a/.changeset/yellow-donkeys-cross.md
+++ b/.changeset/yellow-donkeys-cross.md
@@ -1,0 +1,6 @@
+---
+"@getodk/web-forms": patch
+"@getodk/forms": patch
+---
+
+Preserve map state during user edits

--- a/packages/web-forms/src/components/common/map/map-helpers.ts
+++ b/packages/web-forms/src/components/common/map/map-helpers.ts
@@ -13,7 +13,7 @@ import type {
   Polygon as PolygonGeoJSON,
 } from 'geojson';
 
-const toODKDecimal = (n: number): string => (Number.isInteger(n) ? `${n}.0` : String(n));
+const toODKDecimal = (num: number) => (Number.isInteger(num) ? `${num}.0` : String(num));
 
 // Latitude is first for ODK, and longitude is second. Altitude and accuracy default to 0.0 to match Collect behavior.
 export const toODKCoordinateArray = (

--- a/packages/web-forms/src/components/common/map/map-helpers.ts
+++ b/packages/web-forms/src/components/common/map/map-helpers.ts
@@ -13,22 +13,24 @@ import type {
   Polygon as PolygonGeoJSON,
 } from 'geojson';
 
-// Latitude is first for ODK, and longitude is second. Altitude and accuracy default to 0 to match Collect behavior.
+const toODKDecimal = (n: number): string => (Number.isInteger(n) ? `${n}.0` : String(n));
+
+// Latitude is first for ODK, and longitude is second. Altitude and accuracy default to 0.0 to match Collect behavior.
 export const toODKCoordinateArray = (
   longitude: number,
   latitude: number,
   altitude: number | null | undefined,
   accuracy: number | null | undefined
-): number[] => {
+): string[] => {
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
     return [];
   }
 
   return [
-    latitude,
-    longitude,
-    Number.isFinite(altitude) ? altitude! : 0,
-    Number.isFinite(accuracy) ? accuracy! : 0,
+    toODKDecimal(latitude),
+    toODKDecimal(longitude),
+    toODKDecimal(Number.isFinite(altitude) ? altitude! : 0),
+    toODKDecimal(Number.isFinite(accuracy) ? accuracy! : 0),
   ];
 };
 
@@ -50,7 +52,7 @@ export const formatODKValue = (feature: Feature): string => {
   }
 
   const coordinates: Coordinate[] = getFlatCoordinates(geometry as LineString | Polygon);
-  return coordinates.map((coord) => formatCoords(coord)).join('; ');
+  return coordinates.map((coord) => formatCoords(coord)).join(';');
 };
 
 export const isWebGLAvailable = () => {

--- a/packages/web-forms/src/components/common/map/useMapBlock.ts
+++ b/packages/web-forms/src/components/common/map/useMapBlock.ts
@@ -356,9 +356,16 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
 
   /**
    * Places a newly built feature onto the empty layer and marks it saved.
+   * Skips when the incoming geometry's ODK value already matches what's on the map,
+   * So user edits coming back through the engine don't rebuild the feature.
    */
   const loadAndSaveSingleFeature = (feature: Feature | undefined) => {
-    if (!mapInstance || currentMode.capabilities.canLoadMultiFeatures || !feature) {
+    if (
+      !mapInstance ||
+      currentMode.capabilities.canLoadMultiFeatures ||
+      !feature ||
+      feature.get(ODK_VALUE_PROPERTY) === mapFeatures?.getSavedFeatureValue()
+    ) {
       return;
     }
 
@@ -520,8 +527,7 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
   /**
    * Applies a saved feature value to the map.
    * Multi-feature mode: looks it up in the collection.
-   * Single-feature mode: places it only when the map is empty (e.g., a dynamic default).
-   * After the user modifies the feature, it shouldn't rerender the map.
+   * Single-feature mode: applies external updates (defaults, setvalue). Skips when the value matches what's on the map
    */
   const applySavedFeatureValue = (feature: GeoJsonFeature | undefined) => {
     if (currentMode.capabilities.canLoadMultiFeatures) {
@@ -532,7 +538,7 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
       );
     }
 
-    if (!feature || !featuresSource.isEmpty()) {
+    if (!feature) {
       return;
     }
 

--- a/packages/web-forms/src/components/common/map/useMapBlock.ts
+++ b/packages/web-forms/src/components/common/map/useMapBlock.ts
@@ -519,8 +519,9 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
 
   /**
    * Applies a saved feature value to the map.
-   * Looks it up in multi-feature mode, or builds and places it in single-feature mode
-   * @param feature
+   * Multi-feature mode: looks it up in the collection.
+   * Single-feature mode: places it only when the map is empty (e.g., a dynamic default).
+   * After the user modifies the feature, it shouldn't rerender the map.
    */
   const applySavedFeatureValue = (feature: GeoJsonFeature | undefined) => {
     if (currentMode.capabilities.canLoadMultiFeatures) {
@@ -531,8 +532,7 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
       );
     }
 
-    if (!feature) {
-      clearMap();
+    if (!feature || !featuresSource.isEmpty()) {
       return;
     }
 

--- a/packages/web-forms/tests/components/common/map/map-helpers.test.ts
+++ b/packages/web-forms/tests/components/common/map/map-helpers.test.ts
@@ -29,7 +29,7 @@ describe('Map Helpers', () => {
       const coords = fromLonLat([lon, lat]);
       const geom = new Point(coords, COORDINATE_LAYOUT_XYZM);
       const feature = new Feature({ geometry: geom });
-      expect(formatODKValue(feature)).toBe('48.85840000000002 2.2945 0 0');
+      expect(formatODKValue(feature)).toBe('48.85840000000002 2.2945 0.0 0.0');
     });
 
     it('formats Point with latitude, longitude, and altitude', () => {
@@ -39,7 +39,7 @@ describe('Map Helpers', () => {
       const coords = fromLonLat([lon, lat, alt]);
       const geom = new Point(coords, COORDINATE_LAYOUT_XYZM);
       const feature = new Feature({ geometry: geom });
-      expect(formatODKValue(feature)).toBe('48.85840000000002 2.2945 170 0');
+      expect(formatODKValue(feature)).toBe('48.85840000000002 2.2945 170.0 0.0');
     });
 
     it('formats Point with latitude, longitude, altitude, and accuracy', () => {
@@ -50,14 +50,14 @@ describe('Map Helpers', () => {
       const coords = fromLonLat([lon, lat, alt, acc]);
       const geom = new Point(coords, COORDINATE_LAYOUT_XYZM);
       const feature = new Feature({ geometry: geom });
-      expect(formatODKValue(feature)).toBe('48.85840000000002 2.2945 170 5');
+      expect(formatODKValue(feature)).toBe('48.85840000000002 2.2945 170.0 5.0');
     });
 
     it('formats LineString', () => {
       const coords = [fromLonLat([0, 0]), fromLonLat([1, 1]), fromLonLat([2, 2])];
       const geom = new LineString(coords, COORDINATE_LAYOUT_XYZM);
       const feature = new Feature({ geometry: geom });
-      expect(formatODKValue(feature)).toBe('0 0 0 0; 1 1 0 0; 2 2 0 0');
+      expect(formatODKValue(feature)).toBe('0.0 0.0 0.0 0.0;1.0 1.0 0.0 0.0;2.0 2.0 0.0 0.0');
     });
 
     it('formats Polygon', () => {
@@ -66,29 +66,31 @@ describe('Map Helpers', () => {
       ];
       const geom = new Polygon(coords, COORDINATE_LAYOUT_XYZM);
       const feature = new Feature({ geometry: geom });
-      expect(formatODKValue(feature)).toBe('0 0 0 0; 0 1 0 0; 1 1 0 0; 0 0 0 0');
+      expect(formatODKValue(feature)).toBe(
+        '0.0 0.0 0.0 0.0;0.0 1.0 0.0 0.0;1.0 1.0 0.0 0.0;0.0 0.0 0.0 0.0'
+      );
     });
   });
 
   describe('toODKCoordinateArray', () => {
     it('defaults altitude and accuracy to 0 when not provided', () => {
       const result = toODKCoordinateArray(2.2945, 48.8584, null, null);
-      expect(result).toEqual([48.8584, 2.2945, 0, 0]);
+      expect(result).toEqual(['48.8584', '2.2945', '0.0', '0.0']);
     });
 
     it('returns coordinates with altitude and defaults accuracy to 0', () => {
       const result = toODKCoordinateArray(2.2945, 48.8584, 170, null);
-      expect(result).toEqual([48.8584, 2.2945, 170, 0]);
+      expect(result).toEqual(['48.8584', '2.2945', '170.0', '0.0']);
     });
 
     it('returns coordinates with accuracy and defaults altitude to 0', () => {
       const result = toODKCoordinateArray(2.2945, 48.8584, null, 5);
-      expect(result).toEqual([48.8584, 2.2945, 0, 5]);
+      expect(result).toEqual(['48.8584', '2.2945', '0.0', '5.0']);
     });
 
     it('returns coordinates with altitude and accuracy', () => {
       const result = toODKCoordinateArray(2.2945, 48.8584, 170, 5);
-      expect(result).toEqual([48.8584, 2.2945, 170, 5]);
+      expect(result).toEqual(['48.8584', '2.2945', '170.0', '5.0']);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/828

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

https://github.com/user-attachments/assets/2748cb3f-5ccc-42eb-8a58-5f40c445b9cb

#### Why is this the best possible solution? Were any other approaches considered?
The previous fix, combined with coordinates defaulting to zero to match Collect, caused points to disappear and phantom points to appear in incorrect locations during user edits or when adding new points ([see video](https://jam.dev/c/ee836d74-5199-428a-bc95-07db4ddcf42b)).

The engine reformats every value, and the map component watches the prop for changes (needed for dynamic defaults and setvalue). So the value that comes back never equals what was emitted, and the rebuild destroys in-flight user edits.

There are 2 fixes here:
- Formats coordinates sent to the engine (integers padded with .0, segments separated without spaces) so the value the map emits matches the value the engine sends back. There's room for improvement here. For example, the engine could expose its codec functions, but that doesn't fit how the engine is currently structured. It's something to explore as part of another ticket to unblock the release fix.                                                             
- Only redraws the map when the incoming value differs from what's already drawn.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It should not introduce a new behavior, but fixes to match expected behavior.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [x] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
