### PR TITLE
Remove unused i18n message in DatasetShow

### DIFF
--- a/apps/central/src/components/dataset/show.vue
+++ b/apps/central/src/components/dataset/show.vue
@@ -154,8 +154,6 @@ export default {
 <i18n lang="json5">
 {
   "en": {
-    // This is shown at the top of the page.
-    "back": "Back to Project Entities",
     "infoNav": {
       // This dropdown title refers to Entity Lists that are updated by a Form.
       "connectedForms": "Updated by {count} Form | Updated by {count} Forms",

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2199,10 +2199,6 @@
       }
     },
     "DatasetShow": {
-      "back": {
-        "string": "Back to Project Entities",
-        "developer_comment": "This is shown at the top of the page."
-      },
       "infoNav": {
         "connectedForms": {
           "string": "{count, plural, one {Updated by {count} Form} other {Updated by {count} Forms}}",


### PR DESCRIPTION
This PR removes the one i18n message that is known to be unused. **UPDATE:** Since this PR was opened, I've added a couple more messages to the list at getodk/central#1350.

#### What has been done to verify that this works as intended?

Nothing in particular. Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

I searched the `DatasetShow` component for the appearance of `back`, which is the key for the i18n message. I found no occurrences outside the key itself.

Hopefully at some point we can automate the detection of unused i18n messages. That's tracked at getodk/central#829.