### PR TITLE
fix(web-forms#875): build from source not dist

### DIFF
--- a/.changeset/sharp-pants-do.md
+++ b/.changeset/sharp-pants-do.md
@@ -1,0 +1,7 @@
+---
+"@getodk/xforms-engine": patch
+"@getodk/web-forms": patch
+"@getodk/forms": patch
+---
+
+Reduced bundle size for faster loading

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -57,21 +57,17 @@ function isTooBig({ path, size }) {
   // TODO these have all changed drastically
   switch (simpleName) {
     case 'icomoon.svg':    return size >    60_000;
-    case 'index.js':       return size > 2_300_000;
-    case 'main.js':        return size >   400_000;
-    case 'forms.js':       return size > 2_100_000;
+    case 'forms.js':       return size > 1_400_000;
     case 'forms.css':      return size >   500_000;
-    case 'web-form.js':    return size > 1_000_000; // Matches web-form-renderer.js
-    case 'MapBlock.js':    return size >   600_000; // A Web Forms' feature bundle
-    case 'MapBlock.css':   return size >   500_000;
+    case 'web-form.js':    return size >   600_000; // Matches web-form-renderer.js
+    case 'MapBlock.css':   return size >   500_000; // A Web Forms' feature bundle
     case 'WebGLVector.js': return size >   500_000;
-    case 'geojson-map.js': return size >   500_000;
     // This is a performance tracking script from Sentry, shared between apps/central and apps/forms.
-    case 'browserTracingIntegration.js': return size > 400_000;
+    case 'browserTracingIntegration.js': return size > 350_000;
     default: // do nothing
   }
 
-  const type = extname(path).substr(1);
+  const type = extname(path).substring(1);
   switch (type) {
     case 'css':         return size > 220_000;
     case 'html':        return size >   3_000;

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -54,16 +54,20 @@ log('File sizes look OK.');
 function isTooBig({ path, size }) {
   // Special cases:
   const simpleName = basename(path).replace(/(-[\w-]{8})+\./, '.');
+  // TODO these have all changed drastically
   switch (simpleName) {
     case 'icomoon.svg':    return size >    60_000;
     case 'index.js':       return size > 2_300_000;
     case 'main.js':        return size >   400_000;
     case 'forms.js':       return size > 2_100_000;
+    case 'forms.css':      return size >   500_000;
     case 'web-form.js':    return size > 1_000_000; // Matches web-form-renderer.js
     case 'MapBlock.js':    return size >   600_000; // A Web Forms' feature bundle
+    case 'MapBlock.css':   return size >   500_000;
+    case 'WebGLVector.js': return size >   500_000;
     case 'geojson-map.js': return size >   500_000;
     // This is a performance tracking script from Sentry, shared between apps/central and apps/forms.
-    case 'browserTracingIntegration.js': return size > 215_000;
+    case 'browserTracingIntegration.js': return size > 400_000;
     default: // do nothing
   }
 
@@ -77,7 +81,9 @@ function isTooBig({ path, size }) {
     case 'svg':         return size >   5_000;
     case 'ttf':         return size >  18_000;
     case 'webmanifest': return size >     500;
-    case 'woff':        return size >  19_000;
+    case 'wasm':        return size > 200_000;
+    case 'woff':        return size >  25_000;
+    case 'woff2':       return size >  25_000;
     default: // do nothing
   }
   throw new Error(`No check written for file ${path} yet!  Please review this function.`);

--- a/bin/check-bundle-size.js
+++ b/bin/check-bundle-size.js
@@ -54,7 +54,6 @@ log('File sizes look OK.');
 function isTooBig({ path, size }) {
   // Special cases:
   const simpleName = basename(path).replace(/(-[\w-]{8})+\./, '.');
-  // TODO these have all changed drastically
   switch (simpleName) {
     case 'icomoon.svg':    return size >    60_000;
     case 'forms.js':       return size > 1_400_000;

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -27,6 +27,7 @@ http {
       application/json                      json;
       application/vnd.ms-excel              xls;
       application/zip                       zip;
+      application/wasm                      wasm;
 
       application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
 

--- a/packages/web-forms/src/components/FormLoadFailureDialog.vue
+++ b/packages/web-forms/src/components/FormLoadFailureDialog.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import Dialog from 'primevue/dialog';
 import Message from 'primevue/message';
 import { computed, inject } from 'vue';
-import type { FormInitializationError } from '@/lib/error/FormInitializationError.ts';
+import type { FormInitializationError } from '@getodk/web-forms/lib/error/FormInitializationError.ts';
 
 interface FormLoadErrorProps {
 	readonly error: FormInitializationError;

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -1,29 +1,29 @@
 <script setup lang="ts">
-import FormLoadFailureDialog from '@/components/FormLoadFailureDialog.vue';
-import IconSVG from '@/components/common/IconSVG.vue';
-import FormFooter from '@/components/form-layout/FormFooter.vue';
-import FormHeader from '@/components/form-layout/FormHeader.vue';
-import QuestionList from '@/components/form-layout/QuestionList.vue';
-import { waitAllTasksToFinish } from '@/lib/async/event-loop.ts';
-import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow.ts';
+import FormLoadFailureDialog from '@getodk/web-forms/components/FormLoadFailureDialog.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import FormFooter from '@getodk/web-forms/components/form-layout/FormFooter.vue';
+import FormHeader from '@getodk/web-forms/components/form-layout/FormHeader.vue';
+import QuestionList from '@getodk/web-forms/components/form-layout/QuestionList.vue';
+import { waitAllTasksToFinish } from '@getodk/web-forms/lib/async/event-loop.ts';
+import { POST_SUBMIT__NEW_INSTANCE } from '@getodk/web-forms/lib/constants/control-flow.ts';
 import {
 	TRANSLATE,
 	FORM_MEDIA_CACHE,
 	FORM_OPTIONS,
 	IS_FORM_EDIT_MODE,
 	SUBMIT_PRESSED,
-} from '@/lib/constants/injection-keys.ts';
-import type { FormStateSuccessResult } from '@/lib/init/form-state.ts';
-import { initializeFormState } from '@/lib/init/initialize-form-state.ts';
-import { loadFormState } from '@/lib/init/load-form-state';
-import type { EditInstanceOptions, FormOptions } from '@/lib/init/load-form-state.ts';
-import { updateSubmittedFormState } from '@/lib/init/update-submitted-form-state.ts';
-import { geolocationService } from '@/lib/services/geolocationService.ts';
-import { useLocale } from '@/lib/locale/useLocale.ts';
+} from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { FormStateSuccessResult } from '@getodk/web-forms/lib/init/form-state.ts';
+import { initializeFormState } from '@getodk/web-forms/lib/init/initialize-form-state.ts';
+import { loadFormState } from '@getodk/web-forms/lib/init/load-form-state';
+import type { EditInstanceOptions, FormOptions } from '@getodk/web-forms/lib/init/load-form-state.ts';
+import { updateSubmittedFormState } from '@getodk/web-forms/lib/init/update-submitted-form-state.ts';
+import { geolocationService } from '@getodk/web-forms/lib/services/geolocationService.ts';
+import { useLocale } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type {
 	HostSubmissionResultCallback,
 	OptionalAwaitableHostSubmissionResult,
-} from '@/lib/submission/host-submission-result-callback.ts';
+} from '@getodk/web-forms/lib/submission/host-submission-result-callback.ts';
 import type { JRResourceURLString } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import type {
 	ChunkedInstancePayload,
@@ -46,7 +46,7 @@ import {
 	watch,
 	watchEffect,
 } from 'vue';
-import { FormInitializationError } from '@/lib/error/FormInitializationError';
+import { FormInitializationError } from '@getodk/web-forms/lib/error/FormInitializationError';
 
 const webFormsVersion = __WEB_FORMS_VERSION__;
 type ObjectURL = `blob:${string}`;

--- a/packages/web-forms/src/components/common/ActionsInfoDialog.vue
+++ b/packages/web-forms/src/components/common/ActionsInfoDialog.vue
@@ -7,7 +7,7 @@ export interface ActionInfo {
 </script>
 
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
 import Dialog from 'primevue/dialog';
 
 defineProps<{

--- a/packages/web-forms/src/components/common/CheckboxWidget.vue
+++ b/packages/web-forms/src/components/common/CheckboxWidget.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import TextMedia from '@/components/common/TextMedia.vue';
-import { selectOptionId } from '@/lib/format/select-option-id.ts';
+import TextMedia from '@getodk/web-forms/components/common/TextMedia.vue';
+import { selectOptionId } from '@getodk/web-forms/lib/format/select-option-id.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import Checkbox from 'primevue/checkbox';
 

--- a/packages/web-forms/src/components/common/GeolocationFormattedValue.vue
+++ b/packages/web-forms/src/components/common/GeolocationFormattedValue.vue
@@ -9,9 +9,9 @@ import type {
 	GeotraceNoteValue,
 	GeoshapeNoteValue,
 } from '@getodk/xforms-engine';
-import { truncateGeoCoordinates, truncateDecimals } from '@/lib/format/truncate-decimals.ts';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { truncateGeoCoordinates, truncateDecimals } from '@getodk/web-forms/lib/format/truncate-decimals.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { computed, inject } from 'vue';
 
 type GeolocationNode = GeopointInputNode | GeopointNoteNode | GeoshapeNoteNode | GeotraceNoteNode;

--- a/packages/web-forms/src/components/common/MarkdownBlock.vue
+++ b/packages/web-forms/src/components/common/MarkdownBlock.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { getStylePropertyMap, getUrl, purify } from '@/lib/format/markdown';
+import { getStylePropertyMap, getUrl, purify } from '@getodk/web-forms/lib/format/markdown';
 import type { MarkdownNode } from '@getodk/xforms-engine';
 
 interface MarkdownProps {

--- a/packages/web-forms/src/components/common/MultiselectDropdown.vue
+++ b/packages/web-forms/src/components/common/MultiselectDropdown.vue
@@ -3,8 +3,8 @@ import type { SelectNode } from '@getodk/xforms-engine';
 import MultiSelect from 'primevue/multiselect';
 import { computed, inject } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 
 interface MultiselectDropdownProps {
 	readonly question: SelectNode;

--- a/packages/web-forms/src/components/common/RadioButton.vue
+++ b/packages/web-forms/src/components/common/RadioButton.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import TextMedia from '@/components/common/TextMedia.vue';
-import { selectOptionId } from '@/lib/format/select-option-id.ts';
+import TextMedia from '@getodk/web-forms/components/common/TextMedia.vue';
+import { selectOptionId } from '@getodk/web-forms/lib/format/select-option-id.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import RadioButton from 'primevue/radiobutton';
 

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -3,8 +3,8 @@ import type { SelectNode } from '@getodk/xforms-engine';
 import Select from 'primevue/select';
 import { computed, inject } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 
 interface SearchableDropdownProps {
 	readonly question: SelectNode;

--- a/packages/web-forms/src/components/common/TextMedia.vue
+++ b/packages/web-forms/src/components/common/TextMedia.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import AudioBlock from '@/components/common/media/AudioBlock.vue';
-import ImageBlock from '@/components/common/media/ImageBlock.vue';
-import VideoBlock from '@/components/common/media/VideoBlock.vue';
+import AudioBlock from '@getodk/web-forms/components/common/media/AudioBlock.vue';
+import ImageBlock from '@getodk/web-forms/components/common/media/ImageBlock.vue';
+import VideoBlock from '@getodk/web-forms/components/common/media/VideoBlock.vue';
 import type { TextRange } from '@getodk/xforms-engine';
 import { computed } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';

--- a/packages/web-forms/src/components/common/ValidationMessage.vue
+++ b/packages/web-forms/src/components/common/ValidationMessage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
-import { QUESTION_HAS_ERROR, TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import MarkdownBlock from '@getodk/web-forms/components/common/MarkdownBlock.vue';
+import { QUESTION_HAS_ERROR, TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { AnyViolation } from '@getodk/xforms-engine';
 import { computed, type ComputedRef, inject } from 'vue';
 

--- a/packages/web-forms/src/components/common/canvas/AsyncCanvas.vue
+++ b/packages/web-forms/src/components/common/canvas/AsyncCanvas.vue
@@ -4,11 +4,11 @@
  * This prevents unnecessary bloat in the application bundle, reducing initial load times and improving performance.
  * Use dynamic imports instead (e.g., `await import(importPath)`) for lazy-loading these dependencies when required.
  */
-import { getModeConfig, type CanvasMode } from '@/components/common/canvas/getModeConfig.ts';
-import { loadCanvas, type CanvasBlockComponent } from '@/components/common/canvas/loadCanvas.ts';
-import AsyncLoader from '@/components/common/AsyncLoader.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { getModeConfig, type CanvasMode } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
+import { loadCanvas, type CanvasBlockComponent } from '@getodk/web-forms/components/common/canvas/loadCanvas.ts';
+import AsyncLoader from '@getodk/web-forms/components/common/AsyncLoader.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { getCurrentInstance, inject, shallowRef } from 'vue';
 
 const props = defineProps<{

--- a/packages/web-forms/src/components/common/canvas/CanvasBlock.vue
+++ b/packages/web-forms/src/components/common/canvas/CanvasBlock.vue
@@ -3,15 +3,15 @@
  * IMPORTANT: Lazy-loaded for Konva isolation. Keep Konva imports/code here only to bundle separately and
  * load on demand. Avoids main bundle bloat.
  */
-import CanvasControls from '@/components/common/canvas/CanvasControls.vue';
-import { type CanvasMode, getModeConfig, MODES } from '@/components/common/canvas/getModeConfig.ts';
+import CanvasControls from '@getodk/web-forms/components/common/canvas/CanvasControls.vue';
+import { type CanvasMode, getModeConfig, MODES } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
 import {
 	DEFAULT_STROKE_COLOR,
 	STROKE_WIDTH,
 	useCanvasDrawing,
-} from '@/components/common/canvas/useCanvasDrawing.ts';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+} from '@getodk/web-forms/components/common/canvas/useCanvasDrawing.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type Konva from 'konva';
 import Message from 'primevue/message';
 import { computed, inject, onMounted, onUnmounted, ref, watch } from 'vue';

--- a/packages/web-forms/src/components/common/canvas/CanvasControls.vue
+++ b/packages/web-forms/src/components/common/canvas/CanvasControls.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import ActionsInfoDialog, { type ActionInfo } from '@/components/common/ActionsInfoDialog.vue';
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import ActionsInfoDialog, { type ActionInfo } from '@getodk/web-forms/components/common/ActionsInfoDialog.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import ColorPicker, { type ColorPickerChangeEvent } from 'primevue/colorpicker';
 import { computed, inject, onBeforeUnmount, ref, watch } from 'vue';
-import { DEFAULT_STROKE_COLOR } from '@/components/common/canvas/useCanvasDrawing.ts';
-import type { CanvasModeConfig } from '@/components/common/canvas/getModeConfig.ts';
+import { DEFAULT_STROKE_COLOR } from '@getodk/web-forms/components/common/canvas/useCanvasDrawing.ts';
+import type { CanvasModeConfig } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
 
 const CONTROL_ICONS = {
 	clearAll: 'mdiTrashCanOutline',

--- a/packages/web-forms/src/components/common/canvas/loadCanvas.ts
+++ b/packages/web-forms/src/components/common/canvas/loadCanvas.ts
@@ -6,7 +6,7 @@
  * when multiple "import('./CanvasBlock.vue')" calls are in-flight simultaneously.
  */
 import type { App, DefineComponent } from 'vue';
-import type { CanvasMode } from '@/components/common/canvas/getModeConfig.ts';
+import type { CanvasMode } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
 
 export type CanvasBlockComponent = DefineComponent<{
   mode: CanvasMode;

--- a/packages/web-forms/src/components/common/map/AsyncMap.vue
+++ b/packages/web-forms/src/components/common/map/AsyncMap.vue
@@ -4,12 +4,12 @@
  * This prevents unnecessary bloat in the main application bundle, reducing initial load times and improving performance.
  * Use dynamic imports instead (e.g., `await import(importPath)`) for lazy-loading these dependencies only when required.
  */
-import { createFeatureCollectionAndProps } from '@/components/common/map/geojson-parsers.ts';
-import type { Mode, SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
-import { loadMapBlock, type MapBlockComponent } from '@/components/common/map/loadMapBlock.ts';
-import AsyncLoader from '@/components/common/AsyncLoader.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { createFeatureCollectionAndProps } from '@getodk/web-forms/components/common/map/geojson-parsers.ts';
+import type { Mode, SingleFeatureType } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { loadMapBlock, type MapBlockComponent } from '@getodk/web-forms/components/common/map/loadMapBlock.ts';
+import AsyncLoader from '@getodk/web-forms/components/common/AsyncLoader.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { SelectItem } from '@getodk/xforms-engine';
 import { computed, inject, shallowRef } from 'vue';
 

--- a/packages/web-forms/src/components/common/map/MapAdvancedPanel.vue
+++ b/packages/web-forms/src/components/common/map/MapAdvancedPanel.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
 import {
 	isNullLocation,
 	isValidLatitude,
 	isValidLongitude,
 	toGeoJsonCoordinateArray,
-} from '@/components/common/map/geojson-parsers.ts';
+} from '@getodk/web-forms/components/common/map/geojson-parsers.ts';
 import { fromLonLat } from 'ol/proj';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { computed, inject, ref, watch } from 'vue';
 import type { Coordinate } from 'ol/coordinate';
 

--- a/packages/web-forms/src/components/common/map/MapBlock.vue
+++ b/packages/web-forms/src/components/common/map/MapBlock.vue
@@ -4,17 +4,17 @@
  * Keep OpenLayers imports/code here only to bundle separately and
  * load on demand. Avoids main bundle bloat.
  */
-import IconSVG from '@/components/common/IconSVG.vue';
-import { type Mode, type SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
-import MapAdvancedPanel from '@/components/common/map/MapAdvancedPanel.vue';
-import MapConfirmDialog from '@/components/common/map/MapConfirmDialog.vue';
-import MapControls from '@/components/common/map/MapControls.vue';
-import MapProperties from '@/components/common/map/MapProperties.vue';
-import MapStatusBar from '@/components/common/map/MapStatusBar.vue';
-import MapUpdateCoordsDialog from '@/components/common/map/MapUpdateCoordsDialog.vue';
-import { STATES, useMapBlock } from '@/components/common/map/useMapBlock.ts';
-import { TRANSLATE, QUESTION_HAS_ERROR } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { type Mode, type SingleFeatureType } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import MapAdvancedPanel from '@getodk/web-forms/components/common/map/MapAdvancedPanel.vue';
+import MapConfirmDialog from '@getodk/web-forms/components/common/map/MapConfirmDialog.vue';
+import MapControls from '@getodk/web-forms/components/common/map/MapControls.vue';
+import MapProperties from '@getodk/web-forms/components/common/map/MapProperties.vue';
+import MapStatusBar from '@getodk/web-forms/components/common/map/MapStatusBar.vue';
+import MapUpdateCoordsDialog from '@getodk/web-forms/components/common/map/MapUpdateCoordsDialog.vue';
+import { STATES, useMapBlock } from '@getodk/web-forms/components/common/map/useMapBlock.ts';
+import { TRANSLATE, QUESTION_HAS_ERROR } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { Feature, FeatureCollection } from 'geojson';
 import type { Coordinate } from 'ol/coordinate';
 import { toLonLat } from 'ol/proj';

--- a/packages/web-forms/src/components/common/map/MapConfirmDialog.vue
+++ b/packages/web-forms/src/components/common/map/MapConfirmDialog.vue
@@ -2,9 +2,9 @@
 import {
 	SINGLE_FEATURE_TYPES,
 	type SingleFeatureType,
-} from '@/components/common/map/getModeConfig.ts';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import { inject } from 'vue';

--- a/packages/web-forms/src/components/common/map/MapControls.vue
+++ b/packages/web-forms/src/components/common/map/MapControls.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import ActionsInfoDialog, { type ActionInfo } from '@/components/common/ActionsInfoDialog.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import ActionsInfoDialog, { type ActionInfo } from '@getodk/web-forms/components/common/ActionsInfoDialog.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { computed, inject, ref } from 'vue';
 
 const props = defineProps<{

--- a/packages/web-forms/src/components/common/map/MapProperties.vue
+++ b/packages/web-forms/src/components/common/map/MapProperties.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import { ODK_VALUE_PROPERTY } from '@/components/common/map/useMapBlock.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { ODK_VALUE_PROPERTY } from '@getodk/web-forms/components/common/map/useMapBlock.ts';
 import Button from 'primevue/button';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { computed, inject } from 'vue';
 
 const props = defineProps<{

--- a/packages/web-forms/src/components/common/map/MapStatusBar.vue
+++ b/packages/web-forms/src/components/common/map/MapStatusBar.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
 import {
 	SINGLE_FEATURE_TYPES,
 	type SingleFeatureType,
-} from '@/components/common/map/getModeConfig.ts';
-import { isCoordsEqual } from '@/components/common/map/vertex-geometry.ts';
-import { truncateGeoCoordinates, truncateDecimals } from '@/lib/format/truncate-decimals.ts';
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { isCoordsEqual } from '@getodk/web-forms/components/common/map/vertex-geometry.ts';
+import { truncateGeoCoordinates, truncateDecimals } from '@getodk/web-forms/lib/format/truncate-decimals.ts';
 import type { Feature, LineString, Point, Polygon, Position } from 'geojson';
 import type { Coordinate } from 'ol/coordinate';
 import { toLonLat } from 'ol/proj';
 import Button from 'primevue/button';
 import ProgressSpinner from 'primevue/progressspinner';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { computed, inject } from 'vue';
 
 interface StatusDetails {

--- a/packages/web-forms/src/components/common/map/MapUpdateCoordsDialog.vue
+++ b/packages/web-forms/src/components/common/map/MapUpdateCoordsDialog.vue
@@ -2,16 +2,16 @@
 import {
 	parseGeoJSONGeometry,
 	getGeometryFromJSON,
-} from '@/components/common/map/geojson-parsers.ts';
-import type { SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
-import { getValidCoordinates } from '@/components/common/map/map-helpers.ts';
+} from '@getodk/web-forms/components/common/map/geojson-parsers.ts';
+import type { SingleFeatureType } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { getValidCoordinates } from '@getodk/web-forms/components/common/map/map-helpers.ts';
 import type { Geometry, LineString, Point, Polygon } from 'geojson';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import Textarea from 'primevue/textarea';
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { inject, ref, watch } from 'vue';
 
 const props = defineProps<{

--- a/packages/web-forms/src/components/common/map/loadMapBlock.ts
+++ b/packages/web-forms/src/components/common/map/loadMapBlock.ts
@@ -6,7 +6,10 @@
  * when multiple "import('./MapBlock.vue')" calls are in-flight simultaneously.
  */
 import type { DefineComponent } from 'vue';
-import type { Mode, SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
+import type {
+  Mode,
+  SingleFeatureType,
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import type { Feature } from 'geojson';
 
 export type MapBlockComponent = DefineComponent<{

--- a/packages/web-forms/src/components/common/map/map-helpers.ts
+++ b/packages/web-forms/src/components/common/map/map-helpers.ts
@@ -1,8 +1,11 @@
 import {
   SINGLE_FEATURE_TYPES,
   type SingleFeatureType,
-} from '@/components/common/map/getModeConfig.ts';
-import { getFlatCoordinates, isCoordsEqual } from '@/components/common/map/vertex-geometry.ts';
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import {
+  getFlatCoordinates,
+  isCoordsEqual,
+} from '@getodk/web-forms/components/common/map/vertex-geometry.ts';
 import type { Coordinate } from 'ol/coordinate';
 import type Feature from 'ol/Feature';
 import type { LineString, Point, Polygon } from 'ol/geom';

--- a/packages/web-forms/src/components/common/map/map-styles.ts
+++ b/packages/web-forms/src/components/common/map/map-styles.ts
@@ -4,10 +4,10 @@ import { LineString, MultiPoint, Point, type Polygon } from 'ol/geom';
 import { Fill, Stroke, Style } from 'ol/style';
 import CircleStyle from 'ol/style/Circle';
 import type { Rule } from 'ol/style/flat';
-import mapLocationIcon from '@/assets/images/map-location.svg';
-import mapSavedLocationIcon from '@/assets/images/map-saved-location.svg';
+import mapLocationIcon from '@getodk/web-forms/assets/images/map-location.svg';
+import mapSavedLocationIcon from '@getodk/web-forms/assets/images/map-saved-location.svg';
 import type { StyleFunction } from 'ol/style/Style';
-import { getFlatCoordinates } from '@/components/common/map/vertex-geometry.ts';
+import { getFlatCoordinates } from '@getodk/web-forms/components/common/map/vertex-geometry.ts';
 import { Map } from 'ol';
 import { getPointResolution } from 'ol/proj';
 

--- a/packages/web-forms/src/components/common/map/useMapBlock.ts
+++ b/packages/web-forms/src/components/common/map/useMapBlock.ts
@@ -1,18 +1,21 @@
-import { toGeoJsonCoordinateArray } from '@/components/common/map/geojson-parsers.ts';
+import { toGeoJsonCoordinateArray } from '@getodk/web-forms/components/common/map/geojson-parsers.ts';
 import {
   getModeConfig,
   type Mode,
   MODES,
   SINGLE_FEATURE_TYPES,
   type SingleFeatureType,
-} from '@/components/common/map/getModeConfig.ts';
-import { formatODKValue, isWebGLAvailable } from '@/components/common/map/map-helpers.ts';
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import {
+  formatODKValue,
+  isWebGLAvailable,
+} from '@getodk/web-forms/components/common/map/map-helpers.ts';
 import {
   getDrawStyles,
   getSavedStyles,
   getSelectedStyles,
   getUnselectedStyles,
-} from '@/components/common/map/map-styles.ts';
+} from '@getodk/web-forms/components/common/map/map-styles.ts';
 import {
   FEATURE_ID_PROPERTY,
   IS_SELECTED_PROPERTY,
@@ -21,23 +24,23 @@ import {
   SELECTED_VERTEX_INDEX_PROPERTY,
   useMapFeatures,
   type UseMapFeatures,
-} from '@/components/common/map/useMapFeatures.ts';
+} from '@getodk/web-forms/components/common/map/useMapFeatures.ts';
 import {
   useMapInteractions,
   type UseMapInteractions,
-} from '@/components/common/map/useMapInteractions.ts';
+} from '@getodk/web-forms/components/common/map/useMapInteractions.ts';
 import {
   COORDINATE_LAYOUT_XYZM,
   DEFAULT_VIEW_CENTER,
   MIN_ZOOM,
   useMapViewControls,
   type UseMapViewControls,
-} from '@/components/common/map/useMapViewControls.ts';
+} from '@getodk/web-forms/components/common/map/useMapViewControls.ts';
 import {
   deleteVertexFromFeature,
   getVertexByIndex,
   updateVertexCoordinate,
-} from '@/components/common/map/vertex-geometry.ts';
+} from '@getodk/web-forms/components/common/map/vertex-geometry.ts';
 import type { Feature as GeoJsonFeature, FeatureCollection } from 'geojson';
 import { Map, View } from 'ol';
 import { Attribution, Zoom } from 'ol/control';
@@ -52,8 +55,8 @@ import { fromLonLat, get as getProjection } from 'ol/proj';
 import { OSM } from 'ol/source';
 import VectorSource from 'ol/source/Vector';
 import { shared as iconImageCache } from 'ol/style/IconImageCache';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { inject, shallowRef, watch } from 'vue';
 
 export const STATES = {

--- a/packages/web-forms/src/components/common/map/useMapFeatures.ts
+++ b/packages/web-forms/src/components/common/map/useMapFeatures.ts
@@ -2,12 +2,12 @@ import {
   type ModeCapabilities,
   SINGLE_FEATURE_TYPES,
   type SingleFeatureType,
-} from '@/components/common/map/getModeConfig.ts';
-import { ODK_VALUE_PROPERTY } from '@/components/common/map/useMapBlock.ts';
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { ODK_VALUE_PROPERTY } from '@getodk/web-forms/components/common/map/useMapBlock.ts';
 import {
   COORDINATE_LAYOUT_XYZM,
   type UseMapViewControls,
-} from '@/components/common/map/useMapViewControls.ts';
+} from '@getodk/web-forms/components/common/map/useMapViewControls.ts';
 import type { FeatureCollection, Feature as GeoJsonFeature } from 'geojson';
 import { Map } from 'ol';
 import type { Coordinate } from 'ol/coordinate';

--- a/packages/web-forms/src/components/common/map/useMapInteractions.ts
+++ b/packages/web-forms/src/components/common/map/useMapInteractions.ts
@@ -2,12 +2,12 @@ import {
   type ModeCapabilities,
   SINGLE_FEATURE_TYPES,
   type SingleFeatureType,
-} from '@/components/common/map/getModeConfig.ts';
-import { getPhantomPointStyle } from '@/components/common/map/map-styles.ts';
+} from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { getPhantomPointStyle } from '@getodk/web-forms/components/common/map/map-styles.ts';
 import {
   IS_SELECTED_PROPERTY,
   SELECTED_VERTEX_INDEX_PROPERTY,
-} from '@/components/common/map/useMapFeatures.ts';
+} from '@getodk/web-forms/components/common/map/useMapFeatures.ts';
 import {
   addShapeVertex,
   addTraceVertex,
@@ -15,7 +15,7 @@ import {
   getVertexIndex,
   isNearVertex,
   isOnFeatureEdge,
-} from '@/components/common/map/vertex-geometry.ts';
+} from '@getodk/web-forms/components/common/map/vertex-geometry.ts';
 import { Collection, Map, MapBrowserEvent } from 'ol';
 import type { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';

--- a/packages/web-forms/src/components/common/map/useMapViewControls.ts
+++ b/packages/web-forms/src/components/common/map/useMapViewControls.ts
@@ -1,5 +1,5 @@
-import { toGeoJsonCoordinateArray } from '@/components/common/map/geojson-parsers.ts';
-import { createCurrentLocationStyle } from '@/components/common/map/map-styles.ts';
+import { toGeoJsonCoordinateArray } from '@getodk/web-forms/components/common/map/geojson-parsers.ts';
+import { createCurrentLocationStyle } from '@getodk/web-forms/components/common/map/map-styles.ts';
 import type { TimerID } from '@getodk/common/types/timers.ts';
 import { Map, type View } from 'ol';
 import type { Coordinate } from 'ol/coordinate';

--- a/packages/web-forms/src/components/common/map/vertex-geometry.ts
+++ b/packages/web-forms/src/components/common/map/vertex-geometry.ts
@@ -1,4 +1,4 @@
-import { COORDINATE_LAYOUT_XYZM } from '@/components/common/map/useMapViewControls.ts';
+import { COORDINATE_LAYOUT_XYZM } from '@getodk/web-forms/components/common/map/useMapViewControls.ts';
 import type { Coordinate } from 'ol/coordinate';
 import Feature from 'ol/Feature';
 import { Point, LineString, Polygon } from 'ol/geom';

--- a/packages/web-forms/src/components/common/media/AudioBlock.vue
+++ b/packages/web-forms/src/components/common/media/AudioBlock.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import MediaBlockBase from '@/components/common/media/MediaBlockBase.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import MediaBlockBase from '@getodk/web-forms/components/common/media/MediaBlockBase.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import { inject, ref } from 'vue';
 

--- a/packages/web-forms/src/components/common/media/ImageBlock.vue
+++ b/packages/web-forms/src/components/common/media/ImageBlock.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import MediaBlockBase from '@/components/common/media/MediaBlockBase.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import MediaBlockBase from '@getodk/web-forms/components/common/media/MediaBlockBase.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import { computed, inject, ref, triggerRef } from 'vue';
 

--- a/packages/web-forms/src/components/common/media/MediaBlockBase.vue
+++ b/packages/web-forms/src/components/common/media/MediaBlockBase.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { FORM_MEDIA_CACHE, FORM_OPTIONS, TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { FormOptions } from '@/lib/init/load-form-state.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { FORM_MEDIA_CACHE, FORM_OPTIONS, TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { FormOptions } from '@getodk/web-forms/lib/init/load-form-state.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type {
 	JRResourceURL,
 	JRResourceURLString,

--- a/packages/web-forms/src/components/common/media/VideoBlock.vue
+++ b/packages/web-forms/src/components/common/media/VideoBlock.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import MediaBlockBase from '@/components/common/media/MediaBlockBase.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import MediaBlockBase from '@getodk/web-forms/components/common/media/MediaBlockBase.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { JRResourceURL } from '@getodk/common/jr-resources/JRResourceURL.ts';
 import { inject } from 'vue';
 

--- a/packages/web-forms/src/components/form-elements/ControlHint.vue
+++ b/packages/web-forms/src/components/form-elements/ControlHint.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
+import MarkdownBlock from '@getodk/web-forms/components/common/MarkdownBlock.vue';
 import type { AnyControlNode as QuestionNode } from '@getodk/xforms-engine';
 import { computed } from 'vue';
 const props = defineProps<{ question: QuestionNode }>();

--- a/packages/web-forms/src/components/form-elements/ControlLabel.vue
+++ b/packages/web-forms/src/components/form-elements/ControlLabel.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import AudioBlock from '@/components/common/media/AudioBlock.vue';
-import ImageBlock from '@/components/common/media/ImageBlock.vue';
-import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
-import VideoBlock from '@/components/common/media/VideoBlock.vue';
+import AudioBlock from '@getodk/web-forms/components/common/media/AudioBlock.vue';
+import ImageBlock from '@getodk/web-forms/components/common/media/ImageBlock.vue';
+import MarkdownBlock from '@getodk/web-forms/components/common/MarkdownBlock.vue';
+import VideoBlock from '@getodk/web-forms/components/common/media/VideoBlock.vue';
 import type { AnyControlNode as QuestionNode } from '@getodk/xforms-engine';
 import { computed } from 'vue';
 

--- a/packages/web-forms/src/components/form-elements/NoteControl.vue
+++ b/packages/web-forms/src/components/form-elements/NoteControl.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import GeolocationFormattedValue from '@/components/common/GeolocationFormattedValue.vue';
+import GeolocationFormattedValue from '@getodk/web-forms/components/common/GeolocationFormattedValue.vue';
 import { UnreachableError } from '@getodk/common/lib/error/UnreachableError.ts';
 import type {
 	AnyNoteNode,

--- a/packages/web-forms/src/components/form-elements/RankControl.vue
+++ b/packages/web-forms/src/components/form-elements/RankControl.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
-import ValidationMessage from '@/components/common/ValidationMessage.vue';
-import ControlText from '@/components/form-elements/ControlText.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import MarkdownBlock from '@getodk/web-forms/components/common/MarkdownBlock.vue';
+import ValidationMessage from '@getodk/web-forms/components/common/ValidationMessage.vue';
+import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { TimerID } from '@getodk/common/types/timers.ts';
 import type { RankNode } from '@getodk/xforms-engine';
 import { inject, type Ref } from 'vue';

--- a/packages/web-forms/src/components/form-elements/TriggerControl.vue
+++ b/packages/web-forms/src/components/form-elements/TriggerControl.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { TriggerNode } from '@getodk/xforms-engine';
 import Checkbox from 'primevue/checkbox';
 import { inject } from 'vue';

--- a/packages/web-forms/src/components/form-elements/input/InputControl.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputControl.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { SINGLE_FEATURE_TYPES } from '@/components/common/map/getModeConfig.ts';
-import ValidationMessage from '@/components/common/ValidationMessage.vue';
-import ControlText from '@/components/form-elements/ControlText.vue';
-import InputGeopoint from '@/components/form-elements/input/geopoint/InputGeopoint.vue';
-import InputGeopointWithMap from '@/components/form-elements/input/InputGeopointWithMap.vue';
-import InputDate from '@/components/form-elements/input/InputDate.vue';
-import InputDateTime from '@/components/form-elements/input/InputDateTime.vue';
-import InputDecimal from '@/components/form-elements/input/InputDecimal.vue';
-import InputGeoMultiPoint from '@/components/form-elements/input/InputGeoMultiPoint.vue';
-import InputInt from '@/components/form-elements/input/InputInt.vue';
-import InputNumbersAppearance from '@/components/form-elements/input/InputNumbersAppearance.vue';
-import InputText from '@/components/form-elements/input/InputText.vue';
-import InputTime from '@/components/form-elements/input/InputTime.vue';
-import { IS_FORM_EDIT_MODE } from '@/lib/constants/injection-keys.ts';
+import { SINGLE_FEATURE_TYPES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import ValidationMessage from '@getodk/web-forms/components/common/ValidationMessage.vue';
+import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
+import InputGeopoint from '@getodk/web-forms/components/form-elements/input/geopoint/InputGeopoint.vue';
+import InputGeopointWithMap from '@getodk/web-forms/components/form-elements/input/InputGeopointWithMap.vue';
+import InputDate from '@getodk/web-forms/components/form-elements/input/InputDate.vue';
+import InputDateTime from '@getodk/web-forms/components/form-elements/input/InputDateTime.vue';
+import InputDecimal from '@getodk/web-forms/components/form-elements/input/InputDecimal.vue';
+import InputGeoMultiPoint from '@getodk/web-forms/components/form-elements/input/InputGeoMultiPoint.vue';
+import InputInt from '@getodk/web-forms/components/form-elements/input/InputInt.vue';
+import InputNumbersAppearance from '@getodk/web-forms/components/form-elements/input/InputNumbersAppearance.vue';
+import InputText from '@getodk/web-forms/components/form-elements/input/InputText.vue';
+import InputTime from '@getodk/web-forms/components/form-elements/input/InputTime.vue';
+import { IS_FORM_EDIT_MODE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { AnyInputNode } from '@getodk/xforms-engine';
 import { inject } from 'vue';
 

--- a/packages/web-forms/src/components/form-elements/input/InputGeoMultiPoint.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputGeoMultiPoint.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import AsyncMap from '@/components/common/map/AsyncMap.vue';
-import { MODES, type SingleFeatureType } from '@/components/common/map/getModeConfig.ts';
+import AsyncMap from '@getodk/web-forms/components/common/map/AsyncMap.vue';
+import { MODES, type SingleFeatureType } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import type { GeoshapeInputNode, GeotraceInputNode } from '@getodk/xforms-engine';
 
 interface InputGeoMultiPointProps {

--- a/packages/web-forms/src/components/form-elements/input/InputGeopointWithMap.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputGeopointWithMap.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import AsyncMap from '@/components/common/map/AsyncMap.vue';
-import { type Mode, MODES, SINGLE_FEATURE_TYPES } from '@/components/common/map/getModeConfig.ts';
-import { IS_FORM_EDIT_MODE } from '@/lib/constants/injection-keys.ts';
+import AsyncMap from '@getodk/web-forms/components/common/map/AsyncMap.vue';
+import { type Mode, MODES, SINGLE_FEATURE_TYPES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
+import { IS_FORM_EDIT_MODE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { GeopointInputNode } from '@getodk/xforms-engine';
 import { computed, inject, type ShallowRef } from 'vue';
 

--- a/packages/web-forms/src/components/form-elements/input/InputTime.vue
+++ b/packages/web-forms/src/components/form-elements/input/InputTime.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
 import { ISO_TIME_WITH_OPTIONAL_OFFSET_PATTERN } from '@getodk/common/constants/datetime.ts';
 import type { TimeInputNode } from '@getodk/xforms-engine';
 import DatePicker from 'primevue/datepicker';

--- a/packages/web-forms/src/components/form-elements/input/geopoint/GeolocationRequestDialog.vue
+++ b/packages/web-forms/src/components/form-elements/input/geopoint/GeolocationRequestDialog.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import ElapsedTime from '@/components/common/ElapsedTime.vue';
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
-import { truncateDecimals } from '@/lib/format/truncate-decimals.ts';
+import ElapsedTime from '@getodk/web-forms/components/common/ElapsedTime.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
+import { truncateDecimals } from '@getodk/web-forms/lib/format/truncate-decimals.ts';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import ProgressSpinner from 'primevue/progressspinner';

--- a/packages/web-forms/src/components/form-elements/input/geopoint/InputGeopoint.vue
+++ b/packages/web-forms/src/components/form-elements/input/geopoint/InputGeopoint.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import GeolocationFormattedValue from '@/components/common/GeolocationFormattedValue.vue';
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE, QUESTION_HAS_ERROR } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import GeolocationFormattedValue from '@getodk/web-forms/components/common/GeolocationFormattedValue.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE, QUESTION_HAS_ERROR } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import { computed, type ComputedRef, inject, ref } from 'vue';
 import Button from 'primevue/button';
 import type { GeopointInputNode } from '@getodk/xforms-engine';

--- a/packages/web-forms/src/components/form-elements/select/Select1Control.vue
+++ b/packages/web-forms/src/components/form-elements/select/Select1Control.vue
@@ -1,15 +1,15 @@
 <script lang="ts" setup>
-import ColumnarAppearance from '@/components/appearances/ColumnarAppearance.vue';
-import FieldListTable from '@/components/appearances/FieldListTable.vue';
-import UnsupportedAppearance from '@/components/appearances/UnsupportedAppearance.vue';
-import LikertWidget from '@/components/common/LikertWidget.vue';
-import AsyncMap from '@/components/common/map/AsyncMap.vue';
-import RadioButton from '@/components/common/RadioButton.vue';
-import SearchableDropdown from '@/components/common/SearchableDropdown.vue';
-import ValidationMessage from '@/components/common/ValidationMessage.vue';
-import ControlText from '@/components/form-elements/ControlText.vue';
+import ColumnarAppearance from '@getodk/web-forms/components/appearances/ColumnarAppearance.vue';
+import FieldListTable from '@getodk/web-forms/components/appearances/FieldListTable.vue';
+import UnsupportedAppearance from '@getodk/web-forms/components/appearances/UnsupportedAppearance.vue';
+import LikertWidget from '@getodk/web-forms/components/common/LikertWidget.vue';
+import AsyncMap from '@getodk/web-forms/components/common/map/AsyncMap.vue';
+import RadioButton from '@getodk/web-forms/components/common/RadioButton.vue';
+import SearchableDropdown from '@getodk/web-forms/components/common/SearchableDropdown.vue';
+import ValidationMessage from '@getodk/web-forms/components/common/ValidationMessage.vue';
+import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
 import type { SelectNode } from '@getodk/xforms-engine';
-import { MODES } from '@/components/common/map/getModeConfig.ts';
+import { MODES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import { computed, ref, watchEffect } from 'vue';
 
 interface Select1ControlProps {

--- a/packages/web-forms/src/components/form-elements/select/SelectNControl.vue
+++ b/packages/web-forms/src/components/form-elements/select/SelectNControl.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
-import ColumnarAppearance from '@/components/appearances/ColumnarAppearance.vue';
-import FieldListTable from '@/components/appearances/FieldListTable.vue';
-import UnsupportedAppearance from '@/components/appearances/UnsupportedAppearance.vue';
-import CheckboxWidget from '@/components/common/CheckboxWidget.vue';
-import MultiselectDropdown from '@/components/common/MultiselectDropdown.vue';
-import ValidationMessage from '@/components/common/ValidationMessage.vue';
-import ControlText from '@/components/form-elements/ControlText.vue';
+import ColumnarAppearance from '@getodk/web-forms/components/appearances/ColumnarAppearance.vue';
+import FieldListTable from '@getodk/web-forms/components/appearances/FieldListTable.vue';
+import UnsupportedAppearance from '@getodk/web-forms/components/appearances/UnsupportedAppearance.vue';
+import CheckboxWidget from '@getodk/web-forms/components/common/CheckboxWidget.vue';
+import MultiselectDropdown from '@getodk/web-forms/components/common/MultiselectDropdown.vue';
+import ValidationMessage from '@getodk/web-forms/components/common/ValidationMessage.vue';
+import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
 import type { SelectNode } from '@getodk/xforms-engine';
 import { computed, ref, watchEffect } from 'vue';
 

--- a/packages/web-forms/src/components/form-elements/upload/DeleteConfirmDialog.vue
+++ b/packages/web-forms/src/components/form-elements/upload/DeleteConfirmDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import { inject } from 'vue';

--- a/packages/web-forms/src/components/form-elements/upload/UploadAudioHeader.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadAudioHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import type { HTMLInputElementEvent, Ref } from 'vue';

--- a/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadControl.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { getModeConfig, MODES, VALID_CANVAS_MODES } from '@/components/common/canvas/getModeConfig.ts';
-import IconSVG from '@/components/common/IconSVG.vue';
-import ControlText from '@/components/form-elements/ControlText.vue';
-import { FORM_OPTIONS, TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import { resize } from '@/lib/services/resizeImage';
-import type { FormOptions } from '@/lib/init/load-form-state';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { getModeConfig, MODES, VALID_CANVAS_MODES } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
+import { FORM_OPTIONS, TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import { resize } from '@getodk/web-forms/lib/services/resizeImage';
+import type { FormOptions } from '@getodk/web-forms/lib/init/load-form-state';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import Message from 'primevue/message';

--- a/packages/web-forms/src/components/form-elements/upload/UploadFileHeader.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadFileHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import type { HTMLInputElementEvent, Ref } from 'vue';

--- a/packages/web-forms/src/components/form-elements/upload/UploadImageHeader.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadImageHeader.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { getModeConfig, MODES, type CanvasMode } from '@/components/common/canvas/getModeConfig.ts';
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { getModeConfig, MODES, type CanvasMode } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import type { HTMLInputElementEvent, Ref } from 'vue';

--- a/packages/web-forms/src/components/form-elements/upload/UploadImagePreview.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadImagePreview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import AsyncCanvas from '@/components/common/canvas/AsyncCanvas.vue';
-import { getModeConfig, type CanvasMode } from '@/components/common/canvas/getModeConfig.ts';
-import ImageBlock from '@/components/common/media/ImageBlock.vue';
+import AsyncCanvas from '@getodk/web-forms/components/common/canvas/AsyncCanvas.vue';
+import { getModeConfig, type CanvasMode } from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
+import ImageBlock from '@getodk/web-forms/components/common/media/ImageBlock.vue';
 import { computed } from 'vue';
 
 type ObjectURL = `blob:${string}`;

--- a/packages/web-forms/src/components/form-elements/upload/UploadVideoHeader.vue
+++ b/packages/web-forms/src/components/form-elements/upload/UploadVideoHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import type { HTMLInputElementEvent, Ref } from 'vue';

--- a/packages/web-forms/src/components/form-layout/FormFooter.vue
+++ b/packages/web-forms/src/components/form-layout/FormFooter.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { RootNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import { inject } from 'vue';

--- a/packages/web-forms/src/components/form-layout/FormLanguageMenu.vue
+++ b/packages/web-forms/src/components/form-layout/FormLanguageMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
 import type { ActiveLanguage, FormLanguage } from '@getodk/xforms-engine';
 import Select from 'primevue/select';
 

--- a/packages/web-forms/src/components/form-layout/FormPanel.vue
+++ b/packages/web-forms/src/components/form-layout/FormPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import MarkdownBlock from '@getodk/web-forms/components/common/MarkdownBlock.vue';
 import type { MarkdownNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import Menu, { type MenuState } from 'primevue/menu';

--- a/packages/web-forms/src/components/form-layout/FormQuestion.vue
+++ b/packages/web-forms/src/components/form-layout/FormQuestion.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { QUESTION_HAS_ERROR, SUBMIT_PRESSED } from '@/lib/constants/injection-keys.ts';
+import { QUESTION_HAS_ERROR, SUBMIT_PRESSED } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type {
 	AnyInputNode,
 	AnyNoteNode,
@@ -8,13 +8,13 @@ import type {
 	SelectNode,
 } from '@getodk/xforms-engine';
 import { computed, inject, provide, type Ref, ref, watch } from 'vue';
-import InputControl from '@/components/form-elements/input/InputControl.vue';
+import InputControl from '@getodk/web-forms/components/form-elements/input/InputControl.vue';
 import NoteControl from '../form-elements/NoteControl.vue';
-import RangeControl from '@/components/form-elements/range/RangeControl.vue';
+import RangeControl from '@getodk/web-forms/components/form-elements/range/RangeControl.vue';
 import RankControl from '../form-elements/RankControl.vue';
-import SelectControl from '@/components/form-elements/select/SelectControl.vue';
+import SelectControl from '@getodk/web-forms/components/form-elements/select/SelectControl.vue';
 import TriggerControl from '../form-elements/TriggerControl.vue';
-import UploadControl from '@/components/form-elements/upload/UploadControl.vue';
+import UploadControl from '@getodk/web-forms/components/form-elements/upload/UploadControl.vue';
 
 const props = defineProps<{ question: ControlNode }>();
 

--- a/packages/web-forms/src/components/form-layout/QuestionList.vue
+++ b/packages/web-forms/src/components/form-layout/QuestionList.vue
@@ -5,7 +5,7 @@ import type {
 	GroupNode,
 	RepeatRangeNode,
 } from '@getodk/xforms-engine';
-import { isOnCurrentPage } from '@/lib/pagination/pagination.ts';
+import { isOnCurrentPage } from '@getodk/web-forms/lib/pagination/pagination.ts';
 import ExpectModelNode from '../dev-only/ExpectModelNode.vue';
 import FormGroup from './FormGroup.vue';
 import FormQuestion from './FormQuestion.vue';

--- a/packages/web-forms/src/components/form-layout/RepeatInstance.vue
+++ b/packages/web-forms/src/components/form-layout/RepeatInstance.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { GeneralChildNode, GroupNode, RepeatInstanceNode } from '@getodk/xforms-engine';
 import { type MenuItem } from 'primevue/menuitem';
 import { computed, inject } from 'vue';

--- a/packages/web-forms/src/components/form-layout/RepeatRange.vue
+++ b/packages/web-forms/src/components/form-layout/RepeatRange.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import IconSVG from '@/components/common/IconSVG.vue';
-import MarkdownBlock from '@/components/common/MarkdownBlock.vue';
-import { TRANSLATE } from '@/lib/constants/injection-keys.ts';
-import type { Translate } from '@/lib/locale/useLocale.ts';
-import { isOnCurrentPage } from '@/lib/pagination/pagination.ts';
+import IconSVG from '@getodk/web-forms/components/common/IconSVG.vue';
+import MarkdownBlock from '@getodk/web-forms/components/common/MarkdownBlock.vue';
+import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
+import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
+import { isOnCurrentPage } from '@getodk/web-forms/lib/pagination/pagination.ts';
 import type { RepeatRangeNode, RepeatRangeUncontrolledNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
 import { computed, inject } from 'vue';

--- a/packages/web-forms/src/index.ts
+++ b/packages/web-forms/src/index.ts
@@ -1,6 +1,6 @@
 import { webFormsPlugin } from './web-forms-plugin';
 import OdkWebForm from './components/OdkWebForm.vue';
-import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow.ts';
+import { POST_SUBMIT__NEW_INSTANCE } from './lib/constants/control-flow.ts';
 
 // Applies styles when Web Forms is used as a plugin.
 import '@fontsource/roboto/300.css';

--- a/packages/web-forms/src/index.ts
+++ b/packages/web-forms/src/index.ts
@@ -1,6 +1,6 @@
 import { webFormsPlugin } from './web-forms-plugin';
-import OdkWebForm from './components/OdkWebForm.vue';
-import { POST_SUBMIT__NEW_INSTANCE } from './lib/constants/control-flow.ts';
+import OdkWebForm from '@getodk/web-forms/components/OdkWebForm.vue';
+import { POST_SUBMIT__NEW_INSTANCE } from '@getodk/web-forms/lib/constants/control-flow.ts';
 
 // Applies styles when Web Forms is used as a plugin.
 import '@fontsource/roboto/300.css';

--- a/packages/web-forms/src/lib/init/engine-config.ts
+++ b/packages/web-forms/src/lib/init/engine-config.ts
@@ -1,4 +1,4 @@
-import type { FormOptions } from '@/lib/init/load-form-state.ts';
+import type { FormOptions } from '@getodk/web-forms/lib/init/load-form-state.ts';
 import type {
   EditFormInstance,
   InstanceAttachmentsConfig,

--- a/packages/web-forms/src/lib/init/update-submitted-form-state.ts
+++ b/packages/web-forms/src/lib/init/update-submitted-form-state.ts
@@ -1,6 +1,6 @@
-import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow.ts';
-import type { FormOptions } from '@/lib/init/load-form-state.ts';
-import type { OptionalHostSubmissionResult } from '@/lib/submission/host-submission-result-callback.ts';
+import { POST_SUBMIT__NEW_INSTANCE } from '@getodk/web-forms/lib/constants/control-flow.ts';
+import type { FormOptions } from '@getodk/web-forms/lib/init/load-form-state.ts';
+import type { OptionalHostSubmissionResult } from '@getodk/web-forms/lib/submission/host-submission-result-callback.ts';
 import type { InstanceDefaults, PreloadProperties } from '@getodk/xforms-engine';
 import { getFormInstanceConfig } from './engine-config.ts';
 import type { FormStateSuccessResult } from './form-state.ts';

--- a/packages/web-forms/src/lib/locale/useLocale.ts
+++ b/packages/web-forms/src/lib/locale/useLocale.ts
@@ -5,7 +5,7 @@ import { usePrimeVue } from 'primevue/config';
 import type { Ref } from 'vue';
 import { computed, onUnmounted, shallowRef, watch } from 'vue';
 // English strings always available as language fallback
-import enRaw from '@locales/strings_en.json';
+import enRaw from '../../../locales/strings_en.json';
 
 export type TranslateValues = NonNullable<Parameters<IntlShape['formatMessage']>[1]>;
 export type Translate = (id: string, values?: TranslateValues) => string;
@@ -16,7 +16,7 @@ const FALLBACK = 'en';
 export const STORAGE_KEY = 'odk-web-forms-locale';
 
 const availableTranslations = import.meta.glob<{ default: TransifexTranslation }>(
-  '@locales/strings_*.json'
+  '../../../locales/strings_*.json'
 );
 
 /**

--- a/packages/web-forms/src/web-forms-plugin.ts
+++ b/packages/web-forms/src/web-forms-plugin.ts
@@ -1,4 +1,4 @@
-import { odkThemePreset } from '@/odk-theme-preset.ts';
+import { odkThemePreset } from './odk-theme-preset.ts';
 import { type App } from 'vue';
 import PrimeVue from 'primevue/config';
 import resetStyles from './assets/styles/reset.scss?raw';

--- a/packages/web-forms/tests/components/OdkWebForm.test.ts
+++ b/packages/web-forms/tests/components/OdkWebForm.test.ts
@@ -1,12 +1,12 @@
-import type { OdkWebFormsProps } from '@/components/OdkWebForm.vue';
-import OdkWebForm from '@/components/OdkWebForm.vue';
-import { waitAllTasksToFinish } from '@/lib/async/event-loop.ts';
-import { POST_SUBMIT__NEW_INSTANCE } from '@/lib/constants/control-flow.ts';
+import type { OdkWebFormsProps } from '@getodk/web-forms/components/OdkWebForm.vue';
+import OdkWebForm from '@getodk/web-forms/components/OdkWebForm.vue';
+import { waitAllTasksToFinish } from '@getodk/web-forms/lib/async/event-loop.ts';
+import { POST_SUBMIT__NEW_INSTANCE } from '@getodk/web-forms/lib/constants/control-flow.ts';
 import type {
   HostSubmissionResult,
   HostSubmissionResultCallback,
   OptionalAwaitableHostSubmissionResult,
-} from '@/lib/submission/host-submission-result-callback.ts';
+} from '@getodk/web-forms/lib/submission/host-submission-result-callback.ts';
 import type {
   MonolithicInstancePayload,
   ResolvableInstanceAttachmentsMap,

--- a/packages/web-forms/tests/components/common/canvas/getModeConfig.test.ts
+++ b/packages/web-forms/tests/components/common/canvas/getModeConfig.test.ts
@@ -2,7 +2,7 @@ import {
   getModeConfig,
   MODES,
   VALID_CANVAS_MODES,
-} from '@/components/common/canvas/getModeConfig.ts';
+} from '@getodk/web-forms/components/common/canvas/getModeConfig.ts';
 import { describe, it, expect } from 'vitest';
 
 describe('getModeConfig', () => {

--- a/packages/web-forms/tests/components/common/map/geojson-parsers.test.ts
+++ b/packages/web-forms/tests/components/common/map/geojson-parsers.test.ts
@@ -4,7 +4,7 @@ import {
   parseGeoJSONGeometry,
   getGeometryFromJSON,
   toGeoJsonCoordinateArray,
-} from '@/components/common/map/geojson-parsers.ts';
+} from '@getodk/web-forms/components/common/map/geojson-parsers.ts';
 import type { SelectItem } from '@getodk/xforms-engine';
 
 describe('GeoJson Parsers', () => {

--- a/packages/web-forms/tests/components/common/map/getModeConfig.test.ts
+++ b/packages/web-forms/tests/components/common/map/getModeConfig.test.ts
@@ -1,4 +1,4 @@
-import { getModeConfig, MODES } from '@/components/common/map/getModeConfig.ts';
+import { getModeConfig, MODES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import { describe, it, expect } from 'vitest';
 
 describe('getModeConfig', () => {

--- a/packages/web-forms/tests/components/common/map/map-helpers.test.ts
+++ b/packages/web-forms/tests/components/common/map/map-helpers.test.ts
@@ -1,10 +1,10 @@
-import { SINGLE_FEATURE_TYPES } from '@/components/common/map/getModeConfig.ts';
+import { SINGLE_FEATURE_TYPES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import {
   formatODKValue,
   getValidCoordinates,
   toODKCoordinateArray,
-} from '@/components/common/map/map-helpers.ts';
-import { COORDINATE_LAYOUT_XYZM } from '@/components/common/map/useMapViewControls.ts';
+} from '@getodk/web-forms/components/common/map/map-helpers.ts';
+import { COORDINATE_LAYOUT_XYZM } from '@getodk/web-forms/components/common/map/useMapViewControls.ts';
 import Feature from 'ol/Feature';
 import { LineString, Point, Polygon } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';

--- a/packages/web-forms/tests/components/common/map/map-styles.test.ts
+++ b/packages/web-forms/tests/components/common/map/map-styles.test.ts
@@ -4,7 +4,7 @@ import {
   getSavedStyles,
   getSelectedStyles,
   getUnselectedStyles,
-} from '@/components/common/map/map-styles.ts';
+} from '@getodk/web-forms/components/common/map/map-styles.ts';
 import Feature from 'ol/Feature';
 import { LineString, MultiPoint, Point, Polygon } from 'ol/geom';
 import { Style } from 'ol/style';

--- a/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
+++ b/packages/web-forms/tests/components/form-elements/ControlLabel.test.ts
@@ -1,4 +1,4 @@
-import ControlLabel from '@/components/form-elements/ControlLabel.vue';
+import ControlLabel from '@getodk/web-forms/components/form-elements/ControlLabel.vue';
 import type { AnyInputNode } from '@getodk/xforms-engine';
 import { mount } from '@vue/test-utils';
 import { assocPath } from 'ramda';

--- a/packages/web-forms/tests/components/form-elements/RankControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/RankControl.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { DOMWrapper, mount, VueWrapper } from '@vue/test-utils';
 import { getReactiveForm, globalMountOptions } from '../../helpers.ts';
-import QuestionList from '@/components/form-layout/QuestionList.vue';
-import FormQuestion from '@/components/form-layout/FormQuestion.vue';
-import SelectControl from '@/components/form-elements/select/SelectControl.vue';
-import RankControl from '@/components/form-elements/RankControl.vue';
+import QuestionList from '@getodk/web-forms/components/form-layout/QuestionList.vue';
+import FormQuestion from '@getodk/web-forms/components/form-layout/FormQuestion.vue';
+import SelectControl from '@getodk/web-forms/components/form-elements/select/SelectControl.vue';
+import RankControl from '@getodk/web-forms/components/form-elements/RankControl.vue';
 import type { RankNode } from '@getodk/xforms-engine';
 
 describe('RankControl', () => {

--- a/packages/web-forms/tests/components/form-elements/input/InputControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/input/InputControl.test.ts
@@ -1,5 +1,8 @@
-import FormQuestion from '@/components/form-layout/FormQuestion.vue';
-import { SUBMIT_PRESSED, IS_FORM_EDIT_MODE } from '@/lib/constants/injection-keys.ts';
+import FormQuestion from '@getodk/web-forms/components/form-layout/FormQuestion.vue';
+import {
+  SUBMIT_PRESSED,
+  IS_FORM_EDIT_MODE,
+} from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import { mount } from '@vue/test-utils';
 import { assert, describe, expect, it } from 'vitest';
 import { ref, shallowRef } from 'vue';

--- a/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
@@ -1,5 +1,5 @@
-import FormQuestion from '@/components/form-layout/FormQuestion.vue';
-import { SUBMIT_PRESSED } from '@/lib/constants/injection-keys.ts';
+import FormQuestion from '@getodk/web-forms/components/form-layout/FormQuestion.vue';
+import { SUBMIT_PRESSED } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { AnyNode, RootNode, SelectNode } from '@getodk/xforms-engine';
 import { DOMWrapper, mount } from '@vue/test-utils';
 import { assert, beforeEach, describe, expect, it } from 'vitest';

--- a/packages/web-forms/tests/components/form-layout/FormHeader.test.ts
+++ b/packages/web-forms/tests/components/form-layout/FormHeader.test.ts
@@ -1,4 +1,4 @@
-import FormHeader from '@/components/form-layout/FormHeader.vue';
+import FormHeader from '@getodk/web-forms/components/form-layout/FormHeader.vue';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { getReactiveForm } from '../../helpers.ts';

--- a/packages/web-forms/tests/components/form-layout/FormLanguageMenu.test.ts
+++ b/packages/web-forms/tests/components/form-layout/FormLanguageMenu.test.ts
@@ -1,4 +1,4 @@
-import FormLanguageMenu from '@/components/form-layout/FormLanguageMenu.vue';
+import FormLanguageMenu from '@getodk/web-forms/components/form-layout/FormLanguageMenu.vue';
 import type { FormLanguage, SyntheticDefaultLanguage } from '@getodk/xforms-engine';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';

--- a/packages/web-forms/tests/components/form-layout/FormPanel.test.ts
+++ b/packages/web-forms/tests/components/form-layout/FormPanel.test.ts
@@ -1,4 +1,4 @@
-import FormPanel, { type PanelProps } from '@/components/form-layout/FormPanel.vue';
+import FormPanel, { type PanelProps } from '@getodk/web-forms/components/form-layout/FormPanel.vue';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { globalMountOptions } from '../../helpers.ts';

--- a/packages/web-forms/tests/components/form-layout/FormQuestion.test.ts
+++ b/packages/web-forms/tests/components/form-layout/FormQuestion.test.ts
@@ -1,8 +1,8 @@
-import InputControl from '@/components/form-elements/input/InputControl.vue';
-import RankControl from '@/components/form-elements/RankControl.vue';
-import SelectControl from '@/components/form-elements/select/SelectControl.vue';
-import FormQuestion from '@/components/form-layout/FormQuestion.vue';
-import { IS_FORM_EDIT_MODE } from '@/lib/constants/injection-keys.ts';
+import InputControl from '@getodk/web-forms/components/form-elements/input/InputControl.vue';
+import RankControl from '@getodk/web-forms/components/form-elements/RankControl.vue';
+import SelectControl from '@getodk/web-forms/components/form-elements/select/SelectControl.vue';
+import FormQuestion from '@getodk/web-forms/components/form-layout/FormQuestion.vue';
+import { IS_FORM_EDIT_MODE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';

--- a/packages/web-forms/tests/components/form-layout/RepeatRange.test.ts
+++ b/packages/web-forms/tests/components/form-layout/RepeatRange.test.ts
@@ -1,7 +1,7 @@
-import FormGroup from '@/components/form-layout/FormGroup.vue';
-import RepeatInstance from '@/components/form-layout/RepeatInstance.vue';
-import RepeatRange from '@/components/form-layout/RepeatRange.vue';
-import { IS_FORM_EDIT_MODE } from '@/lib/constants/injection-keys.ts';
+import FormGroup from '@getodk/web-forms/components/form-layout/FormGroup.vue';
+import RepeatInstance from '@getodk/web-forms/components/form-layout/RepeatInstance.vue';
+import RepeatRange from '@getodk/web-forms/components/form-layout/RepeatRange.vue';
+import { IS_FORM_EDIT_MODE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { RepeatRangeNode } from '@getodk/xforms-engine';
 import { mount } from '@vue/test-utils';
 import { assert, describe, expect, it } from 'vitest';

--- a/packages/web-forms/tests/helpers.ts
+++ b/packages/web-forms/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { TRANSLATE, SUBMIT_PRESSED } from '@/lib/constants/injection-keys.ts';
+import { TRANSLATE, SUBMIT_PRESSED } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { AnyFunction } from '@getodk/common/types/helpers.d.ts';
 import type { RootNode } from '@getodk/xforms-engine';
 import { createInstance } from '@getodk/xforms-engine';

--- a/packages/web-forms/tests/lib/locale/useLocale.test.ts
+++ b/packages/web-forms/tests/lib/locale/useLocale.test.ts
@@ -1,4 +1,8 @@
-import { normalizeMessages, STORAGE_KEY, useLocale } from '@/lib/locale/useLocale.ts';
+import {
+  normalizeMessages,
+  STORAGE_KEY,
+  useLocale,
+} from '@getodk/web-forms/lib/locale/useLocale.ts';
 import type { FormLanguage, RootNode } from '@getodk/xforms-engine';
 import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/web-forms/tsconfig.app.json
+++ b/packages/web-forms/tsconfig.app.json
@@ -24,8 +24,6 @@
     "noEmit": false,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "paths": {
-      "@/*": ["./src/*"],
-      "@locales/*": ["./locales/*"],
       "@getodk/common/test-utils/*": ["../common/test-utils/*"],
       "@getodk/common/types/*": ["../common/types/*"],
       "@getodk/common/*": ["../common/src/*"],

--- a/packages/web-forms/tsconfig.app.json
+++ b/packages/web-forms/tsconfig.app.json
@@ -28,7 +28,8 @@
       "@locales/*": ["./locales/*"],
       "@getodk/common/test-utils/*": ["../common/test-utils/*"],
       "@getodk/common/types/*": ["../common/types/*"],
-      "@getodk/common/*": ["../common/src/*"]
+      "@getodk/common/*": ["../common/src/*"],
+      "@getodk/web-forms/*": ["./src/*"]
     },
     "types": ["node"],
     "skipLibCheck": true,

--- a/packages/web-forms/vite.config.e2e.ts
+++ b/packages/web-forms/vite.config.e2e.ts
@@ -78,12 +78,13 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@getodk/common': resolve(__dirname, '../common/src'),
-        '@': fileURLToPath(new URL('./src', import.meta.url)),
-        '@locales': fileURLToPath(new URL('./locales', import.meta.url)),
+        '@getodk/xforms-engine': resolve(__dirname, '../xforms-engine/src'),
+        '@getodk/xpath': resolve(__dirname, '../xpath/src'),
+        '@getodk/web-forms': resolve(__dirname, './src'),
         'primevue/menuitem': 'primevue/menu',
         // With following lines, fonts byte array are copied into css file
         // Roboto fonts
-        './fonts': resolve('../../node_modules/@fontsource/roboto'),
+        // './fonts': resolve('../../node_modules/@fontsource/roboto'),
       },
     },
     css: {

--- a/packages/web-forms/vite.config.e2e.ts
+++ b/packages/web-forms/vite.config.e2e.ts
@@ -77,13 +77,10 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@getodk/common': resolve(__dirname, '../common/src'),
+        '@getodk/web-forms': resolve(__dirname, './src'),
         '@getodk/xforms-engine': resolve(__dirname, '../xforms-engine/src'),
         '@getodk/xpath': resolve(__dirname, '../xpath/src'),
-        '@getodk/web-forms': resolve(__dirname, './src'),
         'primevue/menuitem': 'primevue/menu',
-        // With following lines, fonts byte array are copied into css file
-        // Roboto fonts
-        // './fonts': resolve('../../node_modules/@fontsource/roboto'),
       },
     },
     css: {

--- a/packages/web-forms/vite.config.e2e.ts
+++ b/packages/web-forms/vite.config.e2e.ts
@@ -4,7 +4,6 @@ import vueJsx from '@vitejs/plugin-vue-jsx';
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -83,7 +83,7 @@ export default defineConfig(({ mode }) => {
         'primevue/menuitem': 'primevue/menu',
         // With following lines, fonts byte array are copied into css file
         // Roboto fonts
-        './fonts': resolve('../../node_modules/@fontsource/roboto'),
+        // './fonts': resolve('../../node_modules/@fontsource/roboto'),
       },
     },
     build: {

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -77,13 +77,10 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@getodk/common': resolve(__dirname, '../common/src'),
+        '@getodk/web-forms': resolve(__dirname, './src'),
         '@getodk/xforms-engine': resolve(__dirname, '../xforms-engine/src'),
         '@getodk/xpath': resolve(__dirname, '../xpath/src'),
-        '@getodk/web-forms': resolve(__dirname, './src'),
         'primevue/menuitem': 'primevue/menu',
-        // With following lines, fonts byte array are copied into css file
-        // Roboto fonts
-        // './fonts': resolve('../../node_modules/@fontsource/roboto'),
       },
     },
     build: {

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -114,7 +114,7 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         external: ['vue'],
         onwarn(warning, warn) {
-          if (warning.code === 'EVAL' && warning.id?.endsWith('xforms-engine/dist/index.js')) {
+          if (warning.code === 'EVAL' && warning.id?.endsWith('web-tree-sitter/tree-sitter.js')) {
             return; // ignore eval warning for tree-sitter
           }
           warn(warning);

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -77,8 +77,9 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@getodk/common': resolve(__dirname, '../common/src'),
-        '@': fileURLToPath(new URL('./src', import.meta.url)),
-        '@locales': fileURLToPath(new URL('./locales', import.meta.url)),
+        '@getodk/xforms-engine': resolve(__dirname, '../xforms-engine/src'),
+        '@getodk/xpath': resolve(__dirname, '../xpath/src'),
+        '@getodk/web-forms': resolve(__dirname, './src'),
         'primevue/menuitem': 'primevue/menu',
         // With following lines, fonts byte array are copied into css file
         // Roboto fonts

--- a/packages/xforms-engine/tsconfig.json
+++ b/packages/xforms-engine/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "include": ["src", "test", "vite-env.d.ts"],
   "compilerOptions": {
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": true,
     "declarationDir": "./dist",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",

--- a/packages/xforms-engine/vite.config.ts
+++ b/packages/xforms-engine/vite.config.ts
@@ -112,6 +112,8 @@ export default defineConfig(({ mode }) => {
         '@getodk/common/test-utils': resolvePath(__dirname, '../common/test-utils'),
         '@getodk/common/types': resolvePath(__dirname, '../common/types'),
         '@getodk/common': resolvePath(__dirname, '../common/src'),
+        '@getodk/xforms-engine': resolvePath(__dirname, '../xforms-engine/src'),
+        '@getodk/xpath': resolvePath(__dirname, '../xpath/src'),
       },
 
       // prettier-ignore

--- a/packages/xforms-engine/vite.config.ts
+++ b/packages/xforms-engine/vite.config.ts
@@ -82,7 +82,7 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         external,
         onwarn(warning, warn) {
-          if (warning.code === 'EVAL' && warning.id?.includes('/xpath/dist/expressionParser')) {
+          if (warning.code === 'EVAL' && warning.id?.endsWith('web-tree-sitter/tree-sitter.js')) {
             return; // ignore eval warning for tree-sitter
           }
           warn(warning);

--- a/vite.config.js
+++ b/vite.config.js
@@ -83,6 +83,15 @@ export default defineConfig(({ mode }) => ({
       dropMessageCompiler: true
     })
   ],
+  resolve: {
+    alias: {
+      '@getodk/web-forms': resolve(__dirname, './packages/web-forms/src'),
+      '@getodk/xforms-engine': resolve(__dirname, './packages/xforms-engine/src'),
+      '@getodk/xpath': resolve(__dirname, './packages/xpath/src'),
+      '@getodk/common': resolve(__dirname, './packages/common/src'),
+      'primevue/menuitem': 'primevue/menu',
+    }
+  },
   define: {
     __WEB_FORMS_VERSION__: JSON.stringify(webFormsPackage.version)
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -114,7 +114,7 @@ export default defineConfig(({ mode }) => ({
         }
       },
       onwarn(warning, warn) {
-        if (warning.code === 'EVAL' && warning.id?.includes('dist/index')) {
+        if (warning.code === 'EVAL' && warning.id?.endsWith('web-tree-sitter/tree-sitter.js')) {
           return; // ignore eval warning for tree-sitter
         }
         warn(warning);

--- a/vite.config.js
+++ b/vite.config.js
@@ -85,10 +85,10 @@ export default defineConfig(({ mode }) => ({
   ],
   resolve: {
     alias: {
+      '@getodk/common': resolve(__dirname, './packages/common/src'),
       '@getodk/web-forms': resolve(__dirname, './packages/web-forms/src'),
       '@getodk/xforms-engine': resolve(__dirname, './packages/xforms-engine/src'),
       '@getodk/xpath': resolve(__dirname, './packages/xpath/src'),
-      '@getodk/common': resolve(__dirname, './packages/common/src'),
       'primevue/menuitem': 'primevue/menu',
     }
   },


### PR DESCRIPTION
Closes getodk/web-forms#875

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual testing
CI
Checking file sizes:

1. Test localhost using: `npm run dev:build`
2. In chrome, disable cache, load a simple form, and look at how much was downloaded
3. Compare with staging

Staging: 1.9MB transferred, 5.5MB resources
This PR: 1.1MB transferred, 2.9MB resources

If my testing is correct, that's 43% less transferred.

Your mileage varies with different forms, but this PR is always smaller.

#### Why is this the best possible solution? Were any other approaches considered?

This gets HMR working so when running `npm dev` any change in any package updates the browser.
It also changes the bundling massively which makes it hard to verify that everything is still working and not bloating.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

It reduces the size of the overall download so it should be a net positive.
There is a risk that because we're now not consuming the dist index.js of each package that we break users of the libraries. If this actually happens we can fix it with testing.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.