### PR TITLE
Reference window explicitly to make it easier to mock localStorage

### DIFF
--- a/apps/central/src/util/storage.js
+++ b/apps/central/src/util/storage.js
@@ -14,19 +14,19 @@ except according to the terms contained in the LICENSE file.
 export const localStore = {
   getItem(name) {
     try {
-      return localStorage.getItem(name);
+      return window.localStorage.getItem(name);
     } catch (e) {
       return null;
     }
   },
   setItem(name, value) {
     try {
-      localStorage.setItem(name, value);
+      window.localStorage.setItem(name, value);
     } catch (e) {}
   },
   removeItem(name) {
     try {
-      localStorage.removeItem(name);
+      window.localStorage.removeItem(name);
     } catch (e) {}
   }
 };


### PR DESCRIPTION
I made this change while working to move from Karma to Vitest (getodk/central#1267). It references `localStorage` as `window.localStorage` instead. I don't really remember why such a thing would be needed. 🤔 But I also don't think I would have made such a change without a reason. The commit message says something about mocking `localStorage`. We do mock `localStorage` in test/unit/storage.spec.js. Does Vitest have an issue with referencing `localStorage` without `window`?

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

I guess we'll find out soon enough whether this change is really necessary. If it's not necessary, I'd just as well not make it. For that reason, I'm marking this PR as draft. Though I guess there's also no harm in making this change.