### PR TITLE
Add node: prefix to import of fs

### DIFF
--- a/apps/central/bin/transifex/destructure.js
+++ b/apps/central/bin/transifex/destructure.js
@@ -1,7 +1,7 @@
 // For a description of our Transifex workflow and how this script fits into it,
 // see CONTRIBUTING.md.
 
-const fs = require('fs');
+const fs = require('node:fs');
 
 const { destructure, readSourceMessages, rekeyTranslations, writeTranslations } = require('../util/transifex');
 const { logThenThrow, mapComponentsToFiles } = require('../util/util');


### PR DESCRIPTION
I made this change locally while working on moving from Karma to Vitest. It's just a small change, but I think it's an improvement. It's not super related to Vitest though, so I've moved it into its own PR.

Instead of importing `fs`, this PR imports `node:fs`, adding the `node:` prefix.

#### What has been done to verify that this works as intended?

Nothing in particular. Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

There's at least one other file in bin/ that imports `node:fs` rather than just `fs`. I think `node:fs` is slightly preferred these days.

I checked all the files in bin/ for other places to add the `node:` prefix, but I didn't see any. I didn't check other files outside bin/.