### PR TITLE
fix(web-forms#848): use current form definition's version when editing a submission

### DIFF
--- a/.changeset/salty-worlds-stick.md
+++ b/.changeset/salty-worlds-stick.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": patch
+---
+
+Use current form version when editing a submission.

--- a/packages/xforms-engine/src/instance/attachments/buildAttributes.ts
+++ b/packages/xforms-engine/src/instance/attachments/buildAttributes.ts
@@ -1,12 +1,16 @@
 import type { StaticAttribute } from '../../integration/xpath/static-dom/StaticAttribute.ts';
 import type { StaticDocument } from '../../integration/xpath/static-dom/StaticDocument.ts';
 import type { StaticElement } from '../../integration/xpath/static-dom/StaticElement.ts';
+import type { AttributeDefinition } from '../../parse/model/AttributeDefinition.ts';
 import { Attribute } from '../Attribute';
 import type { AnyNode } from '../hierarchy.ts';
 import type { InputControl } from '../InputControl.ts';
 import type { ModelValue } from '../ModelValue.ts';
 import type { Note } from '../Note.ts';
 import type { RangeControl } from '../RangeControl.ts';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AttributeOwner = AnyNode | InputControl<any> | ModelValue<any> | Note<any> | RangeControl<any>;
 
 function buildInstanceAttributeMap(
   instanceNode: StaticAttribute | StaticDocument | StaticElement | null
@@ -21,19 +25,41 @@ function buildInstanceAttributeMap(
   return map;
 }
 
-export function buildAttributes(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  owner: AnyNode | InputControl<any> | ModelValue<any> | Note<any> | RangeControl<any>
-): Attribute[] {
+/**
+ * Root's `version` reflects the current form definition, not the source XML.
+ * Submissions should carry the latest form definition's version.
+ */
+const isFormMetadataAttribute = (
+  owner: AttributeOwner,
+  attributeDefinition: AttributeDefinition
+) => {
+  return owner.nodeType === 'root' && attributeDefinition.qualifiedName.localName === 'version';
+};
+
+const resolveAttributeSourceNode = (
+  owner: AttributeOwner,
+  attributeDefinition: AttributeDefinition,
+  instanceAttributes: Map<string, StaticAttribute>
+): StaticAttribute => {
+  if (isFormMetadataAttribute(owner, attributeDefinition)) {
+    return attributeDefinition.template;
+  }
+
+  const instanceAttribute = instanceAttributes.get(
+    attributeDefinition.qualifiedName.getPrefixedName()
+  );
+
+  return instanceAttribute ?? attributeDefinition.template;
+};
+
+export function buildAttributes(owner: AttributeOwner): Attribute[] {
   const attributes = owner.definition.attributes;
   if (!attributes) {
     return [];
   }
   const instanceAttributes = buildInstanceAttributeMap(owner.instanceNode);
   return Array.from(attributes.values()).map((attributeDefinition) => {
-    const instanceNode =
-      instanceAttributes.get(attributeDefinition.qualifiedName.getPrefixedName()) ??
-      attributeDefinition.template;
-    return new Attribute(owner, attributeDefinition, instanceNode);
+    const sourceNode = resolveAttributeSourceNode(owner, attributeDefinition, instanceAttributes);
+    return new Attribute(owner, attributeDefinition, sourceNode);
   });
 }

--- a/packages/xforms-engine/test/integration/instance-edit.test.ts
+++ b/packages/xforms-engine/test/integration/instance-edit.test.ts
@@ -339,6 +339,46 @@ describe('Instance edit semantics', () => {
     });
   });
 
+  describe('root version metadata', () => {
+    const CURRENT_VERSION = '2';
+
+    const versionedForm = html(
+      head(
+        title('Form version on edit'),
+        model(
+          mainInstance(
+            t(
+              `data id="form-version-edit" version="${CURRENT_VERSION}"`,
+              t('a'),
+              t('meta', t('instanceID'))
+            )
+          ),
+          bind('/data/a').type('string'),
+          bind('/data/meta/instanceID').preload('uid')
+        )
+      ),
+      body(input('/data/a'))
+    );
+
+    const sourceSubmissionXML = `<data id="form-version-edit" version="1"><a>value</a><meta><instanceID>123456</instanceID></meta></data>`;
+
+    it('adopts the current version of the form definition when editing an older submission', async () => {
+      const scenario = await Scenario.init('Form version on edit', versionedForm, {
+        editInstance: sourceSubmissionXML,
+      });
+
+      expect(scenario.attributeOf('/data', 'version').getValue()).toBe(CURRENT_VERSION);
+    });
+
+    it('serializes the edited submission with the current version of the form definition', async () => {
+      const scenario = await Scenario.init('Form version on edit', versionedForm, {
+        editInstance: sourceSubmissionXML,
+      });
+
+      expect(scenario.proposed_serializeInstance()).toContain(`version="${CURRENT_VERSION}"`);
+    });
+  });
+
   /**
    * However weird it might be to test "restore" behavior _in the edit-specific
    * suite_... the intent is to document that the behaviors under test are


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/848

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

 When editing a submission originally filled against an older form version, the edited instance retained the old `version` attribute on the root element. This PR makes root's `version` always resolve from the current form definition instead of the source XML.


#### What has been done to verify that this works as intended?

Tested using these forms:

[Form v1](https://github.com/user-attachments/files/30002919/form-v1.xml)

[Form v2](https://github.com/user-attachments/files/30002900/form-with-new-field.xml)


#### Why is this the best possible solution? Were any other approaches considered?

 - The `buildAttributes` treats source XML as authoritative for all attributes on all nodes, falling back to the template only when the source lacks the attribute.
- That rule is correct for element attributes that hold user data, but wrong for root's `version`, which is form metadata. It describes the form definition the submission is filled against, not something the user edited.
- Rather than changing the source-wins rule globally (which would break user-data attributes), the fix narrowly identifies form-metadata attributes and resolves them from the template. The predicate is scoped to root's `version`, the only mutable root-level metadata attribute in ODK XForms; `id` is stable across versions, and non-root attributes remain user data.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Unblocks edition of submissions when the form definition changes. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No

