### PR TITLE
EntityUpload: ignore columns that don't match on letter case

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -51,7 +51,7 @@ except according to the terms contained in the LICENSE file.
           </div>
         </div>
         <entity-upload-warnings v-if="warnings != null" v-bind="warnings"
-          @rows="showWarningRows"/>
+          :filename="fileMetadata.name" @rows="showWarningRows"/>
         <entity-upload-file-select v-show="csvEntities == null"
           :parsing="parsing" @change="selectFile">
           <entity-upload-header-help :errors="headerErrors"/>
@@ -208,18 +208,26 @@ const validateHeader = ({ columns, errors, meta }, file) => {
     errorDetails.missingLabel = !hasLabel;
 
     warningDetails.missingProperties = [];
+    const lowercaseProperties = new Map();
     for (const { name } of dataset.properties) {
       if (!columnSet.has(name)) warningDetails.missingProperties.push(name);
+
+      lowercaseProperties.set(name.toLowerCase(), name);
     }
 
     warningDetails.systemProperties = [];
     warningDetails.invalidProperties = [];
+    warningDetails.caseMismatch = [];
     for (const column of columnSet) {
       if (column === 'label') continue; // eslint-disable-line no-continue
       if (column.startsWith('__')) {
         warningDetails.systemProperties.push(column);
       } else if (!validatePropertyName(column)) {
         warningDetails.invalidProperties.push(column);
+      } else {
+        const property = lowercaseProperties.get(column.toLowerCase());
+        if (property != null)
+          warningDetails.caseMismatch.push({ column, property });
       }
     }
 

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -226,7 +226,7 @@ const validateHeader = ({ columns, errors, meta }, file) => {
         warningDetails.invalidProperties.push(column);
       } else {
         const property = lowercaseProperties.get(column.toLowerCase());
-        if (property != null)
+        if (property != null && column !== property)
           warningDetails.caseMismatch.push({ column, property });
       }
     }
@@ -236,6 +236,7 @@ const validateHeader = ({ columns, errors, meta }, file) => {
       warningDetails.missingProperties.length +
       warningDetails.systemProperties.length +
       warningDetails.invalidProperties.length +
+      warningDetails.caseMismatch.length +
       (hasLabel ? 1 : 0);
 
     // Remove empty arrays from warningDetails. EntityUploadWarnings expects

--- a/apps/central/src/components/entity/upload/alert.vue
+++ b/apps/central/src/components/entity/upload/alert.vue
@@ -60,12 +60,14 @@ const { formatRange } = useI18nUtils();
   border-radius: 12px;
   padding: 10px 15px;
 
+  p {
+    margin-bottom: 10px;
+    &:last-child { margin-bottom: 0; }
+  }
+
   // Title
   > :first-child {
     @include line-clamp(2);
-    margin-bottom: 10px;
-
-    &:last-child { margin-bottom: 0; }
 
     // Icon
     > :first-child { margin-right: $margin-right-icon; }

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -22,6 +22,31 @@ except according to the terms contained in the LICENSE file.
         <p><i18n-list :list="systemProperties"/></p>
       </template>
     </entity-upload-alert>
+    <entity-upload-alert v-if="caseMismatch != null"
+      id="entity-upload-warnings-case-mismatch" type="warning">
+      <template #title>{{ $t('caseMismatch.title') }}</template>
+      <template #body>
+        <p>
+          <span>{{ $t('caseMismatch.description') }}</span>
+          <sentence-separator/>
+          <span>{{ $tc('columnsIgnored', caseMismatch.length) }}</span>
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>{{ $t('header.existingProperty') }}</th>
+              <th v-tooltip.text>{{ filename }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="{ column, property } of caseMismatch" :key="column">
+              <td v-tooltip.text>{{ column }}</td>
+              <td v-tooltip.text>{{ property }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+    </entity-upload-alert>
     <entity-upload-alert v-if="invalidProperties != null" type="warning">
       <template #title>{{ $tc('invalidProperties', invalidProperties.length) }}</template>
       <template #body>
@@ -53,13 +78,20 @@ except according to the terms contained in the LICENSE file.
 <script setup>
 import EntityUploadAlert from './alert.vue';
 import I18nList from '../../i18n/list.vue';
+import SentenceSeparator from '../../sentence-separator.vue';
 
 defineOptions({
   name: 'EntityUploadWarnings'
 });
 defineProps({
+  filename: {
+    type: String,
+    required: true
+  },
+
   // Column header warnings
   systemProperties: Array,
+  caseMismatch: Array,
   invalidProperties: Array,
   missingProperties: Array,
 
@@ -71,8 +103,15 @@ defineEmits(['rows']);
 </script>
 
 <style lang="scss">
+@import '../../../assets/scss/mixins';
+
 #entity-upload-warnings {
   margin-top: 20px;
+}
+
+#entity-upload-warnings-case-mismatch {
+  table { table-layout: fixed; }
+  th, td { @include text-overflow-ellipsis; }
 }
 </style>
 
@@ -86,16 +125,25 @@ defineEmits(['rows']);
     "introduction": "Some rows contain warnings that may affect upload results.",
 
     "systemProperties": "System properties can’t be set by .csv upload",
+    "caseMismatch": {
+      "title": "Column is similar to an existing property but does not match",
+      "description": "Column names are case-sensitive. Check the spelling and capitalization."
+    },
     "invalidProperties": "This column is not a valid property name | These columns are not valid property names",
     // @transifexKey component.EntityUploadHeaderReview.missingProperties
     // This text is followed by a list of Entity property names.
     "missingProperties": "This property is not included in your file and will be left empty: | These properties are not included in your file and will be left empty:",
     "propertiesIgnored": "This property will be ignored. | These properties will be ignored.",
+    "columnsIgnored": "This column will be ignored. | These properties will be ignored.",
 
     // This is a warning that is followed by a list of rows.
     "row": {
       "raggedRows": "Fewer columns were found than expected in some rows:",
       "largeCell": "Some cells are abnormally large, which can indicate difficulties reading your file:"
+    },
+
+    "header": {
+      "existingProperty": "Existing property"
     }
   }
 }

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -35,7 +35,7 @@ except according to the terms contained in the LICENSE file.
           <table class="table">
             <thead>
               <tr>
-                <th>{{ $t('header.existingProperty') }}</th>
+                <th>{{ $t('caseMismatch.existingProperty') }}</th>
                 <th v-tooltip.text>{{ filename }}</th>
               </tr>
             </thead>
@@ -137,15 +137,21 @@ defineEmits(['rows']);
     "title": "Review warnings",
     "introduction": "Some rows contain warnings that may affect upload results.",
 
+    // "Properties" refers to Entity properties.
     "systemProperties": "System properties can’t be set by .csv upload",
     "caseMismatch": {
+      // "Property" refers to an Entity property.
       "title": "Column is similar to an existing property but does not match",
-      "description": "Column names are case-sensitive. Check the spelling and capitalization."
+      "description": "Column names are case-sensitive. Check the spelling and capitalization.",
+      // "Property" refers to an Entity property.
+      "existingProperty": "Existing property"
     },
+    // "Property" refers to an Entity property.
     "invalidProperties": "This column is not a valid property name | These columns are not valid property names",
     // @transifexKey component.EntityUploadHeaderReview.missingProperties
     // This text is followed by a list of Entity property names.
     "missingProperties": "This property is not included in your file and will be left empty: | These properties are not included in your file and will be left empty:",
+    // "Property" refers to an Entity property.
     "propertiesIgnored": "This property will be ignored. | These properties will be ignored.",
     "columnsIgnored": "This column will be ignored. | These columns will be ignored.",
 
@@ -153,10 +159,6 @@ defineEmits(['rows']);
     "row": {
       "raggedRows": "Fewer columns were found than expected in some rows:",
       "largeCell": "Some cells are abnormally large, which can indicate difficulties reading your file:"
-    },
-
-    "header": {
-      "existingProperty": "Existing property"
     }
   }
 }

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -134,7 +134,7 @@ defineEmits(['rows']);
     // This text is followed by a list of Entity property names.
     "missingProperties": "This property is not included in your file and will be left empty: | These properties are not included in your file and will be left empty:",
     "propertiesIgnored": "This property will be ignored. | These properties will be ignored.",
-    "columnsIgnored": "This column will be ignored. | These properties will be ignored.",
+    "columnsIgnored": "This column will be ignored. | These columns will be ignored.",
 
     // This is a warning that is followed by a list of rows.
     "row": {

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -40,8 +40,8 @@ except according to the terms contained in the LICENSE file.
           </thead>
           <tbody>
             <tr v-for="{ column, property } of caseMismatch" :key="column">
-              <td v-tooltip.text>{{ column }}</td>
               <td v-tooltip.text>{{ property }}</td>
+              <td v-tooltip.text>{{ column }}</td>
             </tr>
           </tbody>
         </table>

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -31,20 +31,22 @@ except according to the terms contained in the LICENSE file.
           <sentence-separator/>
           <span>{{ $tc('columnsIgnored', caseMismatch.length) }}</span>
         </p>
-        <table>
-          <thead>
-            <tr>
-              <th>{{ $t('header.existingProperty') }}</th>
-              <th v-tooltip.text>{{ filename }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="{ column, property } of caseMismatch" :key="column">
-              <td v-tooltip.text>{{ property }}</td>
-              <td v-tooltip.text>{{ column }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <div>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>{{ $t('header.existingProperty') }}</th>
+                <th v-tooltip.text>{{ filename }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="{ column, property } of caseMismatch" :key="column">
+                <td v-tooltip.text>{{ property }}</td>
+                <td v-tooltip.text>{{ column }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </template>
     </entity-upload-alert>
     <entity-upload-alert v-if="invalidProperties != null" type="warning">
@@ -110,7 +112,18 @@ defineEmits(['rows']);
 }
 
 #entity-upload-warnings-case-mismatch {
-  table { table-layout: fixed; }
+  div:has(> table) {
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 10px;
+    padding: 6px;
+  }
+
+  table {
+    margin-bottom: 0;
+    table-layout: fixed;
+  }
+
+  thead { background-color: transparent; }
   th, td { @include text-overflow-ellipsis; }
 }
 </style>

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -548,4 +548,39 @@ describe('EntityUpload', () => {
         }
       }]);
   });
+
+  it('ignores columns that only differ from properties on letter case', () => {
+    testData.extendedDatasets.createPast(1, {
+      properties: [{ name: 'height' }, { name: 'circumference' }, { name: 'species' }]
+    });
+    return showModal()
+      .complete()
+      .request(async (modal) => {
+        await selectFile(
+          modal,
+          createCSV('label,height,CIRCUMFERENCE,Species\ndogwood,1,2,dogwood\nelm,,3,elm')
+        );
+
+        // A warning is shown.
+        const warnings = modal.getComponent(EntityUploadWarnings).props();
+        warnings.caseMismatch.should.eql([
+          { column: 'CIRCUMFERENCE', property: 'circumference' },
+          { column: 'Species', property: 'species' }
+        ]);
+
+        return modal.get('.modal-actions .btn-primary').trigger('click');
+      })
+      .respondWithProblem()
+      .testRequests([{
+        method: 'POST',
+        url: '/v1/projects/1/datasets/trees/entities',
+        data: {
+          source: { name: 'my_data.csv', size: 66 },
+          entities: [
+            { label: 'dogwood', data: { height: '1' } },
+            { label: 'elm' }
+          ]
+        }
+      }]);
+  });
 });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -575,7 +575,7 @@ describe('EntityUpload', () => {
         method: 'POST',
         url: '/v1/projects/1/datasets/trees/entities',
         data: {
-          source: { name: 'my_data.csv', size: 66 },
+          source: { name: 'my_data.csv', size: 65 },
           entities: [
             { label: 'dogwood', data: { height: '1' } },
             { label: 'elm' }

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -44,11 +44,11 @@ describe('EntityUploadWarnings', () => {
     th.text().should.equal('my_entity_data.csv');
     await th.should.be.textTooltip();
 
-    const tdText = table.findAll('tr').map(tr =>
+    const tdText = table.findAll('tbody tr').map(tr =>
       tr.findAll('td').map(td => td.text()));
     tdText.should.eql([
-      ['CIRCUMFERENCE', 'circumference'],
-      ['Species', 'species']
+      ['circumference', 'CIRCUMFERENCE'],
+      ['species', 'Species']
     ]);
     await table.get('td').should.be.textTooltip();
   });

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -3,9 +3,12 @@ import { nextTick } from 'vue';
 import EntityUploadAlert from '../../../../src/components/entity/upload/alert.vue';
 import EntityUploadWarnings from '../../../../src/components/entity/upload/warnings.vue';
 
-import { mount } from '../../../util/lifecycle';
+import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
-const mountComponent = (options) => mount(EntityUploadWarnings, options);
+const mountComponent = (options) =>
+  mount(EntityUploadWarnings, mergeMountOptions(options, {
+    props: { filename: 'test.csv' }
+  }));
 
 describe('EntityUploadWarnings', () => {
   it('shows a warning for system properties', async () => {
@@ -19,6 +22,35 @@ describe('EntityUploadWarnings', () => {
     p.length.should.equal(3);
     p[0].text().should.startWith('System properties can’t be set');
     p[2].text().should.equal('__id, __foo');
+  });
+
+  it('shows a warning for columns that only differ from properties on letter case', async () => {
+    const component = mountComponent({
+      props: {
+        filename: 'my_entity_data.csv',
+        caseMismatch: [
+          { column: 'CIRCUMFERENCE', property: 'circumference' },
+          { column: 'Species', property: 'species' }
+        ]
+      }
+    });
+
+    const warning = component.getComponent(EntityUploadAlert);
+    const title = warning.get('p').text();
+    title.should.startWith('Column is similar to an existing property');
+
+    const table = warning.get('table');
+    const th = table.get('th:last-child');
+    th.text().should.equal('my_entity_data.csv');
+    await th.should.be.textTooltip();
+
+    const tdText = table.findAll('tr').map(tr =>
+      tr.findAll('td').map(td => td.text()));
+    tdText.should.eql([
+      ['CIRCUMFERENCE', 'circumference'],
+      ['Species', 'species']
+    ]);
+    await table.get('td').should.be.textTooltip();
   });
 
   it('shows a warning for columns that are invalid property names', async () => {

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -7,7 +7,7 @@ import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
 const mountComponent = (options) =>
   mount(EntityUploadWarnings, mergeMountOptions(options, {
-    props: { filename: 'test.csv' }
+    props: { filename: 'my_data.csv' }
   }));
 
 describe('EntityUploadWarnings', () => {
@@ -24,10 +24,9 @@ describe('EntityUploadWarnings', () => {
     p[2].text().should.equal('__id, __foo');
   });
 
-  it('shows a warning for columns that only differ from properties on letter case', async () => {
+  it('shows a warning for columns that differ from properties on letter case', async () => {
     const component = mountComponent({
       props: {
-        filename: 'my_entity_data.csv',
         caseMismatch: [
           { column: 'CIRCUMFERENCE', property: 'circumference' },
           { column: 'Species', property: 'species' }
@@ -41,8 +40,8 @@ describe('EntityUploadWarnings', () => {
 
     const table = warning.get('table');
     const th = table.get('th:last-child');
-    th.text().should.equal('my_entity_data.csv');
-    await th.should.be.textTooltip();
+    th.text().should.equal('my_data.csv');
+    await th.should.have.textTooltip();
 
     const tdText = table.findAll('tbody tr').map(tr =>
       tr.findAll('td').map(td => td.text()));
@@ -50,7 +49,7 @@ describe('EntityUploadWarnings', () => {
       ['circumference', 'CIRCUMFERENCE'],
       ['species', 'Species']
     ]);
-    await table.get('td').should.be.textTooltip();
+    await table.get('td').should.have.textTooltip();
   });
 
   it('shows a warning for columns that are invalid property names', async () => {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2905,11 +2905,22 @@
       "systemProperties": {
         "string": "System properties can’t be set by .csv upload"
       },
+      "caseMismatch": {
+        "title": {
+          "string": "Column is similar to an existing property but does not match"
+        },
+        "description": {
+          "string": "Column names are case-sensitive. Check the spelling and capitalization."
+        }
+      },
       "invalidProperties": {
         "string": "{count, plural, one {This column is not a valid property name} other {These columns are not valid property names}}"
       },
       "propertiesIgnored": {
         "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}"
+      },
+      "columnsIgnored": {
+        "string": "{count, plural, one {This column will be ignored.} other {These properties will be ignored.}}"
       },
       "row": {
         "raggedRows": {
@@ -2919,6 +2930,12 @@
         "largeCell": {
           "string": "Some cells are abnormally large, which can indicate difficulties reading your file:",
           "developer_comment": "This is a warning that is followed by a list of rows."
+        }
+      },
+      "header": {
+        "existingProperty": {
+          "string": "Existing property",
+          "developer_comment": "This is the text of a table column header."
         }
       }
     },

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2903,21 +2903,29 @@
         "string": "Some rows contain warnings that may affect upload results."
       },
       "systemProperties": {
-        "string": "System properties can’t be set by .csv upload"
+        "string": "System properties can’t be set by .csv upload",
+        "developer_comment": "\"Properties\" refers to Entity properties."
       },
       "caseMismatch": {
         "title": {
-          "string": "Column is similar to an existing property but does not match"
+          "string": "Column is similar to an existing property but does not match",
+          "developer_comment": "\"Property\" refers to an Entity property."
         },
         "description": {
           "string": "Column names are case-sensitive. Check the spelling and capitalization."
+        },
+        "existingProperty": {
+          "string": "Existing property",
+          "developer_comment": "\"Property\" refers to an Entity property."
         }
       },
       "invalidProperties": {
-        "string": "{count, plural, one {This column is not a valid property name} other {These columns are not valid property names}}"
+        "string": "{count, plural, one {This column is not a valid property name} other {These columns are not valid property names}}",
+        "developer_comment": "\"Property\" refers to an Entity property."
       },
       "propertiesIgnored": {
-        "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}"
+        "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}",
+        "developer_comment": "\"Property\" refers to an Entity property."
       },
       "columnsIgnored": {
         "string": "{count, plural, one {This column will be ignored.} other {These columns will be ignored.}}"
@@ -2930,12 +2938,6 @@
         "largeCell": {
           "string": "Some cells are abnormally large, which can indicate difficulties reading your file:",
           "developer_comment": "This is a warning that is followed by a list of rows."
-        }
-      },
-      "header": {
-        "existingProperty": {
-          "string": "Existing property",
-          "developer_comment": "This is the text of a table column header."
         }
       }
     },

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2920,7 +2920,7 @@
         "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}"
       },
       "columnsIgnored": {
-        "string": "{count, plural, one {This column will be ignored.} other {These properties will be ignored.}}"
+        "string": "{count, plural, one {This column will be ignored.} other {These columns will be ignored.}}"
       },
       "row": {
         "raggedRows": {


### PR DESCRIPTION
This PR makes progress on getodk/central#2164, following #1827. This PR handles the second case described in the issue, whereby a column closely matches the name of an entity property, but differs on letter case.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I tried to do something similar as what I did in #1819 and #1827.