### PR TITLE
fix(web-forms#852): remove sentry exceptions on non-response

### DIFF
--- a/.changeset/young-trams-cheer.md
+++ b/.changeset/young-trams-cheer.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Reduces sentry warnings for requests that don't respond

--- a/apps/forms/src/components/submission.vue
+++ b/apps/forms/src/components/submission.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, defineAsyncComponent } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { captureException } from '@sentry/vue';
 import {
   type Form,
   getFormByEnketoId,
@@ -212,7 +211,6 @@ const load = async () => {
         errorCode.value = e.statusCode ?? 500;
       }
     } else {
-      captureException(e);
       errorCode.value = 500;
     }
     hideSpinner();

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 
 import { computed, ref } from 'vue';
-import { captureException } from '@sentry/vue';
 import { OdkWebForm, POST_SUBMIT__NEW_INSTANCE } from '@getodk/web-forms';
 import { type MonolithicInstancePayload } from '@getodk/xforms-engine';
 import { queryString, type Form } from '../utils/api';
@@ -86,7 +85,6 @@ const postPrimaryInstance = async (file:File) => {
     const data = await response.json();
     return { success: false, data: { response: { data } } };
   } catch (error) {
-    captureException(error);
     return { success: false, data: error };
   }
 };
@@ -187,7 +185,6 @@ const uploadAttachment = async (attachment: File, instanceId: string) => {
     const data = await response.json();
     result = { success: response.ok, data: { response: { data } } };
   } catch (error) {
-    captureException(error);
     result = { success: false, data: { response: error } };
   }
 


### PR DESCRIPTION
Closes getodk/web-forms#852

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?



#### Why is this the best possible solution? Were any other approaches considered?

I'm not sure this is the best but submitting it to see what you think. This error is thrown on ios when the request just doesn't respond. This can happen if the user just goes offline, and in this case we needn't bother sentry.

If I'm right about where the error originated from (and I think I am) then it is being caught and handled and displayed properly to the user.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.