### PR TITLE
EntityUpload: update titles above tables

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -446,6 +446,7 @@ watch(() => props.state, (state) => {
   font-weight: bold;
   margin-bottom: 4px;
 
+  // Explanatory/descriptive text that immediately follows the title
   + p, + p + p {
     margin-bottom: 10px;
     &:last-of-type { margin-bottom: 20px; }

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -417,14 +417,12 @@ watch(() => props.state, (state) => {
 
   .panel-simple {
     .panel-heading {
-      @include text-overflow-ellipsis;
       background-color: $color-action-background;
       border-bottom: none;
       color: #fff;
     }
 
     .panel-body { padding: 0; }
-
     thead { background-color: #c5dfe7; }
   }
 

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -15,29 +15,24 @@ except according to the terms contained in the LICENSE file.
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <div :class="{ backdrop: uploading }">
-        <div class="panel panel-simple">
-          <div class="panel-heading">
-            <h1 class="panel-title" v-tooltip.text>
-              {{ $t('table.server', dataset) }}
-            </h1>
-          </div>
-          <div class="panel-body">
-            <entity-upload-table :ref="setTable(0)"
-              :entities="serverEntities.value" :row-index="serverRow"
-              :page-size="serverPage.size"
-              :awaiting-response="serverEntities.awaitingResponse"/>
-            <loading :state="serverEntities.initiallyLoading"/>
-            <p v-if="serverEntities.dataExists && serverEntities.value.length === 0"
-              class="empty-table-message">
-              {{ $t('noEntities') }}
-            </p>
-            <pagination v-if="serverPage.count !== 0"
-              v-model:page="serverPage.page" v-model:size="serverPage.size"
-              :count="serverPage.count" :size-options="pageSizeOptions"
-              :spinner="serverEntities.awaitingResponse"/>
-          </div>
+        <p class="entity-upload-section-title">{{ $t('currentEntities') }}</p>
+        <div class="entity-upload-table-container">
+          <entity-upload-table :ref="setTable(0)"
+            :entities="serverEntities.value" :row-index="serverRow"
+            :page-size="serverPage.size"
+            :awaiting-response="serverEntities.awaitingResponse"/>
+          <loading :state="serverEntities.initiallyLoading"/>
+          <p v-if="serverEntities.dataExists && serverEntities.value.length === 0"
+            class="empty-table-message">
+            {{ $t('noEntities') }}
+          </p>
+          <pagination v-if="serverPage.count !== 0"
+            v-model:page="serverPage.page" v-model:size="serverPage.size"
+            :count="serverPage.count" :size-options="pageSizeOptions"
+            :spinner="serverEntities.awaitingResponse"/>
         </div>
-        <div class="panel panel-simple">
+        <p class="entity-upload-section-title">{{ $t('newEntities') }}</p>
+        <div class="entity-upload-table-container panel panel-simple">
           <div class="panel-heading">
             <h1 class="panel-title">{{ $t('table.file') }}</h1>
           </div>
@@ -421,27 +416,21 @@ watch(() => props.state, (state) => {
   }
 
   .panel-simple {
-    margin-bottom: 0;
-
     .panel-heading {
       @include text-overflow-ellipsis;
-      background-color: #ccc;
+      background-color: $color-action-background;
       border-bottom: none;
+      color: #fff;
     }
 
     .panel-body { padding: 0; }
-  }
-  .panel-simple + .panel-simple {
-    .panel-heading {
-      background-color: $color-action-background;
-      color: #fff;
-    }
 
     thead { background-color: #c5dfe7; }
   }
 
   .pagination { margin-left: $padding-left-table-data; }
 
+  .entity-upload-table-container { margin-block: 10px 20px; }
   // margin-bottom of the tables
   .entity-upload-table {
     // The margin before text, either the Loading component or the
@@ -452,13 +441,6 @@ watch(() => props.state, (state) => {
     // The margin if there is no text or Pagination
     &:last-child { margin-bottom: 0; }
   }
-  // margin-bottom of the first .panel-simple
-  .panel-simple:first-child {
-    // The margin if the last element of the .panel-body is text
-    margin-bottom: 10px;
-    // The margin if the last element is Pagination
-    &:has(tbody) { margin-bottom: 12px; }
-  }
 }
 
 .entity-upload-section-title {
@@ -466,7 +448,7 @@ watch(() => props.state, (state) => {
   font-weight: bold;
   margin-bottom: 4px;
 
-  ~ p {
+  + p, + p + p {
     margin-bottom: 10px;
     &:last-of-type { margin-bottom: 20px; }
   }
@@ -478,10 +460,9 @@ watch(() => props.state, (state) => {
   "en": {
     // This is the title at the top of a pop-up.
     "title": "Import Data from File",
+    "currentEntities": "Your current Entities",
+    "newEntities": "New Entities",
     "table": {
-      // This is shown above a list of Entities on the server. {name} is the
-      // name of the Entity List.
-      "server": "{name} server data",
       "file": "Data to import"
     },
     // @transifexKey component.EntityList.noEntities

--- a/apps/central/src/components/entity/upload/errors.vue
+++ b/apps/central/src/components/entity/upload/errors.vue
@@ -88,7 +88,7 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
 @import '../../../assets/scss/variables';
 
 #entity-upload-errors {
-  margin-top: 20px;
+  margin-bottom: 20px;
 
   code { border: 1px solid $color-danger; }
 }

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -107,10 +107,6 @@ defineEmits(['rows']);
 <style lang="scss">
 @import '../../../assets/scss/mixins';
 
-#entity-upload-warnings {
-  margin-top: 20px;
-}
-
 #entity-upload-warnings-case-mismatch {
   div:has(> table) {
     background-color: rgba(255, 255, 255, 0.5);

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2783,11 +2783,13 @@
         "string": "Import Data from File",
         "developer_comment": "This is the title at the top of a pop-up."
       },
+      "currentEntities": {
+        "string": "Your current Entities"
+      },
+      "newEntities": {
+        "string": "New Entities"
+      },
       "table": {
-        "server": {
-          "string": "{name} server data",
-          "developer_comment": "This is shown above a list of Entities on the server. {name} is the name of the Entity List."
-        },
         "file": {
           "string": "Data to import"
         }


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. It adds titles above the tables in the `EntityUpload` modal:

- Above the first table: "Your current Entities"
  - Remove the previous `.panel-title` of "[Entity List name] server data"
  - With the `.panel-title` gone, we don't need to wrap the table in a `.panel` anymore.
- Above the second table: "New Entities"
- Also adding a class `entity-upload-table-container` to set the margin between the table and the title above it, as well as the margin below each table (including the margin between the first table and the title above the second table).
  - With the new, fixed `margin-bottom` on the `.entity-upload-table-container`, we no longer need `margin-top` on `EntityUploadErrors`.
  - Move the `margin-top` on `EntityUploadWarnings` to `margin-bottom` on `EntityUploadErrors`. `margin-bottom` is more common in the codebase than `margin-top`.
  - `EntityUploadWarnings` doesn't need any margin anymore. That's in part because `EntityFileSelect` still sets `margin-top`. It's possible that I'll change that in a later PR.

#### What has been done to verify that this works as intended?

I tried it out locally. Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

I wasn't exactly sure how to structure some things. For example, I debated whether to place the `.entity-upload-section-title` inside the new `.entity-upload-table-container` or above/before it. I think the approach I took makes sense, but it should also be easy to adjust if we want to later.