### PR TITLE
chore(web-forms#443): silence known build warnings

### DIFF
--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -67,25 +67,14 @@ if (webkitFlakinessMitigations) {
 }
 
 export default defineConfig(({ mode }) => {
-  const isDev = mode === 'development';
-  const external = ['vue'];
-  const globals = { vue: 'Vue' };
-  const extraPlugins: PluginOption[] = [];
-  const lib: LibraryOptions = {
-    formats: ['es'],
-    entry: resolve(__dirname, 'src/index.ts'),
-    name: 'OdkWebForms',
-    fileName: 'index',
-  };
-
-  const versionSuffix = buildNumber && isDev ? ` - ${buildNumber}` : '';
+  const versionSuffix = buildNumber && mode === 'development' ? ` - ${buildNumber}` : '';
 
   return {
     define: {
       __WEB_FORMS_VERSION__: `"v${version}${versionSuffix}"`,
     },
     base: './',
-    plugins: [vue(), vueJsx(), cssInjectedByJsPlugin(), ...extraPlugins],
+    plugins: [vue(), vueJsx(), cssInjectedByJsPlugin()],
     resolve: {
       alias: {
         '@getodk/common': resolve(__dirname, '../common/src'),
@@ -119,15 +108,19 @@ export default defineConfig(({ mode }) => {
 
         // Per Vite docs
       },
-      lib,
+      lib: {
+        formats: ['es'],
+        entry: resolve(__dirname, 'src/index.ts'),
+        name: 'OdkWebForms',
+        fileName: 'index',
+      },
       rollupOptions: {
-        external,
+        external: ['vue'],
         onwarn(warning, warn) {
-          if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+          if (warning.code === 'EVAL' && warning.id?.endsWith('xforms-engine/dist/index.js')) {
+            return; // ignore eval warning for tree-sitter
+          }
           warn(warning);
-        },
-        output: {
-          globals,
         },
       },
     },

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -68,7 +68,7 @@ if (webkitFlakinessMitigations) {
 
 export default defineConfig(({ mode }) => {
   const isDev = mode === 'development';
-  const external = ['fs', 'path', 'vue'];
+  const external = ['vue'];
   const globals = { vue: 'Vue' };
   const extraPlugins: PluginOption[] = [];
   const lib: LibraryOptions = {

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -6,7 +6,6 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
-import type { LibraryOptions, PluginOption } from 'vite';
 import { defineConfig } from 'vite';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -67,29 +67,18 @@ if (webkitFlakinessMitigations) {
 }
 
 export default defineConfig(({ mode }) => {
-  const isVueBundled = mode === 'demo';
   const isDev = mode === 'development';
-
-  let lib: LibraryOptions | undefined;
-  let external: string[];
-  let globals: Record<string, string>;
+  const external = ['fs', 'path', 'vue'];
+  const globals = { vue: 'Vue' };
   const extraPlugins: PluginOption[] = [];
+  const lib: LibraryOptions = {
+    formats: ['es'],
+    entry: resolve(__dirname, 'src/index.ts'),
+    name: 'OdkWebForms',
+    fileName: 'index',
+  };
 
-  if (isVueBundled) {
-    external = [];
-    globals = {};
-  } else {
-    external = ['vue'];
-    globals = { vue: 'Vue' };
-    lib = {
-      formats: ['es'],
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'OdkWebForms',
-      fileName: 'index',
-    };
-  }
-
-  const versionSuffix = buildNumber && (isVueBundled || isDev) ? ` - ${buildNumber}` : '';
+  const versionSuffix = buildNumber && isDev ? ` - ${buildNumber}` : '';
 
   return {
     define: {
@@ -133,6 +122,10 @@ export default defineConfig(({ mode }) => {
       lib,
       rollupOptions: {
         external,
+        onwarn(warning, warn) {
+          if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+          warn(warning);
+        },
         output: {
           globals,
         },

--- a/packages/xforms-engine/vite.config.ts
+++ b/packages/xforms-engine/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => {
 
   const entries = Object.values(libEntry);
 
-  const external = ['fs', 'path', '@getodk/common'];
+  const external = ['@getodk/common'];
 
   if (IS_SOLID_BUILD_TARGET) {
     external.push('solid-js', 'solid-js/store');

--- a/packages/xforms-engine/vite.config.ts
+++ b/packages/xforms-engine/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => {
 
   const entries = Object.values(libEntry);
 
-  const external = ['@getodk/common'];
+  const external = ['fs', 'path', '@getodk/common'];
 
   if (IS_SOLID_BUILD_TARGET) {
     external.push('solid-js', 'solid-js/store');
@@ -79,7 +79,13 @@ export default defineConfig(({ mode }) => {
           return entryName.replace(/^\.src\//, '').replace(/\.ts$/, '.js');
         },
       },
-      rollupOptions: { external },
+      rollupOptions: {
+        external,
+        onwarn(warning, warn) {
+          if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+          warn(warning);
+        },
+      },
     },
 
     esbuild: {

--- a/packages/xforms-engine/vite.config.ts
+++ b/packages/xforms-engine/vite.config.ts
@@ -82,7 +82,9 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         external,
         onwarn(warning, warn) {
-          if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+          if (warning.code === 'EVAL' && warning.id?.includes('/xpath/dist/expressionParser')) {
+            return; // ignore eval warning for tree-sitter
+          }
           warn(warning);
         },
       },

--- a/packages/xpath/src/expressionParser.ts
+++ b/packages/xpath/src/expressionParser.ts
@@ -14,7 +14,9 @@ import type * as ODKXPathMainEntrypoint from './index.ts';
  * - - -
  */
 
+// @ts-ignore
 import xpathLanguage from '@getodk/tree-sitter-xpath/dist/tree-sitter-xpath.wasm?url';
+// @ts-ignore
 import webTreeSitter from 'web-tree-sitter/tree-sitter.wasm?url';
 import { ExpressionParser } from './static/grammar/ExpressionParser.ts';
 

--- a/packages/xpath/src/expressionParser.ts
+++ b/packages/xpath/src/expressionParser.ts
@@ -14,12 +14,7 @@ import type * as ODKXPathMainEntrypoint from './index.ts';
  * - - -
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import xpathLanguage from '@getodk/tree-sitter-xpath/dist/tree-sitter-xpath.wasm?url';
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import webTreeSitter from 'web-tree-sitter/tree-sitter.wasm?url';
 import { ExpressionParser } from './static/grammar/ExpressionParser.ts';
 

--- a/packages/xpath/src/expressionParser.ts
+++ b/packages/xpath/src/expressionParser.ts
@@ -14,8 +14,11 @@ import type * as ODKXPathMainEntrypoint from './index.ts';
  * - - -
  */
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import xpathLanguage from '@getodk/tree-sitter-xpath/dist/tree-sitter-xpath.wasm?url';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import webTreeSitter from 'web-tree-sitter/tree-sitter.wasm?url';
 import { ExpressionParser } from './static/grammar/ExpressionParser.ts';

--- a/packages/xpath/src/global-types/internal/tree-sitter.d.ts
+++ b/packages/xpath/src/global-types/internal/tree-sitter.d.ts
@@ -1,0 +1,9 @@
+declare module '@getodk/tree-sitter-xpath/dist/tree-sitter-xpath.wasm?url' {
+  const url: string;
+  export default url;
+}
+
+declare module 'web-tree-sitter/tree-sitter.wasm?url' {
+  const url: string;
+  export default url;
+}

--- a/packages/xpath/vite.config.ts
+++ b/packages/xpath/vite.config.ts
@@ -90,6 +90,10 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         external: ['fs', 'path', 'temporal-polyfill'],
+        onwarn(warning, warn) {
+          if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+          warn(warning);
+        },
       },
     },
     define: {

--- a/packages/xpath/vite.config.ts
+++ b/packages/xpath/vite.config.ts
@@ -91,7 +91,9 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         external: ['temporal-polyfill'],
         onwarn(warning, warn) {
-          if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+          if (warning.code === 'EVAL' && warning.id?.endsWith('web-tree-sitter/tree-sitter.js')) {
+            return; // ignore eval warning for tree-sitter
+          }
           warn(warning);
         },
       },

--- a/packages/xpath/vite.config.ts
+++ b/packages/xpath/vite.config.ts
@@ -89,7 +89,7 @@ export default defineConfig(({ mode }) => {
         formats: ['es'],
       },
       rollupOptions: {
-        external: ['fs', 'path', 'temporal-polyfill'],
+        external: ['temporal-polyfill'],
         onwarn(warning, warn) {
           if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
           warn(warning);

--- a/vite.config.js
+++ b/vite.config.js
@@ -105,7 +105,9 @@ export default defineConfig(({ mode }) => ({
         }
       },
       onwarn(warning, warn) {
-        if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+        if (warning.code === 'EVAL' && warning.id?.includes('dist/index')) {
+          return; // ignore eval warning for tree-sitter
+        }
         warn(warning);
       },
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -104,7 +104,6 @@ export default defineConfig(({ mode }) => ({
           return 'assets/central/[name]-[hash].js';
         }
       },
-      external: ['fs', 'path'],
       onwarn(warning, warn) {
         if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
         warn(warning);

--- a/vite.config.js
+++ b/vite.config.js
@@ -104,6 +104,11 @@ export default defineConfig(({ mode }) => ({
           return 'assets/central/[name]-[hash].js';
         }
       },
+      external: ['fs', 'path'],
+      onwarn(warning, warn) {
+        if (warning.code === 'EVAL') return; // ignore eval warning for tree-sitter
+        warn(warning);
+      },
     },
   },
   test: {


### PR DESCRIPTION
Closes getodk/web-forms#443

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

This does 3 things...

##### 1. Ignore the eval warning
```
@getodk/xpath:build: [build:js   ] ../../node_modules/web-tree-sitter/tree-sitter.js (1210:36): Use of eval in "../../node_modules/web-tree-sitter/tree-sitter.js" is strongly discouraged as it poses security risks and may cause issues with minification.
```

##### 2. Ignore the missing module warning
```
@getodk/xpath:build: [build:js   ] src/expressionParser.ts:17:27 - error TS2307: Cannot find module '@getodk/tree-sitter-xpath/dist/tree-sitter-xpath.wasm?url' or its corresponding type declarations.
@getodk/xpath:build: [build:js   ] 
@getodk/xpath:build: [build:js   ] 17 import xpathLanguage from '@getodk/tree-sitter-xpath/dist/tree-sitter-xpath.wasm?url';
```

##### 3. Also cleaned up old vite config about building the demo.

#### What has been done to verify that this works as intended?

Run build.

#### Why is this the best possible solution? Were any other approaches considered?

We can't actually fix these warnings so silencing them makes new warnings easier to spot.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.