### PR TITLE
EntityUpload: show both header warnings and data error

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -300,6 +300,7 @@ const parseEntities = async (file, headerResults, signal) => {
 };
 const selectFile = (file) => {
   redAlert.hide();
+  fileMetadata.value = null;
   headerErrors.value = null;
   dataError.value = null;
 
@@ -320,15 +321,17 @@ const selectFile = (file) => {
         return Promise.resolve();
       }
 
+      const metadata = { name: file.name, size: file.size };
       return parseEntities(file, headerResults, signal)
         .then(results => {
           csvEntities.value = results.data;
-          fileMetadata.value = { name: file.name, size: file.size };
+          fileMetadata.value = metadata;
           if (validation.warnings != null || results.warnings.count !== 0)
             warnings.value = { ...validation.warnings, ...results.warnings.details };
         })
         .catch(error => {
           if (!signal.aborted) {
+            fileMetadata.value = metadata;
             dataError.value = error.message;
             warnings.value = validation.warnings;
           }

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -302,6 +302,7 @@ const selectFile = (file) => {
   redAlert.hide();
   fileMetadata.value = null;
   headerErrors.value = null;
+  warnings.value = null;
   dataError.value = null;
 
   const abortController = new AbortController();

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -328,7 +328,11 @@ const selectFile = (file) => {
             warnings.value = { ...validation.warnings, ...results.warnings.details };
         })
         .catch(error => {
-          if (!signal.aborted) dataError.value = error.message;
+          if (!signal.aborted) {
+            dataError.value = error.message;
+            warnings.value = validation.warnings;
+          }
+
           throw error;
         });
     })

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -235,7 +235,7 @@ describe('EntityUpload', () => {
       warnings.largeCell.should.equal(3);
     });
 
-    it('only shows header warnings if there is a data error', async () => {
+    it('does not show data warnings if there is a data error', async () => {
       testData.extendedDatasets.createPast(1, {
         properties: [{ name: 'height' }, { name: 'circumference' }]
       });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -235,12 +235,36 @@ describe('EntityUpload', () => {
       warnings.largeCell.should.equal(3);
     });
 
-    it('does not show warnings if there is a data error', async () => {
+    it('only shows header warnings if there is a data error', async () => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [{ name: 'height' }, { name: 'circumference' }]
+      });
       const modal = await showModal();
-      await selectFile(modal, createCSV('label,height\nx\ny,""\n"",1'));
+
+      // First, select a CSV that triggers warnings about both the column header
+      // and the data, but does not trigger errors.
+      const warningsCSV = 'label,height\nx\ny,""';
+      await selectFile(modal, createCSV(warningsCSV));
+      modal.findComponent(EntityUploadErrors).exists().should.be.false;
+      const initialWarnings = modal.getComponent(EntityUploadWarnings).props();
+      initialWarnings.missingProperties.should.eql(['circumference']);
+      initialWarnings.raggedRows.should.eql([[1, 1]]);
+
+      // Next, select a similar CSV that also has an error in the data (a
+      // missing label).
+      await modal.get('#entity-upload-popup .btn-link').trigger('click');
+      await selectFile(modal, createCSV(`${warningsCSV}\n"",1`));
+
+      // This time, we see an error.
       const { dataError } = modal.getComponent(EntityUploadErrors).props();
       dataError.should.startWith('There is a problem on row 4');
-      modal.findComponent(EntityUploadWarnings).exists().should.be.false;
+
+      // There's a warning about the column header, but no warning about the
+      // data.
+      const warnings = modal.getComponent(EntityUploadWarnings);
+      warnings.props().missingProperties.should.eql(['circumference']);
+      should.not.exist(warnings.props().raggedRows);
+      warnings.findAll('.entity-upload-alert').length.should.equal(1);
     });
 
     it('shows rows to which a warning applies after they are selected', async () => {


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. For that issue, we want users to be able to see both errors and warnings at the same time. The idea is to show the user as much information as possible. Whatever issues with the CSV Central knows about, it can show to the user.

There are four types of errors/warnings:

1. Errors with the column header
2. Warnings about the column header
3. Errors in the data below the column header
4. Warnings about the data below the column header

Not all combinations of these four are possible. The following table summarizes the combinations:

&nbsp; | Header errors | Header warnings | Data error | Data warnings
-- | -- | -- | -- | --
Header errors | ✅ | Future PR | ❌ | ❌
Header warnings | Future PR | ✅ | This PR | ✅
Data error | ❌ | This PR | ✅ | ❌
Data warnings | ❌ | ✅ | ❌ | ✅

✅ = possible today
❌ = not possible and also not currently planned to become possible

Some of these combinations we're not currently planning to make happen: they would require larger changes to `EntityUpload`. However, some of these combinations are straightforward to implement.

This PR implements one of those straightforward combinations: showing header warnings alongside a data error.

#### What has been done to verify that this works as intended?

I updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

I considered using `.finally()`, i.e., setting `warnings` and/or `fileMetadata` in `.finally()`. However, I was worried that there would be a tick in which not all expected refs were set. I thought Vue might would try to re-render during that tick and that there could end up being a required component prop that was missing.