### PR TITLE
fix(web-forms#847): fix styling of media controls in repeats

### DIFF
--- a/.changeset/strict-rivers-carry.md
+++ b/.changeset/strict-rivers-carry.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+Fixed styling for media upload questions in repeats

--- a/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
@@ -339,12 +339,14 @@ onUnmounted(() => {
 	border-radius: var(--odk-radius);
 
 	:deep(.upload-control-header) {
-		border-radius: var(--odk-radius) var(--odk-radius) 0 0;
 		background: var(--odk-light-background-color);
 		justify-content: flex-start;
 		gap: var(--odk-spacing-xl);
 		border-bottom: 1px solid var(--odk-border-color);
 		padding: 12px var(--odk-spacing-xl);
+		display: flex;
+		align-items: center;
+		width: 100%;
 	}
 
 	:deep(.upload-control-content) {

--- a/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
@@ -9,7 +9,6 @@ import type { Translate } from '@/lib/locale/useLocale.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import Message from 'primevue/message';
-import Panel from 'primevue/panel';
 import { computed, inject, onUnmounted, ref, watchEffect } from 'vue';
 import DeleteConfirmDialog from './DeleteConfirmDialog.vue';
 import UploadAudioHeader from './UploadAudioHeader.vue';
@@ -246,8 +245,8 @@ onUnmounted(() => {
 <template>
 	<ControlText :question="question" />
 
-	<Panel :class="{ 'mobile-only-header': isBlankCanvas }">
-		<template #header>
+	<div class="upload-control" :class="{ 'mobile-only-header': isBlankCanvas }">
+		<div class="upload-control-header">
 			<template v-if="mediaType === 'image'">
 				<UploadImageHeader
 					:question="question"
@@ -267,8 +266,8 @@ onUnmounted(() => {
 			<template v-else>
 				<UploadFileHeader :question="question" :accept="accept" :is-disabled="isDisabled" @change="onChange" />
 			</template>
-		</template>
-		<template #default>
+		</div>
+		<div class="upload-control-content">
 			<div class="drag-and-drop" :class="{ 'disabled': isDisabled, 'canvas-mode': !!canvasMode && showImagePreview }" @drop.prevent.stop="onDrop" @dragover.prevent>
 				<div v-if="canvasEmptyPlaceholder.length && !question.currentState.value" class="canvas-empty-placeholder">
 					{{ canvasEmptyPlaceholder }}
@@ -321,9 +320,8 @@ onUnmounted(() => {
 					{{ t('upload_control.drag_and_drop.placeholder') }}
 				</div>
 			</div>
-		</template>
-	</Panel>
-
+		</div>
+	</div>
 	<DeleteConfirmDialog
 		v-model:visible="confirmDeleteAction"
 		@delete-file="clearValueConfirmed"
@@ -333,26 +331,27 @@ onUnmounted(() => {
 <style scoped lang="scss">
 @use '../../../assets/styles/breakpoints' as odk;
 
-.p-panel {
+.upload-control {
 	background: var(--odk-base-background-color);
 	box-shadow: none;
 	border: 1px solid var(--odk-border-color);
-  overflow: hidden;
+	overflow: hidden;
+	border-radius: var(--odk-radius);
 
-	:deep(.p-panel-header) {
+	:deep(.upload-control-header) {
 		border-radius: var(--odk-radius) var(--odk-radius) 0 0;
 		background: var(--odk-light-background-color);
 		justify-content: flex-start;
 		gap: var(--odk-spacing-xl);
 		border-bottom: 1px solid var(--odk-border-color);
-		padding: var(--p-panel-header-padding);
+		padding: 12px var(--odk-spacing-xl);
 	}
 
-	:deep(.p-panel-content-container .p-panel-content) {
+	:deep(.upload-control-content) {
 		padding: 0;
 	}
 
-	&.mobile-only-header :deep(.p-panel-header) {
+	&.mobile-only-header :deep(.upload-control-header) {
 		display: none;
 	}
 }
@@ -420,16 +419,16 @@ onUnmounted(() => {
 }
 
 @include odk.sm-constrained {
-	.p-panel :deep(.p-panel-header) {
+	.upload-control :deep(.upload-control-header) {
 		flex-direction: column;
 		justify-content: center;
 
-		.p-panel-header-actions {
+		.upload-control-header-actions {
 			display: none;
 		}
 	}
 
-	.p-panel.mobile-only-header :deep(.p-panel-header) {
+	.upload-control.mobile-only-header :deep(.upload-control-header) {
 		display: flex;
 	}
 

--- a/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
@@ -333,14 +333,12 @@ onUnmounted(() => {
 
 .upload-control {
 	background: var(--odk-base-background-color);
-	box-shadow: none;
 	border: 1px solid var(--odk-border-color);
 	overflow: hidden;
 	border-radius: var(--odk-radius);
 
-	:deep(.upload-control-header) {
+	.upload-control-header {
 		background: var(--odk-light-background-color);
-		justify-content: flex-start;
 		gap: var(--odk-spacing-xl);
 		border-bottom: 1px solid var(--odk-border-color);
 		padding: 12px var(--odk-spacing-xl);
@@ -349,11 +347,7 @@ onUnmounted(() => {
 		width: 100%;
 	}
 
-	:deep(.upload-control-content) {
-		padding: 0;
-	}
-
-	&.mobile-only-header :deep(.upload-control-header) {
+	&.mobile-only-header .upload-control-header {
 		display: none;
 	}
 }
@@ -421,16 +415,12 @@ onUnmounted(() => {
 }
 
 @include odk.sm-constrained {
-	.upload-control :deep(.upload-control-header) {
+	.upload-control .upload-control-header {
 		flex-direction: column;
 		justify-content: center;
-
-		.upload-control-header-actions {
-			display: none;
-		}
 	}
 
-	.upload-control.mobile-only-header :deep(.upload-control-header) {
+	.upload-control.mobile-only-header .upload-control-header {
 		display: flex;
 	}
 

--- a/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
@@ -345,6 +345,7 @@ onUnmounted(() => {
 		justify-content: flex-start;
 		gap: var(--odk-spacing-xl);
 		border-bottom: 1px solid var(--odk-border-color);
+		padding: var(--p-panel-header-padding);
 	}
 
 	:deep(.p-panel-content-container .p-panel-content) {

--- a/packages/web-forms/src/components/form-layout/FormPanel.vue
+++ b/packages/web-forms/src/components/form-layout/FormPanel.vue
@@ -104,7 +104,7 @@ h2 {
 		margin-bottom: var(--odk-spacing-xl);
 	}
 
-	:deep(.p-panel-header) {
+	> :deep(.p-panel-header) {
 		display: flex;
 		align-items: center;
 		background: var(--odk-light-background-color);
@@ -143,7 +143,7 @@ h2 {
 		border: none;
 		margin-bottom: 0;
 
-		:deep(.p-panel-header) {
+		> :deep(.p-panel-header) {
 			background: none;
 
 			h2 {
@@ -185,15 +185,15 @@ h2 {
 }
 
 .p-panel.is-repeat {
-	.p-panel.p-panel-toggleable.is-repeat :deep(.p-panel-header) {
+	.p-panel.p-panel-toggleable.is-repeat > :deep(.p-panel-header) {
 		// Nested repeats
 		border-radius: var(--odk-radius);
 		width: calc(100% - 30px);
 		margin: 0 auto;
 	}
 
-	:deep(.p-panel-header),
-	.p-panel.p-panel-toggleable.is-repeat :deep(.p-panel-header) {
+	> :deep(.p-panel-header),
+	.p-panel.p-panel-toggleable.is-repeat > :deep(.p-panel-header) {
 		background: var(--p-surface-200);
 	}
 }

--- a/packages/web-forms/src/components/form-layout/FormPanel.vue
+++ b/packages/web-forms/src/components/form-layout/FormPanel.vue
@@ -104,7 +104,7 @@ h2 {
 		margin-bottom: var(--odk-spacing-xl);
 	}
 
-	> :deep(.p-panel-header) {
+	:deep(.p-panel-header) {
 		display: flex;
 		align-items: center;
 		background: var(--odk-light-background-color);
@@ -143,7 +143,7 @@ h2 {
 		border: none;
 		margin-bottom: 0;
 
-		> :deep(.p-panel-header) {
+		:deep(.p-panel-header) {
 			background: none;
 
 			h2 {
@@ -185,15 +185,15 @@ h2 {
 }
 
 .p-panel.is-repeat {
-	.p-panel.p-panel-toggleable.is-repeat > :deep(.p-panel-header) {
+	.p-panel.p-panel-toggleable.is-repeat :deep(.p-panel-header) {
 		// Nested repeats
 		border-radius: var(--odk-radius);
 		width: calc(100% - 30px);
 		margin: 0 auto;
 	}
 
-	> :deep(.p-panel-header),
-	.p-panel.p-panel-toggleable.is-repeat > :deep(.p-panel-header) {
+	:deep(.p-panel-header),
+	.p-panel.p-panel-toggleable.is-repeat :deep(.p-panel-header) {
 		background: var(--p-surface-200);
 	}
 }


### PR DESCRIPTION
Closes getodk/web-forms#847

This was caused by using primevue panels for both repeats and file uploads so the styling for one also impact the other.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested a range of forms

#### Why is this the best possible solution? Were any other approaches considered?

It's a minimal solution. I think we should think about our approach to styling, for example, considering adding our own classes instead of using the primevue classes. This would help here because we could add a different class for FormPanel than UploadControl which would give us more control as to what styles we're using.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Unintended changes are possible...

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.