### PR TITLE
chore(#2113): fetch git history so new tags are found

### DIFF
--- a/.github/workflows/wf-publish.yml
+++ b/.github/workflows/wf-publish.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up npm registry
         uses: actions/setup-node@v6


### PR DESCRIPTION
Closes getodk/central#2113

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Research. It's difficult to test until its executed in a GH actions environment.

#### Why is this the best possible solution? Were any other approaches considered?

It'll be a little slower to checkout because it has to fetch more, but we don't release that often.
It would be cleaner if we knew the name of the tag to explicitly push the tag name. We could try and find that by looking in the package.json. But that feels clumsy and brittle.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.