### PR TITLE
Bump version for v2026.2 release

### DIFF
--- a/.changeset/brave-poets-sin.md
+++ b/.changeset/brave-poets-sin.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Display errors encountered while loading the forms app

--- a/.changeset/brave-wolves-dance.md
+++ b/.changeset/brave-wolves-dance.md
@@ -1,5 +1,0 @@
----
-'@getodk/web-forms': minor
----
-
-Added 'Select answer' placeholder to select one and select multiple with dropdowns when no option has been selected yet.

--- a/.changeset/calm-pugs-cheat.md
+++ b/.changeset/calm-pugs-cheat.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": minor
----
-
-Changed the vue component parameter from track-device to device-id which now expects the app to provide the id rather than autogenerating one

--- a/.changeset/chilly-mice-admire.md
+++ b/.changeset/chilly-mice-admire.md
@@ -1,5 +1,0 @@
----
-'@getodk/web-forms': patch
----
-
-Fixed vertical range control to record the correct value

--- a/.changeset/clean-dancers-leave.md
+++ b/.changeset/clean-dancers-leave.md
@@ -1,5 +1,0 @@
----
-'@getodk/web-forms': patch
----
-
-Increases hit target of range control to make it easier to click on

--- a/.changeset/curly-cups-camp.md
+++ b/.changeset/curly-cups-camp.md
@@ -1,7 +1,0 @@
----
-'@getodk/xforms-engine': minor
-'@getodk/common': minor
-'@getodk/web-forms': minor
----
-
-Added support for submission encryption

--- a/.changeset/dark-rules-lick.md
+++ b/.changeset/dark-rules-lick.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Change icon and text of the choose files button on Form draft's attachment section

--- a/.changeset/eager-teeth-mate.md
+++ b/.changeset/eager-teeth-mate.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Revoke media's object URLs on Web Forms unmount

--- a/.changeset/four-streets-turn.md
+++ b/.changeset/four-streets-turn.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Hid the language selector if there is only one language to choose from

--- a/.changeset/frank-poets-show.md
+++ b/.changeset/frank-poets-show.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Show point, trace, and shape on map when default value is set dynamically

--- a/.changeset/frank-wings-attend.md
+++ b/.changeset/frank-wings-attend.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Catch undefined errors and show a user facing dialog

--- a/.changeset/hungry-groups-wave.md
+++ b/.changeset/hungry-groups-wave.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/web-forms": patch
----
-
-Improves usability of error message when external resource failed to load

--- a/.changeset/icy-areas-know.md
+++ b/.changeset/icy-areas-know.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/xpath": patch
----
-
-Fixed two memory leaks and improved `position()` performance on large same-name sibling sets.

--- a/.changeset/itchy-shrimps-call.md
+++ b/.changeset/itchy-shrimps-call.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/web-forms": patch
----
-
-Fixes geopoint values to include altitude and accuracy, defaulting to 0 if missing, matching ODK Collect.

--- a/.changeset/jolly-coins-thank.md
+++ b/.changeset/jolly-coins-thank.md
@@ -1,6 +1,0 @@
----
-"@getodk/central-frontend": patch
-"@getodk/forms": patch
----
-
-Pass Sentry DSN at runtime via client-config.json

--- a/.changeset/khaki-years-wash.md
+++ b/.changeset/khaki-years-wash.md
@@ -1,6 +1,0 @@
----
-"@getodk/central-frontend": patch
-"@getodk/forms": patch
----
-
-Added Sentry error reporting

--- a/.changeset/lemon-deserts-report.md
+++ b/.changeset/lemon-deserts-report.md
@@ -1,6 +1,0 @@
----
-"@getodk/central-frontend": minor
-"@getodk/forms": minor
----
-
-Separated web-forms and enketo into a new app

--- a/.changeset/loud-spoons-tickle.md
+++ b/.changeset/loud-spoons-tickle.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Feature: add access filter options on dataset settings page

--- a/.changeset/loud-tips-arrive.md
+++ b/.changeset/loud-tips-arrive.md
@@ -1,5 +1,0 @@
----
-'@getodk/web-forms': minor
----
-
-Improved display of range widget to include selected value

--- a/.changeset/lovely-jokes-behave.md
+++ b/.changeset/lovely-jokes-behave.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": minor
-"@getodk/web-forms": minor
----
-
-Add support for annotate, draw and signature question types

--- a/.changeset/metal-apes-battle.md
+++ b/.changeset/metal-apes-battle.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": minor
----
-
-Fixed attachment removal on edit submission.

--- a/.changeset/metal-heads-think.md
+++ b/.changeset/metal-heads-think.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/web-forms": patch
----
-
-Detect whitespace in external instance csv files to make it easier to debug

--- a/.changeset/mighty-experts-repair.md
+++ b/.changeset/mighty-experts-repair.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Add Custom Properties tab in Project to manage App User/Public Link properties

--- a/.changeset/odd-bags-design.md
+++ b/.changeset/odd-bags-design.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": minor
----
-
-Improved error messages for invalid URLs

--- a/.changeset/orange-nails-cheat.md
+++ b/.changeset/orange-nails-cheat.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Redirect to login page when auth issues for non-public form

--- a/.changeset/proud-snakes-cover.md
+++ b/.changeset/proud-snakes-cover.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Fixed setvalue with now() into a date field returning empty string

--- a/.changeset/proud-years-chew.md
+++ b/.changeset/proud-years-chew.md
@@ -1,6 +1,0 @@
----
-'@getodk/xforms-engine': patch
-'@getodk/common': patch
----
-
-Fixed handling of ranges with negative step values

--- a/.changeset/public-eyes-marry.md
+++ b/.changeset/public-eyes-marry.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": minor
----
-
-Added 'loaded' event to Web Forms component

--- a/.changeset/quiet-bottles-like.md
+++ b/.changeset/quiet-bottles-like.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Web Forms setting (enketo/ODK-Web-Forms) can be set for the draft Forms. (getodk/central#1693)

--- a/.changeset/rare-wasps-create.md
+++ b/.changeset/rare-wasps-create.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Fixed attachment upload URL for draft form submissions

--- a/.changeset/rich-teams-push.md
+++ b/.changeset/rich-teams-push.md
@@ -1,6 +1,0 @@
----
-'@getodk/xforms-engine': patch
-'@getodk/web-forms': patch
----
-
-Fixed bug where computed image urls blocked form loading

--- a/.changeset/silly-crews-cover.md
+++ b/.changeset/silly-crews-cover.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Removed W+F keyboard shortcut to see "New Preview" button to use ODK Web Forms

--- a/.changeset/slimy-cups-burn.md
+++ b/.changeset/slimy-cups-burn.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.

--- a/.changeset/solid-lies-chew.md
+++ b/.changeset/solid-lies-chew.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": minor
----
-
-Preserved newlines in mixed-content label text

--- a/.changeset/sour-houses-wink.md
+++ b/.changeset/sour-houses-wink.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Serialise MapBlock dynamic import to fix map not loading on first load in iOS Safari

--- a/.changeset/sunny-balloons-occur.md
+++ b/.changeset/sunny-balloons-occur.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fix scroll to top when a new instance is requested in Web Forms

--- a/.changeset/sweet-pianos-poke.md
+++ b/.changeset/sweet-pianos-poke.md
@@ -1,5 +1,0 @@
----
-'@getodk/web-forms': minor
----
-
-Improved the UI of the language switcher on mobile

--- a/.changeset/swift-hats-attack.md
+++ b/.changeset/swift-hats-attack.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Preserve spaces after output elements in dynamic labels

--- a/.changeset/three-forks-sin.md
+++ b/.changeset/three-forks-sin.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Improved messaging regarding the ODK Web Forms experience

--- a/.changeset/two-paws-wish.md
+++ b/.changeset/two-paws-wish.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixed markdown sanitization to reliably work for links

--- a/.changeset/wide-ties-sniff.md
+++ b/.changeset/wide-ties-sniff.md
@@ -1,8 +1,0 @@
----
-"@getodk/common": major
-"@getodk/web-forms": major
-"@getodk/xforms-engine": major
-"@getodk/xpath": major
----
-
-First stable release

--- a/.changeset/yellow-donkeys-cross.md
+++ b/.changeset/yellow-donkeys-cross.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Preserve map state during user edits

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @getodk/central-frontend
 
-## 0.2.0
+## 2026.2.0
 
 ### Minor Changes
 

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @getodk/central-frontend
+
+## 0.2.0
+
+### Minor Changes
+
+- e620e5a: Separated web-forms and enketo into a new app
+- 6947cd1: Add Custom Properties tab in Project to manage App User/Public Link properties
+
+### Patch Changes
+
+- 84750ae: Change icon and text of the choose files button on Form draft's attachment section
+- 13d411a: Pass Sentry DSN at runtime via client-config.json
+- 18f994e: Added Sentry error reporting
+- 6e1b299: Feature: add access filter options on dataset settings page
+- 542f6f2: Web Forms setting (enketo/ODK-Web-Forms) can be set for the draft Forms. (getodk/central#1693)
+- b314f1c: Removed W+F keyboard shortcut to see "New Preview" button to use ODK Web Forms
+- f9c0f85: Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.
+- 7511e9a: Improved messaging regarding the ODK Web Forms experience

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -4,13 +4,35 @@
 
 ### Minor Changes
 
+**Entity filtering**
+
+- getodk/central#1866: Filter Entity Lists using custom user properties
+- getodk/central#1870 (6947cd1): Add Custom Properties tab in Project to manage App User/Public Link properties
+- getodk/central#1791 (6e1b299): Feature: add access filter options on dataset settings page
+
+**Web Forms is now the default web form experience**
+
 - e620e5a: Separated web-forms and enketo into a new app
-- 6947cd1: Add Custom Properties tab in Project to manage App User/Public Link properties
-- 84750ae: Change icon and text of the choose files button on Form draft's attachment section
-- 13d411a: Pass Sentry DSN at runtime via client-config.json
-- 18f994e: Added Sentry error reporting
-- 6e1b299: Feature: add access filter options on dataset settings page
-- 542f6f2: Web Forms setting (enketo/ODK-Web-Forms) can be set for the draft Forms. (getodk/central#1693)
-- b314f1c: Removed W+F keyboard shortcut to see "New Preview" button to use ODK Web Forms
-- f9c0f85: Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.
 - 7511e9a: Improved messaging regarding the ODK Web Forms experience
+- getodk/central#1946 (b314f1c): Removed W+F keyboard shortcut to see "New Preview" button to use ODK Web Forms
+
+**Improved form drafts**
+
+- getodk/central#1681: Update Form drafts experience
+- getodk/central#1944 (f9c0f85): Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.
+- getodk/central#1945 (84750ae): Change icon and text of the choose files button on Form draft's attachment section
+
+**Other improvements + bug fixes**
+
+- getodk/central#1761: Only cap the login logo size vertically, not horizontally
+- getodk/central#1867: Recommend action when Entity processing fails
+- getodk/central#1348: Add pagination to URL for Submission and Entity tables
+- getodk/central#1079: Rename "passphrase" to "encryption password"
+
+**Maintenance**
+
+- 18f994e: Added Sentry error reporting
+- getodk/central#1847: Update What's New modal
+- getodk/central#1846: Update usage information metrics
+- getodk/central#1668: Update dependencies
+- getodk/central#1843: Update translations

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -6,9 +6,6 @@
 
 - e620e5a: Separated web-forms and enketo into a new app
 - 6947cd1: Add Custom Properties tab in Project to manage App User/Public Link properties
-
-### Patch Changes
-
 - 84750ae: Change icon and text of the choose files button on Form draft's attachment section
 - 13d411a: Pass Sentry DSN at runtime via client-config.json
 - 18f994e: Added Sentry error reporting

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -19,7 +19,7 @@
 **Improved form drafts**
 
 - getodk/central#1681: Update Form drafts experience
-- getodk/central#1944 (f9c0f85): Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.
+- f9c0f85: Attachment files now can only be drag and drop to the attachment section. Previously, they could be drop to anywhere on the Form draft page.
 - getodk/central#1945 (84750ae): Change icon and text of the choose files button on Form draft's attachment section
 
 **Other improvements + bug fixes**
@@ -34,5 +34,5 @@
 - 18f994e: Added Sentry error reporting
 - getodk/central#1847: Update What's New modal
 - getodk/central#1846: Update usage information metrics
-- getodk/central#1668: Update dependencies
+- getodk/central#1844: Update dependencies
 - getodk/central#1843: Update translations

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/central-frontend",
-  "version": "0.2.0",
+  "version": "2026.2.0",
   "private": true,
   "scripts": {
     "eslint": "eslint --max-warnings 0 --cache --ext .js,.vue src/ test/ bin/ *.js",

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/central-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "eslint": "eslint --max-warnings 0 --cache --ext .js,.vue src/ test/ bin/ *.js",

--- a/apps/forms/CHANGELOG.md
+++ b/apps/forms/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @getodk/forms
 
-## 0.2.0
+## 2026.2.0
 
 ### Minor Changes
 

--- a/apps/forms/CHANGELOG.md
+++ b/apps/forms/CHANGELOG.md
@@ -1,0 +1,16 @@
+# @getodk/forms
+
+## 0.2.0
+
+### Minor Changes
+
+- e620e5a: Separated web-forms and enketo into a new app
+- 060ec41: Improved error messages for invalid URLs
+
+### Patch Changes
+
+- 45052e9: Display errors encountered while loading the forms app
+- 13d411a: Pass Sentry DSN at runtime via client-config.json
+- 18f994e: Added Sentry error reporting
+- a76aeb8: Redirect to login page when auth issues for non-public form
+- cbbfd27: Fixed attachment upload URL for draft form submissions

--- a/apps/forms/package.json
+++ b/apps/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/forms",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/forms/package.json
+++ b/apps/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/forms",
-  "version": "0.2.0",
+  "version": "2026.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @getodk/common
 
+## 1.0.0
+
+### Major Changes
+
+- 3045945: First stable release
+
+### Minor Changes
+
+- 9918bea: Added support for submission encryption
+
+### Patch Changes
+
+- b7abdc1: Fixed handling of ranges with negative step values
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getodk/common",
   "private": true,
-  "version": "0.15.0",
+  "version": "1.0.0",
   "description": "@getodk/common",
   "type": "module",
   "author": "getodk",

--- a/packages/web-forms/CHANGELOG.md
+++ b/packages/web-forms/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @getodk/web-forms
 
+## 1.0.0
+
+### Major Changes
+
+- 3045945: First stable release
+
+### Minor Changes
+
+- a16775d: Added 'Select answer' placeholder to select one and select multiple with dropdowns when no option has been selected yet.
+- 3882668: Changed the vue component parameter from track-device to device-id which now expects the app to provide the id rather than autogenerating one
+- 9918bea: Added support for submission encryption
+- b7abdc1: Improved display of range widget to include selected value
+- dc8b683: Add support for annotate, draw and signature question types
+- f2600da: Added 'loaded' event to Web Forms component
+- b7abdc1: Improved the UI of the language switcher on mobile
+
+### Patch Changes
+
+- b7abdc1: Fixed vertical range control to record the correct value
+- b7abdc1: Increases hit target of range control to make it easier to click on
+- ffc33b1: Revoke media's object URLs on Web Forms unmount
+- 536aeb9: Hid the language selector if there is only one language to choose from
+- 74837bf: Show point, trace, and shape on map when default value is set dynamically
+- ab71c5e: Catch undefined errors and show a user facing dialog
+- dcff72c: Improves usability of error message when external resource failed to load
+- 2c087b6: Fixes geopoint values to include altitude and accuracy, defaulting to 0 if missing, matching ODK Collect.
+- 06a3ed7: Detect whitespace in external instance csv files to make it easier to debug
+- f1c8db5: Fixed bug where computed image urls blocked form loading
+- 134a9e3: Serialise MapBlock dynamic import to fix map not loading on first load in iOS Safari
+- 5a836a2: Fix scroll to top when a new instance is requested in Web Forms
+- 69a48fe: Fixed markdown sanitization to reliably work for links
+- eb86fa2: Preserve map state during user edits
+
 ## 0.24.0
 
 ### Minor Changes

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/web-forms",
-  "version": "0.24.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "description": "ODK Web Forms",
   "author": "getodk",
@@ -68,7 +68,7 @@
     "@faker-js/faker": "^10.1.0",
     "@fontsource/hanken-grotesk": "^5.2.8",
     "@fontsource/roboto": "^5.2.9",
-    "@getodk/xforms-engine": "0.22.0",
+    "@getodk/xforms-engine": "1.0.0",
     "@primeuix/themes": "1.0.3",
     "@types/image-blob-reduce": "^4",
     "@types/ramda": "^0.31.1",

--- a/packages/xforms-engine/CHANGELOG.md
+++ b/packages/xforms-engine/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @getodk/xforms-engine
 
+## 1.0.0
+
+### Major Changes
+
+- 3045945: First stable release
+
+### Minor Changes
+
+- 9918bea: Added support for submission encryption
+- dc8b683: Add support for annotate, draw and signature question types
+- 5f4083a: Fixed attachment removal on edit submission.
+- 4b93aa8: Preserved newlines in mixed-content label text
+
+### Patch Changes
+
+- dcff72c: Improves usability of error message when external resource failed to load
+- eccae97: Fixed two memory leaks and improved `position()` performance on large same-name sibling sets.
+- 2c087b6: Fixes geopoint values to include altitude and accuracy, defaulting to 0 if missing, matching ODK Collect.
+- 06a3ed7: Detect whitespace in external instance csv files to make it easier to debug
+- b6aea65: Fixed setvalue with now() into a date field returning empty string
+- b7abdc1: Fixed handling of ranges with negative step values
+- f1c8db5: Fixed bug where computed image urls blocked form loading
+- d2ba628: Preserve spaces after output elements in dynamic labels
+
 ## 0.22.0
 
 ### Minor Changes

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/xforms-engine",
-  "version": "0.22.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "description": "XForms engine for ODK Web Forms",
   "type": "module",
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.5",
     "@getodk/tree-sitter-xpath": "^0.2.2",
-    "@getodk/xpath": "0.11.0",
+    "@getodk/xpath": "1.0.0",
     "@js-joda/core": "^5.7.0",
     "@types/papaparse": "^5.5.0",
     "babel-plugin-transform-jsbi-to-bigint": "^1.4.2",

--- a/packages/xpath/CHANGELOG.md
+++ b/packages/xpath/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @getodk/xpath
 
+## 1.0.0
+
+### Major Changes
+
+- 3045945: First stable release
+
+### Patch Changes
+
+- eccae97: Fixed two memory leaks and improved `position()` performance on large same-name sibling sets.
+- Updated dependencies [9918bea]
+- Updated dependencies [b7abdc1]
+- Updated dependencies [3045945]
+  - @getodk/common@1.0.0
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/xpath/package.json
+++ b/packages/xpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/xpath",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "description": "XPath implementation for ODK Web Forms",
   "type": "module",
@@ -57,7 +57,7 @@
     "test:types:test": "tsc --project ./test/tsconfig.json --emitDeclarationOnly false --noEmit"
   },
   "dependencies": {
-    "@getodk/common": "0.15.0",
+    "@getodk/common": "1.0.0",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I ran `npm run version`. As described in getodk/central#2037: "This consumes the `.changeset/` files, bumps package versions, and updates each `CHANGELOG.md`."

#### What has been done to verify that this works as intended?

Not a code change, but we'll check CI.

#### Why is this the best possible solution? Were any other approaches considered?

I'm planning to make additional changes to the Central changelog. I can do that either in a follow-up commit or a follow-up PR.