### PR TITLE
fix(web-forms#892): better handling of dynamically updating attachment names

### DIFF
--- a/.changeset/vast-cobras-lead.md
+++ b/.changeset/vast-cobras-lead.md
@@ -1,0 +1,6 @@
+---
+"@getodk/web-forms": patch
+"@getodk/forms": patch
+---
+
+Improved loading of form attachments to better handle dynamic updates to the filename.

--- a/apps/central/test/data/xml/image-attachment/form.xml
+++ b/apps/central/test/data/xml/image-attachment/form.xml
@@ -1,0 +1,28 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>simple</h:title>
+        <model>
+            <instance>
+                <data id="simple">
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                    <first_name/>
+                </data>
+            </instance>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+            <bind nodeset="/data/first_name" type="string"/>
+            <itext>
+                <translation lang="English" default="">
+                    <text id="name">
+                        <value form="long">Name</value>
+                        <value form="image">jr://images/four.gif</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/first_name"><label ref="jr:itext('name')" /></input>
+    </h:body>
+</h:html>

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -55,6 +55,11 @@ const withToken = (url) => `${url}${queryString({ st: props.st })}`;
 
 const getAttachment = (requestUrl: URL) => {
   const encodedName = encodeURIComponent(requestUrl.pathname.split('/').pop()!);
+  // TODO for testing purposes, put a random delay here to exacerbate the race condition
+  if (encodedName !== 'a.jpg') {
+
+    return new Response("Not Found", { status: 404 });
+  }
   const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath.value}/attachments/${encodedName}`);
   return fetch(url);
 };

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -22,7 +22,7 @@ export interface WebFormsRendererProps {
   instanceId?: string | null;
   submissionAttachments?: string[] | null;
   defaultParameters?: Record<string, string>;
-  st?: string | null
+  st?: string | null;
 }
 
 const props = defineProps<WebFormsRendererProps>();
@@ -54,13 +54,12 @@ const visibleModal = ref();
 const withToken = (url) => `${url}${queryString({ st: props.st })}`;
 
 const getAttachment = (requestUrl: URL) => {
-  const encodedName = encodeURIComponent(requestUrl.pathname.split('/').pop()!);
-  // TODO for testing purposes, put a random delay here to exacerbate the race condition
-  if (encodedName !== 'a.jpg') {
-
-    return new Response("Not Found", { status: 404 });
+  const fileName = requestUrl.pathname.split('/').pop()!;
+  const decoded = decodeURIComponent(fileName);
+  if (!props.form.attachments.some(a => a.name === decoded)) {
+    return new Response('Not Found', { status: 404 });
   }
-  const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath.value}/attachments/${encodedName}`);
+  const url = withToken(`/v1/projects/${props.form.projectId}/forms/${props.form.xmlFormId}${draftPath.value}/attachments/${fileName}`);
   return fetch(url);
 };
 

--- a/apps/forms/src/utils/api.ts
+++ b/apps/forms/src/utils/api.ts
@@ -1,3 +1,7 @@
+export interface Attachment {
+  name: string
+}
+
 export interface Form {
   name: string;
   xmlFormId: string;
@@ -7,6 +11,7 @@ export interface Form {
   enketoOnceId?: string;
   draft: boolean;
   webformsEnabled: boolean;
+  attachments: Attachment[];
 }
 
 export interface Project {
@@ -92,13 +97,24 @@ export const getFormXml = async (projectId: number, formId: string, draft: boole
   return await response.text();
 };
 
-const getForm = async (url: string): Promise<Form> => {
+const getAttachments = async (projectId: number, xmlFormId: string, st?: string | null): Promise<Attachment[]> => {
+  const qs = queryString({ st });
+  const url = `/v1/projects/${projectId}/forms/${xmlFormId}/attachments${qs}`;
+  const response = await fetch(url);
+  const attachments = await response.json() as BackendAttachmentResponseBody[];
+  return attachments
+    .filter(attachment => attachment.exists)
+    .map(attachment => ({ name: attachment.name }))
+};
+
+const getForm = async (url: string, st?: string | null): Promise<Form> => {
   const response = await fetch(url);
   if (!response.ok) {
     const result = await response.json() as BackendStatusResponseBody;
     throw new RequestError(result.message, result.code);
   }
   const result = await response.json() as BackendFormResponseBody;
+  const attachments = await getAttachments(result.projectId, result.xmlFormId, st);
   return {
     name: result.name,
     xmlFormId: result.xmlFormId,
@@ -107,21 +123,22 @@ const getForm = async (url: string): Promise<Form> => {
     state: result.state,
     draft: !result.publishedAt,
     enketoOnceId: result.enketoOnceId,
-    webformsEnabled: !!result.webformsEnabled
+    webformsEnabled: !!result.webformsEnabled,
+    attachments
   };
 };
 
 export const getFormByEnketoId = async (enketoId: string, st?: string | null): Promise<Form> => {
   const qs = queryString({ st });
   const url = `/v1/form-links/${enketoId}/form${qs}`;
-  return getForm(url);
+  return getForm(url, st);
 };
 
 export const getFormByFormId = async (projectId: number, formId: string, draft: boolean, st?: string | null): Promise<Form> => {
   const draftPath = draft ? '/draft' : '';
   const qs = queryString({ st });
   const url = `/v1/projects/${projectId}/forms/${formId}${draftPath}${qs}`;
-  return getForm(url);
+  return getForm(url, st);
 };
 
 export const getProject = async (projectId: number): Promise<Project> => {

--- a/apps/forms/src/utils/api.ts
+++ b/apps/forms/src/utils/api.ts
@@ -97,24 +97,29 @@ export const getFormXml = async (projectId: number, formId: string, draft: boole
   return await response.text();
 };
 
-const getAttachments = async (projectId: number, xmlFormId: string, st?: string | null): Promise<Attachment[]> => {
+const getAttachments = async (projectId: number, xmlFormId: string, draft: boolean, st?: string | null): Promise<Attachment[]> => {
+  const draftPath = draft ? '/draft' : '';
   const qs = queryString({ st });
-  const url = `/v1/projects/${projectId}/forms/${xmlFormId}/attachments${qs}`;
+  const url = `/v1/projects/${projectId}/forms/${xmlFormId}${draftPath}/attachments${qs}`;
   const response = await fetch(url);
+  if (!response.ok) {
+    const result = await response.json() as BackendStatusResponseBody;
+    throw new RequestError(result.message, result.code);
+  }
   const attachments = await response.json() as BackendAttachmentResponseBody[];
   return attachments
     .filter(attachment => attachment.exists)
     .map(attachment => ({ name: attachment.name }))
 };
 
-const getForm = async (url: string, st?: string | null): Promise<Form> => {
+const getForm = async (url: string, draft: boolean, st?: string | null): Promise<Form> => {
   const response = await fetch(url);
   if (!response.ok) {
     const result = await response.json() as BackendStatusResponseBody;
     throw new RequestError(result.message, result.code);
   }
   const result = await response.json() as BackendFormResponseBody;
-  const attachments = await getAttachments(result.projectId, result.xmlFormId, st);
+  const attachments = await getAttachments(result.projectId, result.xmlFormId, draft, st);
   return {
     name: result.name,
     xmlFormId: result.xmlFormId,
@@ -131,14 +136,14 @@ const getForm = async (url: string, st?: string | null): Promise<Form> => {
 export const getFormByEnketoId = async (enketoId: string, st?: string | null): Promise<Form> => {
   const qs = queryString({ st });
   const url = `/v1/form-links/${enketoId}/form${qs}`;
-  return getForm(url, st);
+  return getForm(url, false, st);
 };
 
 export const getFormByFormId = async (projectId: number, formId: string, draft: boolean, st?: string | null): Promise<Form> => {
   const draftPath = draft ? '/draft' : '';
   const qs = queryString({ st });
   const url = `/v1/projects/${projectId}/forms/${formId}${draftPath}${qs}`;
-  return getForm(url, st);
+  return getForm(url, draft, st);
 };
 
 export const getProject = async (projectId: number): Promise<Project> => {

--- a/apps/forms/test/components/web-form-renderer.spec.ts
+++ b/apps/forms/test/components/web-form-renderer.spec.ts
@@ -81,7 +81,16 @@ describe('WebFormRenderer', () => {
       },
       props: {
         xform: testProps.xform!,
-        form: { name: 'simple', xmlFormId: 'simple', projectId: 1, enketoId: '', state: 'open', draft: false, webformsEnabled: true },
+        form: {
+          name: 'simple',
+          xmlFormId: 'simple',
+          projectId: 1,
+          enketoId: '',
+          state: 'open',
+          draft: false,
+          webformsEnabled: true,
+          attachments: testProps.form?.attachments ?? []
+        },
         actionType: testProps.actionType ?? 'new',
         instanceId: testProps.instanceId ?? null,
         submissionAttachments: testProps.submissionAttachments ?? null,
@@ -131,7 +140,17 @@ describe('WebFormRenderer', () => {
       status: 200,
       text: () => Promise.resolve('name,label\ntoronto,Toronto'),
     } as Response);
-    const component = await mountComponent({ xform: formWithAttachmentXml});
+    const given = {
+      name: 'simple',
+      xmlFormId: 'simple',
+      projectId: 1,
+      enketoId: '',
+      state: 'open',
+      draft: false,
+      webformsEnabled: true,
+      attachments: [ { name: 'cities.csv' } ]
+    };
+    const component = await mountComponent({ form: given, xform: formWithAttachmentXml });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const form = component.find('.odk-form');
     expect(form.exists()).to.equal(true);

--- a/apps/forms/test/components/web-form-renderer.spec.ts
+++ b/apps/forms/test/components/web-form-renderer.spec.ts
@@ -10,6 +10,7 @@ import { webFormsPlugin } from '@getodk/web-forms';
 
 import simpleForm from '../../../central/test/data/xml/simple/form.xml?raw';
 import formWithAttachmentXml from '../../../central/test/data/xml/with-attachment/form.xml?raw';
+import formWithImageAttachmentXml from '../../../central/test/data/xml/image-attachment/form.xml?raw';
 import imageUploaderXml from '../../../central/test/data/xml/image-uploader/form.xml?raw';
 import simpleSubmission from '../../../central/test/data/xml/simple/submission.xml?raw';
 import imageUploaderSubmission from '../../../central/test/data/xml/image-uploader/submission.xml?raw';
@@ -155,6 +156,25 @@ describe('WebFormRenderer', () => {
     const form = component.find('.odk-form');
     expect(form.exists()).to.equal(true);
     expect(form.text()).to.match(/Toronto/);
+    fetchSpy.mockReset();
+  });
+
+  it('should not send request for attachments that are not expected', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const given = {
+      name: 'simple',
+      xmlFormId: 'simple',
+      projectId: 1,
+      enketoId: '',
+      state: 'open',
+      draft: false,
+      webformsEnabled: true,
+      attachments: [ { name: 'not-right-image.jpg' } ] // attachment name doesn't match
+    };
+    const component = await mountComponent({ form: given, xform: formWithImageAttachmentXml });
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+    const form = component.find('.odk-form');
+    expect(form.exists()).to.equal(true);
     fetchSpy.mockReset();
   });
 

--- a/apps/forms/test/utils/api.spec.ts
+++ b/apps/forms/test/utils/api.spec.ts
@@ -161,17 +161,24 @@ describe('Test api utility', () => {
     describe('by form id', () => {
 
       [
-        { draft: false, st: undefined, url: '/v1/projects/5/forms/simple' },
-        { draft: true,  st: undefined, url: '/v1/projects/5/forms/simple/draft' },
-        { draft: false, st: 'xyz',     url: '/v1/projects/5/forms/simple?st=xyz' },
-        { draft: true,  st: 'xyz',     url: '/v1/projects/5/forms/simple/draft?st=xyz' },
-      ].forEach(({ draft, st, url }) => {
+        { draft: false, st: undefined },
+        { draft: true,  st: undefined },
+        { draft: false, st: 'xyz',    },
+        { draft: true,  st: 'xyz',    },
+      ].forEach(({ draft, st }) => {
         it(`with draft=${draft}, st=${st}`, async () => {
           stubFormFetch();
           const actual = await getFormByFormId(5, 'simple', draft, st);
           expect(actual).toEqual(expectedForm);
           expect(fetch).toHaveBeenCalledTimes(2);
-          expect(fetch).toHaveBeenCalledWith(url);
+
+          const urlStart = `/v1/projects/5/forms/simple`;
+          const draftPath = draft ? '/draft' : '';
+          const urlEnd = st ? `?st=${st}` : '';
+          const formUrl = urlStart + draftPath + urlEnd;
+          const attachmentUrl = urlStart + draftPath + '/attachments' + urlEnd;
+          expect(fetch).toHaveBeenCalledWith(formUrl);
+          expect(fetch).toHaveBeenCalledWith(attachmentUrl);
         });
       });
 

--- a/apps/forms/test/utils/api.spec.ts
+++ b/apps/forms/test/utils/api.spec.ts
@@ -5,6 +5,7 @@ describe('Test api utility', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('getSubmissionAttachmentNames', () => {
@@ -103,7 +104,8 @@ describe('Test api utility', () => {
       projectId: 5,
       state: 'open',
       draft: false,
-      webformsEnabled: false
+      webformsEnabled: false,
+      attachments: [ { name: 'myfile.png' } ]
     };
     
     const stubFormFetch = () => {
@@ -120,10 +122,39 @@ describe('Test api utility', () => {
         createdAt: '2018-01-19T23:58:03.395Z',
         updatedAt: '2018-03-21T12:45:02.312Z'
       };
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(form),
+      const attachments = [
+        {
+          name: 'myfile.png',
+          type: 'image',
+          exists: true,
+          blobExists: true,
+          datasetExists: false,
+          hash: 'd41d8cd98f00b204e9800998ecf8427e',
+          updatedAt: '2018-03-21T12:45:02.312Z'
+        },
+        {
+          name: 'not-uploaded.jpg',
+          type: 'image',
+          exists: false,
+          blobExists: true,
+          datasetExists: false,
+          hash: 'd41d8cd98f00b204e9800998ecf8427e',
+          updatedAt: '2018-03-21T12:45:02.312Z'
+        },
+      ];
+
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+        let result: object;
+        if (url.includes('/attachments')) {
+          result = attachments;
+        } else {
+          result = form;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(result),
+        };
       }));
     };
 
@@ -139,7 +170,7 @@ describe('Test api utility', () => {
           stubFormFetch();
           const actual = await getFormByFormId(5, 'simple', draft, st);
           expect(actual).toEqual(expectedForm);
-          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(fetch).toHaveBeenCalledTimes(2);
           expect(fetch).toHaveBeenCalledWith(url);
         });
       });
@@ -160,7 +191,7 @@ describe('Test api utility', () => {
         stubFormFetch();
         const actual = await getFormByEnketoId('abc');
         expect(actual).toEqual(expectedForm);
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledTimes(2);
         expect(fetch).toHaveBeenCalledWith('/v1/form-links/abc/form');
       });
 
@@ -168,7 +199,7 @@ describe('Test api utility', () => {
         stubFormFetch();
         const actual = await getFormByEnketoId('abc', 'zyx');
         expect(actual).toEqual(expectedForm);
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledTimes(2);
         expect(fetch).toHaveBeenCalledWith('/v1/form-links/abc/form?st=zyx');
       });
 

--- a/apps/forms/test/utils/sentry.spec.ts
+++ b/apps/forms/test/utils/sentry.spec.ts
@@ -93,7 +93,8 @@ describe('Sentry headers', () => {
           enketoId: '',
           state: 'open',
           draft: false,
-          webformsEnabled: true
+          webformsEnabled: true,
+          attachments: [ { name: 'cities.csv' } ]
         },
         actionType: 'new',
       },

--- a/packages/web-forms/src/components/common/media/MediaBlockBase.vue
+++ b/packages/web-forms/src/components/common/media/MediaBlockBase.vue
@@ -6,7 +6,7 @@ import type {
 	JRResourceURL,
 	JRResourceURLString,
 } from '@getodk/common/jr-resources/JRResourceURL.ts';
-import { computed, inject, ref, watchEffect } from 'vue';
+import { computed, inject, onWatcherCleanup, ref, watchEffect } from 'vue';
 
 type ObjectURL = `blob:${string}`;
 
@@ -32,31 +32,34 @@ const brokenFileSrc = computed(() => {
 	return new URL(`../../../assets/images/${props.brokenFileImage}`, import.meta.url).href;
 });
 
-const loadMedia = async (src?: JRResourceURL): Promise<void> => {
+const loadMedia = async (src?: JRResourceURL): Promise<ObjectURL | null> => {
 	if (src?.href == null || formOptions?.fetchFormAttachment == null) {
 		handleError(t('media_block.fetch.error'));
-		return;
+		return null;
 	}
 
 	try {
 		const cache = mediaCache.get(src.href);
+		console.log('loading media', src, 'cache hit', !!cache);
+
 		if (cache != null) {
-			setMedia(cache);
-			return;
+			return cache;
 		}
 
 		const response = await formOptions.fetchFormAttachment(src);
 		if (!response.ok || response.status !== 200) {
 			handleError(t('media_block.not_found.error', { file: src.href }));
-			return;
+			return null;
 		}
 
 		const data = await response.blob();
 		const url = URL.createObjectURL(data) satisfies string as ObjectURL;
 		mediaCache.set(src.href, url);
-		setMedia(url);
+		return url;
+		
 	} catch {
 		handleError(t('media_block.unknown.error', { file: src.href }));
+		return null;
 	}
 };
 
@@ -72,15 +75,22 @@ const handleError = (error: string) => {
 	errorMessage.value = error;
 };
 
-watchEffect(() => {
+watchEffect(async () => {
 	errorMessage.value = '';
-
+	
 	if (props.blobUrl != null) {
 		setMedia(props.blobUrl);
 		return;
 	}
-
-	void loadMedia(props.resourceUrl);
+	
+	let current = true;
+	onWatcherCleanup(() => {
+		current = false;
+	});
+	const blob = await loadMedia(props.resourceUrl);
+	if (blob && current) {
+		setMedia(blob);
+	}
 });
 </script>
 

--- a/packages/web-forms/src/components/common/media/MediaBlockBase.vue
+++ b/packages/web-forms/src/components/common/media/MediaBlockBase.vue
@@ -10,6 +10,18 @@ import { computed, inject, onWatcherCleanup, ref, watchEffect } from 'vue';
 
 type ObjectURL = `blob:${string}`;
 
+type MediaResponse = MediaResponseError | MediaResponseSuccess;
+
+interface MediaResponseSuccess {
+	ok: true;
+	image: ObjectURL;
+}
+
+interface MediaResponseError {
+	ok: false;
+	error: string;
+}
+
 const props = defineProps<{
 	readonly resourceUrl?: JRResourceURL;
 	readonly blobUrl?: ObjectURL;
@@ -32,38 +44,46 @@ const brokenFileSrc = computed(() => {
 	return new URL(`../../../assets/images/${props.brokenFileImage}`, import.meta.url).href;
 });
 
-const loadMedia = async (src?: JRResourceURL): Promise<ObjectURL | null> => {
+const fetchMedia = async (src?: JRResourceURL): Promise<MediaResponse> => {
 	if (src?.href == null || formOptions?.fetchFormAttachment == null) {
-		handleError(t('media_block.fetch.error'));
-		return null;
+		return { ok: false, error: t('media_block.fetch.error') };
 	}
 
 	try {
 		const cache = mediaCache.get(src.href);
-		console.log('loading media', src, 'cache hit', !!cache);
 
 		if (cache != null) {
-			return cache;
+			return { ok: true, image: cache };
 		}
 
 		const response = await formOptions.fetchFormAttachment(src);
 		if (!response.ok || response.status !== 200) {
-			handleError(t('media_block.not_found.error', { file: src.href }));
-			return null;
+			return { ok: false, error: t('media_block.not_found.error', { file: src.href }) };
 		}
 
 		const data = await response.blob();
-		const url = URL.createObjectURL(data) satisfies string as ObjectURL;
-		mediaCache.set(src.href, url);
-		return url;
-		
+		const image = URL.createObjectURL(data) satisfies string as ObjectURL;
+		mediaCache.set(src.href, image);
+		return { ok: true, image };
 	} catch {
-		handleError(t('media_block.unknown.error', { file: src.href }));
-		return null;
+		return { ok: false, error: t('media_block.unknown.error', { file: src.href }) };
 	}
 };
 
-const setMedia = (value: string) => {
+const loadMedia = async (url: JRResourceURL, signal: AbortSignal) => {
+	const response = await fetchMedia(url);
+	if (signal.aborted) {
+		// url has been modified since sending request
+		return;
+	}
+	if (response.ok) {
+		setMedia(response.image);
+	} else {
+		handleError(response.error);
+	}
+};
+
+const setMedia = (value: ObjectURL) => {
 	mediaUrl.value = value;
 	loading.value = false;
 	errorMessage.value = '';
@@ -75,21 +95,22 @@ const handleError = (error: string) => {
 	errorMessage.value = error;
 };
 
-watchEffect(async () => {
+watchEffect(() => {
+	loading.value = true;
 	errorMessage.value = '';
-	
+
 	if (props.blobUrl != null) {
 		setMedia(props.blobUrl);
 		return;
 	}
-	
-	let current = true;
-	onWatcherCleanup(() => {
-		current = false;
-	});
-	const blob = await loadMedia(props.resourceUrl);
-	if (blob && current) {
-		setMedia(blob);
+
+	if (props.resourceUrl != null) {
+		const controller = new AbortController();
+		onWatcherCleanup(() => {
+			controller.abort();
+		});
+
+		void loadMedia(props.resourceUrl, controller.signal);
 	}
 });
 </script>


### PR DESCRIPTION
Closes getodk/web-forms#892

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual testing
- adding a random delay in responding to requests to test the abort
- testing of filenames with non-url safe characters
- testing entities and other attachments

#### Why is this the best possible solution? Were any other approaches considered?

The first issue is about the requests completing in a random order, and the last request to finish winning. Aborting previous requests means the last one initiated wins.

The second issue was about issuing one request to the server per character typed. By checking the known attachments we can only make a request when it matches.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

It shouldn't do.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.