### PR TITLE
chore(web-forms#876): remove leftover references to the removed web-forms demo app 

### DIFF
--- a/.github/workflows/wf-ci.yml
+++ b/.github/workflows/wf-ci.yml
@@ -250,9 +250,3 @@ jobs:
 
       - if: ${{ matrix.target == 'Web' }}
         run: 'npm run test-browser:${{ matrix.browser }} -w=packages/web-forms'
-
-      - if: ${{ matrix.node-version == '24.16.0' && matrix.target == 'Node' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist-demo
-          path: packages/web-forms/dist-demo

--- a/packages/eslint.config.js
+++ b/packages/eslint.config.js
@@ -54,7 +54,6 @@ export default defineConfig(
 			'**/*.min.js',
 			'**/dist/**/*',
 			'common/fixtures/test-javarosa/**/*',
-			'web-forms/dist-demo/**/*',
 			'web-forms/bin/**/*',
 			'xforms-engine/api-docs/**/*',
 			'**/vendor',

--- a/packages/web-forms/README.md
+++ b/packages/web-forms/README.md
@@ -405,8 +405,6 @@ npm run dev -w=packages/web-forms
 
 Individual test environments, and their corresponding watch modes, also have separate commands which can be found in [`package.json`](./package.json).
 
-Upload XLSForm and XForm functionality in [`demo`](./src/demo/) app and in dev mode depends on [XLSForm-online](https://github.com/getodk/xlsform-online). Run the xlsform-online locally. By default it runs on port 8000, if you are running it on another port then you should update the [`config`](./src/demo/config.json) file.
-
 ### Project Structure
 
 ```
@@ -414,13 +412,12 @@ web-forms/
 ├── public/                   # Static assets (e.g., favicon.ico)
 ├── src/
 │   ├── assets/
-│   │   ├── images/           # Web Forms and Demo page images
-│   │   ├── styles/           # Web Forms and Demo page styles
+│   │   ├── images/           # Web Forms images
+│   │   ├── styles/           # Web Forms styles
 │   ├── components/           # UI components
 │   │   ├── form-elements/    # Form elements or controllers (question types, hints, labels, inputs)
 │   │   ├── form-layout/      # Form layout and rendering (e.g., form panel, groups, repeats, form error classes)
 │   │   ├── common/           # Reusable smaller components (e.g., icon, image, checkbox components)
-│   ├── demo/                 # Demo page
 │   ├── lib/                  # Utilities
 │   ├── index.ts
 │   ├── web-forms-plugin.ts   # Vue plugin

--- a/packages/web-forms/src/index.ts
+++ b/packages/web-forms/src/index.ts
@@ -2,7 +2,7 @@ import { webFormsPlugin } from './web-forms-plugin';
 import OdkWebForm from './components/OdkWebForm.vue';
 import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow.ts';
 
-// Applies styles when the Web Forms is used as a plugin outside the preview demo page.
+// Applies styles when Web Forms is used as a plugin.
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';

--- a/packages/web-forms/vite.config.e2e.ts
+++ b/packages/web-forms/vite.config.e2e.ts
@@ -63,10 +63,9 @@ if (webkitFlakinessMitigations) {
 }
 
 export default defineConfig(({ mode }) => {
-  const isVueBundled = mode === 'demo';
   const isDev = mode === 'development';
 
-  const versionSuffix = buildNumber && (isVueBundled || isDev) ? ` - ${buildNumber}` : '';
+  const versionSuffix = buildNumber && isDev ? ` - ${buildNumber}` : '';
 
   return {
     define: {


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/876

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Searched the whole repo for remaining demo references. Ran the build and lint and CI passes

#### Why is this the best possible solution? Were any other approaches considered?

The demo app was removed and these are just leftovers. So this is just a clean up.  
The dist-demo line in .gitignore was kept on purpose, so people with an old local build don't commit that folder by mistake. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
