### PR TITLE
package-lock: add missing peer dep: solid-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22943,6 +22943,9 @@
         "node": "^24.16.0",
         "npm": "11"
       },
+      "peerDependencies": {
+        "solid-js": "^1.9.7"
+      },
       "peerDependenciesMeta": {
         "solid-js": {
           "optional": true


### PR DESCRIPTION
No idea why, but when I run `npm i` locally, `solid-js` gets added as a peer dependency of `packages/xforms-engine`.

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

I don't know what's going on, but it stops my local working directory from being constantly dirty.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact on users.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.