### PR TITLE
Routes: do not match path with trailing slash

### DIFF
--- a/.changeset/wacky-streets-clean.md
+++ b/.changeset/wacky-streets-clean.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+Do not match routes or redirect if the path has a trailing slash (getodk/central#1697)

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -32,7 +32,8 @@ export default (container, {
     history,
     routes,
     scrollBehavior,
-    sensitive: true
+    sensitive: true,
+    strict: true
   });
   const { requestData, toast, redAlert, unsavedChanges, config } = container;
   const { session } = requestData;

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -26,6 +26,20 @@ describe('createCentralRouter()', () => {
           app.findComponent(NotFound).exists().should.be.true;
         });
     });
+
+    it('does not match on a trailing slash', () => {
+      mockLogin();
+      return load('/account/edit')
+        .afterResponses(app => {
+          app.findComponent(NotFound).exists().should.be.false;
+        })
+        .load('/')
+        .complete()
+        .load('/account/edit/')
+        .afterResponses(app => {
+          app.findComponent(NotFound).exists().should.be.true;
+        });
+    });
   });
 
   describe('i18n', () => {
@@ -152,6 +166,18 @@ describe('createCentralRouter()', () => {
         .respondForComponent('FormSubmissions')
         .afterResponses(app => {
           app.vm.$route.path.should.equal('/projects/1/forms/f/submissions');
+        });
+    });
+
+    // getodk/central#1697
+    it('does not redirect to .../submissions if there is a trailing slash', () => {
+      testData.extendedForms.createPast(1);
+      return load('/projects/1/forms/f/settings')
+        .complete()
+        .route('/projects/1/forms/f/')
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/projects/1/forms/f/');
+          app.findComponent(NotFound).exists().should.be.true;
         });
     });
 


### PR DESCRIPTION
This PR implements "strict" route matching, in which Vue Router will not match a route if the path has a trailing slash.

This PR closes getodk/central#1697. In that issue, the path had a trailing slash. The user was redirected to a strange URL and saw the 404 page. With this PR, the user will continue to see the 404 page: that is the expected behavior, since no route matches the trailing slash. However, the URL will not change: there will be no double slash in the URL (`//`).

In other words, this PR makes it clear that paths with a trailing slash are not expected to match routes.

#### What has been done to verify that this works as intended?

I added new tests, including one specifically about getodk/central#1697.

#### Why is this the best possible solution? Were any other approaches considered?

This PR uses Vue Router's built-in `strict` configuration: https://router.vuejs.org/guide/essentials/route-matching-syntax.html#Sensitive-and-strict-route-options. That said, an alternative approach can be seen at #1799, in which the trailing slash is removed before further route matching.

Personally, I think I have a slight preference for this PR, since it involves less code/complexity. However, I'm happy to run with either approach.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

~There's a chance that someone's existing link will break. However,~ I think any user impact should be low.