### PR TITLE
Update styling for entity.error

### DIFF
--- a/apps/central/src/components/submission/feed-entry.vue
+++ b/apps/central/src/components/submission/feed-entry.vue
@@ -218,7 +218,15 @@ export default {
 
 .submission-feed-entry {
   .entity-error-message{
-    margin: 10px;
+    background-color: $color-danger-light;
+    color: $color-danger;
+    padding: 10px;
+
+    p {
+      max-width: none;
+
+      &:last-child { margin-bottom: 0; }
+    }
   }
 
   .icon-cloud-upload, .icon-comment, .icon-trash, .icon-recycle, .icon-clock-o {


### PR DESCRIPTION
This PR addresses the QA comments at https://github.com/getodk/central/issues/1867#issuecomment-4832277812:

1. Remove the `max-width` on `<p>` when rendering an `entity.error` in the submission activity feed
2. Change the background color

Re: background color, I'm actually not 100% sure what works best there. Nicole mentioned "Reusing the styling from the entity upload designs", but looking at the Figma file, I'm not totally sure which background color she's referring to. Part of the Figma file does show errors with a red background color, so I ran with that. I also made the text color red to match what we did in #1690. Here's what it looks like:

<img width="857" height="96" src="https://github.com/user-attachments/assets/aa021665-ec7a-44c8-a25c-e37880a2aeb0" />

#### What has been done to verify that this works as intended?

I tried it out locally. We don't usually test styles.