### PR TITLE
Fixes: don't close new/upload entity modal on outside click or ESC

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <modal id="entity-upload" :state="state" :hideable="!uploading" size="full"
+  <modal id="entity-upload" :state="state" :hideable="!uploading" :persistent="true" size="full"
     backdrop @hide="$emit('hide')" @mutate="resizeColumnIfShown">
     <template #title>{{ $t('title') }}</template>
     <template #body>

--- a/apps/central/src/components/entity/upsert.vue
+++ b/apps/central/src/components/entity/upsert.vue
@@ -1,5 +1,5 @@
 <template>
-  <modal class="entity-upsert" :state="state" :hideable="!awaitingResponse"
+  <modal class="entity-upsert" :state="state" :hideable="!awaitingResponse" :persistent="true"
     size="large" backdrop @shown="afterShown" @hide="$emit('hide')">
     <template #title>{{ create ? $t('titleCreate') : $t('title', currentVersion) }}</template>
     <template #body>

--- a/apps/central/src/components/modal.vue
+++ b/apps/central/src/components/modal.vue
@@ -17,7 +17,7 @@ checkScroll() method may add the `has-scroll` class. -->
     <div v-show="state" ref="el" v-bind="$attrs" class="modal" tabindex="-1"
       :style="backdrop ? { backgroundColor: 'rgba(0, 0, 0, 0.5)' } : null"
       role="dialog" :aria-labelledby="titleId" @mousedown="modalMousedown"
-      @click="modalClick" @keydown.esc="hideIfCan" @focusout="refocus">
+      @click="modalClick" @keydown.esc="hideOnEsc" @focusout="refocus">
       <div class="modal-dialog" :class="sizeClass" role="document">
         <div class="modal-content">
           <div class="modal-top-actions">
@@ -70,7 +70,9 @@ const props = defineProps({
     default: 'normal'
   },
   // Shows a dark overlay behind the modal
-  backdrop: Boolean
+  backdrop: Boolean,
+  // If true, the modal will not close on ESC key or click outside
+  persistent: Boolean
 });
 const emit = defineEmits(['shown', 'hide', 'mutate']);
 
@@ -204,6 +206,7 @@ onMounted(() => { if (props.state) show(); });
 onBeforeUnmount(() => { if (props.state) hide(); });
 
 const hideIfCan = () => { if (props.hideable) emit('hide'); };
+const hideOnEsc = () => { if (!props.persistent) hideIfCan(); };
 
 const sizeClass = computed(() => {
   switch (props.size) {
@@ -218,6 +221,7 @@ const modalMousedown = (event) => {
   mousedownOutsideDialog = event.target === event.currentTarget;
 };
 const modalClick = (event) => {
+  if (props.persistent) return;
   const mouseupOutsideDialog = event.target === event.currentTarget;
   if (mousedownOutsideDialog && mouseupOutsideDialog) hideIfCan();
 };

--- a/apps/central/test/components/modal.spec.js
+++ b/apps/central/test/components/modal.spec.js
@@ -194,7 +194,21 @@ describe('Modal', () => {
     });
   });
 
-  describe('persistent prop', () => {
+  describe('hiding the modal', () => {
+    it('emits hide on ESC key by default', async () => {
+      const modal = mountComponent();
+      await modal.get('.modal').trigger('keydown.esc');
+      should.exist(modal.emitted().hide);
+    });
+
+    it('emits hide on click outside by default', async () => {
+      const modal = mountComponent();
+      const modalEl = modal.get('.modal');
+      await modalEl.trigger('mousedown');
+      await modalEl.trigger('click');
+      should.exist(modal.emitted().hide);
+    });
+
     it('does not emit hide on ESC key when persistent is true', async () => {
       const modal = mountComponent({
         props: { persistent: true }

--- a/apps/central/test/components/modal.spec.js
+++ b/apps/central/test/components/modal.spec.js
@@ -193,4 +193,24 @@ describe('Modal', () => {
       });
     });
   });
+
+  describe('persistent prop', () => {
+    it('does not emit hide on ESC key when persistent is true', async () => {
+      const modal = mountComponent({
+        props: { persistent: true }
+      });
+      await modal.get('.modal').trigger('keydown.esc');
+      should.not.exist(modal.emitted().hide);
+    });
+
+    it('does not emit hide on click outside when persistent is true', async () => {
+      const modal = mountComponent({
+        props: { persistent: true }
+      });
+      const modalEl = modal.get('.modal');
+      await modalEl.trigger('mousedown');
+      await modalEl.trigger('click');
+      should.not.exist(modal.emitted().hide);
+    });
+  });
 });


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1961

#### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Added a new prop `persistent` which disables hiding on outside click and ESC. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No