### PR TITLE
chore: clean up PR template and fix changeset notes

### DIFF
--- a/.changeset/brave-wolves-dance.md
+++ b/.changeset/brave-wolves-dance.md
@@ -1,5 +1,4 @@
 ---
-'@getodk/central-frontend': minor
 '@getodk/web-forms': minor
 ---
 

--- a/.changeset/calm-pugs-cheat.md
+++ b/.changeset/calm-pugs-cheat.md
@@ -1,6 +1,5 @@
 ---
 "@getodk/web-forms": minor
-"@getodk/forms": minor
 ---
 
 Changed the vue component parameter from track-device to device-id which now expects the app to provide the id rather than autogenerating one

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "restricted",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": false }
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,5 @@
   "access": "restricted",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": [],
-  "privatePackages": { "version": false }
+  "ignore": []
 }

--- a/.changeset/curly-cups-camp.md
+++ b/.changeset/curly-cups-camp.md
@@ -1,6 +1,5 @@
 ---
 '@getodk/xforms-engine': minor
-'@getodk/scenario': minor
 '@getodk/common': minor
 '@getodk/web-forms': minor
 ---

--- a/.changeset/eager-teeth-mate.md
+++ b/.changeset/eager-teeth-mate.md
@@ -1,5 +1,4 @@
 ---
-"@getodk/central-frontend": patch
 "@getodk/web-forms": patch
 ---
 

--- a/.changeset/frank-poets-show.md
+++ b/.changeset/frank-poets-show.md
@@ -1,5 +1,4 @@
 ---
-"@getodk/forms": patch
 "@getodk/web-forms": patch
 ---
 

--- a/.changeset/itchy-shrimps-call.md
+++ b/.changeset/itchy-shrimps-call.md
@@ -1,5 +1,4 @@
 ---
-"@getodk/central-frontend": patch
 "@getodk/xforms-engine": patch
 "@getodk/web-forms": patch
 ---

--- a/.changeset/proud-snakes-cover.md
+++ b/.changeset/proud-snakes-cover.md
@@ -1,6 +1,5 @@
 ---
 "@getodk/xforms-engine": patch
-"@getodk/forms": patch
 ---
 
 Fixed setvalue with now() into a date field returning empty string

--- a/.changeset/public-eyes-marry.md
+++ b/.changeset/public-eyes-marry.md
@@ -1,6 +1,5 @@
 ---
 "@getodk/web-forms": minor
-"@getodk/forms": minor
 ---
 
 Added 'loaded' event to Web Forms component

--- a/.changeset/solid-lies-chew.md
+++ b/.changeset/solid-lies-chew.md
@@ -1,5 +1,4 @@
 ---
-"@getodk/forms": minor
 "@getodk/xforms-engine": minor
 ---
 

--- a/.changeset/sour-houses-wink.md
+++ b/.changeset/sour-houses-wink.md
@@ -1,6 +1,5 @@
 ---
 "@getodk/web-forms": patch
-"@getodk/forms": patch
 ---
 
 Serialise MapBlock dynamic import to fix map not loading on first load in iOS Safari

--- a/.changeset/swift-hats-attack.md
+++ b/.changeset/swift-hats-attack.md
@@ -1,6 +1,5 @@
 ---
 "@getodk/xforms-engine": patch
-"@getodk/forms": patch
 ---
 
 Preserve spaces after output elements in dynamic labels

--- a/.changeset/yellow-donkeys-cross.md
+++ b/.changeset/yellow-donkeys-cross.md
@@ -1,6 +1,5 @@
 ---
 "@getodk/web-forms": patch
-"@getodk/forms": patch
 ---
 
 Preserve map state during user edits

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,12 +11,6 @@ https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIB
 
 #### Why is this the best possible solution? Were any other approaches considered?
 
-#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
+#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?
 
 #### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
-
-#### Before submitting this PR, please make sure you have:
-
-- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
-- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
-- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes


### PR DESCRIPTION

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Verified by running locally the command below and checking the outcome:
```
npm run changeset version
```

#### Why is this the best possible solution? Were any other approaches considered?

- Removes scenario as package, it was breaking the changeset
- Removes references to app/forms or app/central where the change didn't impact those apps. The release notes are linked together in the Central repository's release tag, so duplicating the notes seems unnecessary.
- Updated the PR template based on this [conversation](https://getodk.slack.com/archives/C0259F2544A/p1782142507499009). 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:

- [ ] run `npm run test` and `npm run lint` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments or that everything is internally sourced
- [ ] run `npm run changeset` to generate a changeset file for changes that should be included in the release notes
