### PR TITLE
fix(web-forms#889): fixed styling for form level errors

### DIFF
--- a/.changeset/small-doors-film.md
+++ b/.changeset/small-doors-film.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+Fixed display bugs with top level form error message.

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -422,7 +422,6 @@ onUnmounted(() => {
 		}
 
 		.form-error-message.p-message.p-message-error {
-			display: inline-block;
 			position: sticky;
 			z-index: var(--odk-z-index-error-banner);
 			border-radius: var(--odk-radius);

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -333,7 +333,6 @@ onUnmounted(() => {
 		:class="{ 'submit-pressed': submitPressed }"
 	>
 		<div class="form-wrapper">
-			<div v-if="showValidationError" class="error-banner-placeholder" />
 			<!-- Closable error message to clear the view and avoid overlap with other elements -->
 			<Message
 				v-if="showValidationError"
@@ -422,12 +421,9 @@ onUnmounted(() => {
 			padding: 2rem;
 		}
 
-		.error-banner-placeholder {
-			height: 4rem;
-		}
-
 		.form-error-message.p-message.p-message-error {
-			position: fixed;
+			display: inline-block;
+			position: sticky;
 			z-index: var(--odk-z-index-error-banner);
 			border-radius: var(--odk-radius);
 			background-color: var(--odk-error-background-color);
@@ -435,7 +431,7 @@ onUnmounted(() => {
 			outline: none;
 			max-width: var(--odk-max-form-width);
 			width: 100%;
-			margin: 0rem auto 1rem auto;
+			margin: 0 auto;
 			top: 1rem;
 
 			:deep(.p-message-wrapper) {
@@ -523,15 +519,11 @@ onUnmounted(() => {
 				order: 1;
 			}
 
-			.error-banner-placeholder {
-				order: 2;
-			}
-
 			.form-error-message.p-message.p-message-error {
-				margin: 4rem 1rem 0 1rem;
+				margin: 1rem 1rem 0 1rem;
 				max-width: unset;
 				width: calc(100% - 2rem);
-				top: 22px;
+				order: 2;
 			}
 
 			.questions-card {


### PR DESCRIPTION
Closes getodk/web-forms#889

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Testing in desktop and mobile on firefox and chrome
Needed: testing on safari

#### Why is this the best possible solution? Were any other approaches considered?

"sticky" is the native way to do this.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.