### PR TITLE
Remove unneeded globals from ESLint config

### DIFF
--- a/apps/central/.eslintrc.js
+++ b/apps/central/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     '@vue/airbnb'
   ],
   globals: {
-    $: 'readonly',
-    alert: 'readonly',
-    document: 'readonly',
-    window: 'readonly',
     defineModel: 'readonly'
   },
   rules: {


### PR DESCRIPTION
I had an old commit along these lines in my local branch for moving to Vitest. It's not really needed for Vitest, but I think it's a good change, so I'll go ahead and separate it out into its own PR.

This PR reduces the number of ESLint `globals`, removing `globals` that are no longer needed.

#### What has been done to verify that this works as intended?

ESLint continues to pass.

#### Why is this the best possible solution? Were any other approaches considered?

I kind of wish I knew why these `globals` are no longer needed. (The reason for `$` is clear, but the others not as much.) Did something change about ESLint such that these `globals` are no longer needed? Or were they never needed in the first place?