### PR TITLE
EntityUpload: don't autoscroll if there are alerts

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -400,8 +400,9 @@ const resizeColumnIfShown = () => { if (props.state) resizeLastColumn(); };
 useEventListener(window, 'resize', resizeColumnIfShown);
 
 const actions = ref(null);
-watch(csvEntities, (value) => {
-  if (value != null) nextTick(() => { actions.value.scrollIntoView(); });
+watch([errors, warnings, csvEntities], async () => {
+  if (errors.value == null && warnings.value == null && csvEntities.value != null)
+    nextTick(() => { actions.value.scrollIntoView(); });
 });
 
 watch(() => props.state, (state) => {

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -400,7 +400,7 @@ const resizeColumnIfShown = () => { if (props.state) resizeLastColumn(); };
 useEventListener(window, 'resize', resizeColumnIfShown);
 
 const actions = ref(null);
-watch([errors, warnings, csvEntities], async () => {
+watch([errors, warnings, csvEntities], () => {
   if (errors.value == null && warnings.value == null && csvEntities.value != null)
     nextTick(() => { actions.value.scrollIntoView(); });
 });


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. It updates a specific feature of the `EntityUpload` modal. Specifically: Once the CSV file has been parsed and `csvEntities` has been set, the user will be ready to upload their data. They may want to review their data in the table, but as far as Frontend can tell, there aren't any issues in their data. Given that, we automatically scroll the modal so that the "Append data" button is visible. The modal is full-screen, so in many cases, such scrolling will not be needed. In that case, nothing happens. But if the height of the modal content exceeds the height allotted for it (i.e., almost the entire height of the viewport), it's possible for the button to appear below the fold. It may require scrolling to become visible. If that was true before, I think it will still be true as of getodk/central#1904. We haven't substantially reduced the height of the modal content in the case where `csvEntities` has been set and the data is ready for upload. If anything, it may end up slightly taller, since we're adding a couple of `.entity-upload-section-title`s and adding more padding to the drop zone.

That's all background information on this automatic scrolling. What this PR does is turn off that autoscrolling in the case where there are either errors or warnings. In that case, we aren't sure that the user is ready to upload their data. They may need to take action to fix their CSV file. So it doesn't make as much sense to nudge them toward the "Append data" button. I'm pretty sure that autoscrolling to the button has the potential to skip past one or more errors or warnings. The user may end up a little confused/disoriented if they're scrolled to the middle of a section about errors and warnings.

#### What has been done to verify that this works as intended?

Nothing in particular. We don't have a test of this behavior, and I feel like that's OK. It's sometimes not easy to test scrolling in Karma.

#### Why is this the best possible solution? Were any other approaches considered?

I thought about adding more complicated autoscrolling: scrolling to the "Review errors" section if there are errors and scrolling to "Review warnings" if there are warnings. That's certainly something we can add if it ends up feeling helpful. However, that's not part of the current design. I'm wary that the resulting user experience would feel like jumping around the modal. Also, since those sections are above the drop zone (unlike the button, which is below it), I think that it's very likely that they'd be visible already. If anything, autoscrolling might scroll the user up within the modal, to the top of the errors/warnings section.