### PR TITLE
Restore session for user who ends up on NotFound

### DIFF
--- a/.changeset/free-ears-itch.md
+++ b/.changeset/free-ears-itch.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": major
+---
+
+Restore session when user initially navigates to "Not Found" page

--- a/apps/central/src/routes.js
+++ b/apps/central/src/routes.js
@@ -691,7 +691,6 @@ const routes = [
     component: 'NotFound',
     loading: 'page',
     meta: {
-      restoreSession: false,
       requireLogin: false,
       title: () => [i18n.t('title.pageNotFound')]
     }

--- a/apps/central/test/components/project/show.spec.js
+++ b/apps/central/test/components/project/show.spec.js
@@ -13,6 +13,7 @@ import { mockLogin } from '../../util/session';
 
 describe('ProjectShow', () => {
   it('requires the projectId route param to be integer', async () => {
+    mockLogin();
     const app = await load('/projects/p');
     app.findComponent(NotFound).exists().should.be.true;
   });

--- a/apps/central/test/components/user/edit.spec.js
+++ b/apps/central/test/components/user/edit.spec.js
@@ -6,6 +6,7 @@ import { mockLogin } from '../../util/session';
 
 describe('UserEdit', () => {
   it('requires the id route param to be integer', async () => {
+    mockLogin();
     const app = await load('/users/x/edit');
     app.findComponent(NotFound).exists().should.be.true;
   });

--- a/apps/central/test/router.spec.js
+++ b/apps/central/test/router.spec.js
@@ -50,7 +50,6 @@ describe('createCentralRouter()', () => {
     describe('restoreSession is false for the first route', () => {
       const paths = [
         `/account/claim?token=${'a'.repeat(64)}`,
-        '/not-found'
       ];
       for (const path of paths) {
         it(`does not restore session for a user navigating to ${path}`, () =>
@@ -230,10 +229,12 @@ describe('createCentralRouter()', () => {
   });
 
   describe('requireLogin is false and requireAnonymity is false', () => {
-    it('does not redirect an anonymous user', async () => {
-      const app = await load('/not-found');
-      app.vm.$route.path.should.equal('/not-found');
-    });
+    it('does not redirect an anonymous user', () =>
+      load('/not-found')
+        .restoreSession(false)
+        .afterResponses(app => {
+          app.vm.$route.path.should.equal('/not-found');
+        }));
 
     it('does not redirect a user who is logged in', () => {
       mockLogin();


### PR DESCRIPTION
This PR closes getodk/central#1698. Currently, we set the `restoreSession` route meta field to `false` for the `NotFound` route. However, as I mentioned at https://github.com/getodk/central/issues/1698#issuecomment-4130465074, I can't think of a reason for why that would be necessary. This PR changes `restoreSession` back to the default value of `true` for the route.

I definitely remember leveraging the fact that `NotFound` doesn't restore the session while working on some early tests. However, I don't think tests rely on that fact anymore.

Beyond tests, I don't see conceptually why it'd be a problem to restore the session when navigating to `NotFound`.

Note that `NotFound` is unusual in another way: it's currently the only route accessible by both anonymous users and logged in users (both `requireLogin` and `requireAnonymity` are `false`). However, I don't think that's a reason not to restore the session.

After this change, the only remaining route for which `restoreSession` is `false` will be `AccountClaim`. I think that's fine, but it's interesting to note. There's related discussion about `AccountClaim` at getodk/central#916.

#### What has been done to verify that this works as intended?

I updated tests that started failing after I changed `restoreSession` back to the default value of `true`.

#### Why is this the best possible solution? Were any other approaches considered?

It's a pretty small PR. The only thing that needs to change is the route meta field: changing it back to its default value of `true`.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Hopefully users aren't ending up on `NotFound` too often. If there's a regression in this area, hopefully we'll learn about it during regression testing that's starting soon.