### PR TITLE
Remove attachment confirmation modal if any files match

### DIFF
--- a/.changeset/quiet-paths-serve.md
+++ b/.changeset/quiet-paths-serve.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": patch
+---
+
+Remove attachment confirmation modal and automatically uploading all matching files

--- a/apps/central/src/components/form-attachment/list.vue
+++ b/apps/central/src/components/form-attachment/list.vue
@@ -29,8 +29,8 @@ except according to the terms contained in the LICENSE file.
       :count-of-files-over-drop-zone="countOfFilesOverDropZone"
       :dragover-attachment="dragoverAttachment"
       :planned-uploads="plannedUploads" :unmatched-files="unmatchedFiles"
-      :name-mismatch="nameMismatch" :upload-status="uploadStatus"
-      @confirm="uploadFiles" @cancel="cancelUploads"/>
+      :upload-status="uploadStatus"
+      @cancel="cancelUploads"/>
 
     <form-attachment-upload-files v-bind="uploadFilesModal"
       @hide="uploadFilesModal.hide()" @select="afterFileInputSelection"/>
@@ -207,8 +207,13 @@ export default {
         else
           this.unmatchedFiles.push(file);
       }
+
+      // Automatically upload planned files without confirmation
+      if (this.plannedUploads.length > 0)
+        this.uploadFiles();
+
       // With the changes to this.plannedUploads and this.unmatchedFiles, the
-      // popup will show in the next tick.
+      // popup will show in the next tick if there are no plannedUploads, only unmatched files.
     },
     // cancelUploads() cancels the uploads before they start, after files have
     // been selected. (It does not cancel an upload in progress.)

--- a/apps/central/src/components/form-attachment/list.vue
+++ b/apps/central/src/components/form-attachment/list.vue
@@ -28,15 +28,15 @@ except according to the terms contained in the LICENSE file.
     <form-attachment-popups
       :count-of-files-over-drop-zone="countOfFilesOverDropZone"
       :dragover-attachment="dragoverAttachment"
-      :planned-uploads="plannedUploads" :unmatched-files="unmatchedFiles"
+      :unmatched-files="unmatchedFiles"
       :upload-status="uploadStatus"
-      @cancel="cancelUploads"/>
+      @cancel="clearPendingFiles"/>
 
     <form-attachment-upload-files v-bind="uploadFilesModal"
       @hide="uploadFilesModal.hide()" @select="afterFileInputSelection"/>
     <form-attachment-name-mismatch v-bind="nameMismatch"
       :planned-uploads="plannedUploads" @hide="nameMismatch.hide()"
-      @confirm="uploadFiles" @cancel="cancelUploads"/>
+      @confirm="uploadFiles" @cancel="clearPendingFiles"/>
     <form-attachment-link-dataset v-bind="linkDatasetModal"
       @hide="linkDatasetModal.hide()" @success="afterLinkDataset"/>
   </file-drop-zone>
@@ -87,9 +87,11 @@ export default {
            drop or using the file input) and that are reset once the uploads
            have started or been canceled
            - plannedUploads. An array of file/attachment pairs, indicating which
-             file to upload for which attachment. plannedUploads is used to
-             confirm or cancel the uploads, then to start them, but it is not
-             used during the uploads themselves.
+             file to upload for which attachment. In most flows, plannedUploads
+             is populated and immediately consumed by uploadFiles(). The
+             exception is when a file is dropped onto a mismatched row: in that
+             case plannedUploads holds the pending upload while the name-mismatch
+             modal awaits confirmation.
            - unmatchedFiles. An array of the files whose names did not match any
              attachment's.
         3. Properties set once the uploads have started and reset once they have
@@ -165,7 +167,7 @@ export default {
           ? this.draftAttachments.get(tr.dataset.name)
           : null;
       }
-      this.cancelUploads();
+      this.clearPendingFiles();
       this.updatedAttachments.clear();
     },
     dragleave(_, leftDropZone) {
@@ -208,16 +210,16 @@ export default {
           this.unmatchedFiles.push(file);
       }
 
-      // Automatically upload planned files without confirmation
+      // Automatically upload planned files without confirmation.
+      // If there are no planned files, the popup will show in the next tick for unmatched files.
       if (this.plannedUploads.length > 0)
         this.uploadFiles();
-
-      // With the changes to this.plannedUploads and this.unmatchedFiles, the
-      // popup will show in the next tick if there are no plannedUploads, only unmatched files.
     },
-    // cancelUploads() cancels the uploads before they start, after files have
-    // been selected. (It does not cancel an upload in progress.)
-    cancelUploads() {
+    // clearPendingFiles() clears any pending file selection before an upload
+    // has started. It is called both when the user cancels a name mismatch
+    // (clearing plannedUploads) and when the user dismisses the unmatched-files
+    // popup (clearing unmatchedFiles), so it always clears both.
+    clearPendingFiles() {
       if (this.plannedUploads.length !== 0) this.plannedUploads = [];
       if (this.unmatchedFiles.length !== 0) this.unmatchedFiles = [];
     },

--- a/apps/central/src/components/form-attachment/list.vue
+++ b/apps/central/src/components/form-attachment/list.vue
@@ -90,9 +90,12 @@ export default {
              is populated and immediately consumed by uploadFiles(). The
              exception is when a file is dropped onto a mismatched row: in that
              case plannedUploads holds the pending upload while the name-mismatch
-             modal awaits confirmation.
+             modal awaits confirmation, and is cleared by clearPlanned() on
+             cancel.
            - unmatchedFiles. An array of the files whose names did not match any
-             attachment's.
+             attachment's. Drives the unmatched-files popup, and is cleared by
+             clearUnmatched() on the next dragenter or when the user dismisses
+             the popup.
         3. Properties set once the uploads have started and reset once they have
            finished or stopped
            - uploadStatus. An object with the following properties:

--- a/apps/central/src/components/form-attachment/list.vue
+++ b/apps/central/src/components/form-attachment/list.vue
@@ -15,7 +15,6 @@ except according to the terms contained in the LICENSE file.
     <form-attachment-table
       :file-is-over-drop-zone="countOfFilesOverDropZone !== 0 && !uploading"
       :dragover-attachment="dragoverAttachment"
-      :planned-uploads="plannedUploads"
       :updated-attachments="updatedAttachments"
       @link="linkDatasetModal.show({ attachment: $event })"/>
     <p>

--- a/apps/central/src/components/form-attachment/list.vue
+++ b/apps/central/src/components/form-attachment/list.vue
@@ -29,13 +29,13 @@ except according to the terms contained in the LICENSE file.
       :dragover-attachment="dragoverAttachment"
       :unmatched-files="unmatchedFiles"
       :upload-status="uploadStatus"
-      @cancel="clearPendingFiles"/>
+      @cancel="clearUnmatched"/>
 
     <form-attachment-upload-files v-bind="uploadFilesModal"
       @hide="uploadFilesModal.hide()" @select="afterFileInputSelection"/>
     <form-attachment-name-mismatch v-bind="nameMismatch"
       :planned-uploads="plannedUploads" @hide="nameMismatch.hide()"
-      @confirm="uploadFiles" @cancel="clearPendingFiles"/>
+      @confirm="uploadFiles" @cancel="clearPlanned"/>
     <form-attachment-link-dataset v-bind="linkDatasetModal"
       @hide="linkDatasetModal.hide()" @success="afterLinkDataset"/>
   </file-drop-zone>
@@ -166,7 +166,7 @@ export default {
           ? this.draftAttachments.get(tr.dataset.name)
           : null;
       }
-      this.clearPendingFiles();
+      this.clearUnmatched();
       this.updatedAttachments.clear();
     },
     dragleave(_, leftDropZone) {
@@ -214,13 +214,13 @@ export default {
       if (this.plannedUploads.length > 0)
         this.uploadFiles();
     },
-    // clearPendingFiles() clears any pending file selection before an upload
-    // has started. It is called both when the user cancels a name mismatch
-    // (clearing plannedUploads) and when the user dismisses the unmatched-files
-    // popup (clearing unmatchedFiles), so it always clears both.
-    clearPendingFiles() {
-      if (this.plannedUploads.length !== 0) this.plannedUploads = [];
-      if (this.unmatchedFiles.length !== 0) this.unmatchedFiles = [];
+    // Called when the user cancels the name-mismatch modal.
+    clearPlanned() {
+      this.plannedUploads = [];
+    },
+    // Called on dragenter and when the user dismisses the unmatched-files popup.
+    clearUnmatched() {
+      this.unmatchedFiles = [];
     },
     // uploadFile() may mutate `updates`.
     uploadFile({ attachment, file }, updates) {

--- a/apps/central/src/components/form-attachment/popups.vue
+++ b/apps/central/src/components/form-attachment/popups.vue
@@ -39,45 +39,15 @@ some point. -->
           </i18n-t>
         </template>
         <template v-else-if="shownAfterSelection">
-          <template v-if="plannedUploads.length !== 0">
-            <i18n-t tag="p" keypath="afterSelection.matched.full"
-              :plural="plannedUploads.length">
-              <template #countOfFiles>
-                <strong>{{ $tcn('afterSelection.matched.countOfFiles', plannedUploads.length) }}</strong>
-              </template>
-            </i18n-t>
-            <p v-show="unmatchedFiles.length !== 0"
-              id="form-attachment-popups-unmatched">
-              <span class="icon-exclamation-triangle"></span>
-              <i18n-t tag="span" keypath="afterSelection.someUnmatched.full"
-                :plural="unmatchedFiles.length">
-                <template #countOfFiles>
-                  <strong>{{ $tcn('afterSelection.someUnmatched.countOfFiles', unmatchedFiles.length) }}</strong>
-                </template>
-              </i18n-t>
-            </p>
-            <p class="modal-actions">
-              <button type="button" class="btn btn-link"
-                @click="$emit('cancel')">
-                {{ $t('action.cancel') }}
-              </button>
-              <button type="button" class="btn btn-primary"
-                @click="$emit('confirm')">
-                {{ $t('action.looksGood') }}
-              </button>
-            </p>
-          </template>
-          <template v-else>
-            <p>
-              {{ $tc('afterSelection.noneMatched', unmatchedFiles.length) }}
-            </p>
-            <p class="modal-actions">
-              <button type="button" class="btn btn-primary"
-                @click="$emit('cancel')">
-                {{ $t('action.ok') }}
-              </button>
-            </p>
-          </template>
+          <p>
+            {{ $tc('afterSelection.noneMatched', unmatchedFiles.length) }}
+          </p>
+          <p class="modal-actions">
+            <button type="button" class="btn btn-primary"
+              @click="$emit('cancel')">
+              {{ $t('action.ok') }}
+            </button>
+          </p>
         </template>
         <template v-else-if="shownDuringUpload">
           <p>{{ $tcn('duringUpload.total', uploadStatus.total) }}</p>
@@ -117,26 +87,20 @@ export default {
       type: Array,
       required: true
     },
-    nameMismatch: {
-      type: Object,
-      required: true
-    },
     uploadStatus: {
       type: Object,
       required: true
     }
   },
-  emits: ['confirm', 'cancel'],
+  emits: ['cancel'],
   computed: {
     shownDuringDragover() {
       return this.countOfFilesOverDropZone !== 0;
     },
     shownAfterSelection() {
-      // If the user dropped a single file over a row, then
-      // FormAttachmentPopups is not used to confirm the selection:
-      // FormAttachmentNameMismatch is.
-      return (this.plannedUploads.length !== 0 && !this.nameMismatch.state) ||
-        this.unmatchedFiles.length !== 0;
+      // This popup only shows when all files are unmatched (no planned uploads).
+      // If some files match, they upload automatically without confirmation.
+      return this.unmatchedFiles.length > 0 && this.plannedUploads.length === 0;
     },
     shownDuringUpload() {
       return this.uploadStatus.current != null;
@@ -225,24 +189,6 @@ $popup-width: 300px;
     padding-bottom: 10px;
     border-radius: 0px;
 
-    #form-attachment-popups-unmatched {
-      $padding: 10px;
-
-      background-color: $color-warning-light;
-      font-size: 12px;
-      line-height: 14px;
-      margin-bottom: 17px;
-      padding: $padding;
-      padding-left: 30px;
-      position: relative;
-
-      .icon-exclamation-triangle {
-        left: $padding;
-        margin-top: 1px;
-        position: absolute;
-      }
-    }
-
     .modal-actions {
       text-align: right;
     }
@@ -278,14 +224,6 @@ $popup-width: 300px;
       }
     },
     "afterSelection": {
-      "matched": {
-        "full": "{countOfFiles} ready for upload. | {countOfFiles} ready for upload.",
-        "countOfFiles": "{count} file | {count} files"
-      },
-      "someUnmatched": {
-        "full": "{countOfFiles} has a name we don’t recognize and will be ignored. To upload it, rename it or drag it onto its target. | {countOfFiles} have a name we don’t recognize and will be ignored. To upload them, rename them or drag them individually onto their targets.",
-        "countOfFiles": "{count} file | {count} files"
-      },
       "noneMatched": "We don’t recognize the file you are trying to upload. Please rename it to match the names listed above, or drag it individually onto its target. | We don’t recognize any of the files you are trying to upload. Please rename them to match the names listed above, or drag them individually onto their targets."
     },
     "duringUpload": {

--- a/apps/central/src/components/form-attachment/popups.vue
+++ b/apps/central/src/components/form-attachment/popups.vue
@@ -79,10 +79,6 @@ export default {
       required: true
     },
     dragoverAttachment: Object,
-    plannedUploads: {
-      type: Array,
-      required: true
-    },
     unmatchedFiles: {
       type: Array,
       required: true
@@ -100,7 +96,7 @@ export default {
     shownAfterSelection() {
       // This popup only shows when all files are unmatched (no planned uploads).
       // If some files match, they upload automatically without confirmation.
-      return this.unmatchedFiles.length > 0 && this.plannedUploads.length === 0;
+      return this.unmatchedFiles.length > 0;
     },
     shownDuringUpload() {
       return this.uploadStatus.current != null;

--- a/apps/central/src/components/form-attachment/row.vue
+++ b/apps/central/src/components/form-attachment/row.vue
@@ -94,10 +94,6 @@ export default {
       default: false
     },
     dragoverAttachment: Object,
-    plannedUploads: {
-      type: Array,
-      required: true
-    },
     updatedAttachments: {
       type: Set,
       required: true
@@ -117,11 +113,8 @@ export default {
   },
   computed: {
     targeted() {
-      const targetedByDragover = this.dragoverAttachment != null &&
+      return this.dragoverAttachment != null &&
         this.attachment.name === this.dragoverAttachment.name;
-      const targetedByDrop = this.plannedUploads
-        .some(({ attachment }) => attachment.name === this.attachment.name);
-      return targetedByDragover || targetedByDrop;
     },
     htmlClass() {
       const dragoverTargetsADifferentRow = this.dragoverAttachment != null &&

--- a/apps/central/src/components/form-attachment/table.vue
+++ b/apps/central/src/components/form-attachment/table.vue
@@ -26,7 +26,6 @@ except according to the terms contained in the LICENSE file.
           :key="attachment.name" :attachment="attachment"
           :file-is-over-drop-zone="fileIsOverDropZone"
           :dragover-attachment="dragoverAttachment"
-          :planned-uploads="plannedUploads"
           :updated-attachments="updatedAttachments"
           :linkable="attachment.type === 'file' && dsHashset.has(attachment.name.replace(/\.[^.]+$/i, ''))"
           @link="$emit('link', $event)"/>
@@ -49,10 +48,6 @@ defineOptions({
 defineProps({
   fileIsOverDropZone: Boolean,
   dragoverAttachment: Object,
-  plannedUploads: {
-    type: Array,
-    required: true
-  },
   updatedAttachments: {
     type: Set,
     required: true

--- a/apps/central/test/components/form-attachment/list.spec.js
+++ b/apps/central/test/components/form-attachment/list.spec.js
@@ -175,69 +175,6 @@ describe('FormAttachmentList', () => {
   The user must be logged in before these tests.
   */
   const testMultipleFileSelection = (select) => {
-    describe('table', () => {
-      beforeEach(() => {
-        testData.extendedForms.createPast(1, { draft: true });
-        testData.standardFormAttachments
-          .createPast(1, { name: 'a', blobExists: true })
-          .createPast(1, { name: 'b', blobExists: false })
-          .createPast(1, { name: 'c' });
-      });
-
-      it('highlights only matching rows', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
-          root: false
-        });
-        await select(component, blankFiles(['a', 'b', 'd']));
-        const rows = component.findAllComponents(FormAttachmentRow);
-        const targeted = rows.map(row => row.classes('targeted'));
-        targeted.should.eql([true, true, false]);
-      });
-
-      it('shows the correct labels', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
-          root: false
-        });
-        await select(component, blankFiles(['a', 'b', 'd']));
-        const labels = component.findAllComponents(FormAttachmentRow)
-          .map(row => row.get('.label'));
-        labels[0].should.be.visible();
-        labels[0].text().should.equal('Replace');
-        labels[1].should.be.visible();
-        labels[1].text().should.equal('Upload');
-        labels[2].should.be.hidden();
-      });
-    });
-
-    describe('after the uploads are canceled', () => {
-      beforeEach(() => {
-        testData.extendedForms.createPast(1, { draft: true });
-        testData.standardFormAttachments
-          .createPast(1, { name: 'a', blobExists: true })
-          .createPast(1, { name: 'b', blobExists: false })
-          .createPast(1, { name: 'c' });
-      });
-
-      it('unhighlights the rows', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
-          root: false
-        });
-        await select(component, blankFiles(['a', 'b', 'd']));
-        await component.get('#form-attachment-popups-main .btn-link').trigger('click');
-        component.find('.form-attachment-row.targeted').exists().should.be.false;
-      });
-
-      it('hides the popup', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
-          root: false
-        });
-        await select(component, blankFiles(['a', 'b', 'd']));
-        const popup = component.get('#form-attachment-popups-main');
-        await popup.get('.btn-link').trigger('click');
-        popup.should.be.hidden();
-      });
-    });
-
     describe('unmatched files', () => {
       beforeEach(() => {
         testData.extendedForms.createPast(1, { draft: true });
@@ -247,52 +184,50 @@ describe('FormAttachmentList', () => {
           .createPast(1, { name: 'c' });
       });
 
-      it('renders correctly if there are no unmatched files', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
+      it('renders correctly and automatically uploads files if there are no unmatched files', () =>
+        load('/projects/1/forms/f/draft', {
           root: false,
           attachTo: document.body
-        });
-        await select(component, blankFiles(['a', 'b']));
-        const popup = component.get('#form-attachment-popups-main');
-        popup.should.be.visible();
-        popup.get('p').text().should.equal('2 files ready for upload.');
-        popup.get('#form-attachment-popups-unmatched').should.be.hidden();
-        popup.get('.btn-primary').should.be.focused();
-      });
+        })
+          .complete()
+          .request(component => select(component, blankFiles(['a', 'b'])))
+          .beforeAnyResponse(component => {
+            const popup = component.get('#form-attachment-popups-main');
+            popup.should.be.visible();
+            popup.get('p').text().should.equal('Please wait, uploading your 2 files:');
+          })
+          .respondWithData(() => testData.standardFormAttachments.update(0))
+          .respondWithData(() => testData.standardFormAttachments.update(1)));
 
-      it('renders correctly if there is one unmatched file', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
+      it('renders correctly and automatically uploads files even if there is one unmatched file', () =>
+        load('/projects/1/forms/f/draft', {
           root: false,
           attachTo: document.body
-        });
-        await select(component, blankFiles(['a', 'd']));
-        const popup = component.get('#form-attachment-popups-main');
-        popup.should.be.visible();
-        popup.get('p').text().should.equal('1 file ready for upload.');
-        const unmatched = popup.get('#form-attachment-popups-unmatched');
-        unmatched.should.be.visible();
-        unmatched.find('.icon-exclamation-triangle').exists().should.be.true;
-        unmatched.text().should.startWith('1 file has a name we don’t recognize and will be ignored.');
-        popup.get('.btn-primary').should.be.focused();
-      });
+        })
+          .complete()
+          .request(component => select(component, blankFiles(['a', 'd'])))
+          .beforeAnyResponse(component => {
+            const popup = component.get('#form-attachment-popups-main');
+            popup.should.be.visible();
+            popup.get('p').text().should.equal('Please wait, uploading your 1 file:');
+          })
+          .respondWithData(() => testData.standardFormAttachments.update(0)));
 
-      it('renders correctly if there are multiple unmatched files', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
+      it('renders correctly  and automatically uploads files even if there are multiple unmatched files', () =>
+        load('/projects/1/forms/f/draft', {
           root: false,
           attachTo: document.body
-        });
-        await select(component, blankFiles(['a', 'd', 'e']));
-        const popup = component.get('#form-attachment-popups-main');
-        popup.should.be.visible();
-        popup.get('p').text().should.equal('1 file ready for upload.');
-        const unmatched = popup.get('#form-attachment-popups-unmatched');
-        unmatched.should.be.visible();
-        unmatched.find('.icon-exclamation-triangle').exists().should.be.true;
-        unmatched.text().should.startWith('2 files have a name we don’t recognize and will be ignored.');
-        popup.get('.btn-primary').should.be.focused();
-      });
+        })
+          .complete()
+          .request(component => select(component, blankFiles(['a', 'd', 'e'])))
+          .beforeAnyResponse(component => {
+            const popup = component.get('#form-attachment-popups-main');
+            popup.should.be.visible();
+            popup.get('p').text().should.equal('Please wait, uploading your 1 file:');
+          })
+          .respondWithData(() => testData.standardFormAttachments.update(0)));
 
-      it('renders correctly if all files are unmatched', async () => {
+      it('renders correctly with popup if all files are unmatched', async () => {
         const component = await load('/projects/1/forms/f/draft', {
           root: false,
           attachTo: document.body
@@ -301,7 +236,6 @@ describe('FormAttachmentList', () => {
         const popup = component.get('#form-attachment-popups-main');
         popup.should.be.visible();
         popup.get('p').text().should.startWith('We don’t recognize any of the files');
-        popup.find('#form-attachment-popups-unmatched').exists().should.be.false;
         popup.get('.btn-primary').should.be.focused();
       });
 
@@ -350,75 +284,16 @@ describe('FormAttachmentList', () => {
           .createPast(1, { name: 'd', blobExists: false });
       });
 
-      it('highlights only the matching row', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
-          root: false
-        });
-        await select(component, blankFiles(['a']));
-        const rows = component.findAllComponents(FormAttachmentRow);
-        const targeted = rows.map(row => row.classes('targeted'));
-        targeted.should.eql([true, false, false, false]);
-      });
-
-      describe('label', () => {
-        it('shows the correct text for an existing attachment', async () => {
-          const component = await load('/projects/1/forms/f/draft', {
-            root: false
-          });
-          await select(component, blankFiles(['a']));
-          const labels = component.findAllComponents(FormAttachmentRow)
-            .map(row => row.get('.label'));
-          labels[0].should.be.visible();
-          labels[0].text().should.equal('Replace');
-          labels[1].should.be.hidden();
-          labels[2].should.be.hidden();
-          labels[3].should.be.hidden();
-        });
-
-        it('shows the correct text for a missing attachment', async () => {
-          const component = await load('/projects/1/forms/f/draft', {
-            root: false
-          });
-          await select(component, blankFiles(['b']));
-          const labels = component.findAllComponents(FormAttachmentRow)
-            .map(row => row.get('.label'));
-          labels[0].should.be.hidden();
-          labels[1].should.be.visible();
-          labels[1].text().should.equal('Upload');
-          labels[2].should.be.hidden();
-          labels[3].should.be.hidden();
-        });
-      });
-
-      it('shows the popup with the correct text', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
-          root: false
-        });
-        await select(component, blankFiles(['a']));
-        const popup = component.get('#form-attachment-popups-main');
-        popup.should.be.visible();
-        popup.get('p').text().should.equal('1 file ready for upload.');
-      });
-
-      describe('after the uploads are canceled', () => {
-        it('unhighlights the rows', async () => {
-          const component = await load('/projects/1/forms/f/draft', {
-            root: false
-          });
-          await select(component, blankFiles(['a']));
-          await component.get('#form-attachment-popups-main .btn-link').trigger('click');
-          component.find('.form-attachment-row.targeted').exists().should.be.false;
-        });
-
-        it('hides the popup', async () => {
-          const component = await load('/projects/1/forms/f/draft', {
-            root: false
-          });
-          await select(component, blankFiles(['a']));
-          await component.get('#form-attachment-popups-main .btn-link').trigger('click');
-          component.get('#form-attachment-popups-main').should.be.hidden();
-        });
-      });
+      it('shows the popup with the correct text', () =>
+        load('/projects/1/forms/f/draft', { root: false })
+          .complete()
+          .request(component => select(component, blankFiles(['a'])))
+          .beforeAnyResponse(component => {
+            const popup = component.get('#form-attachment-popups-main');
+            popup.should.be.visible();
+            popup.get('p').text().should.equal('Please wait, uploading your 1 file:');
+          })
+          .respondWithData(() => testData.standardFormAttachments.update(0)));
     });
 
     describe('unmatched file after a selection', () => {
@@ -429,18 +304,19 @@ describe('FormAttachmentList', () => {
           .createPast(1, { name: 'b' });
       });
 
-      it('correctly renders if the file matches', async () => {
-        const component = await load('/projects/1/forms/f/draft', {
+      it('correctly renders if the file matches', () =>
+        load('/projects/1/forms/f/draft', {
           root: false,
           attachTo: document.body
-        });
-        await select(component, blankFiles(['a']));
-        const popup = component.get('#form-attachment-popups-main');
-        popup.should.be.visible();
-        popup.get('p').text().should.equal('1 file ready for upload.');
-        popup.get('#form-attachment-popups-unmatched').should.be.hidden();
-        popup.get('.btn-primary').should.be.focused();
-      });
+        })
+          .complete()
+          .request(component => select(component, blankFiles(['a'])))
+          .beforeAnyResponse(component => {
+            const popup = component.get('#form-attachment-popups-main');
+            popup.should.be.visible();
+            popup.get('p').text().should.equal('Please wait, uploading your 1 file:');
+          })
+          .respondWithData(() => testData.standardFormAttachments.update(0)));
 
       it('correctly renders if the file does not match', async () => {
         const component = await load('/projects/1/forms/f/draft', {
@@ -451,7 +327,6 @@ describe('FormAttachmentList', () => {
         const popup = component.get('#form-attachment-popups-main');
         popup.should.be.visible();
         popup.get('p').text().should.startWith('We don’t recognize the file');
-        popup.find('#form-attachment-popups-unmatched').exists().should.be.false;
         popup.get('.btn-primary').should.be.focused();
       });
 
@@ -692,14 +567,11 @@ describe('FormAttachmentList', () => {
           const confirmUploads = (successCount) =>
             load('/projects/1/forms/f/draft', { root: false })
               .complete()
-              .request(async (component) => {
-                await dragAndDrop(
+              .request(component =>
+                dragAndDrop(
                   component.get('#form-attachment-list'),
                   blankFiles(['a', 'b', 'c'])
-                );
-                const button = component.get('#form-attachment-popups-main .btn-primary');
-                return button.trigger('click');
-              })
+                ))
               .modify(series => {
                 let withResponses = series;
                 for (let i = 0; i < successCount; i += 1) {
@@ -900,18 +772,15 @@ describe('FormAttachmentList', () => {
         testSingleFileSelection((component, files) =>
           dragAndDrop(component.get('#form-attachment-list'), files));
 
-        describe('confirming the upload', () => {
+        describe('uploading', () => {
           testSingleFileUpload(attachmentName =>
             load('/projects/1/forms/f/draft', { root: false })
               .complete()
-              .request(async (component) => {
-                await dragAndDrop(
+              .request(component =>
+                dragAndDrop(
                   component.get('#form-attachment-list'),
                   blankFiles([attachmentName])
-                );
-                const button = component.get('#form-attachment-popups-main .btn-primary');
-                return button.trigger('click');
-              }));
+                )));
         });
       });
     });

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3234,26 +3234,6 @@
         }
       },
       "afterSelection": {
-        "matched": {
-          "full": {
-            "string": "{count, plural, one {{countOfFiles} ready for upload.} other {{countOfFiles} ready for upload.}}",
-            "developer_comment": "{countOfFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} files"
-          },
-          "countOfFiles": {
-            "string": "{count, plural, one {{count} file} other {{count} files}}",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {countOfFiles} is in the following text. (The plural form of the text is shown.)\n\n{countOfFiles} ready for upload."
-          }
-        },
-        "someUnmatched": {
-          "full": {
-            "string": "{count, plural, one {{countOfFiles} has a name we don’t recognize and will be ignored. To upload it, rename it or drag it onto its target.} other {{countOfFiles} have a name we don’t recognize and will be ignored. To upload them, rename them or drag them individually onto their targets.}}",
-            "developer_comment": "{countOfFiles} is a separate string that will be translated below. Its text will be formatted within ODK Central, for example, it might be bold or a link. In its plural form, its text is:\n\n{count} files"
-          },
-          "countOfFiles": {
-            "string": "{count, plural, one {{count} file} other {{count} files}}",
-            "developer_comment": "This text will be formatted within ODK Central, for example, it might be bold or a link. It will be inserted where {countOfFiles} is in the following text. (The plural form of the text is shown.)\n\n{countOfFiles} have a name we don’t recognize and will be ignored. To upload them, rename them or drag them individually onto their targets."
-          }
-        },
         "noneMatched": {
           "string": "{count, plural, one {We don’t recognize the file you are trying to upload. Please rename it to match the names listed above, or drag it individually onto its target.} other {We don’t recognize any of the files you are trying to upload. Please rename them to match the names listed above, or drag them individually onto their targets.}}"
         }


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1720

This removes the confirmation step when you drag multiple attachments onto a form draft. As long as some of the filenames match the expected attachments, the matching files will be uploaded automatically. Only if none of the files match will there be a popup explaining how nothing could be uploaded. 

**Removed**: 
(dragging b.jpg and c.jpg vs dragging b.jpg, c.jpg, other.jpg)
<img height="300" alt="Screenshot 2026-07-13 at 11 55 01 AM" src="https://github.com/user-attachments/assets/9efe9917-6aee-474b-b97b-4eaa2d30ccdc" /> <img height="300" alt="Screenshot 2026-07-13 at 11 55 13 AM" src="https://github.com/user-attachments/assets/479c27e1-827e-4cc2-820f-869bd92dca25" />

**Kept**:
(dragging other.jpg, other2.jpg)
<img height="300" alt="Screenshot 2026-07-13 at 12 31 31 PM" src="https://github.com/user-attachments/assets/12450fb7-5d28-446f-b950-da3b309392fd" />

The popup is now simpler, and the table for rendering the attachments is also a bit simpler in that it wont highlight rows of pending attachments. 

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I've tried it out and updated the tests. I had to make some changes to the tests
- remove sections about testing the highlighting on the table for pending uploads
- change the tests that automatically uploaded attachment data to include the POST requests and chain the requests together instead of using async/await 

#### Why is this the best possible solution? Were any other approaches considered?

This is a pretty complex bit of code but I think I cut out the confirmation step in an acceptable way. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Will help users not to forget to upload their attachments if dragging multiple attachments at once. 

If the users have a mix of matching/non-matching filenames, they'll get less feedback about the non-matching filenames. But they still get feedback (via rows highlighted after upload) on which files did successfully upload. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

I don't think so.
