### PR TITLE
ci/wf-e2e: add timeouts

### DIFF
--- a/.github/workflows/wf-ci-e2e.yml
+++ b/.github/workflows/wf-ci-e2e.yml
@@ -7,6 +7,7 @@ jobs:
   web-forms-e2e-functional:
     name: '@getodk/web-forms (functional e2e)'
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 4
 
     strategy:
       fail-fast: false
@@ -56,6 +57,7 @@ jobs:
   web-forms-e2e-visual:
     name: '@getodk/web-forms (visual e2e)'
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 6
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This job took 42 minutes: https://github.com/getodk/central-frontend/actions/runs/30985056489/job/92238449922?pr=1743

Normal run is < 3 minutes: https://github.com/getodk/central-frontend/actions/runs/30971906331/job/92198578466

Timeouts on these jobs would have been helpful.

Specific cause looks like it was https://github.com/getodk/central/issues/2060.

#### What has been done to verify that this works as intended?

- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

* could add timeouts in all the other places they're missing, but this PR at least improves on the status quo
* timeouts chosen are 2x the most recent `master` builds for each job, hopefully allowing for some normal deviation

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No change - just CI.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.
