### PR TITLE
fix(web-forms#862): catch error accessing disabled localstorage

### DIFF
--- a/.changeset/cute-showers-switch.md
+++ b/.changeset/cute-showers-switch.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Fixed an uncaught promise rejection reading from localStorage

--- a/apps/forms/src/utils/device-id.ts
+++ b/apps/forms/src/utils/device-id.ts
@@ -14,11 +14,16 @@ const getRandomId = () => {
 };
 
 export const getDeviceId = () => {
-  const existingDeviceId = localStorage.getItem(DEVICE_ID_KEY);
-  if (existingDeviceId) {
-    return existingDeviceId;
+  try {
+    const existingDeviceId = localStorage.getItem(DEVICE_ID_KEY);
+    if (existingDeviceId) {
+      return existingDeviceId;
+    }
+    const deviceId = `${DEVICE_ID_PREFIX}:${getRandomId()}`;
+    localStorage.setItem(DEVICE_ID_KEY, deviceId);
+    return deviceId;
+  } catch {
+    // localStorage not available
+    return;
   }
-  const deviceId = `${DEVICE_ID_PREFIX}:${getRandomId()}`;
-  localStorage.setItem(DEVICE_ID_KEY, deviceId);
-  return deviceId;
 };


### PR DESCRIPTION
Closes getodk/web-forms#862

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Testing loading form with localstorage enabled and then disabled.
I checked for other references to localstorage and all seem to be safe.

#### Why is this the best possible solution? Were any other approaches considered?

It's the way.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.
