### PR TITLE
Redirect user navigating to parent route

### DIFF
--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -59,6 +59,12 @@ router.afterEach(unlessFailure(to => {
   //////////////////////////////////////////////////////////////////////////////
   // REDIRECTS
 
+  // All bottom-level routes in routes.js should have route meta fields. Many of
+  // the navigation guards below assume that `to` has well-defined meta fields.
+  // Here, we check that `to` has meta fields. If it doesn't, that means the
+  // user is trying to navigate to a parent route, which isn't expected.
+  router.beforeEach(to => (Object.keys(to.meta).length === 0 ? '/' : true));
+
   // If a route is nested, its relative path is '', and that path is an alias,
   // then we redirect to the canonical path. That turned out to be easier than
   // using the `redirect` option of Vue Router.

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -121,6 +121,13 @@ describe('createCentralRouter()', () => {
   describe('redirects', () => {
     beforeEach(mockLogin);
 
+    it('redirects from a parent route', () =>
+      load('/account')
+        .respondFor('/')
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/');
+        }));
+
     it('redirects to .../submissions from root path of form', async () => {
       testData.extendedForms.createPast(1);
       return load('/projects/1/forms/f/settings')


### PR DESCRIPTION
Closes getodk/central#1850. The core issue is that routes are expected to have route meta fields. routes.js has a section describing those meta fields, as well as a set of default values. However, in this case, the user is navigating directly to a parent route (/account) instead of a bottom-level route (e.g., /account/edit). We only define route meta fields on bottom-level routes. This PR checks for navigation to a parent route and redirects the user elsewhere.

#### What has been done to verify that this works as intended?

I wrote a new test that fails without the changes to router.js.

#### Why is this the best possible solution? Were any other approaches considered?

I made this change after seeing getodk/central#1850 and #1536. #1536 is focused on `validateData` in particular, which makes sense, since that's what the error message mentions. However, I think the potential issues with missing meta fields extends beyond `validateData`. I'm making the check here one of the first `beforeEach()` navigation guards, because many of the navigation guards that follow assume that `to.meta` is well-defined and has default values.