### PR TITLE
List duplicate column headers in EntityUpload

### DIFF
--- a/.changeset/wacky-kids-sneeze.md
+++ b/.changeset/wacky-kids-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+List duplicate column headers in Entity CSV file

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -251,9 +251,9 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
         if (value.length !== 0)
           count += 1;
         else
-          // Remove empty arrays. EntityUploadErrors and EntityUploadWarnings
-          // expect nullish values rather than empty arrays for nonapplicable
-          // errors/warnings.
+          // Remove empty arrays from the object. EntityUploadErrors and
+          // EntityUploadWarnings expect nullish values rather than empty arrays
+          // for nonapplicable errors/warnings.
           delete details[name];
       } else {
         throw new Error('unexpected detail value');

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -79,7 +79,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { computed, inject, nextTick, onBeforeUnmount, reactive, ref, shallowRef, watch } from 'vue';
-import { pick } from 'ramda';
+import { omit, pick } from 'ramda';
 import { useI18n } from 'vue-i18n';
 
 import EntityUploadErrors from './upload/errors.vue';
@@ -194,14 +194,16 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
     errorDetails.invalidQuotes = papaErrors.some(({ type }) => type === 'Quotes');
   } else {
     const columnSet = new Set();
+    const duplicateColumns = new Set();
     for (const column of columns) {
       if (/^\s*$/.test(column))
         errorDetails.emptyColumn = true;
       else if (columnSet.has(column))
-        errorDetails.duplicateColumn = true;
+        duplicateColumns.add(column);
       else
         columnSet.add(column);
     }
+    errorDetails.duplicateColumns = [...duplicateColumns];
 
     const hasLabel = columnSet.has('label');
     errorDetails.missingLabel = !hasLabel;
@@ -237,18 +239,32 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
       warningDetails.invalidProperties.length +
       warningDetails.caseMismatch.length +
       (hasLabel ? 1 : 0);
+  }
 
-    // Remove empty arrays from warningDetails. EntityUploadWarnings expects
-    // nonapplicable warnings to be nullish. Removing these arrays also helps us
-    // count the number of warnings.
-    for (const [name, value] of Object.entries(warningDetails)) {
-      if (value.length === 0) delete warningDetails[name];
+  // Normalize detail objects, adding a `count` property.
+  for (const details of [errorDetails, warningDetails]) {
+    let count = 0;
+    for (const [name, value] of Object.entries(details)) {
+      if (value === true || value === false) { // Boolean value
+        if (value) count += 1;
+      } else if (Array.isArray(value)) {
+        if (value.length !== 0)
+          count += 1;
+        else
+          // Remove empty arrays. EntityUploadErrors and EntityUploadWarnings
+          // expect nullish values rather than empty arrays for nonapplicable
+          // errors/warnings.
+          delete details[name];
+      } else {
+        throw new Error('unexpected detail value');
+      }
     }
+    details.count = count;
   }
 
   const result = {};
-  if (Object.values(errorDetails).includes(true)) result.errors = errorDetails;
-  if (Object.keys(warningDetails).length !== 0) result.warnings = warningDetails;
+  if (errorDetails.count !== 0) result.errors = omit(['count'], errorDetails);
+  if (warningDetails.count !== 0) result.warnings = omit(['count'], warningDetails);
   return result;
 };
 const { t } = useI18n();

--- a/apps/central/src/components/entity/upload/errors.vue
+++ b/apps/central/src/components/entity/upload/errors.vue
@@ -32,10 +32,15 @@
         <p>{{ $t('unknownProperty') }}</p>
       </template>
     </entity-upload-alert>
-    <entity-upload-alert v-if="duplicateColumn" type="danger">
+    <entity-upload-alert v-if="duplicateColumns != null" type="danger">
       <template #title>{{ $t('duplicateColumn.title') }}</template>
       <template #body>
-        <p>{{ $t('duplicateColumn.description') }}</p>
+        <p>
+          <span>{{ $t('duplicateColumn.description') }}</span>
+          <sentence-separator/>
+          <span>{{ $tc('duplicateColumn.headersReused', duplicateColumns.length) }}</span>
+        </p>
+        <p><i18n-list :list="duplicateColumns"/></p>
       </template>
     </entity-upload-alert>
     <entity-upload-alert v-if="emptyColumn" type="danger">
@@ -58,6 +63,8 @@
 import { computed } from 'vue';
 
 import EntityUploadAlert from './alert.vue';
+import I18nList from '../../i18n/list.vue';
+import SentenceSeparator from '../../sentence-separator.vue';
 
 import { formatCSVDelimiter } from '../../../util/csv';
 
@@ -74,7 +81,7 @@ const props = defineProps({
   invalidQuotes: Boolean,
   missingLabel: Boolean,
   unknownProperty: Boolean,
-  duplicateColumn: Boolean,
+  duplicateColumns: Array,
   emptyColumn: Boolean,
 
   // Error in the data below the column header
@@ -116,7 +123,9 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
     "unknownProperty": "If you want to add properties to this Entity List, you can do so in the Entity Properties section on the Overview page of this Entity List, or you can upload and publish a Form that references the property.",
     "duplicateColumn": {
       "title": "Duplicate column headers",
-      "description": "Each column must have a unique header."
+      "description": "Each column must have a unique header.",
+      // This text is followed by a list of column headers.
+      "headersReused": "This header is used more than once: | These headers are used more than once:"
     },
     "emptyColumn": {
       "title": "Empty cell in header row",

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -156,14 +156,15 @@ describe('EntityUpload', () => {
     it('shows errors', async () => {
       const modal = await showModal();
       await selectFile(modal, createCSV('foo,,foo\n1,2,3'));
-      modal.getComponent(EntityUploadErrors).props().should.include({
+      const errors = modal.getComponent(EntityUploadErrors).props();
+      errors.should.include({
         delimiter: ',',
         invalidQuotes: false,
         missingLabel: true,
         unknownProperty: true,
-        duplicateColumn: true,
         emptyColumn: true
       });
+      errors.duplicateColumns.should.eql(['foo']);
     });
 
     it('uses the delimiter from the file', async () => {

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -153,7 +153,15 @@ describe('EntityUpload', () => {
       });
     });
 
-    it('shows errors', async () => {
+    it('shows an error if there are duplicate column headers', async () => {
+      const modal = await showModal();
+      const csv = createCSV('label,label,height,height,height\ndogwood,dogwood,1,1,1');
+      await selectFile(modal, csv);
+      const errors = modal.getComponent(EntityUploadErrors).props();
+      errors.duplicateColumns.should.eql(['label', 'height']);
+    });
+
+    it('shows multiple errors', async () => {
       const modal = await showModal();
       await selectFile(modal, createCSV('foo,,foo\n1,2,3'));
       const errors = modal.getComponent(EntityUploadErrors).props();

--- a/apps/central/test/components/entity/upload/errors.spec.js
+++ b/apps/central/test/components/entity/upload/errors.spec.js
@@ -1,3 +1,5 @@
+import { nextTick } from 'vue';
+
 import EntityUploadErrors from '../../../../src/components/entity/upload/errors.vue';
 
 import { mergeMountOptions, mount } from '../../../util/lifecycle';
@@ -43,6 +45,19 @@ describe('EntityUploadErrors', () => {
       p.length.should.equal(2);
       p[0].text().should.equal(title);
     });
+  });
+
+  it('shows an error if there are duplicate columns', async () => {
+    const component = mountComponent({
+      props: { duplicateColumns: ['height', 'species'] }
+    });
+    // Wait for I18nList to render.
+    await nextTick();
+
+    const p = component.get('.entity-upload-alert').findAll('p');
+    p.length.should.equal(3);
+    p[0].text().should.equal('Duplicate column headers');
+    p[2].text().should.equal('height, species');
   });
 
   it('shows a data error', () => {

--- a/apps/central/test/components/entity/upload/errors.spec.js
+++ b/apps/central/test/components/entity/upload/errors.spec.js
@@ -47,7 +47,7 @@ describe('EntityUploadErrors', () => {
     });
   });
 
-  it('shows an error if there are duplicate columns', async () => {
+  it('shows an error if there are duplicate column headers', async () => {
     const component = mountComponent({
       props: { duplicateColumns: ['height', 'species'] }
     });

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2858,6 +2858,10 @@
         },
         "description": {
           "string": "Each column must have a unique header."
+        },
+        "headersReused": {
+          "string": "{count, plural, one {This header is used more than once:} other {These headers are used more than once:}}",
+          "developer_comment": "This text is followed by a list of column headers."
         }
       },
       "emptyColumn": {


### PR DESCRIPTION
This PR improves the error shown in the `EntityUpload` modal about duplicate column headers in the entity CSV file. If there are duplicate headers, the user must resolve them before uploading their file and creating their entities.

Previously, we didn't show the actual duplicate column headers. We just said that there were duplicate headers. However, we have easy access to the headers; it would be easy to list them. There are multiple warnings now where we list column headers, and we can follow a similar pattern to list duplicate column headers for this error.

#### What has been done to verify that this works as intended?

New and updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

One part part that may seem over-engineered is the normalization of the `errorDetails` and `warningDetails` objects. However, that's needed now that `errorDetails` can contain an array. Previously, it only contained boolean values. The normalization adds a `count` to each details object for the number of errors/warnings, and that also leads into #1838.

One goal of the normalization is to handle `errorDetails` and `warningDetails` more similarly. Previously, `errorDetails` was all boolean values, while `warningDetails` was all arrays. That led to different logic to check for the existence of errors vs. warnings. Now that logic can be the same between the two.

I'm not totally sure that I've structured these objects in the best way over the course of working on `EntityUpload`. However, I think the normalization is a reasonable approach for now.