### PR TITLE
Catch session restore promise in router

### DIFF
--- a/.changeset/shy-pears-think.md
+++ b/.changeset/shy-pears-think.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": major
+---
+
+Do not report session restore errors to Sentry (getodk/central#2072)

--- a/.changeset/shy-pears-think.md
+++ b/.changeset/shy-pears-think.md
@@ -1,5 +1,5 @@
 ---
-"@getodk/central-frontend": major
+"@getodk/central-frontend": minor
 ---
 
 Do not report session restore errors to Sentry (getodk/central#2072)

--- a/apps/central/src/router.js
+++ b/apps/central/src/router.js
@@ -118,7 +118,7 @@ router.afterEach(unlessFailure(to => {
     // navigation.
     const needsLogin = to.meta.restoreSession && !session.dataExists;
     const sessionPromise = needsLogin
-      ? restoreSession(session)
+      ? restoreSession(session).catch(noop)
       : Promise.resolve();
 
     // A test can skip this request by setting `config` before the initial
@@ -139,12 +139,12 @@ router.afterEach(unlessFailure(to => {
 
     const locale = userLocale();
     const localePromise = locale != null
-      ? loadLocale(container, locale)
+      ? loadLocale(container, locale).catch(noop)
       : Promise.resolve();
 
     // Once the session and the config have been received, we can complete
     // login.
-    await Promise.allSettled([sessionPromise, configPromise]);
+    await Promise.all([sessionPromise, configPromise]);
     if (needsLogin && session.dataExists) {
       // If this is the first time that the session has been restored since the
       // most recent OIDC login, set sessionExpires in local storage. If
@@ -155,7 +155,7 @@ router.afterEach(unlessFailure(to => {
       await logIn(container, newSession).catch(noop);
     }
 
-    await localePromise.catch(noop);
+    await localePromise;
     return config.loadError != null ? '/load-error' : true;
   });
 


### PR DESCRIPTION
Closes getodk/central#2072.

#### What has been done to verify that this works as intended?

Nothing in particular. Tests continue to pass. We can monitor Sentry for whether reports continue to come in.

#### Why is this the best possible solution? Were any other approaches considered?

I think the previous approach of using `Promise.allSettled()` was valid. However, now I'm explicitly `.catch()`-ing `sessionPromise`. Now that it's explicitly caught, we can use `Promise.all()` instead of `Promise.allSettled()`.

Instead of adding the `.catch(noop)` in the router, I could have added it to the `restoreSession()` function in src/util/session.js. However, I think it makes the code a little clearer to catch the promise where it's used (in the router).

I don't think the issue has to do with the specific type of error. The `restoreSession()` function already has logic to handle 401 errors specifically. We just need to `.catch()` the promise.