### PR TITLE
fix(web-forms#857): show error indicator when submission attachment cannot be loaded

### DIFF
--- a/.changeset/dull-humans-join.md
+++ b/.changeset/dull-humans-join.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": patch
+---
+
+Show error indicator when submission attachment cannot be loaded

--- a/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
@@ -310,6 +310,9 @@ onUnmounted(() => {
 				<Message v-else-if="fileError" severity="error" :closable="true" @close="fileError = null">
 					{{ fileError }}
 				</Message>
+				<Message v-else-if="loadingError === 'not-found'" severity="error" :closable="false">
+					{{ t('media_block.not_found.error', { file: existingFileName }) }}
+				</Message>
 				<Message v-else-if="loadingError" severity="error" :closable="true" @close="retryFetch()">
 					<template #closeicon>
 						<IconSVG name="mdiRefresh" variant="muted" size="sm" />

--- a/packages/xforms-engine/src/error/AttachmentNotFoundError.ts
+++ b/packages/xforms-engine/src/error/AttachmentNotFoundError.ts
@@ -1,0 +1,5 @@
+export class AttachmentNotFoundError extends Error {
+  constructor(fileName: string) {
+    super(`Attachment not found: ${fileName}`);
+  }
+}

--- a/packages/xforms-engine/src/instance/attachments/InstanceAttachmentsState.ts
+++ b/packages/xforms-engine/src/instance/attachments/InstanceAttachmentsState.ts
@@ -30,7 +30,7 @@ export class InstanceAttachmentsState extends Map<InstanceAttachmentContext, Ins
   }
 
   getInitialFileValue(instanceNode: StaticLeafElement | null): Promise<File> | null {
-    if (instanceNode == null) {
+    if (!instanceNode?.value?.length) {
       return null;
     }
 
@@ -42,11 +42,13 @@ export class InstanceAttachmentsState extends Map<InstanceAttachmentContext, Ins
 
     // Resolve jr:// default values (e.g. annotate with a default image) so the attachment state
     // and submission payload are updated and valid.
-    if (this.fetchFormAttachment != null && JRResourceURL.isJRResourceReference(value)) {
-      return this.resolveFormAttachmentFile(this.fetchFormAttachment, value);
+    if (JRResourceURL.isJRResourceReference(value)) {
+      return this.fetchFormAttachment
+        ? this.resolveFormAttachmentFile(this.fetchFormAttachment, value)
+        : null;
     }
 
-    return null;
+    return Promise.reject(new Error(`Attachment not found: ${value}`));
   }
 
   retryFileValue(instanceNode: StaticLeafElement | null) {

--- a/packages/xforms-engine/src/instance/attachments/InstanceAttachmentsState.ts
+++ b/packages/xforms-engine/src/instance/attachments/InstanceAttachmentsState.ts
@@ -3,6 +3,7 @@ import {
   type JRResourceURLString,
 } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type { FetchFormAttachment } from '../../client/resources.ts';
+import { AttachmentNotFoundError } from '../../error/AttachmentNotFoundError.ts';
 import type { StaticLeafElement } from '../../integration/xpath/static-dom/StaticElement.ts';
 import type { InstanceAttachmentMap } from '../input/InstanceAttachmentMap.ts';
 import type { InstanceAttachmentContext } from '../internal-api/InstanceAttachmentContext.ts';
@@ -48,7 +49,7 @@ export class InstanceAttachmentsState extends Map<InstanceAttachmentContext, Ins
         : null;
     }
 
-    return Promise.reject(new Error(`Attachment not found: ${value}`));
+    return Promise.reject(new AttachmentNotFoundError(value));
   }
 
   retryFileValue(instanceNode: StaticLeafElement | null) {

--- a/packages/xforms-engine/src/lib/reactivity/createInstanceAttachment.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceAttachment.ts
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, type Setter } from 'solid-js';
+import { AttachmentNotFoundError } from '../../error/AttachmentNotFoundError.ts';
 import { ErrorProductionDesignPendingError } from '../../error/ErrorProductionDesignPendingError.ts';
 import type { InstanceAttachmentFileName } from '../../instance/attachments/InstanceAttachment.ts';
 import { InstanceAttachment } from '../../instance/attachments/InstanceAttachment.ts';
@@ -60,11 +61,13 @@ export type InstanceAttachmentFormDataEntry = readonly [
   value: NonNullable<InstanceAttachmentRuntimeValue>,
 ];
 
+export type AttachmentLoadingError = 'network-error' | 'not-found';
+
 interface InstanceAttachmentValueOptions {
   readonly writtenAt?: Date;
   readonly file?: InstanceAttachmentRuntimeValue;
   readonly loading?: boolean;
-  readonly error?: boolean;
+  readonly error?: AttachmentLoadingError;
 }
 
 export interface BaseInstanceAttachmentState {
@@ -72,7 +75,7 @@ export interface BaseInstanceAttachmentState {
   readonly intrinsicName: string | null;
   readonly file: InstanceAttachmentRuntimeValue;
   readonly loading: boolean;
-  readonly loadingError: boolean;
+  readonly loadingError: AttachmentLoadingError | false;
   readonly dirty: boolean;
 }
 
@@ -159,9 +162,10 @@ const resolveFile = (
         return prev.dirty ? prev : instanceAttachmentState(context, { file });
       });
     })
-    .catch(() => {
+    .catch((error: unknown) => {
+      const errorType = error instanceof AttachmentNotFoundError ? 'not-found' : 'network-error';
       setState((prev) => {
-        return prev.dirty ? prev : instanceAttachmentState(context, { error: true });
+        return prev.dirty ? prev : instanceAttachmentState(context, { error: errorType });
       });
     });
 };

--- a/packages/xforms-engine/test/instance/attachments/InstanceAttachmentsState.test.ts
+++ b/packages/xforms-engine/test/instance/attachments/InstanceAttachmentsState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { FetchFormAttachment, FetchResourceResponse } from '../../../src/client/resources';
+import { AttachmentNotFoundError } from '../../../src/error/AttachmentNotFoundError';
 import { InstanceAttachmentsState } from '../../../src/instance/attachments/InstanceAttachmentsState';
 import type { InstanceAttachmentMap } from '../../../src/instance/input/InstanceAttachmentMap';
 import type { StaticLeafElement } from '../../../src/integration/xpath/static-dom/StaticElement';
@@ -78,7 +79,7 @@ describe('InstanceAttachmentsState', () => {
       const state = new InstanceAttachmentsState(null, fetchFormAttachment);
 
       await expect(state.getInitialFileValue(leafWithValue('plain-value.txt'))).rejects.toThrow(
-        'Attachment not found: plain-value.txt'
+        AttachmentNotFoundError
       );
       expect(fetchFormAttachment).not.toHaveBeenCalled();
     });

--- a/packages/xforms-engine/test/instance/attachments/InstanceAttachmentsState.test.ts
+++ b/packages/xforms-engine/test/instance/attachments/InstanceAttachmentsState.test.ts
@@ -65,11 +65,21 @@ describe('InstanceAttachmentsState', () => {
       ).rejects.toThrow('Error fetching form attachment: jr://images/missing.png');
     });
 
-    it('returns null when value is not a jr:// reference and has no source attachment', () => {
+    it('returns null when value is empty', () => {
       const fetchFormAttachment = vi.fn<FetchFormAttachment>();
       const state = new InstanceAttachmentsState(null, fetchFormAttachment);
 
-      expect(state.getInitialFileValue(leafWithValue('plain-value.txt'))).toBeNull();
+      expect(state.getInitialFileValue(leafWithValue(''))).toBeNull();
+      expect(fetchFormAttachment).not.toHaveBeenCalled();
+    });
+
+    it('rejects when value is not a jr:// reference and has no source attachment', async () => {
+      const fetchFormAttachment = vi.fn<FetchFormAttachment>();
+      const state = new InstanceAttachmentsState(null, fetchFormAttachment);
+
+      await expect(state.getInitialFileValue(leafWithValue('plain-value.txt'))).rejects.toThrow(
+        'Attachment not found: plain-value.txt'
+      );
       expect(fetchFormAttachment).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/857

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Unit test updated and manual test

Before:

<img width="500" src="https://github.com/user-attachments/assets/ebf01e2d-8c13-4945-b396-4b5f9801278e" />


After fix:

Not found error
<img width="500" src="https://github.com/user-attachments/assets/767daa1c-5703-4f49-a088-ab847dd84fab" />

Network error
<img width="500" src="https://github.com/user-attachments/assets/e5adf857-5a44-4aaa-a82f-bd4d56fbe7e4" />


#### Why is this the best possible solution? Were any other approaches considered?

If the filename exists but the file itself isn't found, show an error.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Clearer outcome when editing submissions, instead of mistakenly believing the question didn't have an answer. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
