### PR TITLE
Remove unused reference to session resource

### DIFF
--- a/apps/central/src/components/submission/download.vue
+++ b/apps/central/src/components/submission/download.vue
@@ -141,9 +141,9 @@ export default {
   },
   emits: ['hide'],
   setup() {
-    const { session, keys, fields } = useRequestData();
+    const { keys, fields } = useRequestData();
     const { callWait, cancelCall } = useCallWait();
-    return { session, keys, fields, callWait, cancelCall };
+    return { keys, fields, callWait, cancelCall };
   },
   data() {
     return {


### PR DESCRIPTION
The `SubmissionDownload` component retrieves the `session` resource in its `setup()` function. However, it doesn't actually use it. I've updated the component to remove references to `session`.

I noticed this while working on getodk/central#1315.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

It's just removing an unused variable.

I think our linting will catch this sort of thing automatically for Composition API components. It's harder to spot for Options API components.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No user-facing change; it's just a refactor.