### PR TITLE
Add breakpoint() for debugging tests in non-headless browser

### DIFF
--- a/apps/central/docs/CONTRIBUTING.md
+++ b/apps/central/docs/CONTRIBUTING.md
@@ -325,6 +325,11 @@ Most Backend resources have a `createdAt` property. To generate an object whose 
 
 To learn more about stores and views, see [`/apps/central/test/data/data-store.js`](/apps/central/test/data/data-store.js).
 
+#### Debugging Tests
+
+Vitest has a [guide](https://vitest.dev/guide/debugging) to debugging tests. Another option in addition to the ones described there is to run `npm run test:debug`. This will open a browser to run tests: the browser will not be headless. If you attach a component to the document body, you will be able to see it in the browser. To do so, specify `attachTo: document.body` to `mount()`.
+
+You can pause `npm run test:debug` before a particular line of code by calling `await breakpoint()` before the line. In the browser console, call `breakpoint.next()` to step past the breakpoint. You can call `await breakpoint()` before multiple lines.
 
 #### E2E Tests
 

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -8,6 +8,7 @@
     "lint": "npm run eslint && npm run transifex:lint",
     "lint:fix": "npm run eslint:fix && npm run transifex:fix",
     "test": "./test/run.sh",
+    "test:debug": "vitest --browser.headless=false --testTimeout=3600000",
     "transifex:destructure": "node bin/transifex/destructure.js",
     "transifex:fix": "node bin/transifex/restructure.js > transifex/strings_en.json",
     "transifex:lint": "./bin/transifex/lint.sh"

--- a/apps/central/test/index.js
+++ b/apps/central/test/index.js
@@ -5,6 +5,7 @@ import { expect, should } from 'chai';
 import '../src/styles';
 
 import testData from './data';
+import { breakpoint } from './setup/debug';
 import { loadAsyncRouteComponents } from './util/load-async';
 import { mockLogin } from './util/session';
 import { setupLanguages } from './util/i18n';
@@ -16,6 +17,11 @@ window.test = it;
 
 window.should = should();
 window.expect = expect;
+
+// Chrome devtools allows you to select the window in the console. We set
+// `breakpoint` on both windows so that it is always available.
+window.breakpoint = breakpoint;
+window.parent.breakpoint = breakpoint;
 
 
 

--- a/apps/central/test/setup/debug.js
+++ b/apps/central/test/setup/debug.js
@@ -1,0 +1,14 @@
+import { block } from '../util/util';
+
+const next = [];
+// eslint-disable-next-line import/prefer-default-export
+export const breakpoint = () => {
+  const [lock, unlock] = block();
+  next.push(unlock);
+  return lock;
+};
+breakpoint.next = () => {
+  if (next.length === 0) return;
+  const unlock = next.shift();
+  unlock();
+};


### PR DESCRIPTION
I created this commit while working on moving to Vitest (getodk/central#1267). It's not needed for that move, but it's something I thought would be helpful for debugging tests. I decided to separate it out from the main PR for moving to Vitest in order to make the main PR smaller.

With Vitest, you have the option to run tests in a non-headless browser. Tests open in an actual browser window and run. You can see them whiz by, it's actually kind of fun. It also gives you the ability to view a particular failing test in the browser, which can facilitate debugging. You can look at what's in the DOM, do some console-logging, etc. This PR adds a function named `breakpoint()` that's intended to facilitate that sort of debugging.

#### What has been done to verify that this works as intended?

I'm pretty sure I had this working at some point locally. It's just for local development, so it shouldn't affect CI. Vitest needs to be in place in order for it to work.

#### Why is this the best possible solution? Were any other approaches considered?

It's been a long time since I worked on this commit. Vitest may already provide better approaches to debugging.