### PR TITLE
ci: standardise cache action on v6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,14 +28,14 @@ jobs:
     - run: npm run build
     - run: npm run lint
     - run: ./bin/check-bundle-size.js
-    - uses: 'actions/cache/save@v5'
+    - uses: 'actions/cache/save@v6'
       id: cache-install
       with:
         path: |
           node_modules
           **/node_modules
         key: install-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-    - uses: 'actions/cache/save@v5'
+    - uses: 'actions/cache/save@v6'
       id: cache-build
       with:
         path: |
@@ -65,7 +65,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - uses: 'actions/cache@v5'
+    - uses: 'actions/cache@v6'
       id: cache-install
       with:
         path: |
@@ -73,7 +73,7 @@ jobs:
           **/node_modules
         key: install-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
         fail-on-cache-miss: true
-    - uses: 'actions/cache@v5'
+    - uses: 'actions/cache@v6'
       id: cache-build
       with:
         path: |
@@ -96,7 +96,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - uses: 'actions/cache@v5'
+    - uses: 'actions/cache@v6'
       id: cache-install
       with:
         path: |
@@ -104,7 +104,7 @@ jobs:
           **/node_modules
         key: install-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
         fail-on-cache-miss: true
-    - uses: 'actions/cache@v5'
+    - uses: 'actions/cache@v6'
       id: cache-build
       with:
         path: |

--- a/.github/workflows/wf-ci-e2e.yml
+++ b/.github/workflows/wf-ci-e2e.yml
@@ -22,14 +22,14 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-install
         with:
           path: |
             node_modules
             **/node_modules
           key: install-v${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-build
         with:
           path: |
@@ -74,14 +74,14 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-install
         with:
           path: |
             node_modules
             **/node_modules
           key: install-v${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-build
         with:
           path: |

--- a/.github/workflows/wf-ci.yml
+++ b/.github/workflows/wf-ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-install
         with:
           path: |
@@ -52,7 +52,7 @@ jobs:
             **/node_modules
           key: install-v${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-build
         with:
           path: |
@@ -104,14 +104,14 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-install
         with:
           path: |
             node_modules
             **/node_modules
           key: install-v${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-build
         with:
           path: |
@@ -163,14 +163,14 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-install
         with:
           path: |
             node_modules
             **/node_modules
           key: install-v${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-build
         with:
           path: |
@@ -222,14 +222,14 @@ jobs:
         with:
           node-version: '${{ matrix.node-version }}'
 
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-install
         with:
           path: |
             node_modules
             **/node_modules
           key: install-v${{ matrix.node-version }}-${{ hashFiles('package-lock.json', '.npmrc', '.github/workflows/*.yml', 'packages/*/package.json', 'packages/*/package-lock.json') }}
-      - uses: 'actions/cache@v5'
+      - uses: 'actions/cache@v6'
         id: cache-build
         with:
           path: |


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

- [x] reviewed release notes at https://github.com/actions/cache/releases
- [x] ci

#### Why is this the best possible solution? Were any other approaches considered?

* v6 is most recent
* already used in some places, but not consistently

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No impact - just tests.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.