### PR TITLE
Remove EntityUploadPopup animation

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <modal id="entity-upload" :state="state" :hideable="!uploading" size="full"
-    backdrop @hide="$emit('hide')" @mutate="resizeColumnUnlessAnimating">
+    backdrop @hide="$emit('hide')" @mutate="resizeColumnIfShown">
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <div :class="{ backdrop: uploading }">
@@ -62,9 +62,7 @@ except according to the terms contained in the LICENSE file.
       <entity-upload-popup v-if="csvEntities != null"
         :filename="fileMetadata.name" :count="csvEntities.length"
         :awaiting-response="uploading"
-        :progress="uploadProgress" @clear="clearFile"
-        @animationstart="animatePopup(true)"
-        @animationend="animatePopup(false)"/>
+        :progress="uploadProgress" @clear="clearFile"/>
       <div ref="actions" class="modal-actions">
         <button type="button" class="btn btn-link" :aria-disabled="uploading"
           @click="$emit('hide')">
@@ -354,24 +352,15 @@ const upload = () => {
     .catch(noop);
 };
 
-const popupAnimating = ref(false);
-const animatePopup = (animating) => { popupAnimating.value = animating; };
-watch(csvEntities, (value) => {
-  if (value == null) popupAnimating.value = false;
-});
-
 // Resize the last column of the tables.
 const tables = [null, null];
 const setTable = (i) => (el) => { tables[i] = el; };
 const resizeLastColumn = () => {
   for (const table of tables) table.resizeLastColumn();
 };
-watch(popupAnimating, (animating) => { if (!animating) resizeLastColumn(); });
 watch(() => props.state, (state) => { if (!state) nextTick(resizeLastColumn); });
-const resizeColumnUnlessAnimating = () => {
-  if (props.state && !popupAnimating.value) resizeLastColumn();
-};
-useEventListener(window, 'resize', resizeColumnUnlessAnimating);
+const resizeColumnIfShown = () => { if (props.state) resizeLastColumn(); };
+useEventListener(window, 'resize', resizeColumnIfShown);
 
 const actions = ref(null);
 watch(csvEntities, (value) => {

--- a/apps/central/src/components/entity/upload/popup.vue
+++ b/apps/central/src/components/entity/upload/popup.vue
@@ -10,8 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <div id="entity-upload-popup" @animationstart="$emit('animationstart')"
-    @animationend="$emit('animationend')">
+  <div id="entity-upload-popup">
     <div id="entity-upload-popup-heading">
       <div v-tooltip.text>{{ filename }}</div>
       <button v-show="!awaitingResponse" type="button" class="btn btn-link"
@@ -50,7 +49,7 @@ const props = defineProps({
     required: true
   }
 });
-defineEmits(['clear', 'animationstart', 'animationend']);
+defineEmits(['clear']);
 
 const { t, n } = useI18n();
 const status = computed(() => (props.progress < 1
@@ -62,15 +61,7 @@ const status = computed(() => (props.progress < 1
 @use 'sass:color';
 @import '../../../assets/scss/mixins';
 
-@keyframes tocorner {
-  0% { transform: translate(-70px, -70px); }
-  100% { transform: translate(0, 0); }
-}
-
 #entity-upload-popup {
-  animation-duration: 2s;
-  animation-name: tocorner;
-  animation-timing-function: cubic-bezier(0.05, 0.9, 0, 1);
   background-color: $color-subpanel-background;
   border: 2px solid $color-action-foreground;
   border-radius: 6px;


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. There's a bit of logic in the entity upload modal around the animation of the popup that's shown when a file is selected. However, we will soon show the popup in many fewer cases. In the remaining case (during the upload itself), the popup doesn't really need to animate. It's nice to simplify the code by removing the logic here.

#### What has been done to verify that this works as intended?

Nothing in particular. Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly it's removing code. The animation helped drive the dynamic resizing of the tables (related: #1812). With this PR, we resize the tables in the following cases:

- When the content of `.modal-body` changes (e.g., when entities from a CSV file are shown in the modal)
- When the window is resized
- When the modal is hidden (I think to reset the tables as soon as possible once the modal is hidden)

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

The main things at risk are the appearance of the popup and the appearance of the tables (in particular, their column widths). If there are any big problems there, I think we'll catch them during QA.