### PR TITLE
Remove webpack magic comments

### DIFF
--- a/apps/central/src/util/i18n.js
+++ b/apps/central/src/util/i18n.js
@@ -68,10 +68,7 @@ export const loadLocale = ({ i18n, logger }, locale) => {
     return Promise.resolve();
   }
 
-  return import(
-    /* webpackChunkName: "i18n-[request]" */
-    `../locales/${locale}.json`
-  )
+  return import(`../locales/${locale}.json`)
     .then(m => {
       i18n.setLocaleMessage(locale, m.default);
       setLocale(i18n, locale);

--- a/apps/central/src/util/load-async.js
+++ b/apps/central/src/util/load-async.js
@@ -10,13 +10,9 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
 
-/*
-Most dynamic imports are housed in this file. Using a dynamic import with
-loadAsync() has a couple of benefits:
-
-  - It is possible to check whether the import has been completed.
-  - webpack magic comments will not be repeated across files.
-*/
+// Most dynamic imports are housed in this file. Using a dynamic import with
+// loadAsync() has the benefit that it is possible to check whether the import
+// has been completed. Use loadedAsync() to check the status of an import.
 
 const loader = (load) => {
   const obj = {
@@ -32,180 +28,138 @@ const loader = (load) => {
 
 const loaders = new Map()
   .set('AccountClaim', loader(() => import(
-    /* webpackChunkName: "component-account-claim" */
     '../components/account/claim.vue'
   )))
   .set('AccountEdit', loader(() => import(
-    /* webpackChunkName: "component-account-edit" */
     '../components/account/edit.vue'
   )))
   .set('AccountResetPassword', loader(() => import(
-    /* webpackChunkName: "component-account-reset-password" */
     '../components/account/reset-password.vue'
   )))
   .set('AnalyticsIntroduction', loader(() => import(
-    /* webpackChunkName: "component-analytics-introduction" */
     '../components/analytics/introduction.vue'
   )))
   .set('AnalyticsList', loader(() => import(
-    /* webpackChunkName: "component-analytics-list" */
     '../components/analytics/list.vue'
   )))
   .set('AuditList', loader(() => import(
-    /* webpackChunkName: "component-audit-list" */
     '../components/audit/list.vue'
   )))
   .set('ClientConfigError', loader(() => import(
-    /* webpackChunkName: "component-client-config-error" */
     '../components/client-config-error.vue'
   )))
   .set('ConfigLogin', loader(() => import(
     '../components/config/login.vue'
   )))
   .set('DatasetList', loader(() => import(
-    /* webpackChunkName: "component-dataset-list" */
     '../components/dataset/list.vue'
   )))
   .set('DatasetShow', loader(() => import(
-    /* webpackChunkName: "component-dataset-show" */
     '../components/dataset/show.vue'
   )))
   .set('DatasetOverview', loader(() => import(
-    /* webpackChunkName: "component-dataset-overview" */
     '../components/dataset/overview.vue'
   )))
   .set('DatasetEntities', loader(() => import(
-    /* webpackChunkName: "component-dataset-entities" */
     '../components/dataset/entities.vue'
   )))
   .set('DatasetSettings', loader(() => import(
-    /* webpackChunkName: "component-dataset-settings" */
     '../components/dataset/settings.vue'
   )))
   .set('Download', loader(() => import(
-    /* webpackChunkName: "component-download" */
     '../components/download.vue'
   )))
   .set('EntityBranchData', loader(() => import(
-    /* webpackChunkName: "component-entity-branch-data" */
     '../components/entity/branch-data.vue'
   )))
   .set('EntityShow', loader(() => import(
-    /* webpackChunkName: "component-entity-show" */
     '../components/entity/show.vue'
   )))
   .set('EntityUpload', loader(() => import(
-    /* webpackChunkName: "component-entity-upload" */
     '../components/entity/upload.vue'
   )))
   .set('FeedbackButton', loader(() => import(
-    /* webpackChunkName: "component-feedback-button" */
     '../components/feedback-button.vue'
   )))
   .set('FieldKeyList', loader(() => import(
-    /* webpackChunkName: "component-field-key-list" */
     '../components/field-key/list.vue'
   )))
   .set('FormEdit', loader(() => import(
-    /* webpackChunkName: "component-form-edit" */
     '../components/form/edit.vue'
   )))
   .set('FormNewPage', loader(() => import(
-    /* webpackChunkName: "component-form-new-page" */
     '../components/form/new-page.vue'
   )))
   .set('FormSettings', loader(() => import(
-    /* webpackChunkName: "component-form-settings" */
     '../components/form/settings.vue'
   )))
   .set('FormShow', loader(() => import(
-    /* webpackChunkName: "component-form-show" */
     '../components/form/show.vue'
   )))
   .set('FormSubmissions', loader(() => import(
-    /* webpackChunkName: "component-form-submissions" */
     '../components/form/submissions.vue'
   )))
   .set('GeojsonMap', loader(() => import(
     '../components/geojson-map.vue'
   )))
   .set('FormVersionList', loader(() => import(
-    /* webpackChunkName: "component-form-version-list" */
     '../components/form-version/list.vue'
   )))
   .set('FormVersionViewXml', loader(() => import(
-    /* webpackChunkName: "component-form-version-view-xml" */
     '../components/form-version/view-xml.vue'
   )))
   .set('GeojsonMapDevTools', loader(() => import(
     '../components/geojson-map/dev-tools.vue'
   )))
   .set('Home', loader(() => import(
-    /* webpackChunkName: "component-home" */
     '../components/home.vue'
   )))
   .set('HomeConfigSection', loader(() => import(
-    /* webpackChunkName: "component-home-config-section" */
     '../components/home/config-section.vue'
   )))
   .set('HoverCards', loader(() => import(
-    /* webpackChunkName: "component-hover-cards" */
     '../components/hover-cards.vue'
   )))
   .set('NotFound', loader(() => import(
-    /* webpackChunkName: "component-not-found" */
     '../components/not-found.vue'
   )))
   .set('OutdatedVersion', loader(() => import(
-    /* webpackChunkName: "component-outdated-version" */
     '../components/outdated-version.vue'
   )))
   .set('ProjectFormAccess', loader(() => import(
-    /* webpackChunkName: "component-project-form-access" */
     '../components/project/form-access.vue'
   )))
   .set('ProjectOverview', loader(() => import(
-    /* webpackChunkName: "component-project-overview" */
     '../components/project/overview.vue'
   )))
   .set('ProjectSettings', loader(() => import(
-    /* webpackChunkName: "component-project-settings" */
     '../components/project/settings.vue'
   )))
   .set('ProjectShow', loader(() => import(
-    /* webpackChunkName: "component-project-show" */
     '../components/project/show.vue'
   )))
   .set('ProjectUserList', loader(() => import(
-    /* webpackChunkName: "component-project-user-list" */
     '../components/project/user/list.vue'
   )))
   .set('CustomPropertyList', loader(() => import(
-    /* webpackChunkName: "component-custom-properties-list" */
     '../components/project/custom-properties/list.vue'
   )))
   .set('PublicLinkList', loader(() => import(
-    /* webpackChunkName: "component-public-link-list" */
     '../components/public-link/list.vue'
   )))
   .set('SubmissionShow', loader(() => import(
-    /* webpackChunkName: "component-submission-show" */
     '../components/submission/show.vue'
   )))
   .set('SystemHome', loader(() => import(
-    /* webpackChunkName: "component-system-home" */
     '../components/system/home.vue'
   )))
   .set('UserEdit', loader(() => import(
-    /* webpackChunkName: "component-user-edit" */
     '../components/user/edit.vue'
   )))
   .set('UserHome', loader(() => import(
-    /* webpackChunkName: "component-user-home" */
     '../components/user/home.vue'
   )))
   .set('UserList', loader(() => import(
-    /* webpackChunkName: "component-user-list" */
     '../components/user/list.vue'
   )));
 


### PR DESCRIPTION
This PR removes all webpack magic comments from Central Frontend; it closes getodk/central#1268.

Since we're using Vite to build these days, webpack magic comments have no effect in production. That means this PR has no user-facing effects.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

See getodk/central#1268 for related discussion. This PR just removes webpack magic comments (specifically for `webpackChunkName`). It doesn't replace them with alternative Vite configuration. We can always add more Vite configuration if/when that becomes necessary. However, the Vite defaults seem pretty good so far.

To make sure I found and removed all magic comments, I searched the codebase for `webpack`.