### PR TITLE
EntityUpload: ignore columns that start with __

### DIFF
--- a/.changeset/honest-guests-love.md
+++ b/.changeset/honest-guests-love.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+When importing Entities from CSV, ignore columns that start with `__` (getodk/central#1785)

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -253,10 +253,13 @@ const rowToEntity = (values, columns) => {
   let hasProperty = false;
   for (const [i, value] of values.entries()) {
     if (value === '') continue; // eslint-disable-line no-continue
+
     const column = columns[i];
-    if (column === 'label' || dataset.propertyMap.has(column)) {
+    if (column === 'label') {
+      obj.label = value;
+    } else if (dataset.propertyMap.has(column)) {
       obj[column] = value;
-      if (column !== 'label') hasProperty = true;
+      hasProperty = true;
     }
   }
   const { label } = obj;

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -206,17 +206,27 @@ const validateHeader = ({ columns, errors, meta }, file) => {
     const hasLabel = columnSet.has('label');
     errorDetails.missingLabel = !hasLabel;
 
-    const missingProperties = [];
+    warningDetails.missingProperties = [];
     for (const { name } of dataset.properties) {
-      if (!columnSet.has(name)) missingProperties.push(name);
+      if (!columnSet.has(name)) warningDetails.missingProperties.push(name);
     }
-    if (missingProperties.length !== 0)
-      warningDetails.missingProperties = missingProperties;
 
-    // Count of columns that are properties
-    const columnProperties = dataset.properties.length - missingProperties.length;
-    errorDetails.unknownProperty = columnSet.size !== columnProperties +
+    warningDetails.systemProperties = [];
+    for (const column of columnSet) {
+      if (column.startsWith('__')) {
+        warningDetails.systemProperties.push(column);
+      }
+    }
+
+    errorDetails.unknownProperty = columnSet.size !==
+      dataset.properties.length -
+      warningDetails.missingProperties.length +
+      warningDetails.systemProperties.length +
       (hasLabel ? 1 : 0);
+
+    for (const [name, value] of Object.entries(warningDetails)) {
+      if (value.length === 0) delete warningDetails[name];
+    }
   }
 
   const result = {};
@@ -241,8 +251,10 @@ const rowToEntity = (values, columns) => {
   for (const [i, value] of values.entries()) {
     if (value === '') continue; // eslint-disable-line no-continue
     const column = columns[i];
-    obj[column] = value;
-    if (column !== 'label') hasProperty = true;
+    if (column === 'label' || dataset.propertyMap.has(column)) {
+      obj[column] = value;
+      if (column !== 'label') hasProperty = true;
+    }
   }
   const { label } = obj;
   if (label == null || /^\s+$/.test(label))

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -224,6 +224,9 @@ const validateHeader = ({ columns, errors, meta }, file) => {
       warningDetails.systemProperties.length +
       (hasLabel ? 1 : 0);
 
+    // Remove empty arrays from warningDetails. EntityUploadWarnings expects
+    // nonapplicable warnings to be nullish. Removing these arrays also helps us
+    // count the number of warnings.
     for (const [name, value] of Object.entries(warningDetails)) {
       if (value.length === 0) delete warningDetails[name];
     }

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -15,6 +15,13 @@ except according to the terms contained in the LICENSE file.
     <p>{{ $t('introduction') }}</p>
 
     <!-- Column header warnings -->
+    <entity-upload-alert v-if="systemProperties != null" type="warning">
+      <template #title>{{ $t('systemProperties') }}</template>
+      <template #body>
+        <p>{{ $tc('propertiesIgnored', systemProperties.length) }}</p>
+        <p><i18n-list :list="systemProperties"/></p>
+      </template>
+    </entity-upload-alert>
     <entity-upload-alert v-if="missingProperties != null" type="warning">
       <template #title>
         {{ $tc('missingProperties', missingProperties.length) }}
@@ -45,6 +52,7 @@ defineOptions({
 });
 defineProps({
   // Column header warnings
+  systemProperties: Array,
   missingProperties: Array,
 
   // Data warnings (below the column header)
@@ -69,9 +77,11 @@ defineEmits(['rows']);
     "title": "Review warnings",
     "introduction": "Some rows contain warnings that may affect upload results.",
 
+    "systemProperties": "System properties can’t be set by .csv upload",
     // @transifexKey component.EntityUploadHeaderReview.missingProperties
     // This text is followed by a list of Entity property names.
     "missingProperties": "This property is not included in your file and will be left empty: | These properties are not included in your file and will be left empty:",
+    "propertiesIgnored": "This property will be ignored. | These properties will be ignored.",
 
     // This is a warning that is followed by a list of rows.
     "row": {

--- a/apps/central/src/request-data/resources.js
+++ b/apps/central/src/request-data/resources.js
@@ -91,20 +91,30 @@ export default (container, createResource) => {
     transformResponse: ({ data }) => shallowReactive(transformForm(data))
   }));
   createResource('dataset', (dataset) => {
-    // Add projectId to forms. FormLink expects this property to exist on form
-    // objects.
+    /* eslint-disable no-param-reassign */
     const transformData = (data) => {
+      // Add projectId to forms. FormLink expects this property to exist on form
+      // objects.
       const { projectId } = data;
       for (const form of data.sourceForms) form.projectId = projectId;
       for (const form of data.linkedForms) form.projectId = projectId;
       for (const property of data.properties) {
         for (const form of property.forms) form.projectId = projectId;
       }
+
       // The backend doesn't return accessFilter key if it is null (access to all), so we normalize
       // it here.
       if (!('accessFilter' in data)) Object.assign(data, { accessFilter: null });
+
+      if (data.properties != null) {
+        data.propertyMap = new Map();
+        for (const property of data.properties)
+          data.propertyMap.set(property.name, property);
+      }
+
       return data;
     };
+    /* eslint-enable no-param-reassign */
 
     return {
       transformResponse: ({ data }) =>

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -479,4 +479,36 @@ describe('EntityUpload', () => {
         }
       }]);
   });
+
+  it('ignores system properties', () => {
+    testData.extendedDatasets.createPast(1, {
+      properties: [{ name: 'height' }]
+    });
+    return showModal()
+      .complete()
+      .request(async (modal) => {
+        await selectFile(
+          modal,
+          createCSV('label,height,__id,__foo\ndogwood,1,e1,x\nelm,,e2,y')
+        );
+
+        // A warning is shown.
+        const warnings = modal.getComponent(EntityUploadWarnings).props();
+        warnings.systemProperties.should.eql(['__id', '__foo']);
+
+        return modal.get('.modal-actions .btn-primary').trigger('click');
+      })
+      .respondWithProblem()
+      .testRequests([{
+        method: 'POST',
+        url: '/v1/projects/1/datasets/trees/entities',
+        data: {
+          source: { name: 'my_data.csv', size: 48 },
+          entities: [
+            { label: 'dogwood', data: { height: '1' } },
+            { label: 'elm' }
+          ]
+        }
+      }]);
+  });
 });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -506,6 +506,8 @@ describe('EntityUpload', () => {
           source: { name: 'my_data.csv', size: 48 },
           entities: [
             { label: 'dogwood', data: { height: '1' } },
+            // If there were only system properties, no proper entity
+            // properties, don't bother sending an empty `data` object.
             { label: 'elm' }
           ]
         }

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -8,7 +8,20 @@ import { mount } from '../../../util/lifecycle';
 const mountComponent = (options) => mount(EntityUploadWarnings, options);
 
 describe('EntityUploadWarnings', () => {
-  it('shows missing properties', async () => {
+  it('shows a warning for system properties', async () => {
+    const component = mountComponent({
+      props: { systemProperties: ['__id', '__foo'] }
+    });
+    // Wait for I18nList to render.
+    await nextTick();
+
+    const p = component.getComponent(EntityUploadAlert).findAll('p');
+    p.length.should.equal(3);
+    p[0].text().should.startWith('System properties can’t be set');
+    p[2].text().should.equal('__id, __foo');
+  });
+
+  it('shows a warning for missing properties', async () => {
     const component = mountComponent({
       props: { missingProperties: ['foo', 'bar'] }
     });

--- a/apps/central/test/request-data/resources.spec.js
+++ b/apps/central/test/request-data/resources.spec.js
@@ -117,7 +117,7 @@ describe('createResources()', () => {
       expect(dataset.accessFilter).to.be.null;
     });
 
-    it('keys properties by name', () => {
+    it('adds propertyMap', () => {
       testData.extendedDatasets.createPast(1, {
         properties: [{ name: 'height' }, { name: 'circumference' }]
       });

--- a/apps/central/test/request-data/resources.spec.js
+++ b/apps/central/test/request-data/resources.spec.js
@@ -117,6 +117,16 @@ describe('createResources()', () => {
       expect(dataset.accessFilter).to.be.null;
     });
 
+    it('keys properties by name', () => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [{ name: 'height' }, { name: 'circumference' }]
+      });
+      const { propertyMap } = createResource();
+      [...propertyMap.keys()].should.eql(['height', 'circumference']);
+      propertyMap.get('height').name.should.equal('height');
+      propertyMap.get('circumference').name.should.equal('circumference');
+    });
+
     describe('replaceData', () => {
       it('adds projectId to forms in replaced data and accessFilter is set to null', () => {
         testData.extendedDatasets.createPast(1, {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2902,6 +2902,12 @@
       "introduction": {
         "string": "Some rows contain warnings that may affect upload results."
       },
+      "systemProperties": {
+        "string": "System properties can’t be set by .csv upload"
+      },
+      "propertiesIgnored": {
+        "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}"
+      },
       "row": {
         "raggedRows": {
           "string": "Fewer columns were found than expected in some rows:",


### PR DESCRIPTION
Closes getodk/central#1785.

#### What has been done to verify that this works as intended?

Mostly new tests, some local testing.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly it follows the same pattern as the `missingProperties` warning.

The one main difference is that we need to ignore these system properties when constructing the entity JSON. I updated `rowToEntity()` to do so. I'll almost certainly need to return to that function when working on getodk/central#1786.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

We should test entity upload fully once all the related issues are complete.