### PR TITLE
Don't check for popup overlap when resizing entity upload tables

### DIFF
--- a/apps/central/src/components/entity/upload/table.vue
+++ b/apps/central/src/components/entity/upload/table.vue
@@ -10,8 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div ref="container" class="entity-upload-table"
-    :class="{ 'overlaps-popup': overlapsPopup }" :style="{ minHeight }">
+  <div ref="container" class="entity-upload-table" :style="{ minHeight }">
     <table class="table">
       <thead>
         <tr>
@@ -98,37 +97,17 @@ watch(
 const isHighlighted = (index) => props.highlighted != null &&
   index >= props.highlighted[0] && index <= props.highlighted[1];
 
-const overlapsPopup = ref(false);
 const resizeLastColumn = () => {
   // Undo previous resizing.
   const th = container.value.querySelector('th:last-child');
   th.style.width = '';
 
-  if (container.value.clientWidth === 0) {
-    overlapsPopup.value = false;
-    return;
-  }
-
-  // Check whether the column is obscured by the pop-up.
-  const popup = container.value.closest('.modal-body')
-    .querySelector('#entity-upload-popup');
-  if (popup != null) {
-    const popupRect = popup.getBoundingClientRect();
-    const containerRect = container.value.getBoundingClientRect();
-    overlapsPopup.value = popupRect.top < containerRect.bottom;
-    if (overlapsPopup.value) {
-      const overlap = containerRect.right - popupRect.left;
-      // Adding 10px for some extra space between the column and the pop-up.
-      th.style.width = px(th.clientWidth + overlap + 10);
-    }
-  }
-
   // If the container fits the table without scrolling horizontally, then the
   // columns probably have room to grow. In that case, we allocate the extra
   // width to the last column rather than distributing it evenly among the
   // columns.
-  if (container.value.scrollWidth === container.value.clientWidth)
-    th.style.width = 'auto';
+  const { clientWidth, scrollWidth } = container.value;
+  if (clientWidth !== 0 && scrollWidth === clientWidth) th.style.width = 'auto';
 };
 
 const resetScroll = () => { container.value.scroll(0, 0); };
@@ -147,20 +126,12 @@ defineExpose({ resizeLastColumn, resetScroll });
     table-layout: fixed;
   }
 
-  $col-width: 160px;
   th, td {
     div { @include text-overflow-ellipsis; }
   }
-  &.overlaps-popup {
-    th, td {
-      &:last-child div {
-        width: #{$col-width - $padding-left-table-data - $padding-right-table-data};
-      }
-    }
-  }
 
   th {
-    width: $col-width;
+    width: 160px;
     // Wide enough to fit a 6-digit number.
     &:first-child { width: 54px; }
   }


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. In the entity upload modal, we dynamically size the last column of the entity tables. In the past, we've accounted for possible overlap between the table and the popup that's shown once a file is selected. However, we will soon not show the popup in most cases. That means that we can remove the logic around that overlap detection, simplifying the modal. That's what this PR does.

#### What has been done to verify that this works as intended?

Nothing in particular. I didn't modify tests, but they continue to pass. I think that means that we didn't previously test this behavior.

#### Why is this the best possible solution? Were any other approaches considered?

My main question was *when* to make this change: whether as part of a larger PR or in a separate one. I ended up thinking that it made sense to remove the overlap detection in a separate, smaller PR, even though the popup will continue to be shown as I continue working on getodk/central#1904.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

The only risk should be to the tables' appearance. If there's an issue there, hopefully we'll catch it during QA.