### PR TITLE
fix(web-forms#887): remove map feature when value is cleared  

### DIFF
--- a/.changeset/puny-wings-cry.md
+++ b/.changeset/puny-wings-cry.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+Remove point, trace or shape from the map when its value is cleared by form logic.

--- a/packages/web-forms/src/components/common/map/MapBlock.vue
+++ b/packages/web-forms/src/components/common/map/MapBlock.vue
@@ -127,6 +127,7 @@ watch(
 	() => props.savedFeatureValue,
 	(newValue) => {
 		mapHandler.applySavedFeatureValue(newValue);
+		pointPlaced.value = !!mapHandler.getSavedFeatureValue()?.length;
 	}
 );
 

--- a/packages/web-forms/src/components/common/map/useMapBlock.ts
+++ b/packages/web-forms/src/components/common/map/useMapBlock.ts
@@ -528,6 +528,16 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
   };
 
   /**
+   * The form value is gone but the map still shows a feature, so remove it.
+   * Does nothing when the map already removed it itself.
+   */
+  const removeStaleSavedFeature = () => {
+    if (mapFeatures?.getSavedFeature()) {
+      discardSavedFeature();
+    }
+  };
+
+  /**
    * Applies a saved feature value to the map.
    * Multi-feature mode: looks it up in the collection.
    * Single-feature mode: applies external updates (defaults, setvalue). Skips when the value matches what's on the map
@@ -542,6 +552,7 @@ export function useMapBlock(config: MapBlockConfig, events: MapBlockEvents) {
     }
 
     if (!feature) {
+      removeStaleSavedFeature();
       return;
     }
 


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/887

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

CI pass and manual tests using form from the issue and `All questions` form:

https://github.com/user-attachments/assets/986607c9-f0b3-439d-b7d7-c2d40373a88f

#### Why is this the best possible solution? Were any other approaches considered?

The map never noticed when the form cleared the value (e.g. setValue). Now, we add a couple of simple validations to catch that scenario. 

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Users see the pin (or line/polygon) disappear when the form clears the value. Before, it stayed on the map by mistake.                                                                             
                                                                                                                                                                                                     
Nothing else changed. Placing, dragging, deleting, undo and select-from-map all work as before.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
