### PR TITLE
destructure.js: fix @transifexKey nesting

### DIFF
--- a/apps/central/bin/util/transifex.js
+++ b/apps/central/bin/util/transifex.js
@@ -683,10 +683,58 @@ const rekeySource = (structured, transifexPaths) => {
 };
 
 const rekeyTranslations = (source, translated, transifexPaths) => {
-  for (const { sourcePath, transifexPath } of transifexPaths)
-    setPath(sourcePath, getPath(transifexPath, translated), translated);
+  // It's possible for one transifexPath to be a subpath of another,
+  // representing an ancestor message object. We want to rekey those shorter
+  // subpaths only after first rekeying the longer/deeper paths. Here, we
+  // reorder transifexPaths along those lines. Other than that though, we try to
+  // preserve the original order.
+  const ordered = [...transifexPaths];
+  for (let i = 0; i < ordered.length - 1;) {
+    let changed = false;
+    for (let j = i + 1; j < ordered.length; j += 1) {
+      if (startsWith(ordered[i].transifexPath, ordered[j].transifexPath) &&
+        !equals(ordered[i].transifexPath, ordered[j].transifexPath)) {
+        const ancestor = ordered[i]; // Subpath
+        const descendant = ordered[j]; // Longer/deeper path
+        ordered.splice(j, 1);
+        ordered.splice(i, 1, descendant, ancestor);
+        changed = true;
+        break;
+      }
+    }
+    if (changed)
+      i = 0; // Start over
+    else
+      i += 1;
+  }
+
+  // A single `transifexPath` can be copied to multiple `sourcePath`s. Here, we
+  // count how many times each `transifexPath` appears.
+  const pathCounts = new Map();
   for (const { transifexPath } of transifexPaths) {
-    if (!hasPath(transifexPath, source)) deletePath(transifexPath, translated);
+    const key = transifexPath.join('.');
+    pathCounts.set(key, (pathCounts.get(key) ?? 0) + 1);
+  }
+  const decrementCount = (path) => {
+    const key = path.join('.');
+    const newCount = pathCounts.get(key) - 1;
+    pathCounts.set(key, newCount);
+    return newCount;
+  };
+
+  for (const { sourcePath, transifexPath } of ordered) {
+    if (hasPath(sourcePath, translated))
+      throw new Error(`@transifexKey: attempted to copy the value at ${transifexPath.join('.')} to ${sourcePath.join('.')}, but there is already a value at ${sourcePath.join('.')}.`);
+    if (!hasPath(transifexPath, translated))
+      throw new Error(`@transifexKey: attempted to copy the value at ${transifexPath.join('.')} to ${sourcePath.join('.')}, but there is no value at ${transifexPath.join('.')}.`);
+
+    setPath(sourcePath, getPath(transifexPath, translated), translated);
+
+    // Delete the old transifexPath as soon as possible (as soon as the count is
+    // zero) in order to account for subpaths. We don't want to move a
+    // descendant message along with its ancestor message object.
+    if (!hasPath(transifexPath, source) && decrementCount(transifexPath) === 0)
+      deletePath(transifexPath, translated);
   }
 };
 


### PR DESCRIPTION
Closes getodk/central#2127.

There's some description of the problem in getodk/central#2127 and in code comments, but I plan to add more detail to this PR. It's kind of a complex case.

#### What has been done to verify that this works as intended?

After this change (along with #1751), destructure.js at last runs without error. 🎉 I used this code in the previous release to run destructure.js, and the resulting Vue I18n JSON matched my expectations.

Given the complexity of the case, I'm tempted to add the first tests of our Transifex scripts. Doing so would probably help document this case.

#### Why is this the best possible solution? Were any other approaches considered?

I'll add more detail later explaining the underlying problem, after which I think the code approach will make more sense. The code itself isn't optimized, which is one reason why I've marked this PR as draft.

getodk/central#2127 proposes two main approaches: handling this case vs. detecting and disallowing it. This PR implements the former approach (handling this case), but the latter approach would probably be more straightforward. I'll probably continue to run with the former approach for now, since I've already written code for it. However, I may turn to the latter approach (just detecting this case) if I feel like it'd require fewer new tests.