### PR TITLE
central/test/unit: default to karma continuous mode locally

### DIFF
--- a/apps/central/karma.conf.js
+++ b/apps/central/karma.conf.js
@@ -74,7 +74,7 @@ module.exports = (config) => {
     browserDisconnectTimeout: 300_000,
     browserDisconnectTolerance: 3,
     reporters: ['spec'],
-    singleRun: true,
+    singleRun: !!(process.env.CI || process.env.KARMA_FORCE_SINGLE_RUN),
     client: {
       mocha: {
         grep: process.env.TEST_PATTERN || '.',


### PR DESCRIPTION
* in CI: use singleRun mode
* otherwise: use continuous mode, unless `KARMA_FORCE_SINGLE_RUN` env var is set

#### What has been done to verify that this works as intended?

- [x] ci
- [x] ran locally without `KARMA_FORCE_SINGLE_RUN` set
- [x] ran locally with `KARMA_FORCE_SINGLE_RUN` set

#### Why is this the best possible solution? Were any other approaches considered?

Karma tests take ages to start, so running them continuously can save some bother.

A good alternative would be to ditch karma completely, per https://github.com/getodk/central/issues/1267.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No effect - just tests.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.