### PR TITLE
chore(#2146): allow failure downloading fonts on redirect

### DIFF
--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -135,6 +135,7 @@ test.describe('ODK Web Forms', () => {
     urls.forEach(t => {
       test(t.name, async ({ allowedLogs, page }) => {
         allowedLogs.push((consoleMsg, normalisedMsg) => {
+          // the redirect causes the browser to cancel outstanding requests which should not fail the test
           if(normalisedMsg.includes('downloadable font: download failed')) return true;
           if(normalisedMsg !== 'Failed to load resource: the server responded with a status of 401 (Unauthorized)') return false;
           const { url } = consoleMsg.location();

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -135,7 +135,8 @@ test.describe('ODK Web Forms', () => {
     urls.forEach(t => {
       test(t.name, async ({ allowedLogs, page }) => {
         allowedLogs.push((consoleMsg, normalisedMsg) => {
-          if(normalisedMsg !== 'Failed to load resource: the server responded with a status of 401 (Unauthorized)') return;
+          if(normalisedMsg.includes('downloadable font: download failed')) return true;
+          if(normalisedMsg !== 'Failed to load resource: the server responded with a status of 401 (Unauthorized)') return false;
           const { url } = consoleMsg.location();
           return url.startsWith('http://central-test.localhost/v1/form-links/') ||
                  url === `http://central-test.localhost/v1/projects/${projectId}` ||


### PR DESCRIPTION
Closes getodk/central#2146

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

This makes the minimal change to get this one test to pass reliably without impacting others.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.