### PR TITLE
mockHttp(): include response counts in error message

### DIFF
--- a/apps/central/test/util/http.js
+++ b/apps/central/test/util/http.js
@@ -854,7 +854,7 @@ class MockHttp {
       throw new Error('request without response: no response specified for request');
     } else if (this._orderedResponsesRequested < this._orderedResponses.length) {
       this._listRequestResponseLog();
-      throw new Error('response without request: not all responses were requested');
+      throw new Error(`response without request: ${this._orderedResponses.length} required response(s) were specified, but only ${this._orderedResponsesRequested} of them were requested`);
     } else if (this._orderedResponsesReturned !== this._orderedResponses.length) {
       this._listRequestResponseLog();
       throw new Error('All responses were requested, but not all were returned in time. By default, all responses are expected to be returned in microtasks, before the next task. You may need to use the pollWork option of afterResponses().');


### PR DESCRIPTION
I made a small improvement to `mockHttp()` while working on moving from Karma to Vitest a while ago. Here I've extracted it into its own PR. This PR improves an error message in `mockHttp()`, surfacing more information that will hopefully facilitate debugging.

#### What has been done to verify that this works as intended?

Nothing in particular. Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

It's just changing an error message. The error message now includes more information (two new counts).