### PR TITLE
fix(web-forms#846): setvalue order wrong on second update

### DIFF
--- a/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
@@ -267,9 +267,13 @@ const registerSetValueActions = (
 };
 
 const registerValueChangedActions = (context: ValueContext, getValue: Accessor<string>) => {
-  context.valueChangedActions?.forEach((action) => {
-    let previous = getValue();
-    createComputed(() => {
+  if (!context.valueChangedActions?.length) {
+    return;
+  }
+  let previous: string;
+  createComputed(() => {
+    const sourceValue = getValue();
+    context.valueChangedActions.forEach((action) => {
       const ref = bindRefToRepeatInstance(context, action.ref);
       const destinationNodes = context.evaluator.evaluateNodes(ref, {
         contextNode: context.contextNode,
@@ -283,8 +287,6 @@ const registerValueChangedActions = (context: ValueContext, getValue: Accessor<s
         destinationNode.isAttached() &&
         context.isAttached()
       ) {
-        const sourceValue = getValue();
-
         if (
           previous !== undefined &&
           previous !== sourceValue &&
@@ -293,17 +295,18 @@ const registerValueChangedActions = (context: ValueContext, getValue: Accessor<s
           if (action.type === 'geopoint') {
             getGeopointValue(context, (point) => destinationNode.setEncodedValue(point));
           } else {
-            const value = destinationNode.evaluator.evaluateString(
-              action.computation.expression,
-              destinationNode
-            );
+            const value = untrack(() => {
+              return context.evaluator.evaluateString(
+                action.computation.expression,
+                destinationNode
+              );
+            });
             destinationNode.setEncodedValue(value);
           }
         }
-
-        previous = sourceValue;
       }
     });
+    previous = sourceValue;
   });
 };
 

--- a/packages/xforms-engine/test/integration/actions-events/set-value-action.test.ts
+++ b/packages/xforms-engine/test/integration/actions-events/set-value-action.test.ts
@@ -717,7 +717,7 @@ describe('setvalue action', () => {
                 mainInstance(
                   t(
                     'data id="setvalue-multiple"',
-                    t('my-value-1', '1'),
+                    t('my-value-1'),
                     t('my-value-2'),
                     t('my-value-3'),
                     t('my-value-4'),
@@ -749,6 +749,13 @@ describe('setvalue action', () => {
         expect(scenario.answerOf('/data/my-value-3')).toEqualAnswer(intAnswer(4));
         expect(scenario.answerOf('/data/my-value-4')).toEqualAnswer(intAnswer(5));
         expect(scenario.answerOf('/data/my-value-5')).toEqualAnswer(intAnswer(6));
+
+        scenario.answer('/data/my-value-1', '3');
+        expect(scenario.answerOf('/data/my-value-1')).toEqualAnswer(intAnswer(3));
+        expect(scenario.answerOf('/data/my-value-2')).toEqualAnswer(intAnswer(4));
+        expect(scenario.answerOf('/data/my-value-3')).toEqualAnswer(intAnswer(5));
+        expect(scenario.answerOf('/data/my-value-4')).toEqualAnswer(intAnswer(6));
+        expect(scenario.answerOf('/data/my-value-5')).toEqualAnswer(intAnswer(7));
       });
 
       it('handles removed repeats', async () => {


### PR DESCRIPTION
Closes getodk/web-forms#846

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Integration test was modified to set the value a second time. Initially this failed but after patch it passed.
Also checked the QA form and everything is behaving as expected.

#### Why is this the best possible solution? Were any other approaches considered?

Now there is one value changed listener that iterates over the setvalue elements, which puts us in control of the execution order rather than relying on solid to do it.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.