### PR TITLE
async-route: show load error in console

### DIFF
--- a/apps/central/src/components/async-route.vue
+++ b/apps/central/src/components/async-route.vue
@@ -111,8 +111,9 @@ export default {
             this.component = markRaw(m.default);
           }
         })
-        .catch(() => {
+        .catch(err => {
           if (!canceled) {
+            console.error('async-route', 'loadError:', err);
             // It would be ideal to show a more informative error message.
             // However, the error seems to provide limited information. For
             // example, if there is a 404 because Frontend was rebuilt, the

--- a/apps/central/src/components/async-route.vue
+++ b/apps/central/src/components/async-route.vue
@@ -113,7 +113,7 @@ export default {
         })
         .catch(err => {
           if (!canceled) {
-            console.error('async-route', 'loadError:', err); // eslint-disable-line no-console
+            logger.error('async-route', 'loadError:', err);
 
             // It would be ideal to show a more informative error message.
             // However, the error seems to provide limited information. For

--- a/apps/central/src/components/async-route.vue
+++ b/apps/central/src/components/async-route.vue
@@ -32,7 +32,7 @@ import { noop } from '../util/util';
 export default {
   name: 'AsyncRoute',
   components: { Loading, PageBody },
-  inject: ['alert', 'location'],
+  inject: ['alert', 'location', 'logger'],
   inheritAttrs: false,
   // See routes.js for more information about these props.
   props: {
@@ -113,7 +113,7 @@ export default {
         })
         .catch(err => {
           if (!canceled) {
-            logger.error('async-route', 'loadError:', err);
+            this.logger.error('async-route', 'loadError:', err);
 
             // It would be ideal to show a more informative error message.
             // However, the error seems to provide limited information. For

--- a/apps/central/src/components/async-route.vue
+++ b/apps/central/src/components/async-route.vue
@@ -113,7 +113,8 @@ export default {
         })
         .catch(err => {
           if (!canceled) {
-            console.error('async-route', 'loadError:', err);
+            console.error('async-route', 'loadError:', err); // eslint-disable-line no-console
+
             // It would be ideal to show a more informative error message.
             // However, the error seems to provide limited information. For
             // example, if there is a 404 because Frontend was rebuilt, the

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -103,6 +103,9 @@ const globalAllowedLogs = [
   // * https://github.com/getodk/central/issues/1584
   // * https://github.com/getodk/central/issues/2070
   'SyntaxError: 17',
+
+  // Failing on these messages is highly disruptive, as it can randomly happen to non-fatal messages.
+  'Execution context was destroyed, most likely because of a navigation',
 ];
 
 function isFatalConsoleMessage(allowedLogs, consoleMsg, normalisedMsg) {


### PR DESCRIPTION
For the end-user, there is already a toast displayed when a load error occurs, reading:

> The page you requested could not be loaded. Please refresh the page and try again.

Without this logging, there is no indication to a developer what the error actually is.

<kbd>

<img width="877" height="249" alt="Screenshot_2026-08-05_08-54-33" src="https://github.com/user-attachments/assets/1fdf57b0-aacf-49c3-b61c-d04e579709fb" />


</kbd>

#### What has been done to verify that this works as intended?

- [x] ran locally
- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

If bundle size or prod behaviour are sacrosanct, the logging could be filtered from the final bundle somehow?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Most users won't encounter these errors, and if they do then they're unlikely to notice the logging.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.