### PR TITLE
fix(#2084): remove unsupported namespace declaration

### DIFF
--- a/apps/central/src/assets/css/namespaces.css
+++ b/apps/central/src/assets/css/namespaces.css
@@ -1,1 +1,0 @@
-@namespace svg "http://www.w3.org/2000/svg";

--- a/apps/central/src/styles.js
+++ b/apps/central/src/styles.js
@@ -11,7 +11,6 @@ except according to the terms contained in the LICENSE file.
 */
 
 // Import global styles.
-import './assets/css/namespaces.css';
 import './assets/css/bootstrap.css';
 import './assets/css/icomoon.css';
 import './assets/scss/app.scss';


### PR DESCRIPTION
Closes getodk/central#2084

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Code dive, build, CI, test.

#### Why is this the best possible solution? Were any other approaches considered?

Not needed.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None - the unsupported declaration was just being dropped by esbuild anyway.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.