### PR TITLE
transifex:destructure: don't warn for variable enclosed in guillemets

### DIFF
--- a/apps/central/bin/util/transifex.js
+++ b/apps/central/bin/util/transifex.js
@@ -998,7 +998,7 @@ const validateTranslation = (locale) => ({ source, translated, path }) => {
       logThenThrow({ source, translated }, 'unexpected linked locale message');
 
     if (locales[locale].warnVariableSeparator) {
-      const noSeparator = '[^\\] !"\'(),./:;<>?[’“”„–—-]';
+      const noSeparator = '[^\\] !"\'(),./:;<>?[’“”„«»–—-]';
       if (new RegExp(`${noSeparator}\\{|\\}${noSeparator}`, 'u').test(translated[i])) {
         console.warn(`warning: ${path.join('.')}: variable without separator.`);
       }


### PR DESCRIPTION
It's very common in Transifex for translators not to add spaces around variables. destructure.js logs a warning in that case so that the developer knows about it and can choose to correct it in Transifex. We're about to have our first translations with guillemets («these»), but right now the destructure.js warning doesn't understand them. It logs a warning when it shouldn't:

```
destructuring fr
warning: component.FieldKeyEdit.title: variable without separator.
warning: component.PublicLinkEdit.title: variable without separator.
```

This PR adds guillements to the punctuation regex in destructure.js.

#### What has been done to verify that this works as intended?

When I make this change, I no longer see the warning.

#### Why is this the best possible solution? Were any other approaches considered?

I followed the existing pattern of listing punctuation characters in a regex.