### PR TITLE
Table redesign/zebra rows

### DIFF
--- a/apps/central/src/assets/scss/_variables.scss
+++ b/apps/central/src/assets/scss/_variables.scss
@@ -92,6 +92,9 @@ $padding-right-table-data: 8px;
 $padding-top-table-data: 8px;
 // Row
 $color-selected-row: #E4EDF1;
+$color-header-row: #FFF;
+$color-odd-row: #F6F6F6;
+$color-even-row: #FCFCFC;
 
 // Panels
 $box-shadow-panel-main: 0 0 24px rgba(0, 0, 0, 0.25), 0 35px 115px rgba(0, 0, 0, 0.28);

--- a/apps/central/src/assets/scss/app.scss
+++ b/apps/central/src/assets/scss/app.scss
@@ -620,6 +620,10 @@ tr.uncommitted-change { background-color: #ffef67; }
   > thead {
     background-color: $color-table-heading-background;
 
+    > tr {
+      background-color: $color-header-row;
+    }
+
     > tr > th {
       border-bottom: $border-bottom-table-heading;
       font-size: $font-size-table-heading;
@@ -632,6 +636,15 @@ tr.uncommitted-change { background-color: #ffef67; }
       border-top: $border-top-table-data;
       padding: $padding-top-table-data $padding-right-table-data
                $padding-bottom-table-data $padding-left-table-data;
+    }
+
+    // Zebra striping
+    > tr:nth-child(even) {
+      background-color: $color-even-row;
+    }
+
+    > tr:nth-child(odd) {
+      background-color: $color-odd-row;
     }
   }
 

--- a/apps/central/src/components/project/form-access/row.vue
+++ b/apps/central/src/components/project/form-access/row.vue
@@ -125,8 +125,6 @@ export default {
 }
 
 .project-form-access-row-draft {
-  background-color: rgba(0, 0, 0, 0.0225);
-
   .icon-edit { margin-right: 9px; }
 }
 </style>

--- a/apps/central/src/components/project/form-access/table.vue
+++ b/apps/central/src/components/project/form-access/table.vue
@@ -155,48 +155,15 @@ export default {
         white-space: nowrap;
       }
 
-      // The background behind the text
-      &::before {
-        bottom: 0;
-        content: '';
-        height: 102px;
-        // This seems to need to be height divided by 2.
-        left: 51px;
-        position: absolute;
-        transform: skewX(-45deg);
-        transform-origin: center left;
-      }
       &, &::before {
         min-width: 42px;
         width: 42px;
-      }
-      &:first-child {
-        &, &::before {
-          background-color: $color-table-heading-background;
-        }
-
-        &::before {
-          border-left: 1px solid #eee;
-        }
-      }
-      &:nth-child(2n + 3)::before {
-        background-color: #eee;
-      }
-      &:last-child::before {
-        display: none;
       }
 
       &:last-child {
         min-width: 102px;
         width: 102px;
       }
-    }
-
-    td:nth-child(2n + 3) {
-      background-color: #eee;
-    }
-    td:last-child {
-      background-color: transparent;
     }
   }
 }

--- a/apps/central/src/components/project/home-block.vue
+++ b/apps/central/src/components/project/home-block.vue
@@ -209,12 +209,20 @@ export default {
       border-bottom-left-radius: 5px;
     }
 
-    tr:nth-child(3n + 2 of .project-form-row) {
-      background: #eee;
+    tr:nth-child(even of .project-form-row) {
+      background: $color-even-row;
     }
 
-    tr:nth-child(3n + 2 of .project-dataset-row) {
-      background: #eee;
+    tr:nth-child(odd of .project-form-row) {
+      background: $color-odd-row;
+    }
+
+    tr:nth-child(even of .project-dataset-row) {
+      background: $color-even-row;;
+    }
+
+    tr:nth-child(odd of .project-dataset-row) {
+      background: $color-odd-row;
     }
 
     .col-icon {

--- a/apps/central/src/components/project/home-block.vue
+++ b/apps/central/src/components/project/home-block.vue
@@ -218,7 +218,7 @@ export default {
     }
 
     tr:nth-child(even of .project-dataset-row) {
-      background: $color-even-row;;
+      background: $color-even-row;
     }
 
     tr:nth-child(odd of .project-dataset-row) {

--- a/apps/central/src/components/table/freeze.vue
+++ b/apps/central/src/components/table/freeze.vue
@@ -161,22 +161,6 @@ defineExpose({ getRowPair });
   td:last-child { border-right: $border-top-table-data; }
 }
 
-// Zebra striping
-.table-freeze-frozen,
-.table-freeze-scrolling {
-  thead tr {
-    background-color: $color-header-row;
-  }
-
-  tbody tr:nth-child(even) {
-    background-color: $color-even-row;
-  }
-
-  tbody tr:nth-child(odd) {
-    background-color: $color-odd-row;
-  }
-}
-
 // Styles related to actions (buttons and links). If there are actions, they
 // should be in a .btn-group.
 .table-freeze-frozen {

--- a/apps/central/src/components/table/freeze.vue
+++ b/apps/central/src/components/table/freeze.vue
@@ -161,6 +161,22 @@ defineExpose({ getRowPair });
   td:last-child { border-right: $border-top-table-data; }
 }
 
+// Zebra striping
+.table-freeze-frozen,
+.table-freeze-scrolling {
+  thead tr {
+    background-color: $color-header-row;
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: $color-even-row;
+  }
+
+  tbody tr:nth-child(odd) {
+    background-color: $color-odd-row;
+  }
+}
+
 // Styles related to actions (buttons and links). If there are actions, they
 // should be in a .btn-group.
 .table-freeze-frozen {


### PR DESCRIPTION
Towards https://github.com/getodk/central/issues/1604

<img width="1868" height="720" alt="image" src="https://github.com/user-attachments/assets/8d6d24f7-ab0a-4436-bb93-5fbadafaf049" />


#### What has been done to verify that this works as intended?

Manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Just added zebra stripe style to the table freeze and simple tables. For Form Access table removed the redundant css. 

I'll add rounded border on table in subsequent PR.

Form list table has different background color for review state column, I'll adjust that with the new state badges.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No