### PR TITLE
Update publishing notes text

### DIFF
--- a/apps/central/src/components/form-draft/publish.vue
+++ b/apps/central/src/components/form-draft/publish.vue
@@ -199,10 +199,10 @@ export default {
       "409_6": "The version name of this Draft conflicts with a past version of this Form or a deleted Form. Please use the field below to change it to something new or upload a new Form definition."
     },
     "field": {
-      "note": "Notes"
+      "note": "Version notes"
     },
     "placeholder": {
-      "note": "Add optional publishing notes…"
+      "note": "Describe this version (optional)…"
     }
   }
 }

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3447,13 +3447,13 @@
       },
       "field": {
         "note": {
-          "string": "Notes",
+          "string": "Version notes",
           "developer_comment": "This is the text of a form field."
         }
       },
       "placeholder": {
         "note": {
-          "string": "Add optional publishing notes…"
+          "string": "Describe this version (optional)…"
         }
       }
     },


### PR DESCRIPTION
I'm not sure that "publishing notes" would be meaningful to users.

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

I tried to steer people towards what we want them to use the field for. If we were prompting only on edits, we could say something like "Describe what changed" but given that it's also shown on first publish, that doesn't work. Using the word "version" gives a hint that the text ends up on the Versions tab.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?
Text-only.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
Added to https://github.com/getodk/docs/issues/2054