### PR TITLE
Fixes: css adjustment for lengthy custom properties

### DIFF
--- a/apps/central/src/components/actor-properties/upsert.vue
+++ b/apps/central/src/components/actor-properties/upsert.vue
@@ -50,12 +50,16 @@ nextTick(() => {
 
 <style lang="scss">
 .actor-properties-upsert {
-  .table > thead {
-    background-color: transparent;
+  .table {
+    table-layout: fixed;
 
-    tr > th {
-      border: none;
-      padding: 10px 0;
+    > thead {
+      background-color: transparent;
+
+      tr > th {
+        border: none;
+        padding: 10px 0;
+      }
     }
   }
 

--- a/apps/central/src/components/dataset/owner-only.vue
+++ b/apps/central/src/components/dataset/owner-only.vue
@@ -281,7 +281,7 @@ const confirm = () => {
 }
 
 .filter-select-label {
-  flex-grow: 1;
+  flex-basis: 50%;
   font-size: 12px;
 
   .form-control {


### PR DESCRIPTION
Addresses https://github.com/getodk/central/issues/1339#issuecomment-4800005413 and addresses first issue of https://github.com/getodk/central/issues/1791#issuecomment-4790792225


`table-layout: fixes` is required for ellipsis/tooltip 

<img width="619" height="600" alt="image" src="https://github.com/user-attachments/assets/bb875046-76fa-4105-88b5-5baf9e551815" />

And setting `flex-basis: 50%` seems reasonable for dropdowns in filter by property modal:

<img width="619" height="275" alt="image" src="https://github.com/user-attachments/assets/4c6e8f02-1b29-4a1d-9fda-72cc3268c59b" />
