### PR TITLE
fix(web-forms#870): fix rendering of outputs in ordered lists

### DIFF
--- a/.changeset/brave-lights-end.md
+++ b/.changeset/brave-lights-end.md
@@ -1,0 +1,5 @@
+---
+"@getodk/xforms-engine": patch
+---
+
+Fixed a bug rendering outputs in single ordered list items

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -213,12 +213,8 @@ function escapeEditableChunks(chunks: readonly TextChunk[]) {
 
 // mdast tends to add too many paragraphs which if left in place, puts a block level
 // element where it's not needed
-function removeSingleParagraph(nodes: MarkdownNode[]) : MarkdownNode[] {
-  if (
-    nodes.length === 1 &&
-    nodes[0]?.role === 'parent' &&
-    nodes[0]?.elementName === 'p'
-  ) {
+function removeSingleParagraph(nodes: MarkdownNode[]): MarkdownNode[] {
+  if (nodes.length === 1 && nodes[0]?.role === 'parent' && nodes[0]?.elementName === 'p') {
     return nodes[0].children;
   }
   return nodes;

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -1,7 +1,7 @@
 import type { Heading, Literal, RootContent } from 'mdast';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { newlineToBreak } from 'mdast-util-newline-to-break';
-import { type MarkdownNode, type StyleProperty } from '../../client';
+import { type MarkdownNode, type ParentMarkdownNode, type StyleProperty } from '../../client';
 import type { TextChunk } from '../../client/TextRange.ts';
 import {
   Anchor,
@@ -27,7 +27,9 @@ import {
 
 const OUTPUT_STRING_REGEX = /`(--ODK-OUTPUT-STRING-[0-9]+--)`/g;
 const LEADING_SPACES_AND_TABS_REGEX = /^[ \t]+/;
+const LEADING_NUMBER_REGEX = /^\s*([0-9]+\.\s*)/;
 const STYLE_PROPERTY_REGEX = /style\s*=\s*(?:'|")(.+)(?:'|")/i;
+
 const HTML_TAG_MAP = {
   span: Span,
   div: Div,
@@ -209,13 +211,45 @@ function escapeEditableChunks(chunks: readonly TextChunk[]) {
     .join('');
 }
 
-function isSingleOrderedList(odk: MarkdownNode[]) {
-  return (
-    odk.length === 1 &&
-    odk[0]?.role === 'parent' &&
-    odk[0]?.elementName === 'ol' &&
-    odk[0].children.length === 1
-  );
+// mdast tends to add too many paragraphs which if left in place, puts a block level
+// element where it's not needed
+function removeSingleParagraph(nodes: MarkdownNode[]) : MarkdownNode[] {
+  if (
+    nodes.length === 1 &&
+    nodes[0]?.role === 'parent' &&
+    nodes[0]?.elementName === 'p'
+  ) {
+    return nodes[0].children;
+  }
+  return nodes;
+}
+
+function getSingleOrderedList(nodes: MarkdownNode[]): ParentMarkdownNode | undefined {
+  if (
+    nodes.length === 1 &&
+    nodes[0]?.role === 'parent' &&
+    nodes[0]?.elementName === 'ol' &&
+    nodes[0].children.length === 1 &&
+    nodes[0].children[0]?.role === 'parent'
+  ) {
+    return nodes[0].children[0];
+  }
+  return;
+}
+
+// do not return a numbered list with only a single element
+// this is almost never what people expect
+function fixSingleOrderedList(nodes: MarkdownNode[], str: string) {
+  const li = getSingleOrderedList(nodes);
+  if (li) {
+    const liContent = removeSingleParagraph(li.children);
+    const num = LEADING_NUMBER_REGEX.exec(str)?.[1];
+    if (num) {
+      liContent.unshift(new ChildMarkdownNode(num));
+      return liContent;
+    }
+  }
+  return nodes;
 }
 
 function escapeBlockquote(str: string) {
@@ -226,19 +260,9 @@ function toOdkMarkdown(str: string): MarkdownNode[] {
   str = escapeBlockquote(str);
   const tree = fromMarkdown(str);
   newlineToBreak(tree);
-  console.log('input', str);
   let odk = mdastToOdkMarkdown(tree.children);
-  if (isSingleOrderedList(odk)) {
-    // do not return a numbered list with only a single element - this is almost never what people expect
-    odk = odk[0].children[0].children;
-    odk[0].children.unshift(new ChildMarkdownNode('21. '));
-    // return [new ChildMarkdownNode(str)];
-  }
-  if (odk.length === 1 && odk[0]?.role === 'parent' && odk[0]?.elementName === 'p') {
-    // mdast tends to add too many paragraphs which if left in place, puts a block level
-    // element where it's not needed
-    return odk[0].children;
-  }
+  odk = fixSingleOrderedList(odk, str);
+  odk = removeSingleParagraph(odk);
   return odk;
 }
 

--- a/packages/xforms-engine/src/instance/text/markdownFormat.ts
+++ b/packages/xforms-engine/src/instance/text/markdownFormat.ts
@@ -226,10 +226,13 @@ function toOdkMarkdown(str: string): MarkdownNode[] {
   str = escapeBlockquote(str);
   const tree = fromMarkdown(str);
   newlineToBreak(tree);
-  const odk = mdastToOdkMarkdown(tree.children);
+  console.log('input', str);
+  let odk = mdastToOdkMarkdown(tree.children);
   if (isSingleOrderedList(odk)) {
     // do not return a numbered list with only a single element - this is almost never what people expect
-    return [new ChildMarkdownNode(str)];
+    odk = odk[0].children[0].children;
+    odk[0].children.unshift(new ChildMarkdownNode('21. '));
+    // return [new ChildMarkdownNode(str)];
   }
   if (odk.length === 1 && odk[0]?.role === 'parent' && odk[0]?.elementName === 'p') {
     // mdast tends to add too many paragraphs which if left in place, puts a block level

--- a/packages/xforms-engine/test/integration/markdown.test.ts
+++ b/packages/xforms-engine/test/integration/markdown.test.ts
@@ -207,7 +207,7 @@ describe('Markdown', () => {
     describe('ordered lists with a single item', () => {
       it('ignores single child at the top level', async () => {
         const given = '3. third question';
-        const expected = [ { value: '3. ' }, { value: 'third question' } ];
+        const expected = [{ value: '3. ' }, { value: 'third question' }];
         await run(given, expected);
       });
 
@@ -554,9 +554,7 @@ double line break`;
         { value: '21. ' },
         {
           elementName: 'span',
-          children: [
-            { value: 'fred' },
-          ],
+          children: [{ value: 'fred' }],
         },
         { value: ' Welcome.' },
       ]);

--- a/packages/xforms-engine/test/integration/markdown.test.ts
+++ b/packages/xforms-engine/test/integration/markdown.test.ts
@@ -544,6 +544,29 @@ double line break`;
         { value: ' Welcome.' },
       ]);
     });
+
+    it.only('allows for outputs inside ordered lists with a single item', async () => {
+      const scenario = await outputScenario('21. <output value=" /data/name " /> Welcome.');
+      scenario.next('/data/name');
+      scenario.answer('fred');
+      const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
+      console.log(JSON.stringify(label, null, 2));
+      expect(label).toMatchObject([
+        {
+          elementName: 'span',
+          children: [
+            { value: '21. ' },
+            {
+              elementName: 'span',
+              children: [
+                { value: 'fred' },
+              ],
+            }
+          ],
+        },
+        { value: ' Welcome.' },
+      ]);
+    });
   });
 
   it('should work in select options', async () => {

--- a/packages/xforms-engine/test/integration/markdown.test.ts
+++ b/packages/xforms-engine/test/integration/markdown.test.ts
@@ -207,7 +207,7 @@ describe('Markdown', () => {
     describe('ordered lists with a single item', () => {
       it('ignores single child at the top level', async () => {
         const given = '3. third question';
-        const expected = [{ value: '3. third question' }];
+        const expected = [ { value: '3. ' }, { value: 'third question' } ];
         await run(given, expected);
       });
 
@@ -545,23 +545,17 @@ double line break`;
       ]);
     });
 
-    it.only('allows for outputs inside ordered lists with a single item', async () => {
+    it('allows for outputs inside ordered lists with a single item', async () => {
       const scenario = await outputScenario('21. <output value=" /data/name " /> Welcome.');
       scenario.next('/data/name');
       scenario.answer('fred');
       const label = scenario.getQuestionLabel({ assertCurrentReference: '/data/name' }).formatted;
-      console.log(JSON.stringify(label, null, 2));
       expect(label).toMatchObject([
+        { value: '21. ' },
         {
           elementName: 'span',
           children: [
-            { value: '21. ' },
-            {
-              elementName: 'span',
-              children: [
-                { value: 'fred' },
-              ],
-            }
+            { value: 'fred' },
           ],
         },
         { value: ' Welcome.' },


### PR DESCRIPTION
Closes getodk/web-forms#870

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Unit testing
Manual testing

#### Why is this the best possible solution? Were any other approaches considered?

There were more extensive fixes which I will be investigating soon (ie: dropping mdast), but this patches what's there without regression.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Should just fix a bug and nothing else.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.