### PR TITLE
Bootstrap/remove bootstrap modal

### DIFF
--- a/apps/central/src/components/modal.vue
+++ b/apps/central/src/components/modal.vue
@@ -10,13 +10,12 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 
-<!-- This component should not use v-bind:class on the .modal element. Bootstrap
-may add the `in` class to the element, and the checkScroll() method may add the
-`has-scroll` class. -->
+<!-- This component should not use v-bind:class on the .modal element. The
+checkScroll() method may add the `has-scroll` class. -->
 <template>
   <teleport-if-exists to="#modals">
-    <div ref="el" v-bind="$attrs" class="modal" tabindex="-1"
-      :data-backdrop="backdrop ? 'static' : 'false'" data-keyboard="false"
+    <div v-show="state" ref="el" v-bind="$attrs" class="modal" tabindex="-1"
+      :style="backdrop ? { backgroundColor: 'rgba(0, 0, 0, 0.5)' } : null"
       role="dialog" :aria-labelledby="titleId" @mousedown="modalMousedown"
       @click="modalClick" @keydown.esc="hideIfCan" @focusout="refocus">
       <div class="modal-dialog" :class="sizeClass" role="document">
@@ -48,25 +47,13 @@ let id = 0;
 </script>
 <script setup>
 import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import 'bootstrap/js/modal';
 
 import RedAlert from './red-alert.vue';
 import TeleportIfExists from './teleport-if-exists.vue';
 
-import { noop } from '../util/util';
-
 /*
-We manually toggle the modal:
-
-  - If the `backdrop` prop is `true`, we specify data-backdrop="static" rather
-    than "true". We also add our own event listeners.
-  - We specify data-keyboard="false" and add our own event listener.
-
-We do this for two reasons:
-
-  - It simplifies communication with the parent component: the modal hides only
-    after the parent component sets the `state` prop to `false`.
-  - It is needed to implement the `hideable` prop.
+Previously this component relied on bootstrap/modal.js plugin. Now it only relies
+on bootstrap's css.
 */
 
 defineOptions({
@@ -82,28 +69,33 @@ const props = defineProps({
     type: String,
     default: 'normal'
   },
+  // Shows a dark overlay behind the modal
   backdrop: Boolean
 });
-const emit = defineEmits(['shown', 'hide', 'resize', 'mutate']);
+const emit = defineEmits(['shown', 'hide', 'mutate']);
 
 const { toast, redAlert, openModal } = inject('container');
 
 const el = ref(null);
 const body = ref(null);
 
-// The modal() method of the Boostrap plugin
-let bs;
+let attachedToDocument = false;
+
 onMounted(() => {
-  if (el.value.closest('body') != null) {
-    const wrapper = $(el.value);
-    bs = wrapper.modal.bind(wrapper);
-  } else {
-    // We do not call modal() if the component is not attached to the document,
-    // because modal() can have side effects on the document. Most tests do not
-    // attach the component to the document.
-    bs = noop;
-  }
+  // Check if the component is attached to the document. Most tests do not
+  // attach the component to the document.
+  attachedToDocument = el.value.closest('body') != null;
 });
+
+const addModalOpenClass = () => {
+  if (!attachedToDocument) return;
+  document.body.classList.add('modal-open');
+};
+
+const removeModalOpenClass = () => {
+  if (!attachedToDocument) return;
+  document.body.classList.remove('modal-open');
+};
 
 /*
 Showing a modal hides alerts, both `toast` and `redAlert`. A modal is a new
@@ -149,28 +141,16 @@ const checkScroll = () => {
     el.value.classList.remove('has-scroll');
 };
 
-let bodyHeight = 0;
-const handleHeightChange = () => {
-  // Call checkScroll() before measuring the height, as the has-scroll class can
-  // affect the height.
-  checkScroll();
-  const newHeight = body.value.getBoundingClientRect().height;
-  if (newHeight !== bodyHeight) {
-    bs('handleUpdate');
-    bodyHeight = newHeight;
-    emit('resize', newHeight);
-  }
-};
 const handleWindowResize = () => {
   // Most of the time, a window resize won't affect the height of the modal.
   // However, if props.size === 'full', it could.
-  if (props.state && props.size === 'full') handleHeightChange();
+  if (props.state && props.size === 'full') checkScroll();
 };
 
 let ignoreMutation = false;
 const observer = new MutationObserver(() => {
   if (!props.state) return;
-  handleHeightChange();
+  checkScroll();
   if (!ignoreMutation) {
     emit('mutate');
     // Ignore mutations for a tick, effectively ignoring any mutations that the
@@ -185,9 +165,8 @@ const observer = new MutationObserver(() => {
 });
 
 const show = () => {
-  bs('show');
+  addModalOpenClass();
   checkScroll();
-  bodyHeight = body.value.getBoundingClientRect().height;
   observer.observe(body.value, {
     subtree: true,
     childList: true,
@@ -195,8 +174,8 @@ const show = () => {
     characterData: true
   });
   window.addEventListener('resize', handleWindowResize);
-  emit('shown');
-  emit('resize', bodyHeight);
+  // Emit shown after nextTick to ensure DOM is updated (v-show has made element visible)
+  nextTick(() => { emit('shown'); });
   openModal.shown(el.value);
 };
 const removeSelection = () => {
@@ -207,12 +186,10 @@ const removeSelection = () => {
 };
 const hide = () => {
   observer.disconnect();
-  bs('hide');
+  removeModalOpenClass();
   el.value.classList.remove('has-scroll');
-  bodyHeight = 0;
   window.removeEventListener('resize', handleWindowResize);
   removeSelection();
-  emit('resize', 0);
   openModal.hidden();
 };
 watch(() => props.state, (state) => {
@@ -273,6 +250,11 @@ const titleId = `modal-title${id}`;
 
 <style lang="scss">
 @import '../assets/scss/mixins';
+
+// Override Bootstrap's display:none so v-show can control visibility
+.modal {
+  display: block;
+}
 
 .modal-dialog {
   margin-top: 20vh;

--- a/apps/central/test/components/dataset/new.spec.js
+++ b/apps/central/test/components/dataset/new.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import DatasetNew from '../../../src/components/dataset/new.vue';
 
 import testData from '../../data';
@@ -30,8 +32,9 @@ describe('DatasetNew', () => {
       hide: '.btn-link'
     }));
 
-  it('focuses the input', () => {
+  it('focuses the input', async () => {
     const modal = mount(DatasetNew, mountOptions({ attachTo: document.body }));
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/dataset/property/new.spec.js
+++ b/apps/central/test/components/dataset/property/new.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import DatasetPropertyNew from '../../../../src/components/dataset/property/new.vue';
 import DatasetProperties from '../../../../src/components/dataset/overview/dataset-properties.vue';
 
@@ -50,8 +52,9 @@ describe('DatasetPropertyNew', () => {
       hide: '.btn-link'
     }));
 
-  it('focuses the input', () => {
+  it('focuses the input', async () => {
     const modal = mount(DatasetPropertyNew, mountOptions({ attachTo: document.body }));
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/entity/restore.spec.js
+++ b/apps/central/test/components/entity/restore.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import EntityRestore from '../../../src/components/entity/restore.vue';
 
 import { mergeMountOptions, mount } from '../../util/lifecycle';
@@ -8,8 +10,9 @@ const mountComponent = (options = undefined) =>
   }));
 
 describe('EntityRestore', () => {
-  it('focuses the checkbox', () => {
+  it('focuses the checkbox', async () => {
     const modal = mountComponent({ attachTo: document.body });
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/entity/update.spec.js
+++ b/apps/central/test/components/entity/update.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import EntityUpdate from '../../../src/components/entity/update.vue';
 import EntityUpdateRow from '../../../src/components/entity/update/row.vue';
 
@@ -66,9 +68,10 @@ describe('EntityUpdate', () => {
     });
   });
 
-  it('focuses the entity label textarea', () => {
+  it('focuses the entity label textarea', async () => {
     testData.extendedEntities.createPast(1);
     const modal = mountComponent({ attachTo: document.body });
+    await nextTick();
     modal.get('textarea').should.be.focused();
   });
 
@@ -83,7 +86,8 @@ describe('EntityUpdate', () => {
     const textareas = modal.findAll('textarea');
     textareas.map(({ element }) => element.style.height).should.eql(['', '']);
     await modal.setProps({ state: true });
-    await modal.vm.$nextTick();
+    await nextTick();
+    await nextTick();
     const heights = textareas.map(({ element }) => element.style.height);
     heights[0].should.not.equal('');
     heights[1].should.not.equal('');

--- a/apps/central/test/components/field-key/new.spec.js
+++ b/apps/central/test/components/field-key/new.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import FieldKeyNew from '../../../src/components/field-key/new.vue';
 import FieldKeyQrPanel from '../../../src/components/field-key/qr-panel.vue';
 
@@ -29,9 +31,10 @@ describe('FieldKeyNew', () => {
     });
   });
 
-  it('focuses the input', () => {
+  it('focuses the input', async () => {
     testData.extendedProjects.createPast(1);
     const modal = mount(FieldKeyNew, mountOptions({ attachTo: document.body }));
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/form-draft/publish.spec.js
+++ b/apps/central/test/components/form-draft/publish.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import FormDraftPublish from '../../../src/components/form-draft/publish.vue';
 import FormVersionRow from '../../../src/components/form-version/row.vue';
 
@@ -138,6 +140,7 @@ describe('FormDraftPublish', () => {
         attachTo: document.body
       }));
       await modal.setProps({ state: true });
+      await nextTick();
       modal.get('input').should.be.focused();
     });
 
@@ -174,6 +177,7 @@ describe('FormDraftPublish', () => {
         attachTo: document.body
       }));
       await modal.setProps({ state: true });
+      await nextTick();
       modal.get('textarea').should.be.focused();
     });
 

--- a/apps/central/test/components/modal.spec.js
+++ b/apps/central/test/components/modal.spec.js
@@ -51,22 +51,12 @@ describe('Modal', () => {
       document.body.classList.contains('modal-open').should.be.true;
     });
 
-    it('emits a shown event', () => {
+    it('emits a shown event', async () => {
       const modal = mountComponent({
         props: { state: true }
       });
+      await nextTick();
       modal.emitted().shown.should.eql([[]]);
-    });
-
-    it('emits a resize event', () => {
-      const modal = mountComponent({
-        props: { state: true },
-        slots: {
-          body: { template: '<div id="div" style="height: 10px;"></div>' }
-        },
-        attachTo: document.body
-      });
-      modal.emitted().resize.should.eql([[22]]);
     });
 
     it('updates openModal', () => {
@@ -101,17 +91,6 @@ describe('Modal', () => {
       document.body.classList.contains('modal-open').should.be.false;
     });
 
-    it('emits a resize event', async () => {
-      const modal = mountComponent({
-        slots: {
-          body: { template: '<div id="div" style="height: 10px;"></div>' }
-        },
-        attachTo: document.body
-      });
-      await modal.setProps({ state: false });
-      modal.emitted().resize.should.eql([[22], [0]]);
-    });
-
     it('updates openModal', async () => {
       const modal = mountComponent({
         props: { state: true }
@@ -119,18 +98,6 @@ describe('Modal', () => {
       await modal.setProps({ state: false });
       modal.vm.$container.openModal.should.eql({ state: false, el: null });
     });
-  });
-
-  it('emits a resize event after the height of the modal changes', async () => {
-    const modal = mountComponent({
-      slots: {
-        body: { template: '<div id="div" style="height: 10px;"></div>' }
-      },
-      attachTo: document.body
-    });
-    modal.get('#div').element.setAttribute('style', 'height: 20px;');
-    await nextTick();
-    modal.emitted().resize.should.eql([[22], [32]]);
   });
 
   describe('mutation', () => {

--- a/apps/central/test/components/project/new.spec.js
+++ b/apps/central/test/components/project/new.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import ProjectNew from '../../../src/components/project/new.vue';
 
 import testData from '../../data';
@@ -25,12 +27,13 @@ describe('ProjectNew', () => {
     });
   });
 
-  it('focuses the input', () => {
+  it('focuses the input', async () => {
     mockLogin();
     const modal = mount(ProjectNew, {
       props: { state: true },
       attachTo: document.body
     });
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/public-link/create.spec.js
+++ b/apps/central/test/components/public-link/create.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import PublicLinkCreate from '../../../src/components/public-link/create.vue';
 
 import testData from '../../data';
@@ -26,10 +28,11 @@ describe('PublicLinkCreate', () => {
       hide: '.btn-link'
     }));
 
-  it('focuses the display name input', () => {
+  it('focuses the display name input', async () => {
     const modal = mount(PublicLinkCreate, mountOptions({
       attachTo: document.body
     }));
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/submission/delete.spec.js
+++ b/apps/central/test/components/submission/delete.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import SubmissionDelete from '../../../src/components/submission/delete.vue';
 
 import { mergeMountOptions, mount } from '../../util/lifecycle';
@@ -8,8 +10,9 @@ const mountComponent = (options = undefined) =>
   }));
 
 describe('SubmissionDelete', () => {
-  it('focuses the checkbox', () => {
+  it('focuses the checkbox', async () => {
     const modal = mountComponent({ attachTo: document.body });
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/submission/download.spec.js
+++ b/apps/central/test/components/submission/download.spec.js
@@ -216,19 +216,21 @@ describe('SubmissionDownload', () => {
   });
 
   describe('input focus', () => {
-    it('focuses the splitSelectMultiples checkbox if it is enabled', () => {
+    it('focuses the splitSelectMultiples checkbox if it is enabled', async () => {
       testData.extendedForms.createPast(1, {
         fields: [testData.fields.selectMultiple('/sm')]
       });
       const modal = mountComponent({ attachTo: document.body });
+      await nextTick();
       modal.get('input').should.be.focused();
     });
 
-    it('focuses groupPaths checkbox if splitSelectMultiples checkbox is disabled', () => {
+    it('focuses groupPaths checkbox if splitSelectMultiples checkbox is disabled', async () => {
       testData.extendedForms.createPast(1, {
         fields: [testData.fields.int('/i')]
       });
       const modal = mountComponent({ attachTo: document.body });
+      await nextTick();
       modal.findAll('input')[1].should.be.focused();
     });
   });

--- a/apps/central/test/components/submission/restore.spec.js
+++ b/apps/central/test/components/submission/restore.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import SubmissionRestore from '../../../src/components/submission/restore.vue';
 
 import { mergeMountOptions, mount } from '../../util/lifecycle';
@@ -8,8 +10,9 @@ const mountComponent = (options = undefined) =>
   }));
 
 describe('SubmissionRestore', () => {
-  it('focuses the checkbox', () => {
+  it('focuses the checkbox', async () => {
     const modal = mountComponent({ attachTo: document.body });
+    await nextTick();
     modal.get('input').should.be.focused();
   });
 

--- a/apps/central/test/components/user/new.spec.js
+++ b/apps/central/test/components/user/new.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import UserNew from '../../../src/components/user/new.vue';
 import UserRow from '../../../src/components/user/row.vue';
 
@@ -39,11 +41,12 @@ describe('UserNew', () => {
     });
   });
 
-  it('focuses the email input', () => {
+  it('focuses the email input', async () => {
     const modal = mount(UserNew, {
       props: { state: true },
       attachTo: document.body
     });
+    await nextTick();
     modal.get('input[type="email"]').should.be.focused();
   });
 


### PR DESCRIPTION
Addresses part of https://github.com/getodk/central/issues/1278

Dependent on https://github.com/getodk/central-frontend/pull/1729

#### What has been done to verify that this works as intended?

Test sand manual verification

#### Why is this the best possible solution? Were any other approaches considered?

- Removed the separate overlay element, as it simplified our code. Bootstrap likely had it to support animations or multiple simultaneous modals.
- Removed the `resize` emit since it was not used anywhere.
- Skipped Bootstrap's `handleUpdate` method, which only exists to prevent a slight leftward shift of the modal when the scrollbar appears. The [source code](https://github.com/twbs/bootstrap/blob/68b0d231a13201eb14acd3dc84e51543d16e5f7e/js/modal.js#L295) for this looks overly complex for such a minor UI adjustment. On modern OSes (at least macOS and Windows), scrollbar is shown above the content only when scrolling, so this fix isn't really necessary. If needed later, I'd just nudge the modal slightly left to compensate for the scrollbar.
- I also considered removing everything related to `has-scroll` to simplify the modal component further, but decided against it. For the full-size modal, my plan is to make the modal body scrollable instead of the `.modal` element itself. I'll open an issue with more details on this.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No