### PR TITLE
fix(#2032): request project using verbs query parameter

### DIFF
--- a/.changeset/perky-tools-pump.md
+++ b/.changeset/perky-tools-pump.md
@@ -2,4 +2,4 @@
 "@getodk/forms": minor
 ---
 
-Improved performance by fetching the project verbs from a more efficient server endpoint.
+Improved form loading times by fetching the project verbs from a more efficient server endpoint.

--- a/.changeset/perky-tools-pump.md
+++ b/.changeset/perky-tools-pump.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": minor
+---
+
+Improved performance by fetching the project verbs from a more efficient server endpoint.

--- a/apps/forms/src/utils/api.ts
+++ b/apps/forms/src/utils/api.ts
@@ -125,12 +125,9 @@ export const getFormByFormId = async (projectId: number, formId: string, draft: 
 };
 
 export const getProject = async (projectId: number): Promise<Project> => {
-  const url = `/v1/projects/${projectId}`;
-  const headers = new Headers({
-    'Content-Type': 'application/json',
-    'X-Extended-Metadata': 'true'
-  });
-  const response = await fetch(url, { headers });
+  const qs = queryString({ verbs: true });
+  const url = `/v1/projects/${projectId}${qs}`;
+  const response = await fetch(url);
   if (!response.ok) {
     const result = await response.json() as BackendStatusResponseBody;
     throw new RequestError(result.message, result.code);

--- a/apps/forms/test/utils/api.spec.ts
+++ b/apps/forms/test/utils/api.spec.ts
@@ -195,10 +195,7 @@ describe('Test api utility', () => {
       const actual = await getProject(5);
       expect(actual).toEqual(expected);
       expect(fetch).toHaveBeenCalledTimes(1);
-      expect(fetch).toHaveBeenCalledWith('/v1/projects/5', { headers: new Headers({
-        'Content-Type': 'application/json',
-        'X-Extended-Metadata': 'true'
-      })});
+      expect(fetch).toHaveBeenCalledWith('/v1/projects/5?verbs=true');
     });
 
     it('handles central errors', async () => {

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -140,7 +140,7 @@ test.describe('ODK Web Forms', () => {
           if(normalisedMsg !== 'Failed to load resource: the server responded with a status of 401 (Unauthorized)') return false;
           const { url } = consoleMsg.location();
           return url.startsWith('http://central-test.localhost/v1/form-links/') ||
-                 url === `http://central-test.localhost/v1/projects/${projectId}` ||
+                 url === `http://central-test.localhost/v1/projects/${projectId}?verbs=true` ||
                  url === `http://central-test.localhost/v1/projects/${projectId}/forms/${publishedForm.xmlFormId}`;
         });
 


### PR DESCRIPTION
Closes: getodk/central#2032

NB the e2e tests are failing because this depends on: https://github.com/getodk/central-backend/pull/1917 


<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual testing - verified that verbs is included but other extended properties are not.

#### Why is this the best possible solution? Were any other approaches considered?

...

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Should lead to much better form load performance.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.