### PR TITLE
Fixes/focus modal on shown

### DIFF
--- a/apps/central/src/components/modal.vue
+++ b/apps/central/src/components/modal.vue
@@ -17,7 +17,7 @@ checkScroll() method may add the `has-scroll` class. -->
     <div v-show="state" ref="el" v-bind="$attrs" class="modal" tabindex="-1"
       :style="backdrop ? { backgroundColor: 'rgba(0, 0, 0, 0.5)' } : null"
       role="dialog" :aria-labelledby="titleId" @mousedown="modalMousedown"
-      @click="modalClick" @keydown.esc="hideOnEsc" @focusout="refocus">
+      @click="modalClick" @keydown.esc="hideOnEsc">
       <div class="modal-dialog" :class="sizeClass" role="document">
         <div class="modal-content">
           <div class="modal-top-actions">
@@ -166,6 +166,16 @@ const observer = new MutationObserver(() => {
   }
 });
 
+// Redirects focus back to the modal if it moves outside. Similar to bootstrap's internal
+// implementation
+const enforceFocus = (event) => {
+  if (!props.state || el.value == null) return;
+  // Do not focus the .modal element if it is already focused or if it
+  // contains the focused element.
+  if (event.target === el.value || event.target.closest('.modal') === el.value) return;
+  el.value.focus();
+};
+
 const show = () => {
   addModalOpenClass();
   checkScroll();
@@ -176,8 +186,16 @@ const show = () => {
     characterData: true
   });
   window.addEventListener('resize', handleWindowResize);
+  document.addEventListener('focusin', enforceFocus);
+
   // Emit shown after nextTick to ensure DOM is updated (v-show has made element visible)
-  nextTick(() => { emit('shown'); });
+  nextTick(() => {
+    // Focus the modal so that pressing Escape will hide it.
+    if (document.activeElement != null && document.activeElement.closest('.modal') !== el.value) {
+      el.value.focus();
+    }
+    emit('shown');
+  });
   openModal.shown(el.value);
 };
 const removeSelection = () => {
@@ -191,6 +209,7 @@ const hide = () => {
   removeModalOpenClass();
   el.value.classList.remove('has-scroll');
   window.removeEventListener('resize', handleWindowResize);
+  document.removeEventListener('focusin', enforceFocus);
   removeSelection();
   openModal.hidden();
 };
@@ -226,27 +245,7 @@ const modalClick = (event) => {
   if (mousedownOutsideDialog && mouseupOutsideDialog) hideIfCan();
 };
 
-// Refocuses the modal if it has lost focus. This is needed so that the escape
-// key still hides the modal.
-const refocus = () => {
-  /* As the user moves from one element in the modal to another, there may be
-  the briefest moment when neither element is focused. We should not refocus the
-  modal in that moment, because the second element will soon receive focus, and
-  focusing the .modal element would prevent that. Thus, we use setTimeout() to
-  give the second element time to receive focus. (Using nextTick() instead of
-  setTimeout() didn't work.) */
-  setTimeout(() => {
-    // Do not focus the modal if it has lost focus after being hidden or
-    // unmounted.
-    if (!props.state || el.value == null) return;
-    // Do not focus the .modal element if it is already focused or if it
-    // contains the active element.
-    if (document.activeElement != null &&
-      document.activeElement.closest('.modal') === el.value)
-      return;
-    el.value.focus();
-  });
-};
+
 
 id += 1;
 const titleId = `modal-title${id}`;

--- a/apps/central/src/components/modal.vue
+++ b/apps/central/src/components/modal.vue
@@ -191,7 +191,7 @@ const show = () => {
   // Emit shown after nextTick to ensure DOM is updated (v-show has made element visible)
   nextTick(() => {
     // Focus the modal so that pressing Escape will hide it.
-    if (document.activeElement != null && document.activeElement.closest('.modal') !== el.value) {
+    if (document.activeElement == null || document.activeElement.closest('.modal') !== el.value) {
       el.value.focus();
     }
     emit('shown');

--- a/apps/central/test/components/modal.spec.js
+++ b/apps/central/test/components/modal.spec.js
@@ -138,6 +138,27 @@ describe('Modal', () => {
     });
   });
 
+  describe('focus', () => {
+    it('focuses the modal after it is shown', async () => {
+      const modal = mountComponent({
+        props: { state: true },
+        attachTo: document.body
+      });
+      await nextTick();
+      document.activeElement.should.equal(modal.get('.modal').element);
+    });
+
+    it('emits hide event after Escape key is pressed', async () => {
+      const modal = mountComponent({
+        props: { state: true, hideable: true },
+        attachTo: document.body
+      });
+      await nextTick();
+      await modal.get('.modal').trigger('keydown.esc');
+      should.exist(modal.emitted().hide);
+    });
+  });
+
   describe('size prop', () => {
     it("adds the correct class if the prop is 'large'", () => {
       const modal = mountComponent({

--- a/apps/central/test/components/modal.spec.js
+++ b/apps/central/test/components/modal.spec.js
@@ -147,16 +147,6 @@ describe('Modal', () => {
       await nextTick();
       document.activeElement.should.equal(modal.get('.modal').element);
     });
-
-    it('emits hide event after Escape key is pressed', async () => {
-      const modal = mountComponent({
-        props: { state: true, hideable: true },
-        attachTo: document.body
-      });
-      await nextTick();
-      await modal.get('.modal').trigger('keydown.esc');
-      should.exist(modal.emitted().hide);
-    });
   });
 
   describe('size prop', () => {


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/2163

#### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

Brings back the function that was there with the bootstrap.

- Onshow, modal or it's element should have the focus
- any time focus is back to the document (after focus shift to browser control), it should come back to the modal

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

no


#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

no