### PR TITLE
Show header errors and header warnings at same time

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -315,6 +315,7 @@ const selectFile = (file) => {
       const validation = validateHeader(headerResults);
       if (validation.errors != null) {
         errors.value = validation.errors;
+        warnings.value = validation.warnings;
         return Promise.resolve();
       }
 

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -232,6 +232,15 @@ describe('EntityUpload', () => {
       warnings.largeCell.should.equal(3);
     });
 
+    it('shows both errors and warnings about the header', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('height,__id\n1,e'));
+      const errors = modal.getComponent(EntityUploadErrors).props();
+      errors.missingLabel.should.be.true;
+      const warnings = modal.getComponent(EntityUploadWarnings).props();
+      warnings.systemProperties.should.eql(['__id']);
+    });
+
     it('does not show data warnings if there is a data error', async () => {
       testData.extendedDatasets.createPast(1, {
         properties: [{ name: 'height' }, { name: 'circumference' }]


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. It follows on the work of #1817. We want to show errors and warnings at the same time, surfacing all the information we have to the user. We already show errors + warnings in one situation (covered in #1817). This PR shows them together in another situation: when there are both errors and warnings about the column header. When there's an error in the column header, we don't even try to parse the rest of the file. So these errors and warnings about the column header are the main information we have to share with the user about their file.

See #1817 for more background on showing errors and warnings at the same time.

#### What has been done to verify that this works as intended?

I wrote a new test.