### PR TITLE
Don't cap login logo width

### DIFF
--- a/apps/central/src/components/account/page/container.vue
+++ b/apps/central/src/components/account/page/container.vue
@@ -119,8 +119,11 @@ Notes about the layout:
 
 #account-page-container-logo {
   img {
-    max-width: 130px;
     max-height: 130px;
+    // Prevent the logo from overflowing horizontally. Other than that, we only
+    // want to cap the logo size vertically, not horizontally: see
+    // getodk/central#1761.
+    max-width: 100%;
   }
 
   &:not(:has(img[data-loaded])):not(:has(img[data-error])) {


### PR DESCRIPTION
Closes getodk/central#1761.

#### What has been done to verify that this works as intended?

I tried it locally:

- Really wide image
- Really tall image
- More square image
- Default logo

We don't usually test CSS, so this change shouldn't require changing tests.

#### Why is this the best possible solution? Were any other approaches considered?

I tried a few things in the CSS. I tried just removing `max-width`, but the image ended up overflowing its container (`#account-page-container-logo`). I tried putting `max-width: 100%;` and `overflow-x: hidden;` on the container, but it ended up truncating the image. So I think the `max-width` needs to be on the image itself.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

The QA team should try a variety of image sizes in order to verify that there hasn't been a regression.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I guess it is technically a change to existing behavior. Existing logos could be affected. However, I don't feel like we need to announce or highlight this change to users. Users can always update their logos if somehow the new look/sizing isn't right for them.