### PR TITLE
fix(web-forms#885): removes rounding from geo functions

### DIFF
--- a/.changeset/small-sites-crash.md
+++ b/.changeset/small-sites-crash.md
@@ -1,0 +1,7 @@
+---
+"@getodk/xpath": patch
+"@getodk/web-forms": patch
+"@getodk/xforms-engine": patch
+---
+
+Removed rounding from area() and distance() xpath functions.

--- a/packages/xforms-engine/test/integration/data-types/geo.test.ts
+++ b/packages/xforms-engine/test/integration/data-types/geo.test.ts
@@ -23,10 +23,6 @@ import { EARTH_EQUATORIAL_CIRCUMFERENCE_METERS } from '../../scenario/jr/core/ut
 
 const NINETY_DEGREES_ON_EQUATOR_KM = EARTH_EQUATORIAL_CIRCUMFERENCE_METERS / 4;
 
-interface RelaxedPrecisionOptions {
-  readonly relaxAssertionPrecision: boolean;
-}
-
 /**
  * **PORTING NOTES**
  *
@@ -147,67 +143,35 @@ describe('Geopoint', () => {
 
   describe('GeoDistanceTest.java', () => {
     describe('distance', () => {
-      /**
-       * **PORTING NOTES**
-       *
-       * Test fails with direct port, passes with relaxed precision in
-       * {@link ExpectStatic.toHaveAnswerCloseTo} assertion. This could be a
-       * difference in precision of one or more of:
-       *
-       * - the XPath `distance` implementation
-       * - the constant referenced in the assertion, and any of its underlying
-       *   computations
-       * - the actual {@link ExpectStatic.toHaveAnswerCloseTo} comparison logic
-       *   (but probably not, notes added there)
-       *
-       * Note that the difference between the directly ported tolerance, and the
-       * ported tolerance, is exceedingly small.
-       */
-      describe.each<RelaxedPrecisionOptions>([
-        { relaxAssertionPrecision: false },
-        { relaxAssertionPrecision: true },
-      ])('relax assertion precision: $relaxAssertionPrecision', ({ relaxAssertionPrecision }) => {
-        let testFn: typeof it | typeof it.fails;
+      it('is computed for a `geopoint` nodeset', async () => {
+        const scenario = await Scenario.init(
+          'geopoint nodeset distance',
+          html(
+            head(
+              title('Geopoint nodeset distance'),
+              model(
+                mainInstance(
+                  t(
+                    'data id="geopoint-distance"',
+                    t('location', t('point', '0 1 0.0 0.0')),
+                    t('location', t('point', '0 91 0.0 0.0')),
+                    t('distance')
+                  )
+                ),
+                bind('/data/location/point').type('geopoint'),
+                bind('/data/distance').type('decimal').calculate('distance(/data/location/point)')
+              )
+            ),
+            body(repeat('/data/location', input('/data/location/point')))
+          )
+        );
 
-        if (relaxAssertionPrecision) {
-          testFn = it;
-        } else {
-          testFn = it.fails;
-        }
-
-        testFn('is computed for [a] `geopoint` nodeset', async () => {
-          const scenario = await Scenario.init(
-            'geopoint nodeset distance',
-            html(
-              head(
-                title('Geopoint nodeset distance'),
-                model(
-                  mainInstance(
-                    t(
-                      'data id="geopoint-distance"',
-                      t('location', t('point', '0 1 0.0 0.0')),
-                      t('location', t('point', '0 91 0.0 0.0')),
-                      t('distance')
-                    )
-                  ),
-                  bind('/data/location/point').type('geopoint'),
-                  bind('/data/distance').type('decimal').calculate('distance(/data/location/point)')
-                )
-              ),
-              body(repeat('/data/location', input('/data/location/point')))
-            )
-          );
-
-          // assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
-          // 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7));
-          // })
-          expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
-            expectedDistance(
-              NINETY_DEGREES_ON_EQUATOR_KM,
-              relaxAssertionPrecision ? 0.0999999 : 1e-7
-            )
-          );
-        });
+        // assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+        // 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7));
+        // })
+        expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
+          expectedDistance(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7)
+        );
       });
 
       it('is computed for [a calculated] string', async () => {
@@ -347,57 +311,34 @@ describe('Geoshape', () => {
 
   describe('GeoDistanceTest.java', () => {
     describe('distance', () => {
-      /**
-       * **PORTING NOTES**
-       *
-       * Fails on directly ported precision. Same notes as previous test in
-       * first geopoint distance test. Parameterized to demonstrate passage when
-       * accommodated.
-       */
-      describe.each<RelaxedPrecisionOptions>([
-        { relaxAssertionPrecision: false },
-        { relaxAssertionPrecision: true },
-      ])('relax assertion precision: $relaxAssertionPrecision', ({ relaxAssertionPrecision }) => {
-        let testFn: typeof it | typeof it.fails;
+      it('is computed for geoshape', async () => {
+        const scenario = await Scenario.init(
+          'geoshape distance',
+          html(
+            head(
+              title('Geoshape distance'),
+              model(
+                mainInstance(
+                  t(
+                    'data id="geoshape-distance"',
+                    t('polygon', '0 1 0.0 0.0; 0 91 0.0 0.0; 0 1 0.0 0.0;'),
+                    t('distance')
+                  )
+                ),
+                bind('/data/polygon').type('geoshape'),
+                bind('/data/distance').type('decimal').calculate('distance(/data/polygon)')
+              )
+            ),
+            body(input('/data/polygon'))
+          )
+        );
 
-        if (relaxAssertionPrecision) {
-          testFn = it;
-        } else {
-          testFn = it.fails;
-        }
-
-        testFn('is computed for geoshape', async () => {
-          const scenario = await Scenario.init(
-            'geoshape distance',
-            html(
-              head(
-                title('Geoshape distance'),
-                model(
-                  mainInstance(
-                    t(
-                      'data id="geoshape-distance"',
-                      t('polygon', '0 1 0.0 0.0; 0 91 0.0 0.0; 0 1 0.0 0.0;'),
-                      t('distance')
-                    )
-                  ),
-                  bind('/data/polygon').type('geoshape'),
-                  bind('/data/distance').type('decimal').calculate('distance(/data/polygon)')
-                )
-              ),
-              body(input('/data/polygon'))
-            )
-          );
-
-          // assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
-          // 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM * 2, 1e-7));
-          // })
-          expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
-            expectedDistance(
-              NINETY_DEGREES_ON_EQUATOR_KM * 2,
-              relaxAssertionPrecision ? 0.0999999 : 1e-7
-            )
-          );
-        });
+        // assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+        // 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM * 2, 1e-7));
+        // })
+        expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
+          expectedDistance(NINETY_DEGREES_ON_EQUATOR_KM * 2, 1e-7)
+        );
       });
     });
   });
@@ -406,56 +347,33 @@ describe('Geoshape', () => {
 describe('Geotrace', () => {
   describe('GeoDistanceTest.java', () => {
     describe('distance', () => {
-      /**
-       * **PORTING NOTES**
-       *
-       * Fails on directly ported precision. Same notes as previous test in
-       * first geopoint distance test. Parameterized to demonstrate passage with
-       * relaxed precision.
-       */
-      describe.each<RelaxedPrecisionOptions>([
-        { relaxAssertionPrecision: false },
-        { relaxAssertionPrecision: true },
-      ])('relax assertion precision: $relaxAssertionPrecision', ({ relaxAssertionPrecision }) => {
-        let testFn: typeof it | typeof it.fails;
+      it('is computed for geotrace', async () => {
+        const scenario = await Scenario.init(
+          'geotrace distance',
+          html(
+            head(
+              title('Geotrace distance'),
+              model(
+                mainInstance(
+                  t(
+                    'data id="geotrace-distance"',
+                    t('line', '0 1 0.0 0.0; 0 91 0.0 0.0;'),
+                    t('distance')
+                  )
+                ),
+                bind('/data/line').type('geotrace'),
+                bind('/data/distance').type('decimal').calculate('distance(/data/line)')
+              )
+            ),
+            body(input('/data/line'))
+          )
+        );
 
-        if (relaxAssertionPrecision) {
-          testFn = it;
-        } else {
-          testFn = it.fails;
-        }
-
-        testFn('is computed for geotrace', async () => {
-          const scenario = await Scenario.init(
-            'geotrace distance',
-            html(
-              head(
-                title('Geotrace distance'),
-                model(
-                  mainInstance(
-                    t(
-                      'data id="geotrace-distance"',
-                      t('line', '0 1 0.0 0.0; 0 91 0.0 0.0;'),
-                      t('distance')
-                    )
-                  ),
-                  bind('/data/line').type('geotrace'),
-                  bind('/data/distance').type('decimal').calculate('distance(/data/line)')
-                )
-              ),
-              body(input('/data/line'))
-            )
-          );
-
-          // assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
-          // 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7));
-          expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
-            expectedDistance(
-              NINETY_DEGREES_ON_EQUATOR_KM,
-              relaxAssertionPrecision ? 0.0999999 : 1e-7
-            )
-          );
-        });
+        // assertThat(Double.parseDouble(scenario.answerOf("/data/distance").getDisplayText()),
+        // 		closeTo(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7));
+        expect(scenario.answerOf('/data/distance')).toHaveAnswerCloseTo(
+          expectedDistance(NINETY_DEGREES_ON_EQUATOR_KM, 1e-7)
+        );
       });
 
       describe('when [`geotrace`] trace has fewer than two points', () => {

--- a/packages/xpath/src/functions/xforms/geo.ts
+++ b/packages/xpath/src/functions/xforms/geo.ts
@@ -8,25 +8,8 @@ import { collectLines, validate } from '../../lib/geo/Geotrace.ts';
 import type { GeotraceLine } from '../../lib/geo/GeotraceLine.ts';
 
 const EARTH_EQUATORIAL_RADIUS_METERS = 6_378_100;
-const PRECISION = 100;
 
 const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
-
-const toPrecision = (value: number, precision: number) => {
-  if (value === 0) {
-    return 0;
-  }
-
-  return Math.round(value * precision) / precision;
-};
-
-const toAbsolutePrecision = (value: number, precision: number) => {
-  if (value === 0) {
-    return 0;
-  }
-
-  return Math.abs(toPrecision(value, precision));
-};
 
 const closeShape = (lines: readonly GeotraceLine[]): readonly GeotraceLine[] => {
   const [firstLine, ...rest] = lines;
@@ -58,7 +41,7 @@ const geodesicArea = (lines: readonly GeotraceLine[]): number => {
       (2 + Math.sin(toRadians(end.latitude)) + Math.sin(toRadians(start.latitude)));
   }
 
-  return (total * EARTH_EQUATORIAL_RADIUS_METERS * EARTH_EQUATORIAL_RADIUS_METERS) / 2;
+  return (Math.abs(total) * EARTH_EQUATORIAL_RADIUS_METERS * EARTH_EQUATORIAL_RADIUS_METERS) / 2;
 };
 
 const evaluateArgumentValues = <T extends XPathNode>(
@@ -77,9 +60,7 @@ export const area = new NumberFunction('area', [{ arityType: 'required' }], (con
   if (!valid || !points || points.length < 2) {
     return 0;
   }
-  const areaResult = geodesicArea(collectLines(points));
-
-  return toAbsolutePrecision(areaResult, PRECISION);
+  return geodesicArea(collectLines(points));
 });
 
 const geodesicDistance = (line: GeotraceLine): number => {
@@ -130,7 +111,7 @@ export const distance = new NumberFunction(
     }
 
     const distances = collectLines(points).map(geodesicDistance);
-    return toAbsolutePrecision(sum(distances), PRECISION);
+    return sum(distances);
   }
 );
 

--- a/packages/xpath/src/functions/xforms/geo.ts
+++ b/packages/xpath/src/functions/xforms/geo.ts
@@ -41,7 +41,7 @@ const geodesicArea = (lines: readonly GeotraceLine[]): number => {
       (2 + Math.sin(toRadians(end.latitude)) + Math.sin(toRadians(start.latitude)));
   }
 
-  return (Math.abs(total) * EARTH_EQUATORIAL_RADIUS_METERS * EARTH_EQUATORIAL_RADIUS_METERS) / 2;
+  return Math.abs((total * EARTH_EQUATORIAL_RADIUS_METERS * EARTH_EQUATORIAL_RADIUS_METERS) / 2);
 };
 
 const evaluateArgumentValues = <T extends XPathNode>(

--- a/packages/xpath/test/xforms/geo.test.ts
+++ b/packages/xpath/test/xforms/geo.test.ts
@@ -22,7 +22,7 @@ describe('geo functions', () => {
 
   [
     { argument: SHAPE1, expected: { area: 2333220.7737, distance: 5724.3578 } },
-    { argument: `  ${SHAPE1}  `, expected: { area: 2333220.77, distance: 5724.36 } }, // whitespace should be trimmed
+    { argument: `  ${SHAPE1}  `, expected: { area: 2333220.7737, distance: 5724.3578 } }, // whitespace should be trimmed
     { argument: TRACE1, expected: { area: 151451.7569, distance: 1800.6887 } },
     { argument: TRACE2, expected: { area: 122754.9414, distance: 1684.6153 } },
     { argument: TRACE3, expected: { area: 93911.4893, distance: 2076.2361 } },
@@ -59,15 +59,15 @@ describe('geo functions', () => {
   });
 
   [
-    { argument: ['0 1', '0 0'], expected: 111318.85 },
-    { argument: ['0 1', '', '0 0'], expected: 111318.85 },
-    { argument: ['0 1', '0 0', '0 2'], expected: 333956.54 },
+    { argument: ['0 1', '0 0'], expected: 111318.845 },
+    { argument: ['0 1', '', '0 0'], expected: 111318.845 },
+    { argument: ['0 1', '0 0', '0 2'], expected: 333956.5351 },
     { argument: ['0 0', '0 2'], expected: 222637.69 },
     { argument: ['0 0 ', '  0 2'], expected: 222637.69 },
   ].forEach(({ argument, expected }, i) => {
     const expr = argument.map((arg) => `"${arg}"`).join(',');
     it(`distance(${expr}) works (${i + 1})`, () => {
-      testContext.assertNumberValue(`distance(${expr})`, expected);
+      testContext.assertNumberRounded(`distance(${expr})`, expected, 10 ** 4);
     });
   });
 

--- a/packages/xpath/test/xforms/geo.test.ts
+++ b/packages/xpath/test/xforms/geo.test.ts
@@ -28,8 +28,8 @@ describe('geo functions', () => {
     { argument: TRACE3, expected: { area: 93911.49, distance: 2076.24 } },
     { argument: LINE, expected: { area: 0.0, distance: 861.99 } },
     { argument: SAME, expected: { area: 0.0, distance: 0.0 } },
-    { argument: '0 0;0 1', expected: { area: 0.0, distance: 111318.85 } },
-    { argument: '0 0;0 90', expected: { area: 0.0, distance: 10018696.05 } },
+    { argument: '0 0;0 1', expected: { area: 0.0, distance: 111318.84502143922 } },
+    { argument: '0 0;0 90', expected: { area: 0.0, distance: 10018696.05193053 } },
     { argument: '90 0;90 1', expected: { area: 0.0, distance: 0.0 } },
     { argument: '', expected: { area: 0.0, distance: NaN } },
     { argument: '90 0', expected: { area: 0.0, distance: NaN } }, // single point, no distance
@@ -113,10 +113,26 @@ describe('geo functions', () => {
     });
 
     [
-      { id: 'FunctionArea1', argument: './*', expected: { area: 2333220.77, distance: 5724.36 } },
-      { id: 'FunctionArea4', argument: '.', expected: { area: 2333220.77, distance: 5724.36 } },
-      { id: 'FunctionArea2', argument: './*', expected: { area: 122754.94, distance: 1684.62 } },
-      { id: 'FunctionArea3', argument: './*', expected: { area: 93911.49, distance: 2076.24 } },
+      {
+        id: 'FunctionArea1',
+        argument: './*',
+        expected: { area: 2333220.7737033986, distance: 5724.357765366115 },
+      },
+      {
+        id: 'FunctionArea4',
+        argument: '.',
+        expected: { area: 2333220.7737033986, distance: 5724.357765366115 },
+      },
+      {
+        id: 'FunctionArea2',
+        argument: './*',
+        expected: { area: 122754.94136148645, distance: 1684.6153014069914 },
+      },
+      {
+        id: 'FunctionArea3',
+        argument: './*',
+        expected: { area: 93911.48930565755, distance: 2076.236146373171 },
+      },
     ].forEach(({ id, argument, expected }, i) => {
       it(`area(${argument}) works (${i + 1})`, () => {
         const contextNode = testContext.document.getElementById(id);

--- a/packages/xpath/test/xforms/geo.test.ts
+++ b/packages/xpath/test/xforms/geo.test.ts
@@ -21,25 +21,25 @@ describe('geo functions', () => {
   const SAME = '7.9377 -11.5845 0 0;7.9377 -11.5845 0 0';
 
   [
-    { argument: SHAPE1, expected: { area: 2333220.77, distance: 5724.36 } },
+    { argument: SHAPE1, expected: { area: 2333220.7737, distance: 5724.3578 } },
     { argument: `  ${SHAPE1}  `, expected: { area: 2333220.77, distance: 5724.36 } }, // whitespace should be trimmed
-    { argument: TRACE1, expected: { area: 151451.76, distance: 1800.69 } },
-    { argument: TRACE2, expected: { area: 122754.94, distance: 1684.62 } },
-    { argument: TRACE3, expected: { area: 93911.49, distance: 2076.24 } },
-    { argument: LINE, expected: { area: 0.0, distance: 861.99 } },
+    { argument: TRACE1, expected: { area: 151451.7569, distance: 1800.6887 } },
+    { argument: TRACE2, expected: { area: 122754.9414, distance: 1684.6153 } },
+    { argument: TRACE3, expected: { area: 93911.4893, distance: 2076.2361 } },
+    { argument: LINE, expected: { area: 0.0, distance: 861.9904 } },
     { argument: SAME, expected: { area: 0.0, distance: 0.0 } },
-    { argument: '0 0;0 1', expected: { area: 0.0, distance: 111318.84502143922 } },
-    { argument: '0 0;0 90', expected: { area: 0.0, distance: 10018696.05193053 } },
+    { argument: '0 0;0 1', expected: { area: 0.0, distance: 111318.845 } },
+    { argument: '0 0;0 90', expected: { area: 0.0, distance: 10018696.0519 } },
     { argument: '90 0;90 1', expected: { area: 0.0, distance: 0.0 } },
     { argument: '', expected: { area: 0.0, distance: NaN } },
     { argument: '90 0', expected: { area: 0.0, distance: NaN } }, // single point, no distance
   ].forEach(({ argument, expected }, i) => {
     it(`area("${argument}") works (${i + 1})`, () => {
-      testContext.assertNumberValue(`area("${argument}")`, expected.area);
+      testContext.assertNumberRounded(`area("${argument}")`, expected.area, 10 ** 4);
     });
 
     it(`distance("${argument}") works (${i + 1})`, () => {
-      testContext.assertNumberValue(`distance("${argument}")`, expected.distance);
+      testContext.assertNumberRounded(`distance("${argument}")`, expected.distance, 10 ** 4);
     });
   });
 


### PR DESCRIPTION
Closes getodk/web-forms#885

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Testing

#### Why is this the best possible solution? Were any other approaches considered?

The challenging part was getting the tests to play nicely. Because each js engine has it's own rules about floating point numbers we have to round the results to get them to pass in each browser. This obviously has implications for form designers who may be relying on a high level of precision, however I still believe it's correct to leave it to the designers and the UX to round as appropriate.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Forms that used to get a rounded area or distance are now getting more precise results. This is consistent with Collect so I don't expect anyone is relying on it.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.