### PR TITLE
Replace Karma and Mocha with Vitest

### DIFF
--- a/apps/central/docs/CONTRIBUTING.md
+++ b/apps/central/docs/CONTRIBUTING.md
@@ -292,28 +292,19 @@ If you add code outside a `.vue` file (for example, a utility function), and it 
 
 Our tests use a number of external packages:
 
-- Karma, a test runner that we have configured to run tests in Headless Chrome
-- Mocha, a test framework
+- Vitest, a testing framework for Vite
 - Chai, for assertions
 - Sinon.JS, for spies and stubs
 - faker.js, to generate test data
 - Vue Test Utils, to test Vue components
 
-`npm run test` runs [`/apps/central/test/index.js`](/apps/central/test/index.js), which mocks global utilities and sets up Mocha hooks.
+Vitest is configured to run tests in Chrome, so you must have Chrome installed in order to run tests.
 
-[`/apps/central/test/assertions.js`](/apps/central/test/assertions.js) adds Chai helpers.
+[`test/setup/index.js`](/apps/central/test/setup/index.js) sets up tests, including adding Vitest hooks. [`test/setup/assertions.js`](/apps/central/test/setup/assertions.js) adds Chai helpers.
 
 [Vue Test Utils](https://test-utils.vuejs.org/) renders Vue components for testing, allowing you to test that a component renders and behaves as expected. We have built some functionality on top of Vue Test Utils, in particular [`mount()`](/apps/central/test/util/lifecycle.js). We define components used only for testing in [`/apps/central/test/util/components/`](/apps/central/test/util/components/).
 
 Many tests involve sending a request. You can mock a series of request-response cycles by using `load()` or `mockHttp()`, defined in [`/apps/central/test/util/http.js`](/apps/central/test/util/http.js). You can use these to implement common tests, for example, testing some standard button things: see [`/apps/central/test/util/http/common.js`](/apps/central/test/util/http/common.js).
-
-As provided by default by Mocha, add `.only` after any `describe()` or `it()` call in the tests to run only the marked tests. For example:
-
-```js
-it.only('does something', () => {
-  // ...
-});
-```
 
 #### Test Data
 
@@ -325,6 +316,18 @@ Most Backend resources have a `createdAt` property. To generate an object whose 
 
 To learn more about stores and views, see [`/apps/central/test/data/data-store.js`](/apps/central/test/data/data-store.js).
 
+
+#### Filtering Tests
+
+You can limit which test files are run by specifying a filter to `npm run test`. See the [Vitest docs](https://vitest.dev/guide/cli.html) for more information. To limit which tests are run within a particular file, add `.only` after any `describe()` or `it()` call in the file. For example:
+
+```js
+it.only('does something', () => {
+  // ...
+});
+```
+
+Adding `.only` to one file does not prevent other files from being run. It only limits which tests are run within the one file.
 
 #### E2E Tests
 

--- a/apps/central/test/index.js
+++ b/apps/central/test/index.js
@@ -1,36 +1,60 @@
 import sinon from 'sinon';
 import { enableAutoUnmount } from '@vue/test-utils';
-import { expect, should } from 'chai';
+import { should } from 'chai';
 
 import '../src/styles';
 
 import testData from './data';
+import { afterEachTest, beforeEachTest, setupHooks } from './setup/hooks';
 import { loadAsyncRouteComponents } from './util/load-async';
 import { mockLogin } from './util/session';
 import { setupLanguages } from './util/i18n';
 import './assertions';
-
-window.beforeAll = before; // eslint-disable-line no-undef
-window.afterAll = after; // eslint-disable-line no-undef
-window.test = it;
+import './setup/iframe';
 
 window.should = should();
-window.expect = expect;
+
+// Vitest hasn't made describe() a global yet. Once it tries to, we will run
+// setupHooks() instead. Doing so will set a describe() global that will call
+// the hooks added below.
+Object.defineProperty(window, 'describe', {
+  set(describe) {
+    delete window.describe;
+    setupHooks(describe);
+  },
+  configurable: true
+});
+
+Error.stackTraceLimit = 40;
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // HOOKS
 
+/*
+In this section only, call these alternative hooks:
+
+  - Call beforeEachFile() instead of beforeAll().
+  - Call afterEachFile() instead of afterAll().
+  - Call beforeEachTest() instead of beforeEach().
+  - Call afterEachTest() instead of afterEach().
+
+See test/setup/hooks.js for more details if you're curious.
+*/
+
 // Even if a route is lazy-loaded, load() will need synchronous access to the
 // async components associated with the route.
 beforeAll(loadAsyncRouteComponents);
 
-enableAutoUnmount(afterEach);
-afterEach(() => {
+beforeEachTest(() => { window.resizeTo(1100, 650); });
+
+enableAutoUnmount(afterEachTest);
+afterEachTest(() => {
   const app = document.querySelector('[data-v-app]');
   if (app != null) app.parentNode.removeChild(app);
 
+  // TODO. Update selector.
   const afterScript = document.querySelector('body > script:last-of-type + *');
   if (afterScript != null) {
     console.error(document.body.innerHTML); // eslint-disable-line no-console
@@ -38,7 +62,7 @@ afterEach(() => {
   }
 });
 
-afterEach(() => {
+afterEachTest(() => {
   sinon.restore();
   window.scrollTo(0, 0);
   document.documentElement.setAttribute('lang', 'en');
@@ -47,16 +71,4 @@ afterEach(() => {
   mockLogin.reset();
   document.cookie = '';
 });
-setupLanguages(afterEach);
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-// RUN TESTS
-
-// Run all tests. See the documentation for karma-webpack. We specify the files
-// here rather than in karma.conf.js, because doing so is more performant. When
-// I tried specifying the tests in karma.conf.js, I encountered an out-of-memory
-// error.
-const testsContext = require.context('.', true, /\.spec\.js$/);
-testsContext.keys().forEach(testsContext);
+setupLanguages(afterEachTest);

--- a/apps/central/test/index.js
+++ b/apps/central/test/index.js
@@ -9,7 +9,7 @@ import { afterEachTest, beforeEachTest, setupHooks } from './setup/hooks';
 import { loadAsyncRouteComponents } from './util/load-async';
 import { mockLogin } from './util/session';
 import { setupLanguages } from './util/i18n';
-import './assertions';
+import './setup/assertions';
 import './setup/iframe';
 
 window.should = should();

--- a/apps/central/test/run.sh
+++ b/apps/central/test/run.sh
@@ -8,16 +8,17 @@ cp ../../index.html ../../public/
 output=$(mktemp)
 trap 'rm -- ../../public/index.html "$output"' EXIT
 
-NODE_ENV="test" karma start karma.conf.js | tee "$output"
+vitest run "$@" | tee "$output"
 
-# Search for: warnings from console.warn(), including Vue warnings; Sass
-# warnings; and warnings from Karma.
+# Search for:
+#
+#   - Warnings from console.warn(), including Vue warnings
+#   - Sass warnings
 awk '
   BEGIN { warnings = 0 }
-  /WARN LOG:/            { ++warnings; print "WARNING: " $0 }
+  /stderr/               { ++warnings; print "WARNING: " $0 }
   /ERROR LOG:/           { ++warnings; print "WARNING: " $0 }
   /Module Warning/       { ++warnings; print "WARNING: " $0 }
-  /WARN \[web-server\]:/ { ++warnings; print "WARNING: " $0 }
   END {
     if(warnings > 2) {
       print "All tests passed, but there were " warnings " warnings: see above."

--- a/apps/central/test/setup/assertions.js
+++ b/apps/central/test/setup/assertions.js
@@ -2,7 +2,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { Assertion, AssertionError, use, util } from 'chai';
 import { BaseWrapper, VueWrapper } from '@vue/test-utils';
 
-import { wait } from './util/util';
+import { wait } from '../util/util';
 
 use(chaiAsPromised);
 

--- a/apps/central/test/setup/hooks.js
+++ b/apps/central/test/setup/hooks.js
@@ -1,0 +1,38 @@
+const hooks = {};
+const addHook = (type) => (callback) => {
+  if (hooks[type] == null) hooks[type] = [];
+  hooks[type].push(callback);
+};
+const callHooks = async (type) => {
+  if (hooks[type] == null) return;
+  for (const callback of hooks[type]) await callback();
+};
+
+export const beforeEachFile = addHook('beforeEachFile');
+export const afterEachFile = addHook('afterEachFile');
+export const beforeEachTest = addHook('beforeEachTest');
+export const afterEachTest = addHook('afterEachTest');
+
+let describe;
+const testFile = (title, tests) => {
+  describe(title, () => {
+    beforeAll(() => callHooks('beforeEachFile'));
+    afterAll(() => callHooks('afterEachFile'));
+    beforeEach(() => callHooks('beforeEachTest'));
+    afterEach(() => callHooks('afterEachTest'));
+
+    window.describe = describe;
+    tests();
+    window.describe = testFile;
+  });
+};
+for (const modifier of ['skip', 'skipIf', 'runIf', 'only']) {
+  testFile[modifier] = () => {
+    throw new Error(`describe.${modifier}() is not supported here. Pass a filter to \`npm run test\` instead.`);
+  };
+}
+
+export const setupHooks = (d) => {
+  describe = d;
+  window.describe = testFile;
+};

--- a/apps/central/test/setup/iframe.js
+++ b/apps/central/test/setup/iframe.js
@@ -1,0 +1,29 @@
+/*
+Tests are run in an iframe, which requires some setup.
+
+The iframe is pretty small (300px x 150px), which is actually small enough to
+cause test failures. By default, the iframe can't be resized using
+window.resizeTo(). However, it can be resized using CSS. Below,
+window.resizeTo() is overwritten to resize using CSS. testFile() will call
+window.resizeTo() to increase the size of the iframe.
+
+`npm run test` runs tests in a headless browser. On the other hand,
+`npm run test:debug` opens a browser window. This file styles the page to
+improve its look for when `npm run test:debug` is run.
+*/
+
+import { px } from '../../src/util/dom';
+
+window.resizeTo = (width, height) => {
+  Object.assign(window.frameElement.style, {
+    width: px(width),
+    height: px(height)
+  });
+};
+window.resizeBy = () => { throw new Error('not implemented for iframe'); };
+
+const parentDocument = window.parent.document;
+parentDocument.body.style.backgroundColor = '#000';
+// #vitest-ui doesn't seem to show anything and just takes up space.
+parentDocument.querySelector('#vitest-ui').style.display = 'none';
+window.frameElement.style.border = 'none';

--- a/apps/central/test/util/http.js
+++ b/apps/central/test/util/http.js
@@ -68,7 +68,7 @@ In other words, using mockHttp() involves two phases:
      of request-response cycles is kicked off.
 
 afterResponses() returns a thenable, which usually is ultimately returned to
-Mocha. You can call then(), catch(), or finally() on the thenable:
+Vitest. You can call then(), catch(), or finally() on the thenable:
 
   mockLogin();
   testData.extendedProjects.createPast(3);
@@ -680,17 +680,17 @@ class MockHttp {
     MockHttp uses two promises:
 
       1. The first promise is chained on this._previousPromise and returned by
-         an after responses hook. Usually it is ultimately returned to Mocha.
+         an after responses hook. Usually it is ultimately returned to Vitest.
       2. The second promise, stored here in `promise`, holds the responses,
-         chained in order of request. `promise` is not returned to Mocha, but
+         chained in order of request. `promise` is not returned to Vitest, but
          rather to Frontend from `http` in the container.
 
     The two promises are related: the first promise triggers one or more
     requests; for which responses are returned to Frontend through the second
-    promise; then the first promise is returned to Mocha or whatever else comes
+    promise; then the first promise is returned to Vitest or whatever else comes
     after the hook.
 
-    It is because the second promise is returned to Frontend and not Mocha that
+    It is because the second promise is returned to Frontend and not Vitest that
     this._tryBeforeAnyResponse() and this._tryBeforeEachResponse() catch any
     error even though they are called within a promise chain. Those methods
     catch and store any error so that the after responses hook is able to reject
@@ -878,7 +878,7 @@ class MockHttp {
     return promise.then(({ result }) => result);
   }
 
-  // The inclusion of these methods means that we can return a MockHttp to Mocha
+  // The inclusion of these methods means that we can return a MockHttp to Vitest
   // in lieu of a Promise.
   then(...args) { return this.toPromise().then(...args); }
   catch(onRejected) { return this.toPromise().catch(onRejected); }

--- a/apps/central/vitest.config.js
+++ b/apps/central/vitest.config.js
@@ -1,0 +1,43 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import viteConfig from './vite.config';
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: {
+    root: fileURLToPath(new URL('./', import.meta.url)),
+    include: ['test/**/*.spec.js'],
+    browser: {
+      enabled: true,
+      name: 'chrome',
+      headless: true,
+      providerOptions: {
+        capabilities: {
+          // This is the size of the entire browser window. The size of the
+          // viewport is smaller and is set using window.resizeTo() in
+          // test/setup/iframe.js.
+          'goog:chromeOptions': { args: ['window-size=2000,2000'] }
+        }
+      },
+      fileParallelism: false,
+      isolate: false,
+      testerScripts: [{ src: 'test/setup/index.js', async: false }]
+    },
+    // I'm not sure whether `fileParallelism` and `isolate` are needed here
+    // given that we also specify them under `browser` above.
+    fileParallelism: false,
+    isolate: false,
+    sequence: { hooks: 'list' },
+    globals: true
+  },
+  resolve: {
+    // I think this is needed to compile templates in testing. Most tests import
+    // .vue files, but some specify template strings.
+    alias: { vue: 'vue/dist/vue.esm-bundler.js' }
+  },
+  server: {
+    // Some tests reference this number. This is the port we used with Karma
+    // before moving to Vitest.
+    port: 9876
+  }
+}));


### PR DESCRIPTION
A while ago, I worked on replacing Karma (and Mocha) with Vitest (getodk/central#1267). I never finished that work, but I wanted to share what I have so far.

### State of the PR

I had these changes running locally at some point. However, that was well over a year ago. Importantly, it predated our new monorepo setup, which means that related configuration has changed since I last worked on it.

This PR is not expected to work at the moment. I'll add more details below as to why. Note that I didn't fully review the changes here. This PR is a work-in-progress.

I don't remember whether 100% of tests were passing back when I was working on this. It's very possible that they were. I seem to remember that most of them were at least. Locally, I don't see any changes to individual tests.

### Overall approach

The overall approach I took was to use Vitest browser mode. That's because it seemed most similar to Karma.

At the time, Vitest browser mode was marked as experimental. I'm pretty sure there have been breaking changes to it since I last worked on it.

### Required PRs

My original local commit was on a long branch (now quite outdated) that made a series of changes:

- Introducing Vite for the first time
  - By now, we've been using Vite for a while for local development and the production build. The changes for Vite were extracted to a separate PR.
- Replacing Should.js with Chai
  - IIRC this was needed for Vitest. Something related to the use of ES Modules in test/index.js and the fact that Should.js isn't an ES Module. But I also thought it was a good change by itself, so I extracted it to its own PR. That PR was merged a while ago.

I've rebased my local commit and also extracted other work that was on the same long branch. I've put that other work in separate PRs so that this core PR can be as slim as possible. The following PRs are required in order for the changes in this PR to work:

- #1769
- #1770
- (Maybe needed? Not sure.) #1775

### Follow-up work

I want this PR to be self-contained, i.e., to contain the minimal changes needed to move to Vitest. However, I had other changes on my local branch that can be considered in separate PRs. At least one of those PRs requires this PR to be merged first.

- #1772
  - Enhances the experience of using Vitest during local development
- getodk/central#1269
  - This is just a link to the issue, not a PR. However, the issue makes it clear what the required changes are.
  - I think this isn't strictly necessary for moving to Vitest, but it would be a nice change for the codebase.

### Package changes

I had local changes to package.json. However, that file has changed a lot in the repo since I last worked on this, so I decided not to include those changes in the PR. The packages I used back then are probably outdated by now anyway. But here's the list of packages I added locally:

```json
"vitest": "^1.6.0",
"@vitest/browser": "^1.6.0",
"webdriverio": "^8.36.1",
```

I also removed packages related to Karma, Mocha, Vue CLI, and webpack. With this PR, none of those frameworks will be needed for Central Frontend anymore.

### More details below

I'm going to leave comments below on particular files and lines in order to explain my approach and surface current open questions.