### PR TITLE
user/edit/password: check strength with zxcvbn

### DIFF
--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -28,7 +28,8 @@
     "vue-flatpickr-component": "~9",
     "vue-i18n": "^10.0.7",
     "vue-router": "^4.6.3",
-    "xml-formatter": "~2"
+    "xml-formatter": "~2",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.7.0",

--- a/apps/central/src/components/form-group.vue
+++ b/apps/central/src/components/form-group.vue
@@ -15,8 +15,6 @@ except according to the terms contained in the LICENSE file.
     <input ref="input" v-model="modelValue" v-bind="$attrs" class="form-control"
       :placeholder="requiredLabel(placeholder, required)" :required="required"
       v-tooltip.aria-describedby="tooltip" :autocomplete="autocomplete">
-    <password-strength v-if="autocomplete === 'new-password'"
-      :password="modelValue"/>
     <span class="form-label">{{ requiredLabel(placeholder, required) }}</span>
     <slot name="after"></slot>
   </label>
@@ -24,8 +22,6 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { computed, ref } from 'vue';
-
-import PasswordStrength from './password-strength.vue';
 
 import { requiredLabel } from '../util/dom';
 
@@ -48,7 +44,6 @@ const props = defineProps({
 });
 
 const htmlClass = computed(() => ({
-  'new-password': props.autocomplete === 'new-password',
   'has-error': props.hasError
 }));
 
@@ -56,12 +51,3 @@ const input = ref(null);
 const focus = () => { input.value.focus(); };
 defineExpose({ focus });
 </script>
-
-<style lang="scss">
-.form-group {
-  // Hide a password strength meter for password confirmation.
-  &.new-password ~ .form-group.new-password .password-strength {
-    display: none;
-  }
-}
-</style>

--- a/apps/central/src/components/password-strength.vue
+++ b/apps/central/src/components/password-strength.vue
@@ -23,20 +23,10 @@ https://github.com/apertureless/vue-password-strength-meter -->
 import { computed } from 'vue';
 
 const props = defineProps({
-  password: {
-    type: String,
+  score: {
+    type: Number,
     required: true
   }
-});
-
-const score = computed(() => {
-  const { length } = props.password;
-  if (length === 0) return 0;
-  if (length < 8) return 1;
-  if (length < 10) return 2;
-  if (length < 12) return 3;
-  if (length < 14) return 4;
-  return 5;
 });
 </script>
 

--- a/apps/central/src/components/user/edit/password.vue
+++ b/apps/central/src/components/user/edit/password.vue
@@ -24,7 +24,12 @@ except according to the terms contained in the LICENSE file.
           autocomplete="current-password"/>
         <form-group id="user-edit-password-new-password" v-model="newPassword"
           type="password" :placeholder="$t('field.newPassword')" required
-          :has-error="tooShort || mismatch" autocomplete="new-password"/>
+          :has-error="tooShort || mismatch || !!strError" autocomplete="new-password">
+          <template v-slot:after>
+            <password-strength :score="passwordStrength"/>
+            <div v-if="strError" class="error"><span v-html="strError"></span></div>
+          </template>
+        </form-group>
         <form-group id="user-edit-password-confirm" v-model="confirm"
           type="password" :placeholder="$t('field.passwordConfirm')" required
           :has-error="mismatch" autocomplete="new-password"/>
@@ -40,16 +45,18 @@ except according to the terms contained in the LICENSE file.
 
 <script>
 import FormGroup from '../../form-group.vue';
+import PasswordStrength from '../../password-strength.vue';
 import Spinner from '../../spinner.vue';
 
 import useRequest from '../../../composables/request';
 import { apiPaths } from '../../../util/request';
 import { noop } from '../../../util/util';
 import { useRequestData } from '../../../request-data';
+import { checkPasswordStrength } from '../../../util/password';
 
 export default {
   name: 'UserEditPassword',
-  components: { FormGroup, Spinner },
+  components: { FormGroup, PasswordStrength, Spinner },
   inject: ['alert', 'config'],
   setup() {
     const { currentUser, user } = useRequestData();
@@ -62,43 +69,79 @@ export default {
       newPassword: '',
       tooShort: false,
       confirm: '',
-      mismatch: false
+      mismatch: false,
+      passwordStrength: 0,
+      strError: '',
     };
   },
   methods: {
-    validate() {
+    async validate() {
       this.tooShort = false;
       this.mismatch = false;
+      this.passwordStrength = 0;
+      this.strError = '';
 
-      if (this.newPassword.length < 10) {
-        this.alert.danger(this.$t('alert.passwordTooShort'));
-        this.tooShort = true;
-        return false;
+      let timer;
+      const timeout = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timeout')), 500);
+      });
+      try {
+        const { score, suggestions } = await Promise.race([
+          timeout,
+          checkPasswordStrength(this.newPassword),
+        ]);
+
+        this.passwordStrength = score;
+        if (suggestions.length) this.strError = `
+          <ul>${suggestions.map(s => `<li>${s}</li>`).join('')}</ul>
+        `;
+        return strength > 2;
+      } catch(err) {
+        this.passwordStrength = (() => {
+          const { length } = props.password;
+          if (length === 0) return 0;
+          if (length < 8) return 1;
+          if (length < 10) return 2;
+          if (length < 12) return 3;
+          if (length < 14) return 4;
+          return 5;
+        })();
+
+        if (this.newPassword.length < 10) {
+          this.alert.danger(this.$t('alert.passwordTooShort'));
+          this.tooShort = true;
+          return false;
+        }
+
+        if (this.confirm !== this.newPassword) {
+          this.alert.danger(this.$t('alert.mismatch'));
+          this.mismatch = true;
+          return false;
+        }
+
+        return true;
+      } finally {
+        clearTimeout(timer);
       }
-
-      if (this.confirm !== this.newPassword) {
-        this.alert.danger(this.$t('alert.mismatch'));
-        this.mismatch = true;
-        return false;
-      }
-
-      return true;
     },
     submit() {
-      if (!this.validate()) return;
-      const data = { old: this.oldPassword, new: this.newPassword };
-      this.request({
-        method: 'PUT',
-        url: apiPaths.password(this.user.id),
-        data
-      })
-        .then(() => {
-          this.alert.success(this.$t('alert.success'));
-
-          // The Chrome password manager does not realize that the form was
-          // submitted. Should we navigate to a different page so that it does?
+      (async () => {
+        const valid = await this.validate();
+        if (!valid) return;
+        const data = { old: this.oldPassword, new: this.newPassword };
+        this.request({
+          method: 'PUT',
+          url: apiPaths.password(this.user.id),
+          data
         })
-        .catch(noop);
+          .then(() => {
+            this.alert.success(this.$t('alert.success'));
+
+            // The Chrome password manager does not realize that the form was
+            // submitted. Should we navigate to a different page so that it does?
+          })
+          .catch(noop);
+      })();
     }
   }
 };

--- a/apps/central/src/util/password.js
+++ b/apps/central/src/util/password.js
@@ -1,0 +1,11 @@
+export async function checkPasswordStrength(password) {
+  const { default:zxcvbn } = await import('zxcvbn');
+  const { score, feedback:{ warning, suggestions } } = zxcvbn(password);
+  return {
+    score,
+    suggestions: [
+      warning,
+      ...suggestions,
+    ].filter(it => it),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,8 @@
         "vue-flatpickr-component": "~9",
         "vue-i18n": "^10.0.7",
         "vue-router": "^4.6.3",
-        "xml-formatter": "~2"
+        "xml-formatter": "~2",
+        "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.7.0",
@@ -22758,6 +22759,12 @@
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
       "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
       "license": "MIT AND BSD-3-Clause"
+    },
+    "node_modules/zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
+      "license": "MIT"
     },
     "packages/common": {
       "name": "@getodk/common",


### PR DESCRIPTION
# TODO

- [ ] extract password-strength component extraction to separate PR
- [ ] fix layout
- [ ] some nice screenshots
- [ ] update issue references

---

Falls back to length-based check if zxcvbn load takes too long (it's massive).

Closes #

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
