### PR TITLE
Always show EntityUploadFileSelect

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -56,13 +56,11 @@ except according to the terms contained in the LICENSE file.
         <entity-upload-warnings v-if="warnings != null" v-bind="warnings"
           :filename="fileMetadata.name" @rows="showWarningRows"/>
 
-        <entity-upload-file-select v-show="csvEntities == null"
+        <entity-upload-file-select :disabled="parsing || uploading"
           :parsing="parsing" @change="selectFile"/>
       </div>
-      <entity-upload-popup v-if="csvEntities != null"
-        :filename="fileMetadata.name" :count="csvEntities.length"
-        :awaiting-response="uploading"
-        :progress="uploadProgress" @clear="clearFile"/>
+      <entity-upload-popup v-if="uploading" :filename="fileMetadata.name"
+        :count="csvEntities.length" :progress="uploadProgress"/>
       <div ref="actions" class="modal-actions">
         <button type="button" class="btn btn-link" :aria-disabled="uploading"
           @click="$emit('hide')">
@@ -291,6 +289,7 @@ const parseEntities = async (file, headerResults, signal) => {
 };
 const selectFile = (file) => {
   redAlert.hide();
+  csvEntities.value = null;
   fileMetadata.value = null;
   errors.value = null;
   warnings.value = null;
@@ -339,11 +338,6 @@ const selectFile = (file) => {
       abortParse = noop;
     })
     .catch(noop);
-};
-const clearFile = () => {
-  csvEntities.value = null;
-  fileMetadata.value = null;
-  warnings.value = null;
 };
 watch(() => props.state, (state) => {
   if (state) return;

--- a/apps/central/src/components/entity/upload/file-select.vue
+++ b/apps/central/src/components/entity/upload/file-select.vue
@@ -10,7 +10,7 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 <template>
-  <file-drop-zone id="entity-upload-file-select" :disabled="parsing"
+  <file-drop-zone id="entity-upload-file-select" :disabled="disabled"
     @drop="$emit('change', $event.dataTransfer.files[0])">
     <div id="entity-upload-file-select-heading">
       <div>
@@ -19,7 +19,7 @@ except according to the terms contained in the LICENSE file.
             <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
             <input v-show="false" ref="input" type="file" accept=".csv,.tsv"
               @change="changeInput">
-            <button type="button" class="btn btn-outlined" :aria-disabled="parsing"
+            <button type="button" class="btn btn-outlined" :aria-disabled="disabled"
               @click="input.click()">
               {{ $t('text.chooseFile') }}
             </button>
@@ -45,6 +45,7 @@ defineOptions({
   name: 'EntityUploadFileSelect'
 });
 defineProps({
+  disabled: Boolean,
   parsing: Boolean
 });
 const emit = defineEmits(['change']);

--- a/apps/central/src/components/entity/upload/popup.vue
+++ b/apps/central/src/components/entity/upload/popup.vue
@@ -11,15 +11,9 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div id="entity-upload-popup">
-    <div id="entity-upload-popup-heading">
-      <div v-tooltip.text>{{ filename }}</div>
-      <button v-show="!awaitingResponse" type="button" class="btn btn-link"
-        :aria-label="$t('action.clear')" @click="$emit('clear')">
-        <span class="icon-trash"></span>
-      </button>
-    </div>
+    <div id="entity-upload-popup-heading" v-tooltip.text>{{ filename }}</div>
     <div id="entity-upload-popup-count">{{ $tcn('rowCount', count) }}</div>
-    <div v-show="awaitingResponse" id="entity-upload-popup-status">
+    <div id="entity-upload-popup-status">
       <spinner inline/><span>{{ status }}</span>
     </div>
   </div>
@@ -43,7 +37,6 @@ const props = defineProps({
     type: Number,
     required: true
   },
-  awaitingResponse: Boolean,
   progress: {
     type: Number,
     required: true
@@ -74,24 +67,9 @@ const status = computed(() => (props.progress < 1
 }
 
 #entity-upload-popup-heading {
-  align-items: center;
-  display: flex;
-
-  > div {
-    @include text-overflow-ellipsis;
-    font-size: 18px;
-    font-weight: bold;
-  }
-
-  .btn-link {
-    flex-shrink: 0;
-    margin-left: 9px;
-    padding: 0;
-  }
-  .icon-trash {
-    color: $color-danger;
-    margin-right: 0;
-  }
+  @include text-overflow-ellipsis;
+  font-size: 18px;
+  font-weight: bold;
 }
 
 #entity-upload-popup-status {

--- a/apps/central/src/components/entity/upload/popup.vue
+++ b/apps/central/src/components/entity/upload/popup.vue
@@ -42,7 +42,6 @@ const props = defineProps({
     required: true
   }
 });
-defineEmits(['clear']);
 
 const { t, n } = useI18n();
 const status = computed(() => (props.progress < 1

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -331,7 +331,8 @@ describe('EntityUpload', () => {
     const modal = await showModal();
     const button = modal.get('.modal-actions .btn-primary');
 
-    await selectFile(modal, createCSV('label,label\ndogwood,dogwood'));
+    const problemCSV = createCSV('label,label\ndogwood,dogwood');
+    await selectFile(modal, problemCSV);
     modal.findComponent(EntityUploadErrors).exists().should.be.true;
     modal.findComponent(EntityUploadWarnings).exists().should.be.true;
     button.attributes('aria-disabled').should.equal('true');
@@ -341,7 +342,7 @@ describe('EntityUpload', () => {
     modal.findComponent(EntityUploadWarnings).exists().should.be.false;
     button.attributes('aria-disabled').should.equal('false');
 
-    await selectFile(modal, createCSV('label,label\ndogwood,dogwood'));
+    await selectFile(modal, problemCSV);
     button.attributes('aria-disabled').should.equal('true');
   });
 
@@ -351,9 +352,9 @@ describe('EntityUpload', () => {
     });
     const modal = await showModal();
     await selectFile(modal, createCSV('label\nx\n"12345,67890"'));
+    const button = modal.get('.modal-actions .btn-primary');
 
     modal.findComponent(EntityUploadWarnings).exists().should.be.true;
-    const button = modal.get('.modal-actions .btn-primary');
     button.attributes('aria-disabled').should.equal('false');
 
     await modal.setProps({ state: false });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -4,6 +4,7 @@ import { T } from 'ramda';
 import EntityFilters from '../../../src/components/entity/filters.vue';
 import EntityUpload from '../../../src/components/entity/upload.vue';
 import EntityUploadErrors from '../../../src/components/entity/upload/errors.vue';
+import EntityUploadFileSelect from '../../../src/components/entity/upload/file-select.vue';
 import EntityUploadPopup from '../../../src/components/entity/upload/popup.vue';
 import EntityUploadTable from '../../../src/components/entity/upload/table.vue';
 import EntityUploadWarnings from '../../../src/components/entity/upload/warnings.vue';
@@ -121,22 +122,6 @@ describe('EntityUpload', () => {
       testData.extendedDatasets.createPast(1);
     });
 
-    it('shows the pop-up', async () => {
-      const modal = await showModal();
-      await selectFile(modal);
-      const popup = modal.getComponent(EntityUploadPopup);
-      popup.props().filename.should.equal('my_data.csv');
-      popup.props().count.should.equal(1);
-    });
-
-    it('hides the drop zone', async () => {
-      const modal = await showModal();
-      const dropZone = modal.get('#entity-upload-file-select');
-      dropZone.should.be.visible();
-      await selectFile(modal);
-      dropZone.should.be.hidden();
-    });
-
     it('enables the append button', async () => {
       const modal = await showModal();
       const button = modal.get('.modal-actions .btn-primary');
@@ -201,7 +186,8 @@ describe('EntityUpload', () => {
       await selectFile(modal, createCSV('f\0o'));
       await selectFile(modal);
       modal.should.not.alert();
-      modal.findComponent(EntityUploadPopup).exists().should.be.true;
+      const button = modal.get('.modal-actions .btn-primary');
+      button.attributes('aria-disabled').should.equal('false');
     });
 
     // This is not necessarily the ideal behavior. Showing an alert would be
@@ -258,7 +244,6 @@ describe('EntityUpload', () => {
 
       // Next, select a similar CSV that also has an error in the data (a
       // missing label).
-      await modal.get('#entity-upload-popup .btn-link').trigger('click');
       await selectFile(modal, createCSV(`${warningsCSV}\n"",1`));
 
       // This time, we see an error.
@@ -311,29 +296,29 @@ describe('EntityUpload', () => {
       a.text().should.equal('1–2');
       await a.trigger('click');
       getTables(modal)[1].props().highlighted.should.eql([0, 1]);
-      await modal.get('#entity-upload-popup .btn-link').trigger('click');
       await selectFile(modal, createCSV(csvString));
       should.not.exist(getTables(modal)[1].props().highlighted);
     });
   });
 
-  it('resets after the clear button is clicked', async () => {
+  it('resets errors and warnings after a new file is selected', async () => {
     testData.extendedDatasets.createPast(1, {
       properties: [{ name: 'height' }]
     });
     const modal = await showModal();
-    await selectFile(modal, createCSV('label\nx\n"12345,67890"'));
-
-    const popup = modal.findComponent(EntityUploadPopup);
-    popup.exists().should.be.true;
-    modal.findComponent(EntityUploadWarnings).exists().should.be.true;
-
-    await popup.get('.btn-link').trigger('click');
-
-    modal.findComponent(EntityUploadPopup).exists().should.be.false;
-    modal.findComponent(EntityUploadWarnings).exists().should.be.false;
-    modal.get('#entity-upload-file-select').should.be.visible();
     const button = modal.get('.modal-actions .btn-primary');
+
+    await selectFile(modal, createCSV('label,label\ndogwood,dogwood'));
+    modal.findComponent(EntityUploadErrors).exists().should.be.true;
+    modal.findComponent(EntityUploadWarnings).exists().should.be.true;
+    button.attributes('aria-disabled').should.equal('true');
+
+    await selectFile(modal, createCSV('label,height\ndogwood,1'));
+    modal.findComponent(EntityUploadErrors).exists().should.be.false;
+    modal.findComponent(EntityUploadWarnings).exists().should.be.false;
+    button.attributes('aria-disabled').should.equal('false');
+
+    await selectFile(modal, createCSV('label,label\ndogwood,dogwood'));
     button.attributes('aria-disabled').should.equal('true');
   });
 
@@ -344,16 +329,14 @@ describe('EntityUpload', () => {
     const modal = await showModal();
     await selectFile(modal, createCSV('label\nx\n"12345,67890"'));
 
-    modal.findComponent(EntityUploadPopup).exists().should.be.true;
     modal.findComponent(EntityUploadWarnings).exists().should.be.true;
+    const button = modal.get('.modal-actions .btn-primary');
+    button.attributes('aria-disabled').should.equal('false');
 
     await modal.setProps({ state: false });
     await modal.setProps({ state: true });
 
-    modal.findComponent(EntityUploadPopup).exists().should.be.false;
     modal.findComponent(EntityUploadWarnings).exists().should.be.false;
-    modal.get('#entity-upload-file-select').should.be.visible();
-    const button = modal.get('.modal-actions .btn-primary');
     button.attributes('aria-disabled').should.equal('true');
   });
 
@@ -388,22 +371,31 @@ describe('EntityUpload', () => {
       });
   });
 
-  it('shows a backdrop during the request', () => {
+  it('renders correctly during the request', () => {
     testData.extendedDatasets.createPast(1);
     return showModal()
       .afterResponses(modal => {
+        modal.getComponent(EntityUploadFileSelect).props().disabled.should.be.false;
         modal.find('.backdrop').exists().should.be.false;
+        modal.findComponent(EntityUploadPopup).exists().should.be.false;
       })
       .request(async (modal) => {
         await selectFile(modal);
         return modal.get('.modal-actions .btn-primary').trigger('click');
       })
       .beforeAnyResponse(modal => {
+        modal.getComponent(EntityUploadFileSelect).props().disabled.should.be.true;
         modal.find('.backdrop').exists().should.be.true;
+
+        const popup = modal.getComponent(EntityUploadPopup);
+        popup.props().filename.should.equal('my_data.csv');
+        popup.props().count.should.equal(1);
       })
       .respondWithProblem()
       .afterResponse(modal => {
+        modal.getComponent(EntityUploadFileSelect).props().disabled.should.be.false;
         modal.find('.backdrop').exists().should.be.false;
+        modal.findComponent(EntityUploadPopup).exists().should.be.false;
       });
   });
 

--- a/apps/central/test/components/entity/upload/file-select.spec.js
+++ b/apps/central/test/components/entity/upload/file-select.spec.js
@@ -1,14 +1,24 @@
 import EntityUploadFileSelect from '../../../../src/components/entity/upload/file-select.vue';
+import FileDropZone from '../../../../src/components/file-drop-zone.vue';
 
 import { dragAndDrop, setFiles } from '../../../util/trigger';
 import { mount } from '../../../util/lifecycle';
 
+const mountComponent = (options = {}) => mount(EntityUploadFileSelect, options);
 const csv = new File([''], 'my_data.csv');
 
 describe('EntityUploadFileSelect', () => {
+  it('disables elements if the disabled prop is true', () => {
+    const component = mountComponent({
+      props: { disabled: true }
+    });
+    component.getComponent(FileDropZone).props().disabled.should.be.true;
+    component.get('input + button').attributes('aria-disabled').should.equal('true');
+  });
+
   describe('after a file is selected using the button', () => {
     it('emits a change event', async () => {
-      const component = mount(EntityUploadFileSelect);
+      const component = mountComponent();
       await setFiles(component.get('input'), [csv]);
       const file = component.emitted().change[0][0];
       file.should.be.an.instanceof(File);
@@ -16,7 +26,7 @@ describe('EntityUploadFileSelect', () => {
     });
 
     it('resets the input', async () => {
-      const component = mount(EntityUploadFileSelect);
+      const component = mountComponent();
       const input = component.get('input');
       await setFiles(input, [csv]);
       input.element.value.should.equal('');

--- a/apps/central/test/components/entity/upload/popup.spec.js
+++ b/apps/central/test/components/entity/upload/popup.spec.js
@@ -9,15 +9,9 @@ const mountComponent = (options = undefined) =>
 
 describe('EntityUploadPopup', () => {
   it('shows the filename', async () => {
-    const div = mountComponent().get('#entity-upload-popup-heading div');
+    const div = mountComponent().get('#entity-upload-popup-heading');
     div.text().should.equal('my_data.csv');
     await div.should.have.textTooltip();
-  });
-
-  it('emits a clear event if the clear button is clicked', async () => {
-    const component = mountComponent();
-    await component.get('.btn-link').trigger('click');
-    component.emitted().clear.should.eql([[]]);
   });
 
   it('shows the count', () => {
@@ -28,31 +22,10 @@ describe('EntityUploadPopup', () => {
     text.should.equal('1,000 data rows found');
   });
 
-  it('hides elements during a request', () => {
-    const component = mountComponent({
-      props: { awaitingResponse: true }
-    });
-    component.get('.btn-link').should.be.hidden();
-  });
-
   describe('request status', () => {
-    it('does not show a status if there is no request', () => {
-      const component = mountComponent({
-        props: { awaitingResponse: false }
-      });
-      component.get('#entity-upload-popup-status').should.be.hidden();
-    });
-
-    it('shows the status during a request', () => {
-      const component = mountComponent({
-        props: { awaitingResponse: true }
-      });
-      component.get('#entity-upload-popup-status').should.be.visible();
-    });
-
     it('shows the upload progress', () => {
       const component = mountComponent({
-        props: { awaitingResponse: true, progress: 0.5 }
+        props: { progress: 0.5 }
       });
       const text = component.get('#entity-upload-popup-status').text();
       text.should.equal('Sending file… (50%)');
@@ -60,7 +33,7 @@ describe('EntityUploadPopup', () => {
 
     it('changes the status once all data has been sent', () => {
       const component = mountComponent({
-        props: { awaitingResponse: true, progress: 1 }
+        props: { progress: 1 }
       });
       const text = component.get('#entity-upload-popup-status').text();
       text.should.equal('Processing file…');


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. For that issue, we will show the popup in the `EntityUpload` modal in many fewer cases:

- When errors and warnings are shown, the popup can add friction:
  - The popup can obscure the errors/warnings.
  - Currently, the user must click the clear (trash can) button in the popup before being able to select a new file. That makes it a little harder to iterate on the file.
  - We will no longer show the popup when there are errors or warnings.
- Even when there aren't errors or warnings, the popup doesn't show a lot of useful information:
  - The user doesn't need to see the filename.
  - The user can see the count of rows in the `Pagination` component below the second table.
- We will still show the popup during the actual upload, when the rest of the modal is behind a backdrop.
  - The popup is useful in this case, showing information about the progress of the upload.

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly it's just a change to the logic (to a couple `v-if`s). I also removed code that was no longer relevant.

One other change to mention is that I now disable the file select during the upload request. Previously, the file select wasn't visible during the request, so this wasn't necessary. The file select is already behind a backdrop during the request, but users could probably focus it using the Tab key and interact with it that way during the request. I disabled it fully so that you can't select a new file during the request.