### PR TITLE
chore: adds workflow to automate release and version bump

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,29 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: master
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+        cache: 'npm'
+    - run: npm ci
+    - name: Open release PR
+      uses: changesets/action@v1
+      with:
+        version: npm run version
+        title: 'chore: version bump and release notes'
+        commit: 'chore: version bump and release notes'
+      env:
+        GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Resolves one item from https://github.com/getodk/web-forms/issues/821

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

You can see the PR it generates in my fork: https://github.com/latin-panda/test-central-frontend/pull/1/ 

#### Why is this the best possible solution? Were any other approaches considered?

Manual trigger, mostly because of the PR step. After this, the developer can push the release tag and trigger the other workflow, wf-publish.yml.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

N/A

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I'll update the release steps after approval. 
