### PR TITLE
fix(web-forms#872): allow setvalue actions to write to readonly fields 

### DIFF
--- a/.changeset/tidy-crabs-repair.md
+++ b/.changeset/tidy-crabs-repair.md
@@ -1,0 +1,6 @@
+---
+"@getodk/xforms-engine": patch
+"@getodk/web-forms": patch
+---
+
+Fixed `setvalue` actions failing to set a value on `readonly` fields.

--- a/packages/xforms-engine/src/instance/Attribute.ts
+++ b/packages/xforms-engine/src/instance/Attribute.ts
@@ -93,10 +93,15 @@ export class Attribute
     this.valueType = 'string';
     this.decodeInstanceValue = codec.decodeInstanceValue;
 
-    const instanceValueState = createInstanceValueState(this);
-    const valueState = codec.createRuntimeValueState(instanceValueState);
-
+    const { valueState: instanceValueState, setValueFromAction } = createInstanceValueState(this);
     const [getInstanceValue] = instanceValueState;
+
+    const valueState = codec.createRuntimeValueState(instanceValueState);
+    const [, setActionValue] = codec.createRuntimeValueState([
+      getInstanceValue,
+      setValueFromAction,
+    ]);
+
     const [, setValueState] = valueState;
 
     this.getInstanceValue = getInstanceValue;
@@ -132,7 +137,7 @@ export class Attribute
       return this.getInstanceValue();
     };
     this.setEncodedValue = (value: string) => {
-      this.setValueState(codec.decodeValue(value));
+      setActionValue(codec.decodeValue(value));
     };
   }
 

--- a/packages/xforms-engine/src/instance/Attribute.ts
+++ b/packages/xforms-engine/src/instance/Attribute.ts
@@ -73,7 +73,7 @@ export class Attribute
   };
 
   override readonly getXPathValue: () => string;
-  readonly setEncodedValue: (value: string) => void;
+  readonly setEncodedValue: (value: string, bypassReadonly?: boolean) => void;
 
   constructor(
     readonly owner: AnyNode,
@@ -136,8 +136,13 @@ export class Attribute
     this.getXPathValue = () => {
       return this.getInstanceValue();
     };
-    this.setEncodedValue = (value: string) => {
-      setActionValue(codec.decodeValue(value));
+    this.setEncodedValue = (value: string, bypassReadonly = false) => {
+      const decodedValue = codec.decodeValue(value);
+      if (bypassReadonly) {
+        setActionValue(decodedValue);
+        return;
+      }
+      setValueState(decodedValue);
     };
   }
 

--- a/packages/xforms-engine/src/instance/abstract/ValueNode.ts
+++ b/packages/xforms-engine/src/instance/abstract/ValueNode.ts
@@ -84,6 +84,8 @@ export abstract class ValueNode<
   }
 
   readonly instanceState: InstanceState;
+
+  // Write path for `xforms-value-changed` actions targeting this node; permitted while readonly too.
   readonly setEncodedValue: (value: string) => void;
 
   constructor(
@@ -97,10 +99,15 @@ export abstract class ValueNode<
     this.valueType = definition.valueType;
     this.decodeInstanceValue = codec.decodeInstanceValue;
 
-    const instanceValueState = createInstanceValueState(this);
-    const valueState = codec.createRuntimeValueState(instanceValueState);
-
+    const { valueState: instanceValueState, setValueFromAction } = createInstanceValueState(this);
     const [getInstanceValue] = instanceValueState;
+
+    const valueState = codec.createRuntimeValueState(instanceValueState);
+    const [, setActionValue] = codec.createRuntimeValueState([
+      getInstanceValue,
+      setValueFromAction,
+    ]);
+
     const [, setValueState] = valueState;
 
     this.getInstanceValue = getInstanceValue;
@@ -113,7 +120,7 @@ export abstract class ValueNode<
     this.instanceState = createValueNodeInstanceState(this);
 
     this.setEncodedValue = (value: string) => {
-      this.setValueState(codec.decodeValue(value));
+      setActionValue(codec.decodeValue(value));
     };
   }
 

--- a/packages/xforms-engine/src/instance/abstract/ValueNode.ts
+++ b/packages/xforms-engine/src/instance/abstract/ValueNode.ts
@@ -86,7 +86,7 @@ export abstract class ValueNode<
   readonly instanceState: InstanceState;
 
   // Write path for `xforms-value-changed` actions targeting this node; permitted while readonly too.
-  readonly setEncodedValue: (value: string) => void;
+  readonly setEncodedValue: (value: string, bypassReadonly?: boolean) => void;
 
   constructor(
     parent: GeneralParentNode,
@@ -119,8 +119,13 @@ export abstract class ValueNode<
     this.validation = createValidationState(this, this.instanceConfig);
     this.instanceState = createValueNodeInstanceState(this);
 
-    this.setEncodedValue = (value: string) => {
-      setActionValue(codec.decodeValue(value));
+    this.setEncodedValue = (value: string, bypassReadonly = false) => {
+      const decodedValue = codec.decodeValue(value);
+      if (bypassReadonly) {
+        setActionValue(decodedValue);
+        return;
+      }
+      setValueState(decodedValue);
     };
   }
 

--- a/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
@@ -72,8 +72,8 @@ const createRelevantValueState = (
 };
 
 /**
- * For fields with a `readonly` bind expression, prevent downstream
- * (client/user) writes when the field is in a `readonly` state.
+ * Rejects downstream (client/user) writes while the field is in a `readonly` state.
+ * Engine writes (`calculate` computations, preloads, `setvalue` actions) never pass through this guard.
  */
 const guardDownstreamReadonlyWrites = (
   context: ValueContext,
@@ -310,7 +310,12 @@ const registerValueChangedActions = (context: ValueContext, getValue: Accessor<s
   });
 };
 
-export type InstanceValueState = SimpleAtomicState<string>;
+export interface InstanceValueState {
+  // The node's instance value. The setter rejects client writes while readonly.
+  readonly valueState: SimpleAtomicState<string>;
+  // Unguarded setter for the same value, used by `xforms-value-changed` actions writing to this node.
+  readonly setValueFromAction: SimpleAtomicStateSetter<string>;
+}
 
 /**
  * Provides a consistent interface for value nodes of any type which:
@@ -321,7 +326,8 @@ export type InstanceValueState = SimpleAtomicState<string>;
  * - encodes updated runtime values to store updated instance state
  * - initializes reactive computation of `calculate` bind expressions for those
  *   nodes defined with one
- * - prevents downstream writes to nodes in a readonly state
+ * - prevents downstream (client/user) writes to nodes in a readonly state,
+ *   while still permitting engine-initiated writes to those nodes
  */
 export const createInstanceValueState = (context: ValueContext): InstanceValueState => {
   return context.scope.runTask(() => {
@@ -341,6 +347,9 @@ export const createInstanceValueState = (context: ValueContext): InstanceValueSt
     registerValueChangedActions(context, getValue);
     registerSetValueActions(context, setValue);
 
-    return guardDownstreamReadonlyWrites(context, relevantValueState);
+    return {
+      valueState: guardDownstreamReadonlyWrites(context, relevantValueState),
+      setValueFromAction: setValue,
+    };
   });
 };

--- a/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
+++ b/packages/xforms-engine/src/lib/reactivity/createInstanceValueState.ts
@@ -293,7 +293,7 @@ const registerValueChangedActions = (context: ValueContext, getValue: Accessor<s
           referencesCurrentNode(destinationNode, ref)
         ) {
           if (action.type === 'geopoint') {
-            getGeopointValue(context, (point) => destinationNode.setEncodedValue(point));
+            getGeopointValue(context, (point) => destinationNode.setEncodedValue(point, true));
           } else {
             const value = untrack(() => {
               return context.evaluator.evaluateString(
@@ -301,7 +301,7 @@ const registerValueChangedActions = (context: ValueContext, getValue: Accessor<s
                 destinationNode
               );
             });
-            destinationNode.setEncodedValue(value);
+            destinationNode.setEncodedValue(value, true);
           }
         }
       }

--- a/packages/xforms-engine/test/integration/actions-events/set-value-action.test.ts
+++ b/packages/xforms-engine/test/integration/actions-events/set-value-action.test.ts
@@ -5,9 +5,12 @@ import {
   head,
   html,
   input,
+  instance,
   mainInstance,
   model,
   repeat,
+  select1,
+  select1Dynamic,
   setvalue,
   setvalueLiteral,
   t,
@@ -1139,5 +1142,140 @@ describe('setvalue action', () => {
     scenario.createNewRepeat('/data/repeat');
     expect(scenario.answerOf('/data/repeat[1]/source').getValue()).toBe('first');
     expect(scenario.answerOf('/data/repeat[2]/source').getValue()).toBe('second');
+  });
+
+  describe('`xforms-value-changed` targeting a field with a dynamic `readonly` expression', () => {
+    it('sets the value of a field when its `readonly` expression is true', async () => {
+      const scenario = await Scenario.init(
+        'Setvalue dynamic readonly',
+        html(
+          head(
+            title('Setvalue dynamic readonly'),
+            model(
+              mainInstance(t('data id="setvalue-dynamic-readonly"', t('scope'), t('item'))),
+              instance(
+                'scope',
+                t('item', t('name', '2026_Apple'), t('label', '2026 Apple'), t('item', 'Apple')),
+                t('item', t('name', '2026_Banana'), t('label', '2026 Banana'), t('item', 'Banana')),
+                t('item', t('name', 'Other'), t('label', 'Other'))
+              ),
+              instance(
+                'item',
+                t('item', t('name', 'Apple'), t('label', 'Apple')),
+                t('item', t('name', 'Banana'), t('label', 'Banana')),
+                t('item', t('name', 'Cherry'), t('label', 'Cherry'))
+              ),
+              bind('/data/scope').type('string'),
+              bind('/data/item')
+                .type('string')
+                .relevant("/data/scope != ''")
+                .readonly("/data/scope != 'Other'")
+            )
+          ),
+          body(
+            select1(
+              '/data/scope',
+              t(
+                `itemset nodeset="instance('scope')/root/item"`,
+                t('value ref="name"'),
+                t('label ref="label"')
+              ),
+              setvalue(
+                'xforms-value-changed',
+                '/data/item',
+                "if(/data/scope != 'Other', instance('scope')/root/item[name = /data/scope]/item, '')"
+              )
+            ),
+            select1Dynamic('/data/item', "instance('item')/root/item", 'name', 'label')
+          )
+        )
+      );
+
+      // Selecting a scoped item prefills the followup question and locks it
+      scenario.answer('/data/scope', '2026_Apple');
+
+      expect(scenario.answerOf('/data/item').getValue()).toBe('Apple');
+      expect(scenario.getInstanceNode('/data/item')).toBeReadonly();
+
+      // Selecting 'Other' clears the followup question and unlocks it
+      scenario.answer('/data/scope', 'Other');
+
+      expect(scenario.answerOf('/data/item').getValue()).toBe('');
+      expect(scenario.getInstanceNode('/data/item')).toBeEnabled();
+    });
+
+    it('sets the value of a field when `readonly` expression evaluates to a non-empty string', async () => {
+      const scenario = await Scenario.init(
+        'Setvalue readonly string expression',
+        html(
+          head(
+            title('Setvalue readonly string expression'),
+            model(
+              mainInstance(t('data id="setvalue-readonly-string"', t('source'), t('destination'))),
+              bind('/data/destination')
+                .type('string')
+                .readonly("if(/data/source != 'other', 'yes', 'no')")
+            )
+          ),
+          body(
+            input(
+              '/data/source',
+              setvalue('xforms-value-changed', '/data/destination', "concat('set-', /data/source)")
+            ),
+            input('/data/destination')
+          )
+        )
+      );
+
+      scenario.answer('/data/source', 'other');
+
+      expect(scenario.answerOf('/data/destination').getValue()).toBe('set-other');
+      expect(scenario.getInstanceNode('/data/destination')).toBeReadonly();
+    });
+
+    it('rejects client writes while the field is `readonly` but allows setValue action', async () => {
+      const scenario = await Scenario.init(
+        'Setvalue readonly write permissions',
+        html(
+          head(
+            title('Setvalue readonly write permissions'),
+            model(
+              mainInstance(
+                t('data id="setvalue-readonly-writes"', t('lock'), t('source'), t('destination'))
+              ),
+              bind('/data/destination').type('int').readonly("/data/lock = 'yes'")
+            )
+          ),
+          body(
+            input('/data/lock'),
+            input(
+              '/data/source',
+              setvalue(
+                'xforms-value-changed',
+                '/data/destination',
+                'string-length(/data/source) * 2'
+              )
+            ),
+            input('/data/destination')
+          )
+        )
+      );
+
+      scenario.answer('/data/lock', 'yes');
+      expect(scenario.getInstanceNode('/data/destination')).toBeReadonly();
+
+      scenario.answer('/data/source', 'abc');
+      expect(scenario.answerOf('/data/destination')).toEqualAnswer(intAnswer(6));
+
+      expect(() => scenario.answer('/data/destination', 12)).toThrowError(
+        'Cannot write to readonly field: /data/destination'
+      );
+      expect(scenario.answerOf('/data/destination')).toEqualAnswer(intAnswer(6));
+
+      scenario.answer('/data/lock', 'no');
+      expect(scenario.getInstanceNode('/data/destination')).toBeEnabled();
+      scenario.answer('/data/destination', 12);
+      expect(scenario.answerOf('/data/destination')).toEqualAnswer(intAnswer(12));
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/872

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual testing and added scenario tests 

#### Why is this the best possible solution? Were any other approaches considered?

The readonly only restricts user edits, so action writes should not be blocked.
This fix gives the setvalue action a way to assign a value without going through the guard that rejects writes to readonly fields, making it clear which setter is for actions and which is for client writes. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Fix their broken forms 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
