### PR TITLE
EntityUpload: ignore columns that are invalid property names

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -98,6 +98,7 @@ import { formatCSVRow, parseCSV, parseCSVHeader } from '../../util/csv';
 import { noop } from '../../util/util';
 import { odataEntityToRest } from '../../util/odata';
 import { useRequestData } from '../../request-data';
+import { validatePropertyName } from '../../util/entity';
 
 defineOptions({
   name: 'EntityUpload'
@@ -212,9 +213,13 @@ const validateHeader = ({ columns, errors, meta }, file) => {
     }
 
     warningDetails.systemProperties = [];
+    warningDetails.invalidProperties = [];
     for (const column of columnSet) {
+      if (column === 'label') continue; // eslint-disable-line no-continue
       if (column.startsWith('__')) {
         warningDetails.systemProperties.push(column);
+      } else if (!validatePropertyName(column)) {
+        warningDetails.invalidProperties.push(column);
       }
     }
 
@@ -222,6 +227,7 @@ const validateHeader = ({ columns, errors, meta }, file) => {
       dataset.properties.length -
       warningDetails.missingProperties.length +
       warningDetails.systemProperties.length +
+      warningDetails.invalidProperties.length +
       (hasLabel ? 1 : 0);
 
     // Remove empty arrays from warningDetails. EntityUploadWarnings expects

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -22,6 +22,13 @@ except according to the terms contained in the LICENSE file.
         <p><i18n-list :list="systemProperties"/></p>
       </template>
     </entity-upload-alert>
+    <entity-upload-alert v-if="invalidProperties != null" type="warning">
+      <template #title>{{ $tc('invalidProperties', invalidProperties.length) }}</template>
+      <template #body>
+        <p>{{ $tc('propertiesIgnored', invalidProperties.length) }}</p>
+        <p><i18n-list :list="invalidProperties"/></p>
+      </template>
+    </entity-upload-alert>
     <entity-upload-alert v-if="missingProperties != null" type="warning">
       <template #title>
         {{ $tc('missingProperties', missingProperties.length) }}
@@ -53,6 +60,7 @@ defineOptions({
 defineProps({
   // Column header warnings
   systemProperties: Array,
+  invalidProperties: Array,
   missingProperties: Array,
 
   // Data warnings (below the column header)
@@ -78,6 +86,7 @@ defineEmits(['rows']);
     "introduction": "Some rows contain warnings that may affect upload results.",
 
     "systemProperties": "System properties can’t be set by .csv upload",
+    "invalidProperties": "This column is not a valid property name | These columns are not valid property names",
     // @transifexKey component.EntityUploadHeaderReview.missingProperties
     // This text is followed by a list of Entity property names.
     "missingProperties": "This property is not included in your file and will be left empty: | These properties are not included in your file and will be left empty:",

--- a/apps/central/src/util/entity.js
+++ b/apps/central/src/util/entity.js
@@ -1,0 +1,7 @@
+// This function has been copied from Central Backend (lib/data/dataset.js).
+// eslint-disable-next-line import/prefer-default-export
+export const validatePropertyName = (name) => {
+  const match = /^(?!__)(?!name$)(?!label$)[\p{L}_][\p{L}\d._-]*$/u.exec(name.toLowerCase());
+
+  return (match !== null);
+};

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -513,4 +513,39 @@ describe('EntityUpload', () => {
         }
       }]);
   });
+
+  it('ignores columns that are not valid property names', () => {
+    testData.extendedDatasets.createPast(1, {
+      name: 'people',
+      properties: [{ name: 'height' }]
+    });
+    return showModal()
+      .complete()
+      .request(async (modal) => {
+        await selectFile(
+          modal,
+          createCSV('label,height,LABEL,"First name",phone#\nAlice,123,Alice,Alice,456\nChelsea,,Chelsea,Chelsea,789')
+        );
+
+        // A warning is shown.
+        const warnings = modal.getComponent(EntityUploadWarnings).props();
+        warnings.invalidProperties.should.eql(['LABEL', 'First name', 'phone#']);
+
+        return modal.get('.modal-actions .btn-primary').trigger('click');
+      })
+      .respondWithProblem()
+      .testRequests([{
+        method: 'POST',
+        url: '/v1/projects/1/datasets/people/entities',
+        data: {
+          source: { name: 'my_data.csv', size: 93 },
+          entities: [
+            { label: 'Alice', data: { height: '123' } },
+            // There were no valid entity properties, so don't bother sending an
+            // empty `data` object.
+            { label: 'Chelsea' }
+          ]
+        }
+      }]);
+  });
 });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -524,7 +524,7 @@ describe('EntityUpload', () => {
       .request(async (modal) => {
         await selectFile(
           modal,
-          createCSV('label,height,LABEL,"First name",phone#\nAlice,123,Alice,Alice,456\nChelsea,,Chelsea,Chelsea,789')
+          createCSV('label,height,LABEL,First name,phone#\nAlice,123,Alice,Alice,456\nChelsea,,Chelsea,Chelsea,789')
         );
 
         // A warning is shown.
@@ -538,7 +538,7 @@ describe('EntityUpload', () => {
         method: 'POST',
         url: '/v1/projects/1/datasets/people/entities',
         data: {
-          source: { name: 'my_data.csv', size: 93 },
+          source: { name: 'my_data.csv', size: 91 },
           entities: [
             { label: 'Alice', data: { height: '123' } },
             // There were no valid entity properties, so don't bother sending an

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -30,7 +30,7 @@ describe('EntityUploadWarnings', () => {
 
     const p = component.getComponent(EntityUploadAlert).findAll('p');
     p.length.should.equal(3);
-    p[0].text().should.startWith('These columns are not valid property names');
+    p[0].text().should.equal('These columns are not valid property names');
     p[2].text().should.equal('First name, phone#');
   });
 

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -21,6 +21,19 @@ describe('EntityUploadWarnings', () => {
     p[2].text().should.equal('__id, __foo');
   });
 
+  it('shows a warning for columns that are invalid property names', async () => {
+    const component = mountComponent({
+      props: { invalidProperties: ['First name', 'phone#'] }
+    });
+    // Wait for I18nList to render.
+    await nextTick();
+
+    const p = component.getComponent(EntityUploadAlert).findAll('p');
+    p.length.should.equal(3);
+    p[0].text().should.startWith('These columns are not valid property names');
+    p[2].text().should.equal('First name, phone#');
+  });
+
   it('shows a warning for missing properties', async () => {
     const component = mountComponent({
       props: { missingProperties: ['foo', 'bar'] }

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2905,6 +2905,9 @@
       "systemProperties": {
         "string": "System properties can’t be set by .csv upload"
       },
+      "invalidProperties": {
+        "string": "{count, plural, one {This column is not a valid property name} other {These columns are not valid property names}}"
+      },
       "propertiesIgnored": {
         "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}"
       },


### PR DESCRIPTION
This PR makes progress on getodk/central#2164. It handles one of the two cases described in the issue, whereby one or more columns have names that would be invalid entity property names.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I tried to do something similar as what I did in #1819.