### PR TITLE
chore(central#2099): port release notes for v2026.2.1

### DIFF
--- a/.changeset/cyan-adults-fix.md
+++ b/.changeset/cyan-adults-fix.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Stops Sentry from attaching trace headers to attachment requests.

--- a/.changeset/dull-humans-join.md
+++ b/.changeset/dull-humans-join.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Show error indicator when submission attachment cannot be loaded

--- a/.changeset/every-pears-sip.md
+++ b/.changeset/every-pears-sip.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/web-forms": patch
----
-
-Escapes greater than symbols in markdown

--- a/.changeset/olive-worlds-yawn.md
+++ b/.changeset/olive-worlds-yawn.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Repeat instances are no longer deleted when `jr:count` decreases

--- a/.changeset/real-news-dream.md
+++ b/.changeset/real-news-dream.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Trim whitespace from attachment filename when editing submissions

--- a/.changeset/salty-worlds-stick.md
+++ b/.changeset/salty-worlds-stick.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Use current form version when editing a submission.

--- a/.changeset/sour-ties-scream.md
+++ b/.changeset/sour-ties-scream.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/web-forms": patch
----
-
-Fixed issue with setvalue updated in an unexpected order

--- a/.changeset/strict-rivers-carry.md
+++ b/.changeset/strict-rivers-carry.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixed styling for media upload questions in repeats

--- a/.changeset/young-trams-cheer.md
+++ b/.changeset/young-trams-cheer.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Reduces sentry warnings for requests that don't respond

--- a/apps/forms/CHANGELOG.md
+++ b/apps/forms/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @getodk/forms
 
+## 2026.2.1
+
+### Patch Changes
+
+- 1f33497: Stops Sentry from attaching trace headers to attachment requests.
+- 238035c: Reduces sentry warnings for requests that don't respond
+
 ## 2026.2.0
 
 ### Minor Changes

--- a/packages/web-forms/CHANGELOG.md
+++ b/packages/web-forms/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @getodk/web-forms
 
+## 1.0.1
+
+### Patch Changes
+
+- f31c1ca: Escapes greater than symbols in markdown
+- 0d32c73: Fixed issue with setvalue updated in an unexpected order
+- b0b83c1: Fixed styling for media upload questions in repeats
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/xforms-engine/CHANGELOG.md
+++ b/packages/xforms-engine/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @getodk/xforms-engine
 
+## 1.0.1
+
+### Patch Changes
+
+- 5ef4ccd: Show error indicator when submission attachment cannot be loaded
+- f31c1ca: Escapes greater than symbols in markdown
+- c9d45bc: Repeat instances are no longer deleted when `jr:count` decreases
+- ed2b209: Trim whitespace from attachment filename when editing submissions
+- cc33f84: Use current form version when editing a submission.
+- 0d32c73: Fixed issue with setvalue updated in an unexpected order
+
 ## 1.0.0
 
 ### Major Changes


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2099

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
