### PR TITLE
fix(web-forms#841): attachment upload URL for draft form submissions

### DIFF
--- a/.changeset/rare-wasps-create.md
+++ b/.changeset/rare-wasps-create.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Fixed attachment upload URL for draft form submissions

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -42,6 +42,7 @@ let submissionData: SubmissionData;
 const submissionResult:any = {};
 const isEdit = computed(() => props.actionType === 'edit');
 const isPublicLink = computed(() => props.actionType === 'public-link');
+const draftPath = computed(() => props.form.draft ? '/draft' : '');
 
 const deviceID = getDeviceId();
 
@@ -51,8 +52,7 @@ const withToken = (url) => `${url}${queryString({ st: props.st })}`;
 
 const getAttachment = (requestUrl: URL) => {
   const encodedName = encodeURIComponent(requestUrl.pathname.split('/').pop()!);
-  const draftPath = props.form.draft ? '/draft' : '';
-  const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath}/attachments/${encodedName}`);
+  const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath.value}/attachments/${encodedName}`);
   return fetch(url);
 };
 
@@ -66,9 +66,8 @@ const postPrimaryInstance = async (file:File) => {
     url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}/submissions/${props.instanceId}`;
     method = 'PUT';
   } else {
-    const draftPath = props.form.draft ? '/draft' : '';
     params.deviceID = deviceID;
-    url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath}/submissions`;
+    url = `/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath.value}/submissions`;
     method = 'POST';
   }
   url += queryString(params);
@@ -176,7 +175,7 @@ const uploadAttachment = async (attachment: File, instanceId: string) => {
   const encodedInstanceId = encodeURIComponent(instanceId);
   const encodedName = encodeURIComponent(attachment.name);
 
-  const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}/submissions/${encodedInstanceId}/attachments/${encodedName}`);
+  const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath.value}/submissions/${encodedInstanceId}/attachments/${encodedName}`);
 
   let result;
   try {


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/841

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

<img width="1382" src="https://github.com/user-attachments/assets/928bee3b-94fa-4e22-a9e8-c118797db35e" />

#### Why is this the best possible solution? Were any other approaches considered?

Single source of truth for draft path in one computed variable instead of repeated across three URL-building functions

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Form builders can test and view attachments before publishing the form.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
