### PR TITLE
EntityUpload: update text of missingProperties warning

### DIFF
--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -58,9 +58,10 @@ except according to the terms contained in the LICENSE file.
     </entity-upload-alert>
     <entity-upload-alert v-if="missingProperties != null" type="warning">
       <template #title>
-        {{ $tc('missingProperties', missingProperties.length) }}
+        {{ $tc('missingProperties.title', missingProperties.length) }}
       </template>
       <template #body>
+        <p>{{ $tc('missingProperties.description', missingProperties.length) }}</p>
         <p><i18n-list :list="missingProperties"/></p>
       </template>
     </entity-upload-alert>
@@ -148,9 +149,12 @@ defineEmits(['rows']);
     },
     // "Property" refers to an Entity property.
     "invalidProperties": "This column is not a valid property name | These columns are not valid property names",
-    // @transifexKey component.EntityUploadHeaderReview.missingProperties
-    // This text is followed by a list of Entity property names.
-    "missingProperties": "This property is not included in your file and will be left empty: | These properties are not included in your file and will be left empty:",
+    "missingProperties": {
+      // "Property" refers to an Entity property.
+      "title": "Property not found in file | Properties not found in file",
+      // "Property" refers to an Entity property.
+      "description": "This property will be left empty. | These properties will be left empty."
+    },
     // "Property" refers to an Entity property.
     "propertiesIgnored": "This property will be ignored. | These properties will be ignored.",
     "columnsIgnored": "This column will be ignored. | These columns will be ignored.",

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -73,9 +73,9 @@ describe('EntityUploadWarnings', () => {
     await nextTick();
 
     const p = component.getComponent(EntityUploadAlert).findAll('p');
-    p.length.should.equal(2);
-    p[0].text().should.startWith('These properties are not included in your file');
-    p[1].text().should.equal('foo, bar');
+    p.length.should.equal(3);
+    p[0].text().should.startWith('Properties not found in file');
+    p[2].text().should.equal('foo, bar');
   });
 
   it('shows a warning for ragged rows', () => {

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -74,7 +74,7 @@ describe('EntityUploadWarnings', () => {
 
     const p = component.getComponent(EntityUploadAlert).findAll('p');
     p.length.should.equal(3);
-    p[0].text().should.startWith('Properties not found in file');
+    p[0].text().should.equal('Properties not found in file');
     p[2].text().should.equal('foo, bar');
   });
 

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2886,10 +2886,6 @@
       "title": {
         "string": "Review warnings",
         "developer_comment": "This text is shown above a section where the user can review warnings about their data."
-      },
-      "missingProperties": {
-        "string": "{count, plural, one {This property is not included in your file and will be left empty:} other {These properties are not included in your file and will be left empty:}}",
-        "developer_comment": "This text is followed by a list of Entity property names."
       }
     },
     "EntityUploadPopup": {
@@ -2931,6 +2927,16 @@
       "invalidProperties": {
         "string": "{count, plural, one {This column is not a valid property name} other {These columns are not valid property names}}",
         "developer_comment": "\"Property\" refers to an Entity property."
+      },
+      "missingProperties": {
+        "title": {
+          "string": "{count, plural, one {Property not found in file} other {Properties not found in file}}",
+          "developer_comment": "\"Property\" refers to an Entity property."
+        },
+        "description": {
+          "string": "{count, plural, one {This property will be left empty.} other {These properties will be left empty.}}",
+          "developer_comment": "\"Property\" refers to an Entity property."
+        }
       },
       "propertiesIgnored": {
         "string": "{count, plural, one {This property will be ignored.} other {These properties will be ignored.}}",


### PR DESCRIPTION
This is a follow-up PR to #1551 (for getodk/central#1787). It adjusts the text of the warning introduced in that PR. Instead of it being one long line of text, this PR breaks it up into a shorter title on top, with more information below.

#### What has been done to verify that this works as intended?

I updated a test.