### PR TITLE
Move the action buttons on the data table to the right

### DIFF
--- a/apps/central/src/components/entity/metadata-row.vue
+++ b/apps/central/src/components/entity/metadata-row.vue
@@ -11,6 +11,17 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <tr class="entity-metadata-row" :class="{ 'entity-row-selected': entity.__system.selected }">
+    <td class="col-actions">
+      <entity-actions v-if="!deleted" :entity="entity" :awaiting-response="awaitingResponse"/>
+      <div v-if="deleted && verbs.has('entity.restore')" class="btn-group">
+        <button type="button"
+          class="restore-button btn btn-default"
+          :aria-disabled="awaitingResponse"
+          :aria-label="$t('action.restore')" v-tooltip.aria-label>
+          <span class="icon-recycle"></span><spinner :state="awaitingResponse"/>
+        </button>
+      </div>
+    </td>
     <td class="row-number">{{ $n(rowNumber, 'noGrouping') }}</td>
     <td v-if="!deleted && verbs.has('entity.delete')">
       <input type="checkbox" :aria-label="$t('action.selectRow')" :checked="entity.__system.selected" @change="$emit('selectionChanged', $event.target.checked)">
@@ -19,7 +30,7 @@ except according to the terms contained in the LICENSE file.
       <span v-tooltip.text>{{ entity.__system.creatorName }}</span>
     </td>
     <td><date-time :iso="entity.__system.createdAt"/></td>
-    <td v-if="!deleted" class="action-cell">
+    <td v-if="!deleted" class="last-updated-cell">
       <div class="col-content">
         <date-time :iso="entity.__system.updatedAt" class="updated-at"/>
         <span class="updates">
@@ -33,21 +44,11 @@ except according to the terms contained in the LICENSE file.
             <span>{{ $n(entity.__system.updates, 'default') }}</span>
           </template>
         </span>
-        <span class="icon-angle-right"></span>
       </div>
-      <entity-actions :entity="entity" :awaiting-response="awaitingResponse"/>
     </td>
-    <td v-else class="action-cell">
+    <td v-else class="last-updated-cell">
       <div class="col-content col-deleted-at">
         <date-time :iso="entity.__system.deletedAt"/>
-      </div>
-      <div v-if="verbs.has('entity.restore')" class="btn-group">
-        <button type="button"
-          class="restore-button btn btn-default"
-          :aria-disabled="awaitingResponse"
-          :aria-label="$t('action.restore')" v-tooltip.aria-label>
-          <span class="icon-recycle"></span><spinner :state="awaitingResponse"/>
-        </button>
       </div>
     </td>
   </tr>
@@ -98,13 +99,9 @@ defineEmits(['selectionChanged']);
     max-width: 250px;
   }
 
-  .action-cell {
+  .last-updated-cell {
     padding-top: 4px;
     padding-bottom: 4px;
-
-    // Ensure that the column is wide enough that EntityActions does not wrap.
-    min-width: 170px;
-    &:lang(id) { min-width: 215px; }
   }
 
   .col-content {

--- a/apps/central/src/components/entity/metadata-row.vue
+++ b/apps/central/src/components/entity/metadata-row.vue
@@ -13,7 +13,7 @@ except according to the terms contained in the LICENSE file.
   <tr class="entity-metadata-row" :class="{ 'entity-row-selected': entity.__system.selected }">
     <td class="col-actions">
       <entity-actions v-if="!deleted" :entity="entity" :awaiting-response="awaitingResponse"/>
-      <div v-if="deleted && verbs.has('entity.restore')" class="btn-group">
+      <div v-else-if="deleted && verbs.has('entity.restore')" class="btn-group">
         <button type="button"
           class="restore-button btn btn-default"
           :aria-disabled="awaitingResponse"
@@ -47,9 +47,7 @@ except according to the terms contained in the LICENSE file.
       </div>
     </td>
     <td v-else class="last-updated-cell">
-      <div class="col-content col-deleted-at">
-        <date-time :iso="entity.__system.deletedAt"/>
-      </div>
+      <date-time :iso="entity.__system.deletedAt"/>
     </td>
   </tr>
 </template>

--- a/apps/central/src/components/entity/table.vue
+++ b/apps/central/src/components/entity/table.vue
@@ -21,7 +21,7 @@ except according to the terms contained in the LICENSE file.
       </th>
       <th>{{ $t('header.createdBy') }}</th>
       <th>{{ $t('header.createdAt') }}</th>
-      <th v-if="!deleted">{{ $t('header.updatedAt') }}</th>
+      <th v-if="!deleted">{{ $t('common.lastUpdate') }}</th>
       <th v-else class="col-deleted-at">{{ $t('header.deletedAt') }}</th>
     </template>
     <template #head-scrolling>
@@ -143,11 +143,6 @@ defineExpose({ afterUpdate, afterDelete });
   }
 
   th.col-deleted-at { color: $color-danger; }
-
-  .col-actions {
-    width: 0;
-    padding: 0;
-  }
 }
 </style>
 
@@ -155,9 +150,6 @@ defineExpose({ afterUpdate, afterDelete });
 {
   "en": {
     "header": {
-      // This is the text of a column header of a table of Entities. The column
-      // shows when each Entity was last updated.
-      "updatedAt": "Last Updated",
       // Heading of the column that shows Entity deletion timestamp
       "deletedAt": "Deleted at"
     }

--- a/apps/central/src/components/entity/table.vue
+++ b/apps/central/src/components/entity/table.vue
@@ -14,13 +14,14 @@ except according to the terms contained in the LICENSE file.
     :data="odataEntities.value" key-prop="__id"
     :frozen-only="properties == null" divider @action="afterAction">
     <template #head-frozen>
+      <th class="col-actions"></th>
       <th><span class="sr-only">{{ $t('common.rowNumber') }}</span></th>
       <th v-if="!deleted && project.verbs.has('entity.delete')">
         <input type="checkbox" :aria-label="$t('action.selectRow')" :checked="allSelected" @change="changeAllSelection($event.target.checked)">
       </th>
       <th>{{ $t('header.createdBy') }}</th>
       <th>{{ $t('header.createdAt') }}</th>
-      <th v-if="!deleted">{{ $t('header.updatedAtAndActions') }}</th>
+      <th v-if="!deleted">{{ $t('header.updatedAt') }}</th>
       <th v-else class="col-deleted-at">{{ $t('header.deletedAt') }}</th>
     </template>
     <template #head-scrolling>
@@ -141,7 +142,12 @@ defineExpose({ afterUpdate, afterDelete });
     margin-top: 0;
   }
 
-th.col-deleted-at { color: $color-danger; }
+  th.col-deleted-at { color: $color-danger; }
+
+  .col-actions {
+    width: 0;
+    padding: 0;
+  }
 }
 </style>
 
@@ -150,9 +156,8 @@ th.col-deleted-at { color: $color-danger; }
   "en": {
     "header": {
       // This is the text of a column header of a table of Entities. The column
-      // shows when each Entity was last updated, as well as actions that can be
-      // taken on the Entity.
-      "updatedAtAndActions": "Last Updated / Actions",
+      // shows when each Entity was last updated.
+      "updatedAt": "Last Updated",
       // Heading of the column that shows Entity deletion timestamp
       "deletedAt": "Deleted at"
     }

--- a/apps/central/src/components/field-key/list.vue
+++ b/apps/central/src/components/field-key/list.vue
@@ -219,10 +219,6 @@ export default {
   &.frozen-only .table-freeze-frozen {
     width: 100%;
   }
-  .col-actions {
-    width: 0;
-    padding: 0;
-  }
 }
 </style>
 

--- a/apps/central/src/components/field-key/list.vue
+++ b/apps/central/src/components/field-key/list.vue
@@ -33,11 +33,12 @@ except according to the terms contained in the LICENSE file.
     <table-freeze v-if="dataExists" id="field-key-list-table" :data="fieldKeys.data" key-prop="id"
       :frozen-only="actorProperties.length === 0" :divider="actorProperties.length > 0">
       <template #head-frozen>
+        <th class="col-actions"></th>
         <th>{{ $t('header.displayName') }}</th>
         <th>{{ $t('header.configureClient') }}</th>
         <th>{{ $t('header.createdAt') }}</th>
         <th>{{ $t('header.createdBy') }}</th>
-        <th>{{ $t('header.lastUsedAndActions', { lastUsed: $t('header.lastUsed'), actions: $t('header.actions') }) }}</th>
+        <th>{{ $t('header.lastUsed') }}</th>
       </template>
       <template #head-scrolling>
         <th v-for="property of actorProperties" :key="property.name">
@@ -218,6 +219,10 @@ export default {
   &.frozen-only .table-freeze-frozen {
     width: 100%;
   }
+  .col-actions {
+    width: 0;
+    padding: 0;
+  }
 }
 </style>
 
@@ -240,8 +245,6 @@ export default {
     ],
     "header": {
       "lastUsed": "Last Used",
-      // Header for the table column that shows the last used date and action buttons.
-      "lastUsedAndActions": "{lastUsed} / {actions}",
       // Header for the table column that shows QR codes to configure data collection clients such as ODK Collect.
       "configureClient": "Configure Client"
     },

--- a/apps/central/src/components/field-key/row.vue
+++ b/apps/central/src/components/field-key/row.vue
@@ -11,27 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <tr class="field-key-row" :class="{ success: fieldKey.id === highlighted }">
-    <td class="display-name">
-      <span v-tooltip.text>{{ fieldKey.displayName }}</span>
-    </td>
-    <td>
-      <a v-if="fieldKey.token != null" ref="popoverLink" href="#"
-        class="field-key-row-popover-link" role="button"
-        @click.prevent="toggleQr">
-        <span class="icon-qrcode"></span>{{ $t('seeCode') }}
-      </a>
-      <template v-else>
-        {{ $t('accessRevoked') }}
-      </template>
-    </td>
-    <td><date-time :iso="fieldKey.createdAt"/></td>
-    <td class="created-by">
-      <span v-tooltip.text>{{ fieldKey.createdBy.displayName }}</span>
-    </td>
-    <td class="last-used-and-actions">
-      <div class="col-content">
-        <date-time :iso="fieldKey.lastUsed"/>
-      </div>
+    <td class="col-actions">
       <div class="btn-group">
         <button v-if="fieldKey.token != null && showEdit" type="button"
           class="edit-button btn btn-default"
@@ -47,6 +27,22 @@ except according to the terms contained in the LICENSE file.
         </button>
       </div>
     </td>
+    <td class="display-name"><span v-tooltip.text>{{ fieldKey.displayName }}</span></td>
+    <td>
+      <a v-if="fieldKey.token != null" ref="popoverLink" href="#"
+        class="field-key-row-popover-link" role="button"
+        @click.prevent="toggleQr">
+        <span class="icon-qrcode"></span>{{ $t('seeCode') }}
+      </a>
+      <template v-else>
+        {{ $t('accessRevoked') }}
+      </template>
+    </td>
+    <td><date-time :iso="fieldKey.createdAt"/></td>
+    <td class="created-by">
+      <span v-tooltip.text>{{ fieldKey.createdBy.displayName }}</span>
+    </td>
+    <td><date-time :iso="fieldKey.lastUsed"/></td>
   </tr>
 </template>
 
@@ -78,23 +74,9 @@ export default {
 @import '../../assets/scss/variables';
 
 .field-key-row {
-  .table tbody & td { vertical-align: middle; }
-
   .display-name, .created-by {
     @include text-overflow-ellipsis;
     max-width: 250px;
-  }
-
-  .last-used-and-actions {
-    padding-top: 4px;
-    padding-bottom: 4px;
-    min-width: 120px;
-  }
-
-  .col-content {
-    display: flex;
-    align-items: flex-start;
-    margin-top: 3px;
   }
 
   .btn-group {

--- a/apps/central/src/components/public-link/row.vue
+++ b/apps/central/src/components/public-link/row.vue
@@ -11,6 +11,22 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <tr :class="htmlClass">
+    <td class="col-actions">
+      <div class="btn-group">
+        <button v-if="publicLink.token != null && showEdit" type="button"
+          class="edit-button btn btn-default"
+          :aria-label="$t('action.edit')" v-tooltip.aria-label
+          @click="$emit('edit', publicLink)">
+          <span class="icon-pencil"></span>
+        </button>
+        <button v-if="publicLink.token != null" type="button"
+          class="revoke-button btn btn-default"
+          :aria-label="$t('action.revoke')" v-tooltip.aria-label
+          @click="$emit('revoke', publicLink)">
+          <span class="icon-times-circle"></span>
+        </button>
+      </div>
+    </td>
     <td class="display-name">
       <span v-tooltip.text>{{ publicLink.displayName }}</span>
     </td>
@@ -30,23 +46,9 @@ except according to the terms contained in the LICENSE file.
         </template>
       </template>
     </td>
-    <td class="created-at-and-actions">
+    <td class="created-at">
       <div>
         <date-time :iso="publicLink.createdAt"/>
-      </div>
-      <div class="btn-group">
-        <button v-if="publicLink.token != null && showEdit" type="button"
-          class="edit-button btn btn-default"
-          :aria-label="$t('action.edit')" v-tooltip.aria-label
-          @click="$emit('edit', publicLink)">
-          <span class="icon-pencil"></span>
-        </button>
-        <button v-if="publicLink.token != null" type="button"
-          class="revoke-button btn btn-default"
-          :aria-label="$t('action.revoke')" v-tooltip.aria-label
-          @click="$emit('revoke', publicLink)">
-          <span class="icon-times-circle"></span>
-        </button>
       </div>
     </td>
   </tr>
@@ -107,12 +109,6 @@ export default {
   }
 
   .icon-question-circle { margin-left: 5px; }
-
-  .created-at-and-actions {
-    padding-top: 4px;
-    padding-bottom: 4px;
-    min-width: 120px;
-  }
 
   .btn-group {
     @include icon-btn-group;

--- a/apps/central/src/components/public-link/table.vue
+++ b/apps/central/src/components/public-link/table.vue
@@ -13,10 +13,11 @@ except according to the terms contained in the LICENSE file.
   <table-freeze id="public-link-table" :data="publicLinks.data" key-prop="id"
     :frozen-only="actorProperties.length === 0" :divider="actorProperties.length > 0">
     <template #head-frozen>
+      <th class="col-actions"></th>
       <th>{{ $t('header.displayName') }}</th>
       <th>{{ $t('header.once') }}</th>
       <th class="access-link">{{ $t('header.accessLink') }}</th>
-      <th>{{ $t('header.createdAtAndActions', { createdAt: $t('header.createdAt'), actions: $t('header.actions') }) }}</th>
+      <th>{{ $t('header.createdAt') }}</th>
     </template>
     <template #head-scrolling>
       <th v-for="property of actorProperties" :key="property.name">
@@ -73,6 +74,11 @@ const { publicLinks, actorProperties } = useRequestData();
   td {
     height: 52px; // Access link cells has scrollbar
     vertical-align: unset;
+  }
+  .col-actions {
+    padding: 0;
+    width: 0;
+    vertical-align: top;
   }
 }
 </style>

--- a/apps/central/src/components/public-link/table.vue
+++ b/apps/central/src/components/public-link/table.vue
@@ -76,8 +76,6 @@ const { publicLinks, actorProperties } = useRequestData();
     vertical-align: unset;
   }
   .col-actions {
-    padding: 0;
-    width: 0;
     vertical-align: top;
   }
 }

--- a/apps/central/src/components/submission/metadata-row.vue
+++ b/apps/central/src/components/submission/metadata-row.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     <td class="col-actions">
       <submission-actions v-if="!draft && !deleted" :submission="submission"
         :awaiting-response="awaitingResponse"/>
-      <div v-if="deleted && verbs.has('submission.restore')" class="btn-group">
+      <div v-else-if="deleted && verbs.has('submission.restore')" class="btn-group">
         <button type="button"
           class="restore-button btn btn-default"
           :aria-disabled="awaitingResponse"
@@ -47,9 +47,7 @@ except according to the terms contained in the LICENSE file.
       </div>
     </td>
     <td v-if="!draft && deleted">
-      <div class="col-content col-deleted-at">
-        <date-time :iso="submission.__system.deletedAt"/>
-      </div>
+      <date-time :iso="submission.__system.deletedAt"/>
     </td>
   </tr>
 </template>

--- a/apps/central/src/components/submission/metadata-row.vue
+++ b/apps/central/src/components/submission/metadata-row.vue
@@ -11,12 +11,24 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <tr class="submission-metadata-row">
+    <td class="col-actions">
+      <submission-actions v-if="!draft && !deleted" :submission="submission"
+        :awaiting-response="awaitingResponse"/>
+      <div v-if="deleted && verbs.has('submission.restore')" class="btn-group">
+        <button type="button"
+          class="restore-button btn btn-default"
+          :aria-disabled="awaitingResponse"
+          :aria-label="$t('action.restore')" v-tooltip.aria-label>
+          <span class="icon-recycle"></span><spinner :state="awaitingResponse"/>
+        </button>
+      </div>
+    </td>
     <td class="row-number">{{ $n(rowNumber, 'noGrouping') }}</td>
     <td v-if="!draft" class="submitter-name">
       <span v-tooltip.text>{{ submission.__system.submitterName }}</span>
     </td>
     <td><date-time :iso="submission.__system.submissionDate"/></td>
-    <td v-if="!draft && !deleted" class="state-and-actions">
+    <td v-if="!draft && !deleted">
       <div class="col-content">
         <span class="state">
           <template v-if="missingAttachment">
@@ -32,22 +44,11 @@ except according to the terms contained in the LICENSE file.
             <span>{{ $n(submission.__system.edits, 'default') }}</span>
           </template>
         </span>
-        <span class="icon-angle-right"></span>
       </div>
-      <submission-actions :submission="submission"
-        :awaiting-response="awaitingResponse"/>
     </td>
-    <td v-if="!draft && deleted" class="state-and-actions">
+    <td v-if="!draft && deleted">
       <div class="col-content col-deleted-at">
         <date-time :iso="submission.__system.deletedAt"/>
-      </div>
-      <div v-if="verbs.has('submission.restore')" class="btn-group">
-        <button type="button"
-          class="restore-button btn btn-default"
-          :aria-disabled="awaitingResponse"
-          :aria-label="$t('action.restore')" v-tooltip.aria-label>
-          <span class="icon-recycle"></span><spinner :state="awaitingResponse"/>
-        </button>
       </div>
     </td>
   </tr>
@@ -107,12 +108,6 @@ export default {
   .submitter-name {
     @include text-overflow-ellipsis;
     max-width: 250px;
-  }
-
-  .state-and-actions {
-    // Ensure that the column is wide enough that the .btn-group does not wrap.
-    min-width: 205px;
-    &:lang(id) { min-width: 221px; }
   }
   .col-content {
     align-items: flex-start;

--- a/apps/central/src/components/submission/table.vue
+++ b/apps/central/src/components/submission/table.vue
@@ -14,10 +14,11 @@ except according to the terms contained in the LICENSE file.
     :data="chunkyOData" key-prop="__id" :frozen-only="fields == null" divider
     @action="handleActions">
     <template #head-frozen>
+      <th class="col-actions"></th>
       <th><span class="sr-only">{{ $t('common.rowNumber') }}</span></th>
       <th v-if="!draft">{{ $t('header.submitterName') }}</th>
       <th>{{ $t('header.submissionDate') }}</th>
-      <th v-if="!draft && !deleted">{{ $t('header.stateAndActions') }}</th>
+      <th v-if="!draft && !deleted">{{ $t('header.state') }}</th>
       <th v-if="!draft && deleted" class="col-deleted-at">{{ $t('header.deletedAt') }}</th>
     </template>
     <template #head-scrolling>
@@ -117,6 +118,10 @@ defineExpose({ afterReview, afterDelete });
   }
 
   th.col-deleted-at { color: $color-danger; }
+  .col-actions {
+    padding: 0;
+    width: 0;
+  }
 }
 </style>
 
@@ -124,7 +129,7 @@ defineExpose({ afterReview, afterDelete });
 {
   "en": {
     "header": {
-      "stateAndActions": "State and actions",
+      "state": "State",
       // Heading of the column that shows Submission deletion timestamp
       "deletedAt": "Deleted at"
     }

--- a/apps/central/src/components/submission/table.vue
+++ b/apps/central/src/components/submission/table.vue
@@ -118,10 +118,6 @@ defineExpose({ afterReview, afterDelete });
   }
 
   th.col-deleted-at { color: $color-danger; }
-  .col-actions {
-    padding: 0;
-    width: 0;
-  }
 }
 </style>
 
@@ -129,6 +125,7 @@ defineExpose({ afterReview, afterDelete });
 {
   "en": {
     "header": {
+      // @transifexKey component.ProjectFormAccessTable.header.state
       "state": "State",
       // Heading of the column that shows Submission deletion timestamp
       "deletedAt": "Deleted at"

--- a/apps/central/src/components/table/freeze.vue
+++ b/apps/central/src/components/table/freeze.vue
@@ -157,10 +157,6 @@ defineExpose({ getRowPair });
 
 .table-freeze-frozen.divider {
   box-shadow: 3px 0 0 rgba(0, 0, 0, 0.04);
-  // Adding z-index so that the background color of the other table's thead does
-  // not overlay the box shadow.
-  z-index: 1;
-
   th:last-child { border-right: $border-bottom-table-heading; }
   td:last-child { border-right: $border-top-table-data; }
 }
@@ -185,5 +181,10 @@ defineExpose({ getRowPair });
   }
 
   .btn-group { @include icon-btn-group; }
+
+  .col-actions {
+    width: 0;
+    padding: 0;
+  }
 }
 </style>

--- a/apps/central/src/components/table/freeze.vue
+++ b/apps/central/src/components/table/freeze.vue
@@ -133,7 +133,10 @@ defineExpose({ getRowPair });
 <style lang="scss">
 @import '../../assets/scss/mixins';
 
-.table-freeze { @include clearfix; }
+.table-freeze {
+  @include clearfix;
+  position: relative;
+}
 
 .table-freeze-frozen {
   float: left;
@@ -154,7 +157,6 @@ defineExpose({ getRowPair });
 
 .table-freeze-frozen.divider {
   box-shadow: 3px 0 0 rgba(0, 0, 0, 0.04);
-  position: relative;
   // Adding z-index so that the background color of the other table's thead does
   // not overlay the box shadow.
   z-index: 1;
@@ -166,22 +168,20 @@ defineExpose({ getRowPair });
 // Styles related to actions (buttons and links). If there are actions, they
 // should be in a .btn-group.
 .table-freeze-frozen {
-  // If the table has a .btn-group, it will probably be in the last column.
-  td:last-child { position: relative; }
-
   .btn-group {
     // Setting the background color in case an action is transparent.
     background-color: $color-page-background;
     left: -2000px;
+    // Relative to .table-freeze so that buttons are shown to the right side of the component.
     position: absolute;
-    top: 4px;
+    margin-top: 4px;
   }
 
   .actions-trigger-hover tr:hover .btn-group,
   .actions-trigger-hover .scrolling-hover .btn-group,
   .actions-trigger-focus .btn-group:focus-within {
     left: auto;
-    right: $padding-right-table-data;
+    right: 0px;
   }
 
   .btn-group { @include icon-btn-group; }

--- a/apps/central/test/components/entity/list.spec.js
+++ b/apps/central/test/components/entity/list.spec.js
@@ -263,10 +263,11 @@ describe('EntityList', () => {
 
       it('updates the EntityMetadataRow', async () => {
         const component = await submit();
-        const td = component.get('.entity-metadata-row:nth-child(2) td:last-child');
-        should.exist(td.getComponent(DateTime).props().iso);
-        td.get('.updates').text().should.equal('1');
-        td.get('.update-button').attributes('aria-label').should.equal('Edit (1)');
+        const row = component.get('.entity-metadata-row:nth-child(2)');
+        const lastUpdatedTd = row.get('.last-updated-cell');
+        should.exist(lastUpdatedTd.getComponent(DateTime).props().iso);
+        lastUpdatedTd.get('.updates').text().should.equal('1');
+        row.get('.update-button').attributes('aria-label').should.equal('Edit (1)');
       });
     });
   });

--- a/apps/central/test/components/entity/metadata-row.spec.js
+++ b/apps/central/test/components/entity/metadata-row.spec.js
@@ -33,8 +33,7 @@ describe('EntityMetadataRow', () => {
   it('shows the row number', () => {
     testData.extendedDatasets.createPast(1);
     testData.extendedEntities.createPast(1);
-    const td = mountComponent({ rowNumber: 1000 }).get('td');
-    td.classes('row-number').should.be.true;
+    const td = mountComponent({ rowNumber: 1000 }).get('.row-number');
     td.text().should.equal('1000');
   });
 
@@ -43,8 +42,7 @@ describe('EntityMetadataRow', () => {
     const creator = testData.extendedUsers.first();
     testData.extendedEntities.createPast(1, { creator }).last();
     const row = mountComponent();
-    const td = row.findAll('td')[2];
-    td.classes('creator-name').should.be.true;
+    const td = row.get('.creator-name');
     td.text().should.equal(creator.displayName);
     await td.get('span').should.have.textTooltip();
   });
@@ -142,7 +140,7 @@ describe('EntityMetadataRow', () => {
     it('shows the deleted date', () => {
       testData.extendedDatasets.createPast(1);
       const { deletedAt } = testData.extendedEntities.createPast(1, { deletedAt: new Date().toISOString() }).last();
-      mountComponent({ deleted: true }).get('.action-cell').getComponent(DateTime).props().iso.should.equal(deletedAt);
+      mountComponent({ deleted: true }).get('.last-updated-cell').getComponent(DateTime).props().iso.should.equal(deletedAt);
     });
 
     it('does not have delete button', () => {

--- a/apps/central/test/components/entity/table.spec.js
+++ b/apps/central/test/components/entity/table.spec.js
@@ -42,11 +42,12 @@ describe('EntityTable', () => {
       const component = mountComponent();
       const table = component.get('.table-freeze-frozen');
       headers(table).should.eql([
+        '',
         'Row',
         '',
         'Created by',
         'Created at',
-        'Last Updated / Actions'
+        'Last Updated'
       ]);
     });
   });

--- a/apps/central/test/components/entity/table.spec.js
+++ b/apps/central/test/components/entity/table.spec.js
@@ -47,7 +47,7 @@ describe('EntityTable', () => {
         '',
         'Created by',
         'Created at',
-        'Last Updated'
+        'Last update'
       ]);
     });
   });

--- a/apps/central/test/components/field-key/revoke.spec.js
+++ b/apps/central/test/components/field-key/revoke.spec.js
@@ -72,7 +72,7 @@ describe('FieldKeyRevoke', () => {
       rows.length.should.equal(2);
       rows[0].find('.field-key-row-popover-link').exists().should.be.true;
       rows[1].find('.field-key-row-popover-link').exists().should.be.false;
-      rows[1].findAll('td')[1].text().should.equal('Access revoked');
+      rows[1].findAll('td')[2].text().should.equal('Access revoked');
     });
   });
 });

--- a/apps/central/test/components/field-key/row.spec.js
+++ b/apps/central/test/components/field-key/row.spec.js
@@ -123,7 +123,7 @@ describe('FieldKeyRow', () => {
     testData.extendedProjects.createPast(1, { appUsers: 1 });
     testData.extendedFieldKeys.createPast(1, { token: null });
     return load('/projects/1/app-users').then(app => {
-      const text = app.getComponent(FieldKeyRow).findAll('td')[1].text();
+      const text = app.getComponent(FieldKeyRow).findAll('td')[2].text();
       text.should.equal('Access revoked');
     });
   });

--- a/apps/central/test/components/submission/metadata-row.spec.js
+++ b/apps/central/test/components/submission/metadata-row.spec.js
@@ -38,8 +38,7 @@ describe('SubmissionMetadataRow', () => {
   it('shows the row number', () => {
     testData.extendedForms.createPast(1, { submissions: 1000 });
     testData.extendedSubmissions.createPast(1);
-    const td = mountComponent({ rowNumber: 1000 }).get('td');
-    td.classes('row-number').should.be.true;
+    const td = mountComponent({ rowNumber: 1000 }).get('.row-number');
     td.text().should.equal('1000');
   });
 
@@ -48,8 +47,7 @@ describe('SubmissionMetadataRow', () => {
       mockLogin({ displayName: 'Alice Allison' });
       testData.extendedSubmissions.createPast(1);
       const row = mountComponent({ draft: false });
-      const td = row.findAll('td')[1];
-      td.classes('submitter-name').should.be.true;
+      const td = row.get('.submitter-name');
       td.text().should.equal('Alice Allison');
       await td.get('span').should.have.textTooltip();
     });
@@ -234,17 +232,17 @@ describe('SubmissionMetadataRow', () => {
     row.findAll('.btn-group > *').length.should.equal(1);
   });
 
-  it('does not render the "State and actions" column for a form draft', () => {
+  it('does not render the "State" column for a form draft', () => {
     testData.extendedForms.createPast(1, { draft: true, submissions: 1 });
     testData.extendedSubmissions.createPast(1);
     const row = mountComponent({ draft: true });
-    row.find('.state-and-actions').exists().should.be.false;
+    row.find('.state').exists().should.be.false;
   });
 
   describe('deleted', () => {
     it('shows the deleted date', () => {
       const { deletedAt } = testData.extendedSubmissions.createPast(1, { deletedAt: new Date().toISOString() }).last();
-      mountComponent({ deleted: true }).get('.state-and-actions').getComponent(DateTime).props().iso.should.equal(deletedAt);
+      mountComponent({ deleted: true }).get('.col-deleted-at').getComponent(DateTime).props().iso.should.equal(deletedAt);
     });
 
     it('does not have delete button', () => {

--- a/apps/central/test/components/submission/metadata-row.spec.js
+++ b/apps/central/test/components/submission/metadata-row.spec.js
@@ -242,7 +242,7 @@ describe('SubmissionMetadataRow', () => {
   describe('deleted', () => {
     it('shows the deleted date', () => {
       const { deletedAt } = testData.extendedSubmissions.createPast(1, { deletedAt: new Date().toISOString() }).last();
-      mountComponent({ deleted: true }).get('.col-deleted-at').getComponent(DateTime).props().iso.should.equal(deletedAt);
+      mountComponent({ deleted: true }).findAll('td')[4].getComponent(DateTime).props().iso.should.equal(deletedAt);
     });
 
     it('does not have delete button', () => {

--- a/apps/central/test/components/submission/table.spec.js
+++ b/apps/central/test/components/submission/table.spec.js
@@ -52,10 +52,11 @@ describe('SubmissionTable', () => {
       });
       const table = component.get('.table-freeze-frozen');
       headers(table).should.eql([
+        '',
         'Row',
         'Submitted by',
         'Submitted at',
-        'State and actions'
+        'State'
       ]);
     });
 
@@ -66,7 +67,7 @@ describe('SubmissionTable', () => {
         props: { draft: true }
       });
       const table = component.get('.table-freeze-frozen');
-      headers(table).should.eql(['Row', 'Submitted at']);
+      headers(table).should.eql(['', 'Row', 'Submitted at']);
     });
 
     it('renders the correct headers for deleted submissions', () => {
@@ -76,6 +77,7 @@ describe('SubmissionTable', () => {
       });
       const table = component.get('.table-freeze-frozen');
       headers(table).should.eql([
+        '',
         'Row',
         'Submitted by',
         'Submitted at',

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2719,10 +2719,6 @@
     },
     "EntityTable": {
       "header": {
-        "updatedAt": {
-          "string": "Last Updated",
-          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated."
-        },
         "deletedAt": {
           "string": "Deleted at",
           "developer_comment": "Heading of the column that shows Entity deletion timestamp"
@@ -5513,10 +5509,6 @@
     },
     "SubmissionTable": {
       "header": {
-        "state": {
-          "string": "State",
-          "developer_comment": "This is the text of a table column header."
-        },
         "deletedAt": {
           "string": "Deleted at",
           "developer_comment": "Heading of the column that shows Submission deletion timestamp"

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2719,9 +2719,9 @@
     },
     "EntityTable": {
       "header": {
-        "updatedAtAndActions": {
-          "string": "Last Updated / Actions",
-          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated, as well as actions that can be taken on the Entity."
+        "updatedAt": {
+          "string": "Last Updated",
+          "developer_comment": "This is the text of a column header of a table of Entities. The column shows when each Entity was last updated."
         },
         "deletedAt": {
           "string": "Deleted at",
@@ -2953,10 +2953,6 @@
         "lastUsed": {
           "string": "Last Used",
           "developer_comment": "This is the text of a table column header."
-        },
-        "lastUsedAndActions": {
-          "string": "{lastUsed} / {actions}",
-          "developer_comment": "Header for the table column that shows the last used date and action buttons."
         },
         "configureClient": {
           "string": "Configure Client",
@@ -5517,8 +5513,8 @@
     },
     "SubmissionTable": {
       "header": {
-        "stateAndActions": {
-          "string": "State and actions",
+        "state": {
+          "string": "State",
           "developer_comment": "This is the text of a table column header."
         },
         "deletedAt": {


### PR DESCRIPTION
Towards https://github.com/getodk/central/issues/1604

https://github.com/user-attachments/assets/57c300c5-5106-4320-b2c4-650811a810ad

#### What has been done to verify that this works as intended?

Manual verification

#### Why is this the best possible solution? Were any other approaches considered?

- moved `position: relative;` to the table container so that action buttons could be placed to the `right: 0`
- Also moved the actions buttons to its own column so that vertical alignment is not dependent on the other content in the cell.
- Updated the column header to remove `actions`

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No