### PR TITLE
fix(web-forms#842): redirect to login for auth error on non-public forms

### DIFF
--- a/.changeset/orange-nails-cheat.md
+++ b/.changeset/orange-nails-cheat.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Redirect to login page when auth issues for non-public form

--- a/apps/forms/src/components/submission.vue
+++ b/apps/forms/src/components/submission.vue
@@ -114,7 +114,7 @@ const fetchFormConfig = async (): Promise<Form> => {
     try {
       return await getFormByEnketoId(enketoId.value, st.value);
     } catch(e) {
-      if (e instanceof RequestError && (e.statusCode === 401.2 || e.statusCode === 403.1)) {
+      if (st.value && e instanceof RequestError && (e.statusCode === 401.2 || e.statusCode === 403.1)) {
         // a public form with an invalid st or revoked enketoId should show as form not found
         throw new RequestError('Form not found', 404);
       }

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -102,7 +102,23 @@ test.describe('ODK Web Forms', () => {
     await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
   });
 
-  test('allows user to relogin on session expiry', async ({ page, context }) => {
+  test.describe('redirects to login if 401 on load', async () => {
+    const urls = [
+      { name: 'hyphen prefix', url: (form) => `/-/${form.enketoId}` },
+      { name: 'f prefix', url: (form) => `/f/${form.enketoId}` },
+      { name: 'restful', url: (form) => `/projects/${projectId}/forms/${form.xmlFormId}/submissions/new` }
+    ];
+    urls.forEach(t => {
+      test(t.name, async ({ page }) => {
+        await page.goto(appUrl + t.url(publishedForm));
+        await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
+        await login(page);
+        await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+      });
+    });
+  });
+
+  test('allows user to relogin on session expiry during form fill', async ({ page, context }) => {
     await login(page);
 
     const page2 = await context.newPage();

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import BackendClient from '../backend-client';
-import { login, test } from '../util';
+import { login, test, submitLogin } from '../util';
 
 const appUrl = process.env.ODK_URL;
 const projectId = process.env.PROJECT_ID;
@@ -112,7 +112,7 @@ test.describe('ODK Web Forms', () => {
       test(t.name, async ({ page }) => {
         await page.goto(appUrl + t.url(publishedForm));
         await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
-        await login(page);
+        await submitLogin(page);
         await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
       });
     });

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -5,15 +5,16 @@ const user = process.env.ODK_USER;
 const password = process.env.ODK_PASSWORD;
 const ENCRYPTION_SECRET = 'encryptionsecret';
 
+const submitLogin = async (page) => {
+  await page.getByPlaceholder('email address').fill(user);
+  await page.getByPlaceholder('password').fill(password);
+  await page.getByRole('button', { name: 'Log in' }).click();
+}
+
 const login = async (page) => {
   await page.goto(appUrl);
   await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
-
-  await page.getByPlaceholder('email address').fill(user);
-  await page.getByPlaceholder('password').fill(password);
-
-  await page.getByRole('button', { name: 'Log in' }).click();
-
+  await submitLogin(page);
   await page.waitForURL(appUrl);
 };
 
@@ -111,5 +112,6 @@ async function asText(msg) {
 export {
   test,
   login,
+  submitLogin,
   ENCRYPTION_SECRET
 };


### PR DESCRIPTION
Closes getodk/web-forms#842

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual and e2e testing

#### Why is this the best possible solution? Were any other approaches considered?

Requests without `st` aren't public forms so a session is required, so treat these requests differently than ones with `st`.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

This change should only impact on requests using enketoId without an `st` token, so the risks are low, and now well tested.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
