### PR TITLE
e2e-tests: fix Content-Security-Policies for http

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,7 @@ jobs:
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/enketo/config.json.template
         sed -i 's|\${BASE_URL}|http://${DOMAIN}|g' files/service/config.json.template
         sed -i 's/\$scheme/https/g' files/nginx/odk.conf.template
+        sed -Ei 's/https:([ ;]|$)/http:\1/g' files/nginx/odk.conf.template
         sed 's/your.domain.com/central-test.localhost/; s/^SSL_TYPE=letsencrypt/SSL_TYPE=upstream/' .env.template > .env
     - name: Add domain
       run: echo '127.0.0.1 central-test.localhost' | sudo tee --append /etc/hosts


### PR DESCRIPTION
Convert CSP for use over HTTP, instead of the default HTTPS.

This will need to be reverted if getodk/central#1917 is implemented.

Closes getodk/central#1915

#### What has been done to verify that this works as intended?

- [x] ci passes
- [x] checked for relevant log output
    - [x] present in `master` build (https://github.com/getodk/central-frontend/actions/runs/29315107690/job/87028245558)
    - [x] absent in this branch's build (https://github.com/getodk/central-frontend/actions/runs/29319298282/job/87042020883?pr=1707)

#### Why is this the best possible solution? Were any other approaches considered?

getodk/central#1917 better in the long-term, but this is an improvement over the status quo.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.