### PR TITLE
Fixes: projectId getting undefined for the forms in dataset resource

### DIFF
--- a/apps/central/src/components/dataset/owner-only.vue
+++ b/apps/central/src/components/dataset/owner-only.vue
@@ -225,7 +225,7 @@ const update = async (accessFilter) => {
   });
 
   previousAccessFilter = dataset.accessFilter;
-  Object.assign(dataset.data, { accessFilter: null }, data);
+  dataset.replaceData(data);
 };
 
 const undo = () => {

--- a/apps/central/src/request-data/resources.js
+++ b/apps/central/src/request-data/resources.js
@@ -90,20 +90,33 @@ export default (container, createResource) => {
   createResource('form', () => ({
     transformResponse: ({ data }) => shallowReactive(transformForm(data))
   }));
-  createResource('dataset', (dataset) => ({
-    transformResponse: ({ data }) => {
-      // Add projectId to forms. FormLink expects this property to exist on form
-      // objects.
+  createResource('dataset', (dataset) => {
+    // Add projectId to forms. FormLink expects this property to exist on form
+    // objects.
+    const transformData = (data) => {
       const { projectId } = data;
       for (const form of data.sourceForms) form.projectId = projectId;
       for (const form of data.linkedForms) form.projectId = projectId;
       for (const property of data.properties) {
         for (const form of property.forms) form.projectId = projectId;
       }
+      // The backend doesn't return accessFilter key if it is null (access to all), so we normalize
+      // it here.
+      if (!('accessFilter' in data)) Object.assign(data, { accessFilter: null });
+      return data;
+    };
 
-      return shallowReactive(data);
-    },
-    hasGeometry: computeIfExists(() =>
-      dataset.properties.some(({ name }) => name === 'geometry'))
-  }));
+    return {
+      transformResponse: ({ data }) =>
+        shallowReactive(transformData(data)),
+      // Use this method to replace data in dataset.data. It applies the same
+      // transformation as transformResponse to ensure forms have projectId set
+      // correctly.
+      replaceData: (data) => {
+        Object.assign(dataset.data, transformData(data));
+      },
+      hasGeometry: computeIfExists(() =>
+        dataset.properties.some(({ name }) => name === 'geometry'))
+    };
+  });
 };

--- a/apps/central/test/request-data/resources.spec.js
+++ b/apps/central/test/request-data/resources.spec.js
@@ -114,6 +114,100 @@ describe('createResources()', () => {
       ];
       forms.length.should.equal(6);
       for (const form of forms) form.projectId.should.equal(1);
+      expect(dataset.accessFilter).to.be.null;
+    });
+
+    describe('replaceData', () => {
+      it('adds projectId to forms in replaced data and accessFilter is set to null', () => {
+        testData.extendedDatasets.createPast(1, {
+          properties: [],
+          sourceForms: [],
+          linkedForms: []
+        });
+        const dataset = createResource();
+
+        dataset.replaceData({
+          id: 1,
+          projectId: 1,
+          name: 'trees',
+          approvalRequired: false,
+          ownerOnly: false,
+          entities: 0,
+          lastEntity: undefined,
+          lastUpdate: undefined,
+          conflicts: 0,
+          properties: [
+            {
+              name: 'height',
+              forms: [
+                { name: 'Tree Registration', xmlFormId: 'tree_registration' },
+              ]
+            }
+          ],
+          sourceForms: [
+            { name: 'Tree Registration', xmlFormId: 'tree_registration' },
+          ],
+          linkedForms: [
+            { name: 'National Parks Survey', xmlFormId: 'national_parks_survey' }
+          ]
+        });
+
+        const forms = [
+          ...dataset.sourceForms,
+          ...dataset.linkedForms,
+          ...dataset.properties[0].forms
+        ];
+        forms.length.should.equal(3);
+        for (const form of forms) form.projectId.should.equal(1);
+        expect(dataset.accessFilter).to.be.null;
+      });
+
+      it('sets accessFilter from the response', () => {
+        testData.extendedDatasets.createPast(1, {
+          properties: [],
+          sourceForms: [],
+          linkedForms: []
+        });
+        const dataset = createResource();
+
+        dataset.replaceData({
+          id: 1,
+          projectId: 1,
+          name: 'trees',
+          approvalRequired: false,
+          ownerOnly: true,
+          accessFilter: {
+            type: 'ownerOnly'
+          },
+          entities: 0,
+          lastEntity: undefined,
+          lastUpdate: undefined,
+          conflicts: 0,
+          properties: [
+            {
+              name: 'height',
+              forms: [
+                { name: 'Tree Registration', xmlFormId: 'tree_registration' },
+              ]
+            }
+          ],
+          sourceForms: [
+            { name: 'Tree Registration', xmlFormId: 'tree_registration' },
+          ],
+          linkedForms: [
+            { name: 'National Parks Survey', xmlFormId: 'national_parks_survey' }
+          ]
+        });
+
+        const forms = [
+          ...dataset.sourceForms,
+          ...dataset.linkedForms,
+          ...dataset.properties[0].forms
+        ];
+        forms.length.should.equal(3);
+        for (const form of forms) form.projectId.should.equal(1);
+        dataset.accessFilter.type.should.be.equal('ownerOnly');
+      });
     });
   });
 });


### PR DESCRIPTION
Closes getodk/central#2023

Added `replaceData` function in the `datasets` resource that we can call from any component, which looks cleaner than modifying selective fields.