### PR TITLE
Remove afterEach hook outside test/index.js

### DIFF
--- a/apps/central/test/index.js
+++ b/apps/central/test/index.js
@@ -7,6 +7,7 @@ import '../src/styles';
 import testData from './data';
 import { loadAsyncRouteComponents } from './util/load-async';
 import { mockLogin } from './util/session';
+import { restoreLuxon } from './util/date-time';
 import { setupLanguages } from './util/i18n';
 import './assertions';
 
@@ -43,6 +44,7 @@ afterEach(() => {
   window.scrollTo(0, 0);
   document.documentElement.setAttribute('lang', 'en');
   localStorage.clear();
+  restoreLuxon();
   testData.reset();
   mockLogin.reset();
   document.cookie = '';

--- a/apps/central/test/util/date-time.js
+++ b/apps/central/test/util/date-time.js
@@ -52,7 +52,7 @@ export const setLuxon = (settings) => {
   }
 };
 
-// Restore Luxon settings to their original values.
+// Restores Luxon settings to their original values after a call to setLuxon().
 export const restoreLuxon = () => {
   for (const [name, value] of originalSettings.entries())
     Settings[name] = value;

--- a/apps/central/test/util/date-time.js
+++ b/apps/central/test/util/date-time.js
@@ -4,7 +4,29 @@ import { DateTime, Settings } from 'luxon';
 export const isBefore = (isoString1, isoString2) =>
   DateTime.fromISO(isoString1) < DateTime.fromISO(isoString2);
 
-// Sets a single Luxon setting.
+// Returns an ISO string for a date in the past that is no earlier than the
+// specified dates.
+export const fakePastDate = (dateStrings) => {
+  const parsed = dateStrings
+    .filter(s => s != null)
+    .map(s => Date.parse(s));
+  if (parsed.length === 0) return faker.date.past().toISOString();
+  const from = Math.max(...parsed);
+  let to;
+  do {
+    to = Date.now() - 1000;
+  } while (from > to);
+  return faker.date.between({ from, to }).toISOString();
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// LUXON SETTINGS
+
+const originalSettings = new Map();
+
+// Sets a single Luxon setting. Used by setLuxon() below.
 const setLuxonSetting = (name, value) => {
   if (name === 'now') {
     if (typeof value === 'number') {
@@ -22,32 +44,17 @@ const setLuxonSetting = (name, value) => {
   }
 };
 
-// setLuxon() sets one or more Luxon settings. It will restore the settings to
-// their original values at the end of the test.
-const originalSettings = new Map();
+// Sets one or more Luxon settings.
 export const setLuxon = (settings) => {
   for (const [name, value] of Object.entries(settings)) {
     if (!originalSettings.has(name)) originalSettings.set(name, Settings[name]);
     setLuxonSetting(name, value);
   }
 };
-afterEach(() => {
+
+// Restore Luxon settings to their original values.
+export const restoreLuxon = () => {
   for (const [name, value] of originalSettings.entries())
     Settings[name] = value;
   originalSettings.clear();
-});
-
-// Returns an ISO string for a date in the past that is no earlier than the
-// specified dates.
-export const fakePastDate = (dateStrings) => {
-  const parsed = dateStrings
-    .filter(s => s != null)
-    .map(s => Date.parse(s));
-  if (parsed.length === 0) return faker.date.past().toISOString();
-  const from = Math.max(...parsed);
-  let to;
-  do {
-    to = Date.now() - 1000;
-  } while (from > to);
-  return faker.date.between({ from, to }).toISOString();
 };


### PR DESCRIPTION
test/util/date-time.js contains a global `afterEach` hook. However, when I was trying to move to Vitest (getodk/central#1267), that was a problem. IIRC `afterEach` somehow wasn't in scope in that file, so an error was thrown. My solution was to move the code to an existing `afterEach` hook in test/index.js.

Honestly, I think it's better this way. I think it's a little funny to mix utility functions and Mocha hooks in the same file. It's better to do all the global Mocha setup in one place.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

Another option would have been to define a function named something like `setupLuxon()` and pass it `afterEach` as an argument. That's what we do in test/util/i18n.js. I think I like the pattern in this PR a little better though.