### PR TITLE
chore(#2102): fix race condition in e2e test

### DIFF
--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -150,7 +150,9 @@ test.describe('ODK Web Forms', () => {
     });
   });
 
-  test('allows user to relogin on session expiry during form fill', async ({ page, context }) => {
+for (let i = 0; i < 20; i++) {
+
+  test('allows user to relogin on session expiry during form fill, run: ' + i, async ({ page, context }) => {
     await login(page);
 
     const page2 = await context.newPage();
@@ -164,6 +166,8 @@ test.describe('ODK Web Forms', () => {
     await page.locator('#navbar-actions .dropdown-toggle').click();
 
     await page.getByRole('link', { name: 'log out' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
 
     await page2.getByRole('button', { name: 'send' }).click();
 
@@ -182,4 +186,5 @@ test.describe('ODK Web Forms', () => {
 
     await expect(page2.getByRole('heading', { name: 'successful' })).toBeVisible();
   });
+}
 });

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -150,41 +150,38 @@ test.describe('ODK Web Forms', () => {
     });
   });
 
-  for (let i = 0; i < 20; i++) {
+  test('allows user to relogin on session expiry during form fill', async ({ page, context }) => {
+    await login(page);
 
-    test('allows user to relogin on session expiry during form fill, run: ' + i, async ({ page, context }) => {
-      await login(page);
+    const page2 = await context.newPage();
 
-      const page2 = await context.newPage();
+    await page2.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);
 
-      await page2.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);
+    await expect(page2.getByRole('heading', { name: publishedForm.name })).toBeVisible();
 
-      await expect(page2.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+    await page2.getByLabel('First Name').fill('John Doe');
 
-      await page2.getByLabel('First Name').fill('John Doe');
+    await page.locator('#navbar-actions .dropdown-toggle').click();
 
-      await page.locator('#navbar-actions .dropdown-toggle').click();
+    await page.getByRole('link', { name: 'log out' }).click();
 
-      await page.getByRole('link', { name: 'log out' }).click();
+    await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
 
-      await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
+    await page2.getByRole('button', { name: 'send' }).click();
 
-      await page2.getByRole('button', { name: 'send' }).click();
+    await expect(page2.getByRole('heading', { name: 'Session expired' })).toBeVisible();
 
-      await expect(page2.getByRole('heading', { name: 'Session expired' })).toBeVisible();
+    const [page3] = await Promise.all([
+      context.waitForEvent('page'),
+      page2.getByRole('link', { name: 'here' }).click()
+    ]);
 
-      const [page3] = await Promise.all([
-        context.waitForEvent('page'),
-        page2.getByRole('link', { name: 'here' }).click()
-      ]);
+    await login(page3);
 
-      await login(page3);
+    await page2.getByRole('button', { name: 'close' }).first().click();
 
-      await page2.getByRole('button', { name: 'close' }).first().click();
+    await page2.getByRole('button', { name: 'send' }).click();
 
-      await page2.getByRole('button', { name: 'send' }).click();
-
-      await expect(page2.getByRole('heading', { name: 'successful' })).toBeVisible();
-    });
-  }
+    await expect(page2.getByRole('heading', { name: 'successful' })).toBeVisible();
+  });
 });

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -150,41 +150,41 @@ test.describe('ODK Web Forms', () => {
     });
   });
 
-for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 20; i++) {
 
-  test('allows user to relogin on session expiry during form fill, run: ' + i, async ({ page, context }) => {
-    await login(page);
+    test('allows user to relogin on session expiry during form fill, run: ' + i, async ({ page, context }) => {
+      await login(page);
 
-    const page2 = await context.newPage();
+      const page2 = await context.newPage();
 
-    await page2.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);
+      await page2.goto(`${appUrl}/projects/${projectId}/forms/${publishedForm.xmlFormId}/submissions/new`);
 
-    await expect(page2.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+      await expect(page2.getByRole('heading', { name: publishedForm.name })).toBeVisible();
 
-    await page2.getByLabel('First Name').fill('John Doe');
+      await page2.getByLabel('First Name').fill('John Doe');
 
-    await page.locator('#navbar-actions .dropdown-toggle').click();
+      await page.locator('#navbar-actions .dropdown-toggle').click();
 
-    await page.getByRole('link', { name: 'log out' }).click();
+      await page.getByRole('link', { name: 'log out' }).click();
 
-    await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Welcome to ODK Central' })).toBeVisible();
 
-    await page2.getByRole('button', { name: 'send' }).click();
+      await page2.getByRole('button', { name: 'send' }).click();
 
-    await expect(page2.getByRole('heading', { name: 'Session expired' })).toBeVisible();
+      await expect(page2.getByRole('heading', { name: 'Session expired' })).toBeVisible();
 
-    const [page3] = await Promise.all([
-      context.waitForEvent('page'),
-      page2.getByRole('link', { name: 'here' }).click()
-    ]);
+      const [page3] = await Promise.all([
+        context.waitForEvent('page'),
+        page2.getByRole('link', { name: 'here' }).click()
+      ]);
 
-    await login(page3);
+      await login(page3);
 
-    await page2.getByRole('button', { name: 'close' }).first().click();
+      await page2.getByRole('button', { name: 'close' }).first().click();
 
-    await page2.getByRole('button', { name: 'send' }).click();
+      await page2.getByRole('button', { name: 'send' }).click();
 
-    await expect(page2.getByRole('heading', { name: 'successful' })).toBeVisible();
-  });
-}
+      await expect(page2.getByRole('heading', { name: 'successful' })).toBeVisible();
+    });
+  }
 });


### PR DESCRIPTION
Closes getodk/central#2102

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

My initial commit ran the test 20 times per browser and it passed.

#### Why is this the best possible solution? Were any other approaches considered?

My theory is that the first page was clicking log out but before the server could expire the session the second page was submitting the form.

The test hasn't changed in some time so I don't know why this started happening but probably the logout got slightly slower, or the web-forms submission got slightly faster. Either way, this code is more correct - just because you've clicked the button doesn't mean the server has received the request yet.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None. Test only.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.