### PR TITLE
chore: remove duplicated test run

### DIFF
--- a/.github/workflows/wf-ci.yml
+++ b/.github/workflows/wf-ci.yml
@@ -243,37 +243,7 @@ jobs:
         run: 'npx playwright install ${{ matrix.browser }} --with-deps'
 
       - if: ${{ matrix.target == 'Web' && matrix.browser == 'webkit' }}
-        run: |
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
-          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+        run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'
 
       - if: ${{ matrix.target == 'Web' && matrix.browser != 'webkit' }}
         run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'

--- a/.github/workflows/wf-ci.yml
+++ b/.github/workflows/wf-ci.yml
@@ -242,11 +242,38 @@ jobs:
       - if: ${{ matrix.target == 'Web' }}
         run: 'npx playwright install ${{ matrix.browser }} --with-deps'
 
-      # TODO: hopefully temporary! Attempt to mitigate flakiness in webkit by
-      # running twice when first run fails. At least in local testing, this has
-      # been near (if not at) 100% success.
       - if: ${{ matrix.target == 'Web' && matrix.browser == 'webkit' }}
-        run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms || npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'
+        run: |
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
+          npm run test-browser:${{ matrix.browser }} -w=packages/web-forms
 
       - if: ${{ matrix.target == 'Web' && matrix.browser != 'webkit' }}
         run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'

--- a/.github/workflows/wf-ci.yml
+++ b/.github/workflows/wf-ci.yml
@@ -242,10 +242,7 @@ jobs:
       - if: ${{ matrix.target == 'Web' }}
         run: 'npx playwright install ${{ matrix.browser }} --with-deps'
 
-      - if: ${{ matrix.target == 'Web' && matrix.browser == 'webkit' }}
-        run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'
-
-      - if: ${{ matrix.target == 'Web' && matrix.browser != 'webkit' }}
+      - if: ${{ matrix.target == 'Web' }}
         run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'
 
       - if: ${{ matrix.node-version == '24.16.0' && matrix.target == 'Node' }}


### PR DESCRIPTION


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

The initial commit runs the build 30 times in serial - if any of them fail the whole build would fail. It didn't fail. The subsequent change removes the last 29 runs leaving just one.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
