### PR TITLE
Remove trailing slash from route path

### DIFF
--- a/.changeset/four-buttons-run.md
+++ b/.changeset/four-buttons-run.md
@@ -2,4 +2,4 @@
 "@getodk/central-frontend": minor
 ---
 
-Remove trailing slash from routes (getodk/central#1697)
+Remove trailing slashes from routes (getodk/central#1697)

--- a/.changeset/four-buttons-run.md
+++ b/.changeset/four-buttons-run.md
@@ -2,4 +2,4 @@
 "@getodk/central-frontend": minor
 ---
 
-Trim trailing slash from route (getodk/central#1697)
+Remove trailing slash from routes (getodk/central#1697)

--- a/.changeset/four-buttons-run.md
+++ b/.changeset/four-buttons-run.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+Trim trailing slash from route (getodk/central#1697)

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -65,16 +65,11 @@ router.afterEach(unlessFailure(to => {
   // user is trying to navigate to a parent route, which isn't expected.
   router.beforeEach(to => (Object.keys(to.meta).length === 0 ? '/' : true));
 
-  // Remove any trailing slash from the path.
+  // Remove trailing slashes from the path.
   router.beforeEach(to => {
-    // Two trailing slashes won't match any route, so return `true` to proceed
-    // to NotFound.
-    if (to.path.endsWith('//')) return true;
-
-    if (to.path.endsWith('/') && to.path !== '/')
-      return { path: to.path.slice(0, -1), query: to.query, hash: to.hash };
-
-    return true;
+    let { path } = to;
+    while (path.endsWith('/') && path !== '/') path = path.slice(0, -1);
+    return path === to.path ? true : { path, query: to.query, hash: to.hash };
   });
 
   // If a route is nested, its relative path is '', and that path is an alias,

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -67,10 +67,13 @@ router.afterEach(unlessFailure(to => {
 
   // Remove any trailing slash from the path.
   router.beforeEach(to => {
-    if (to.path.endsWith('//')) // Not a valid Frontend URL
-      return '/';
+    // Two trailing slashes won't match any route, so return `true` to proceed
+    // to NotFound.
+    if (to.path.endsWith('//')) return true;
+
     if (to.path.endsWith('/') && to.path !== '/')
       return { path: to.path.slice(0, -1), query: to.query, hash: to.hash };
+
     return true;
   });
 

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -70,7 +70,7 @@ router.afterEach(unlessFailure(to => {
     if (to.path.endsWith('//')) // Not a valid Frontend URL
       return '/';
     if (to.path.endsWith('/') && to.path !== '/')
-      return { path: to.path.slice(0, -1), query: to.query };
+      return { path: to.path.slice(0, -1), query: to.query, hash: to.hash };
     return true;
   });
 

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -65,6 +65,15 @@ router.afterEach(unlessFailure(to => {
   // user is trying to navigate to a parent route, which isn't expected.
   router.beforeEach(to => (Object.keys(to.meta).length === 0 ? '/' : true));
 
+  // Trim trailing slashes from the path.
+  router.beforeEach(to => {
+    if (to.path.endsWith('//')) // Not a valid Frontend URL
+      return '/';
+    if (to.path.endsWith('/') && to.path !== '/')
+      return { path: to.path.slice(0, -1), query: to.query };
+    return true;
+  });
+
   // If a route is nested, its relative path is '', and that path is an alias,
   // then we redirect to the canonical path. That turned out to be easier than
   // using the `redirect` option of Vue Router.

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -65,7 +65,7 @@ router.afterEach(unlessFailure(to => {
   // user is trying to navigate to a parent route, which isn't expected.
   router.beforeEach(to => (Object.keys(to.meta).length === 0 ? '/' : true));
 
-  // Trim trailing slashes from the path.
+  // Remove any trailing slash from the path.
   router.beforeEach(to => {
     if (to.path.endsWith('//')) // Not a valid Frontend URL
       return '/';

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -135,7 +135,7 @@ describe('createCentralRouter()', () => {
       });
 
       it('removes the slash when there is a querystring', async () => {
-        const app = await load('/audits?action=project.create');
+        const app = await load('/audits/?action=project.create');
         app.vm.$route.path.should.equal('/audits');
       });
 

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -139,12 +139,10 @@ describe('createCentralRouter()', () => {
         app.vm.$route.path.should.equal('/audits');
       });
 
-      it('redirects to / if there are multiple trailing slashes', () =>
-        load('/account/edit//')
-          .respondFor('/')
-          .afterResponses(app => {
-            app.vm.$route.path.should.equal('/');
-          }));
+      it('renders NotFound if there are multiple trailing slashes', async () => {
+        const app = await load('/account/edit//');
+        app.findComponent(NotFound).exists().should.be.true;
+      });
     });
 
     it('redirects to .../submissions from root path of form', async () => {

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -135,8 +135,8 @@ describe('createCentralRouter()', () => {
       });
 
       it('removes the slash when there is a querystring', async () => {
-        const app = await load('/audits/?action=project.create');
-        app.vm.$route.path.should.equal('/audits');
+        const app = await load('/audits/?action=project.create#foo');
+        app.vm.$route.fullPath.should.equal('/audits?action=project.create#foo');
       });
 
       it('renders NotFound if there are multiple trailing slashes', async () => {

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -128,7 +128,7 @@ describe('createCentralRouter()', () => {
           app.vm.$route.path.should.equal('/');
         }));
 
-    describe('trailing slash', () => {
+    describe('trailing slashes', () => {
       it('removes a trailing slash', async () => {
         const app = await load('/account/edit/');
         app.vm.$route.path.should.equal('/account/edit');

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -139,9 +139,17 @@ describe('createCentralRouter()', () => {
         app.vm.$route.fullPath.should.equal('/audits?action=project.create#foo');
       });
 
-      it('renders NotFound if there are multiple trailing slashes', async () => {
-        const app = await load('/account/edit//');
+      it('removes multiple trailing slashes', () =>
+        load('/account/edit//')
+          .respondFor('/account/edit')
+          .afterResponses(app => {
+            app.vm.$route.path.should.equal('/account/edit');
+          }));
+
+      it('does not remove multiple internal slashes', async () => {
+        const app = await load('/account//edit');
         app.findComponent(NotFound).exists().should.be.true;
+        app.vm.$route.path.should.equal('/account//edit');
       });
     });
 

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -128,6 +128,25 @@ describe('createCentralRouter()', () => {
           app.vm.$route.path.should.equal('/');
         }));
 
+    describe('trailing slash', () => {
+      it('removes a trailing slash', async () => {
+        const app = await load('/account/edit/');
+        app.vm.$route.path.should.equal('/account/edit');
+      });
+
+      it('removes the slash when there is a querystring', async () => {
+        const app = await load('/audits?action=project.create');
+        app.vm.$route.path.should.equal('/audits');
+      });
+
+      it('redirects to / if there are multiple trailing slashes', () =>
+        load('/account/edit//')
+          .respondFor('/')
+          .afterResponses(app => {
+            app.vm.$route.path.should.equal('/');
+          }));
+    });
+
     it('redirects to .../submissions from root path of form', async () => {
       testData.extendedForms.createPast(1);
       return load('/projects/1/forms/f/settings')
@@ -136,6 +155,19 @@ describe('createCentralRouter()', () => {
         .respondForComponent('FormSubmissions')
         .afterResponses(app => {
           app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
+        });
+    });
+
+    // getodk/central#1697
+    it('redirects to .../submissions despite a trailing slash', () => {
+      testData.extendedForms.createPast(1);
+      return load('/projects/1/forms/f/settings')
+        .complete()
+        .route('/projects/1/forms/f/')
+        .respondForComponent('FormSubmissions')
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
+          app.findComponent(NotFound).exists().should.be.false;
         });
     });
 

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -153,28 +153,20 @@ describe('createCentralRouter()', () => {
       });
     });
 
-    it('redirects to .../submissions from root path of form', async () => {
-      testData.extendedForms.createPast(1);
-      return load('/projects/1/forms/f/settings')
-        .complete()
-        .route('/projects/1/forms/f')
-        .respondForComponent('FormSubmissions')
-        .afterResponses(app => {
-          app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
-        });
-    });
-
-    // getodk/central#1697
-    it('redirects to .../submissions despite a trailing slash', () => {
-      testData.extendedForms.createPast(1);
-      return load('/projects/1/forms/f/settings')
-        .complete()
-        .route('/projects/1/forms/f/')
-        .respondForComponent('FormSubmissions')
-        .afterResponses(app => {
-          app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
-          app.findComponent(NotFound).exists().should.be.false;
-        });
+    [
+      '/projects/1/forms/f',
+      '/projects/1/forms/f/' // getodk/central#1697
+    ].forEach(rootPath => {
+      it(`redirects to .../submissions from ${rootPath}`, async () => {
+        testData.extendedForms.createPast(1);
+        return load('/projects/1/forms/f/settings')
+          .complete()
+          .route(rootPath)
+          .respondForComponent('FormSubmissions')
+          .afterResponses(app => {
+            app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
+          });
+      });
     });
 
     it('redirects to .../entities from root path of entity list', async () => {


### PR DESCRIPTION
Closes getodk/central#1697.

#### What has been done to verify that this works as intended?

I added new tests.

#### Why is this the best possible solution? Were any other approaches considered?

A few options were considered in getodk/central#1697. The discussion gravitated toward fixing the issue in Central Frontend (the Vue router) rather than in nginx.

We can always implement something at the nginx level later if we decide that that'd be useful. This change doesn't foreclose that.

This PR fixes the issue by removing the trailing slash. That's the idea that came up in the issue. However, I actually think I prefer the approach in #1800. That PR simply doesn't match any Vue routes if the path has a trailing slash.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

This PR adds more redirect logic and a little more complexity to the router. However, I think that aspect of the router is well tested. This PR adds new tests as well.