### PR TITLE
Add explanatory text to EntityUploadWarnings

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -454,6 +454,12 @@ watch(() => props.state, (state) => {
 .entity-upload-section-title {
   font-size: 16px;
   font-weight: bold;
+  margin-bottom: 4px;
+
+  ~ p {
+    margin-bottom: 10px;
+    &:last-of-type { margin-bottom: 20px; }
+  }
 }
 </style>
 

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -12,6 +12,7 @@ except according to the terms contained in the LICENSE file.
 <template>
   <div id="entity-upload-warnings">
     <p class="entity-upload-section-title">{{ $t('title') }}</p>
+    <p>{{ $t('introduction') }}</p>
 
     <!-- Column header warnings -->
     <entity-upload-warning v-if="missingProperties != null">
@@ -66,6 +67,7 @@ defineEmits(['rows']);
     // This text is shown above a section where the user can review warnings
     // about their data.
     "title": "Review warnings",
+    "introduction": "Some rows contain warnings that may affect upload results.",
 
     // @transifexKey component.EntityUploadHeaderReview.missingProperties
     // This text is followed by a list of Entity property names.

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2891,6 +2891,9 @@
       }
     },
     "EntityUploadWarnings": {
+      "introduction": {
+        "string": "Some rows contain warnings that may affect upload results."
+      },
       "row": {
         "raggedRows": {
           "string": "Fewer columns were found than expected in some rows:",


### PR DESCRIPTION
This PR is a follow-up to #1796. I separated it from #1796 because I wanted to keep #1796 smaller. This PR:

- Adds text to `EntityUploadWarnings`
- Styles that text

It makes progress on getodk/central#1904.

#### What has been done to verify that this works as intended?

Tests continue to pass.