### PR TITLE
Show counts of errors and warnings in EntityUpload

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -79,7 +79,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import { computed, inject, nextTick, onBeforeUnmount, reactive, ref, shallowRef, watch } from 'vue';
-import { omit, pick } from 'ramda';
+import { pick } from 'ramda';
 import { useI18n } from 'vue-i18n';
 
 import EntityUploadErrors from './upload/errors.vue';
@@ -263,8 +263,8 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
   }
 
   const result = {};
-  if (errorDetails.count !== 0) result.errors = omit(['count'], errorDetails);
-  if (warningDetails.count !== 0) result.warnings = omit(['count'], warningDetails);
+  if (errorDetails.count !== 0) result.errors = errorDetails;
+  if (warningDetails.count !== 0) result.warnings = warningDetails;
   return result;
 };
 const { t } = useI18n();
@@ -337,12 +337,18 @@ const selectFile = (file) => {
       return parseEntities(file, headerResults, signal)
         .then(results => {
           csvEntities.value = results.data;
-          if (validation.warnings != null || results.warnings.count !== 0)
-            warnings.value = { ...validation.warnings, ...results.warnings.details };
+
+          if (validation.warnings != null || results.warnings.count !== 0) {
+            warnings.value = {
+              ...validation.warnings,
+              ...results.warnings.details,
+              count: (validation.warnings?.count ?? 0) + results.warnings.count
+            };
+          }
         })
         .catch(error => {
           if (!signal.aborted) {
-            errors.value = { dataError: error.message };
+            errors.value = { dataError: error.message, count: 1 };
             warnings.value = validation.warnings;
           }
 

--- a/apps/central/src/components/entity/upload/errors.vue
+++ b/apps/central/src/components/entity/upload/errors.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="entity-upload-errors">
-    <p class="entity-upload-section-title">{{ $t('title') }}</p>
+    <p class="entity-upload-section-title">{{ $tcn('title', count) }}</p>
     <p>{{ $t('introduction') }}</p>
     <i18n-t v-if="delimiter !== ','" tag="p" keypath="delimiterNotComma">
       <template #delimiter>
@@ -76,6 +76,10 @@ const props = defineProps({
     type: String,
     required: true
   },
+  count: {
+    type: Number,
+    required: true
+  },
 
   // Errors about the column header
   invalidQuotes: Boolean,
@@ -105,7 +109,7 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
 {
   "en": {
     // This text is shown above a section that lists errors in the user's data.
-    "title": "Review errors",
+    "title": "Review {count} error | Review {count} errors",
     "introduction": "Errors must be fixed before you can upload Entities.",
     "delimiterNotComma": "These errors may be because we got the cell delimiter wrong. We used {delimiter}.",
 

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <div id="entity-upload-warnings">
-    <p class="entity-upload-section-title">{{ $t('title') }}</p>
+    <p class="entity-upload-section-title">{{ $tcn('title', count) }}</p>
     <p>{{ $t('introduction') }}</p>
 
     <!-- Column header warnings -->
@@ -90,6 +90,10 @@ defineProps({
     type: String,
     required: true
   },
+  count: {
+    type: Number,
+    required: true
+  },
 
   // Column header warnings
   systemProperties: Array,
@@ -134,7 +138,7 @@ defineEmits(['rows']);
     // @transifexKey component.EntityUploadHeaderReview.title
     // This text is shown above a section where the user can review warnings
     // about their data.
-    "title": "Review warnings",
+    "title": "Review {count} warning | Review {count} warnings",
     "introduction": "Some rows contain warnings that may affect upload results.",
 
     // "Properties" refers to Entity properties.

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -159,6 +159,7 @@ describe('EntityUpload', () => {
       const errors = modal.getComponent(EntityUploadErrors).props();
       errors.should.include({
         delimiter: ',',
+        count: 4,
         invalidQuotes: false,
         missingLabel: true,
         unknownProperty: true,
@@ -229,6 +230,7 @@ describe('EntityUpload', () => {
       const csv = createCSV('label,height\nx\ny\n"12345,67890",""');
       await selectFile(modal, csv);
       const warnings = modal.getComponent(EntityUploadWarnings).props();
+      warnings.count.should.equal(2);
       warnings.raggedRows.should.eql([[1, 2]]);
       warnings.largeCell.should.equal(3);
     });
@@ -245,6 +247,7 @@ describe('EntityUpload', () => {
       await selectFile(modal, createCSV(warningsCSV));
       modal.findComponent(EntityUploadErrors).exists().should.be.false;
       const initialWarnings = modal.getComponent(EntityUploadWarnings).props();
+      initialWarnings.count.should.equal(2);
       initialWarnings.missingProperties.should.eql(['circumference']);
       initialWarnings.raggedRows.should.eql([[1, 1]]);
 
@@ -259,10 +262,10 @@ describe('EntityUpload', () => {
 
       // There's a warning about the column header, but no warning about the
       // data.
-      const warnings = modal.getComponent(EntityUploadWarnings);
-      warnings.props().missingProperties.should.eql(['circumference']);
-      should.not.exist(warnings.props().raggedRows);
-      warnings.findAll('.entity-upload-alert').length.should.equal(1);
+      const warnings = modal.getComponent(EntityUploadWarnings).props();
+      warnings.count.should.equal(1);
+      warnings.missingProperties.should.eql(['circumference']);
+      should.not.exist(warnings.raggedRows);
     });
 
     it('shows rows to which a warning applies after they are selected', async () => {

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -225,7 +225,7 @@ describe('EntityUpload', () => {
       });
     });
 
-    it('shows warnings', async () => {
+    it('shows warnings about the data below the column header', async () => {
       const modal = await showModal();
       const csv = createCSV('label,height\nx\ny\n"12345,67890",""');
       await selectFile(modal, csv);
@@ -233,6 +233,16 @@ describe('EntityUpload', () => {
       warnings.count.should.equal(2);
       warnings.raggedRows.should.eql([[1, 2]]);
       warnings.largeCell.should.equal(3);
+    });
+
+    it('shows warnings about both the header and the data', async () => {
+      const modal = await showModal();
+      const csv = createCSV('label,__id,height\ndogwood,e1\nelm,e2,""');
+      await selectFile(modal, csv);
+      const warnings = modal.getComponent(EntityUploadWarnings).props();
+      warnings.count.should.equal(2);
+      warnings.systemProperties.should.eql(['__id']);
+      warnings.raggedRows.should.eql([[1, 1]]);
     });
 
     it('does not show data warnings if there is a data error', async () => {

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -190,8 +190,9 @@ describe('EntityUpload', () => {
     });
     const modal = await showModal();
     await selectFile(modal, createCSV('label,height\n,1'));
-    const { dataError } = modal.getComponent(EntityUploadErrors).props();
-    dataError.should.equal('There is a problem on row 2 of the file: Missing label.');
+    const errors = modal.getComponent(EntityUploadErrors).props();
+    errors.dataError.should.equal('There is a problem on row 2 of the file: Missing label.');
+    errors.count.should.equal(1);
   });
 
   describe('binary file', () => {
@@ -233,7 +234,7 @@ describe('EntityUpload', () => {
       });
     });
 
-    it('shows warnings about the data below the column header', async () => {
+    it('shows warnings about the data below the header', async () => {
       const modal = await showModal();
       const csv = createCSV('label,height\nx\ny\n"12345,67890",""');
       await selectFile(modal, csv);

--- a/apps/central/test/components/entity/upload/errors.spec.js
+++ b/apps/central/test/components/entity/upload/errors.spec.js
@@ -6,7 +6,7 @@ import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
 const mountComponent = (options) =>
   mount(EntityUploadErrors, mergeMountOptions(options, {
-    props: { delimiter: ',' }
+    props: { delimiter: ',', count: 1 }
   }));
 
 describe('EntityUploadErrors', () => {

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -7,7 +7,7 @@ import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
 const mountComponent = (options) =>
   mount(EntityUploadWarnings, mergeMountOptions(options, {
-    props: { filename: 'my_data.csv' }
+    props: { filename: 'my_data.csv', count: 1 }
   }));
 
 describe('EntityUploadWarnings', () => {
@@ -98,7 +98,7 @@ describe('EntityUploadWarnings', () => {
 
   it('shows multiple warnings', () => {
     const component = mountComponent({
-      props: { raggedRows: [[1, 2]], largeCell: 3 }
+      props: { count: 2, raggedRows: [[1, 2]], largeCell: 3 }
     });
     const warnings = component.findAllComponents(EntityUploadAlert);
     warnings.length.should.equal(2);
@@ -109,7 +109,7 @@ describe('EntityUploadWarnings', () => {
 
   it('emits a rows event after a row range is clicked', async () => {
     const component = mountComponent({
-      props: { raggedRows: [[1, 2]], largeCell: 3 }
+      props: { count: 2, raggedRows: [[1, 2]], largeCell: 3 }
     });
     const warnings = component.findAllComponents(EntityUploadAlert);
     warnings.length.should.equal(2);

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2826,7 +2826,7 @@
     },
     "EntityUploadErrors": {
       "title": {
-        "string": "Review errors",
+        "string": "{count, plural, one {Review {count} error} other {Review {count} errors}}",
         "developer_comment": "This text is shown above a section that lists errors in the user's data."
       },
       "introduction": {
@@ -2897,7 +2897,7 @@
     },
     "EntityUploadHeaderReview": {
       "title": {
-        "string": "Review warnings",
+        "string": "{count, plural, one {Review {count} warning} other {Review {count} warnings}}",
         "developer_comment": "This text is shown above a section where the user can review warnings about their data."
       },
       "missingProperties": {


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. It adds the count of errors to the title of the "Review errors" section, and it adds the count of warnings to the title of the "Review warnings" section.

#### What has been done to verify that this works as intended?

New and updated tests. I tried out one case locally.

#### Why is this the best possible solution? Were any other approaches considered?

The hardest part was merging the count from the header warnings object and the count from the data warnings object. The two objects are structured a little differently and have different rules around whether they're present vs. `null`. I'm not sure that setup is ideal, but I'm also not looking to revisit it as part of this PR. Ultimately, we're able to add the two counts without too much trouble.