### PR TITLE
Show file size in form attachment table

### DIFF
--- a/.changeset/neat-insects-wear.md
+++ b/.changeset/neat-insects-wear.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": patch
+---
+
+Show file size in form attachment table

--- a/.changeset/neat-insects-wear.md
+++ b/.changeset/neat-insects-wear.md
@@ -2,4 +2,4 @@
 "@getodk/central-frontend": patch
 ---
 
-Show file size in form attachment table
+Show file size in form attachment table (issue central#1895)

--- a/apps/central/src/components/form-attachment/row.vue
+++ b/apps/central/src/components/form-attachment/row.vue
@@ -76,14 +76,10 @@ except according to the terms contained in the LICENSE file.
 import DateTime from '../date-time.vue';
 
 import { apiPaths } from '../../util/request';
+import { useI18nUtils } from '../../util/i18n';
 import { useRequestData } from '../../request-data';
 
-const formatSize = (bytes) => {
-  if (bytes == null) return null;
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
+
 
 export default {
   name: 'FormAttachmentRow',
@@ -116,6 +112,7 @@ export default {
     // The component assumes that this data will exist when the component is
     // created.
     const { form } = useRequestData();
+    const { formatSize } = useI18nUtils();
     return { form, formatSize };
   },
   computed: {

--- a/apps/central/src/components/form-attachment/row.vue
+++ b/apps/central/src/components/form-attachment/row.vue
@@ -48,6 +48,11 @@ except according to the terms contained in the LICENSE file.
         </span>
       </template>
     </td>
+    <td class="form-attachment-list-size">
+      <template v-if="attachment.blobExists && attachment.size != null">
+        {{ formatSize(attachment.size) }}
+      </template>
+    </td>
     <td class="form-attachment-list-action">
       <div>
         <template v-if="attachment.datasetExists">
@@ -72,6 +77,13 @@ import DateTime from '../date-time.vue';
 
 import { apiPaths } from '../../util/request';
 import { useRequestData } from '../../request-data';
+
+const formatSize = (bytes) => {
+  if (bytes == null) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
 
 export default {
   name: 'FormAttachmentRow',
@@ -104,7 +116,7 @@ export default {
     // The component assumes that this data will exist when the component is
     // created.
     const { form } = useRequestData();
-    return { form };
+    return { form, formatSize };
   },
   computed: {
     targeted() {

--- a/apps/central/src/components/form-attachment/table.vue
+++ b/apps/central/src/components/form-attachment/table.vue
@@ -17,6 +17,7 @@ except according to the terms contained in the LICENSE file.
           <th>{{ $t('header.type') }}</th>
           <th>{{ $t('header.name') }}</th>
           <th>{{ $t('header.uploaded') }}</th>
+          <th>{{ $t('header.size') }}</th>
           <th></th>
         </tr>
       </thead>
@@ -76,6 +77,8 @@ const dsHashset = computed(() =>
 
   th:first-child { width: 125px; }
   th:nth-child(2) { width: 250px; }
+  th:nth-child(3) { width: 200px; }
+  th:nth-child(4) { width: 100px; }
   th:last-child { width: #{200px + $padding-left-table-data + $padding-right-table-data}; }
 }
 </style>
@@ -87,7 +90,9 @@ const dsHashset = computed(() =>
     "header": {
       // This is the text of a table column header. The column shows when each
       // Media File was uploaded.
-      "uploaded": "Uploaded"
+      "uploaded": "Uploaded",
+      // This is the text of a table column header. The column shows the file size of each uploaded Media File.
+      "size": "Size"
     }
   }
 }

--- a/apps/central/src/components/form-attachment/table.vue
+++ b/apps/central/src/components/form-attachment/table.vue
@@ -77,8 +77,7 @@ const dsHashset = computed(() =>
 
   th:first-child { width: 125px; }
   th:nth-child(2) { width: 250px; }
-  th:nth-child(3) { width: 200px; }
-  th:nth-child(4) { width: 100px; }
+  th:nth-child(3) { width: 250px; }
   th:last-child { width: #{200px + $padding-left-table-data + $padding-right-table-data}; }
 }
 </style>

--- a/apps/central/src/i18n.js
+++ b/apps/central/src/i18n.js
@@ -117,7 +117,7 @@ const numberFormats = {
   percent: { style: 'percent' }
 };
 
-for (const unit of ['byte', 'kilobyte', 'megabyte'])
+for (const unit of ['kilobyte', 'megabyte'])
   numberFormats[unit] = { style: 'unit', unit, unitDisplay: 'short', maximumFractionDigits: 1 };
 
 for (let i = 1; i < 15; i += 1)

--- a/apps/central/src/i18n.js
+++ b/apps/central/src/i18n.js
@@ -117,6 +117,9 @@ const numberFormats = {
   percent: { style: 'percent' }
 };
 
+for (const unit of ['byte', 'kilobyte', 'megabyte'])
+  numberFormats[unit] = { style: 'unit', unit, unitDisplay: 'short', maximumFractionDigits: 1 };
+
 for (let i = 1; i < 15; i += 1)
   numberFormats[`maximumFractionDigits${i}`] = { maximumFractionDigits: i };
 

--- a/apps/central/src/util/i18n.js
+++ b/apps/central/src/util/i18n.js
@@ -143,6 +143,12 @@ const useGlobalUtils = memoizeForContainer(({ i18n }) => {
     formatRange: (start, end, key = 'default') => (start === end
       ? i18n.n(start, key)
       : getNumberFormat(key).formatRange(start, end)),
+    formatSize: (bytes) => {
+      if (bytes == null) return null;
+      if (bytes < 1024) return i18n.n(bytes, 'byte');
+      if (bytes < 1024 * 1024) return i18n.n(bytes / 1024, 'kilobyte');
+      return i18n.n(bytes / (1024 * 1024), 'megabyte');
+    },
     formatList: (list, key = 'default') => getListFormat(key).format(list),
     formatListToParts: (list, key = 'default') =>
       getListFormat(key).formatToParts(list),

--- a/apps/central/src/util/i18n.js
+++ b/apps/central/src/util/i18n.js
@@ -145,7 +145,6 @@ const useGlobalUtils = memoizeForContainer(({ i18n }) => {
       : getNumberFormat(key).formatRange(start, end)),
     formatSize: (bytes) => {
       if (bytes == null) return null;
-      if (bytes < 1024) return i18n.n(bytes, 'byte');
       if (bytes < 1024 * 1024) return i18n.n(bytes / 1024, 'kilobyte');
       return i18n.n(bytes / (1024 * 1024), 'megabyte');
     },

--- a/apps/central/test/components/form-attachment/list.spec.js
+++ b/apps/central/test/components/form-attachment/list.spec.js
@@ -68,6 +68,51 @@ describe('FormAttachmentList', () => {
       await a.should.have.textTooltip();
     });
 
+    describe('size', () => {
+      it('shows formatted size for a blob-backed, non-dataset attachment', async () => {
+        testData.standardFormAttachments.createPast(1, {
+          blobExists: true,
+          size: 2048
+        });
+        const component = await load('/projects/1/forms/f/draft', {
+          root: false
+        });
+        component.get('td.form-attachment-list-size').text().should.equal('2.0 KB');
+      });
+
+      it('shows nothing for an attachment without size', async () => {
+        testData.standardFormAttachments.createPast(1, {
+          blobExists: true,
+          size: null
+        });
+        const component = await load('/projects/1/forms/f/draft', {
+          root: false
+        });
+        component.get('td.form-attachment-list-size').text().should.equal('');
+      });
+
+      it('shows nothing for a non-blob attachment (e.g. a dataset)', async () => {
+        testData.standardFormAttachments.createPast(1, {
+          blobExists: false
+        });
+        const component = await load('/projects/1/forms/f/draft', {
+          root: false
+        });
+        component.get('td.form-attachment-list-size').text().should.equal('');
+      });
+
+      it('shows formatted size for a blob-backed attachment of MB size', async () => {
+        testData.standardFormAttachments.createPast(1, {
+          blobExists: true,
+          size: 1572864
+        });
+        const component = await load('/projects/1/forms/f/draft', {
+          root: false
+        });
+        component.get('td.form-attachment-list-size').text().should.equal('1.5 MB');
+      });
+    });
+
     describe('updatedAt', () => {
       it('formats updatedAt for an existing attachment', async () => {
         const { updatedAt } = testData.standardFormAttachments

--- a/apps/central/test/components/form-attachment/list.spec.js
+++ b/apps/central/test/components/form-attachment/list.spec.js
@@ -77,7 +77,7 @@ describe('FormAttachmentList', () => {
         const component = await load('/projects/1/forms/f/draft', {
           root: false
         });
-        component.get('td.form-attachment-list-size').text().should.equal('2.0 KB');
+        component.get('td.form-attachment-list-size').text().should.equal('2 kB');
       });
 
       it('shows nothing for an attachment without size', async () => {

--- a/apps/central/test/data/form-attachments.js
+++ b/apps/central/test/data/form-attachments.js
@@ -27,7 +27,8 @@ export const standardFormAttachments = dataStore({
     hash = undefined,
     datasetExists = false,
     blobExists = hash != null || (inPast && hash !== null && !datasetExists),
-    hasUpdatedAt = inPast
+    hasUpdatedAt = inPast,
+    size = blobExists ? 100 : null
   }) => ({
     type,
     name,
@@ -35,7 +36,8 @@ export const standardFormAttachments = dataStore({
     datasetExists,
     exists: blobExists || datasetExists,
     hash: hash ?? (blobExists ? 'a'.repeat(32) : null),
-    updatedAt: hasUpdatedAt ? fakePastDate([form.createdAt]) : null
+    updatedAt: hasUpdatedAt ? fakePastDate([form.createdAt]) : null,
+    size
   }),
   sort: (attachment1, attachment2) =>
     attachment1.name.localeCompare(attachment2.name)

--- a/apps/central/test/unit/i18n.spec.js
+++ b/apps/central/test/unit/i18n.spec.js
@@ -166,6 +166,45 @@ describe('util/i18n', () => {
       });
     });
 
+    describe('formatSize()', () => {
+      it('formats bytes', () => {
+        const { formatSize } = withSetup(useI18nUtils);
+        formatSize(0).should.equal('0 B');
+        formatSize(1023).should.equal('1,023 B');
+      });
+
+      it('formats kilobytes', () => {
+        const { formatSize } = withSetup(useI18nUtils);
+        formatSize(1024).should.equal('1 kB');
+        formatSize(1536).should.equal('1.5 kB');
+        formatSize(1024 * 1024 - 1).should.equal('1,024 kB');
+      });
+
+      it('formats megabytes', () => {
+        const { formatSize } = withSetup(useI18nUtils);
+        formatSize(1024 * 1024).should.equal('1 MB');
+        formatSize(1024 * 1024 * 1.5).should.equal('1.5 MB');
+      });
+
+      it('formats numbers larger than megabytes as megabytes', () => {
+        const { formatSize } = withSetup(useI18nUtils);
+        formatSize(1024 * 1024).should.equal('1 MB');
+        formatSize(1024 * 1024 * 1024).should.equal('1,024 MB');
+      });
+
+      it('returns null for null', () => {
+        const { formatSize } = withSetup(useI18nUtils);
+        should(formatSize(null)).be.null();
+      });
+
+      it('uses the locale', () => {
+        const container = createTestContainer();
+        const { formatSize } = withSetup(useI18nUtils, { container });
+        container.i18n.locale = 'fr';
+        formatSize(1536).should.equal('1,5 ko');
+      });
+    });
+
     describe('formatList()', () => {
       it('returns a formatted list', () => {
         const { formatList } = withSetup(useI18nUtils);

--- a/apps/central/test/unit/i18n.spec.js
+++ b/apps/central/test/unit/i18n.spec.js
@@ -167,10 +167,10 @@ describe('util/i18n', () => {
     });
 
     describe('formatSize()', () => {
-      it('formats bytes', () => {
+      it('formats small values as kilobytes', () => {
         const { formatSize } = withSetup(useI18nUtils);
-        formatSize(0).should.equal('0 B');
-        formatSize(1023).should.equal('1,023 B');
+        formatSize(0).should.equal('0 kB');
+        formatSize(1023).should.equal('1 kB');
       });
 
       it('formats kilobytes', () => {
@@ -194,14 +194,14 @@ describe('util/i18n', () => {
 
       it('returns null for null', () => {
         const { formatSize } = withSetup(useI18nUtils);
-        should(formatSize(null)).be.null();
+        should.not.exist(formatSize(null));
       });
 
       it('uses the locale', () => {
         const container = createTestContainer();
         const { formatSize } = withSetup(useI18nUtils, { container });
         container.i18n.locale = 'fr';
-        formatSize(1536).should.equal('1,5 ko');
+        formatSize(1536).should.equal('1,5\u202fko'); // narrow no-break space
       });
     });
 

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3181,6 +3181,10 @@
         "uploaded": {
           "string": "Uploaded",
           "developer_comment": "This is the text of a table column header. The column shows when each Media File was uploaded."
+        },
+        "size": {
+          "string": "Size",
+          "developer_comment": "This is the text of a table column header. The column shows the file size of each uploaded Media File."
         }
       }
     },


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1895
Backend to add `size` field to form attachments:
- https://github.com/getodk/central-backend/pull/1877


<img width="1049" height="287" alt="Screenshot 2026-07-17 at 3 25 31 PM" src="https://github.com/user-attachments/assets/40c57b33-fcdf-4c1a-8ed8-0f985d875cc2" />

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Trying it and tests. 

#### Why is this the best possible solution? Were any other approaches considered?

Just pipes through size data now available in backend.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

More helpful to users. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.