### PR TITLE
xforms-engine: remove duplicate solid-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22942,14 +22942,6 @@
       "engines": {
         "node": "^24.16.0",
         "npm": "11"
-      },
-      "peerDependencies": {
-        "solid-js": "^1.9.7"
-      },
-      "peerDependenciesMeta": {
-        "solid-js": {
-          "optional": true
-        }
       }
     },
     "packages/xpath": {

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -89,14 +89,6 @@
     "vite-plugin-no-bundle": "^4.0.0",
     "web-tree-sitter": "0.24.5"
   },
-  "peerDependencies": {
-    "solid-js": "^1.9.7"
-  },
-  "peerDependenciesMeta": {
-    "solid-js": {
-      "optional": true
-    }
-  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
It was previously listed as both a dependency, and a peer dependency.

Before that, it was listed as both a **dev** dependency, and a peer dependency, which made more sense.  When it was moved from dev dependency to full dependency, the `peerDependencies` entry became redundant.

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

No other approaches were considered.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.