### PR TITLE
fix(web-forms#856): trim whitespace from attachment filename when editing submissions

### DIFF
--- a/.changeset/real-news-dream.md
+++ b/.changeset/real-news-dream.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": patch
+---
+
+Trim whitespace from attachment filename when editing submissions

--- a/packages/xforms-engine/src/instance/attachments/InstanceAttachmentsState.ts
+++ b/packages/xforms-engine/src/instance/attachments/InstanceAttachmentsState.ts
@@ -34,7 +34,7 @@ export class InstanceAttachmentsState extends Map<InstanceAttachmentContext, Ins
       return null;
     }
 
-    const { value } = instanceNode;
+    const value = instanceNode.value.trim();
     const sourceFile = this.sourceAttachments?.get(value) ?? null;
     if (sourceFile != null) {
       return sourceFile;
@@ -51,7 +51,7 @@ export class InstanceAttachmentsState extends Map<InstanceAttachmentContext, Ins
 
   retryFileValue(instanceNode: StaticLeafElement | null) {
     if (instanceNode !== null) {
-      this.sourceAttachments?.retry(instanceNode.value);
+      this.sourceAttachments?.retry(instanceNode.value.trim());
     }
   }
 }

--- a/packages/xforms-engine/test/instance/attachments/InstanceAttachmentsState.test.ts
+++ b/packages/xforms-engine/test/instance/attachments/InstanceAttachmentsState.test.ts
@@ -42,6 +42,20 @@ describe('InstanceAttachmentsState', () => {
       expect(fetchFormAttachment).not.toHaveBeenCalled();
     });
 
+    it('returns the source attachment when the instance value has surrounding whitespace', () => {
+      const sourceFile = Promise.resolve(new File([''], 'photo.png', { type: 'image/png' }));
+      const sourceAttachments = new Map([
+        ['photo.png', sourceFile],
+      ]) as unknown as InstanceAttachmentMap;
+      const fetchFormAttachment = vi.fn<FetchFormAttachment>();
+      const state = new InstanceAttachmentsState(sourceAttachments, fetchFormAttachment);
+
+      const result = state.getInitialFileValue(leafWithValue(`photo.png\n        `));
+
+      expect(result).toBe(sourceFile);
+      expect(fetchFormAttachment).not.toHaveBeenCalled();
+    });
+
     it('fetches the form attachment when value is a jr:// reference and no source attachment exists', async () => {
       const blob = new Blob(['data'], { type: 'image/png' });
       const fetchFormAttachment = vi.fn<FetchFormAttachment>().mockResolvedValue(okResponse(blob));


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/856

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Added unit tests and manual testing.

Before:
<img width="500" src="https://github.com/user-attachments/assets/ebf01e2d-8c13-4945-b396-4b5f9801278e" />

After fix:
<img width="500" src="https://github.com/user-attachments/assets/7fcdae89-a74c-45da-a59d-b2c14f025d65" />

#### Why is this the best possible solution? Were any other approaches considered?

Trailing spaces can be difficult to notice, so the match is relaxed slightly to still display the attachment. For other mismatches where the filename cannot be determined or the file failed to load, an error message appears, and it's fixed here: https://github.com/getodk/central-frontend/pull/1719



#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Attachments are visible when the filename in the submission includes trailing spaces. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
