### PR TITLE
Revert "async-route: show load error in console (#1743)"

### DIFF
--- a/apps/central/src/components/async-route.vue
+++ b/apps/central/src/components/async-route.vue
@@ -32,7 +32,7 @@ import { noop } from '../util/util';
 export default {
   name: 'AsyncRoute',
   components: { Loading, PageBody },
-  inject: ['alert', 'location', 'logger'],
+  inject: ['alert', 'location'],
   inheritAttrs: false,
   // See routes.js for more information about these props.
   props: {
@@ -111,10 +111,8 @@ export default {
             this.component = markRaw(m.default);
           }
         })
-        .catch(err => {
+        .catch(() => {
           if (!canceled) {
-            this.logger.error('async-route', 'loadError:', err);
-
             // It would be ideal to show a more informative error message.
             // However, the error seems to provide limited information. For
             // example, if there is a 404 because Frontend was rebuilt, the

--- a/e2e-tests/util.js
+++ b/e2e-tests/util.js
@@ -103,9 +103,6 @@ const globalAllowedLogs = [
   // * https://github.com/getodk/central/issues/1584
   // * https://github.com/getodk/central/issues/2070
   'SyntaxError: 17',
-
-  // Failing on these messages is highly disruptive, as it can randomly happen to non-fatal messages.
-  'Execution context was destroyed, most likely because of a navigation',
 ];
 
 function isFatalConsoleMessage(allowedLogs, consoleMsg, normalisedMsg) {


### PR DESCRIPTION
> [!WARNING]
> Prefer **https://github.com/getodk/central-frontend/pull/1754**

---

This reverts commit 9029bbda371eef06bc444f97187bcefcfb9e9c46.

https://github.com/getodk/central/issues/2107

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
