### PR TITLE
EntityUpload: identify name as system property

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -221,7 +221,7 @@ const validateHeader = ({ columns, errors, meta }, file) => {
     warningDetails.caseMismatch = [];
     for (const column of columnSet) {
       if (column === 'label') continue; // eslint-disable-line no-continue
-      if (column.startsWith('__')) {
+      if (column.startsWith('__') || column === 'name') {
         warningDetails.systemProperties.push(column);
       } else if (!validatePropertyName(column)) {
         warningDetails.invalidProperties.push(column);

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -523,12 +523,12 @@ describe('EntityUpload', () => {
       .request(async (modal) => {
         await selectFile(
           modal,
-          createCSV('label,height,__id,__foo\ndogwood,1,e1,x\nelm,,e2,y')
+          createCSV('label,height,__id,__foo,name\ndogwood,1,e1,x,dogwood\nelm,,e2,y,elm')
         );
 
         // A warning is shown.
         const warnings = modal.getComponent(EntityUploadWarnings).props();
-        warnings.systemProperties.should.eql(['__id', '__foo']);
+        warnings.systemProperties.should.eql(['__id', '__foo', 'name']);
 
         return modal.get('.modal-actions .btn-primary').trigger('click');
       })
@@ -537,7 +537,7 @@ describe('EntityUpload', () => {
         method: 'POST',
         url: '/v1/projects/1/datasets/trees/entities',
         data: {
-          source: { name: 'my_data.csv', size: 48 },
+          source: { name: 'my_data.csv', size: 65 },
           entities: [
             { label: 'dogwood', data: { height: '1' } },
             // If there were only system properties, no proper entity


### PR DESCRIPTION
This is a follow-up PR to #1819 (for getodk/central#1785). Most system properties start with `__`, but there is another property name that's reserved: `name`. Even now, the Frontend code will show a warning about a CSV column header of `name`. However, the warning that's shown is that it's an invalid property name. It's a little clearer to identify it as a system property.

#### What has been done to verify that this works as intended?

I updated a test.