### PR TITLE
fix(web-forms#854): escape greater than symbols in markdown

### DIFF
--- a/.changeset/every-pears-sip.md
+++ b/.changeset/every-pears-sip.md
@@ -1,0 +1,6 @@
+---
+"@getodk/xforms-engine": patch
+"@getodk/web-forms": patch
+---
+
+Escapes greater than symbols in markdown

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -218,7 +218,12 @@ function isSingleOrderedList(odk: MarkdownNode[]) {
   );
 }
 
+function escapeBlockquote(str: string) {
+  return str.replaceAll(/(^|\n)> /g, '$1\\> ');
+}
+
 function toOdkMarkdown(str: string): MarkdownNode[] {
+  str = escapeBlockquote(str);
   const tree = fromMarkdown(str);
   newlineToBreak(tree);
   const odk = mdastToOdkMarkdown(tree.children);

--- a/packages/xforms-engine/test/integration/markdown.test.ts
+++ b/packages/xforms-engine/test/integration/markdown.test.ts
@@ -40,6 +40,20 @@ describe('Markdown', () => {
     await run('\\# nothing \\*to\\* see here', [{ value: '# nothing *to* see here' }]);
   });
 
+  describe('blockquote', () => {
+    it('should allow lines starting with greater than', async () => {
+      await run('> greater than some number', [{ value: '> greater than some number' }]);
+    });
+
+    it('should treat multiple lines as blockquote', async () => {
+      const given = `
+> my quote
+> is here
+      `;
+      await run(given, [{ value: '> my quote' }, { elementName: 'br' }, { value: '> is here' }]);
+    });
+  });
+
   describe('should handle headings', () => {
     it('h1', async () => {
       await run('# big heading', [{ elementName: 'h1', children: [{ value: 'big heading' }] }]);


### PR DESCRIPTION
Closes getodk/web-forms#854

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests added
Loaded the form in the issue

#### Why is this the best possible solution? Were any other approaches considered?

Blockquotes are not supported by web-forms at all as per the spec: https://docs.getodk.org/form-styling/
mdast was discovering the blockquote but the engine markdown formatting was discarding it because it didn't know what to do with it.
By escaping before submitting to mdast the `>` character is preserved.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Before nothing showed so I expect nobody was relying on this behaviour.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.