### PR TITLE
EntityUpload: list columns that can become new properties

### DIFF
--- a/.changeset/huge-dryers-say.md
+++ b/.changeset/huge-dryers-say.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+Prompt user to create Entity properties when CSV upload has unknown columns (getodk/central#1786)

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -283,7 +283,7 @@ const { i18n: globalI18n, redAlert } = inject('container');
 const parseEntities = async (file, headerResults, extraProperties, signal) => {
   const results = await parseCSV(globalI18n, file, headerResults.columns, {
     delimiter: headerResults.meta.delimiter,
-    transformRow: rowToEntity(new Set(extraProperties)),
+    transformRow: rowToEntity(new Set(extraProperties ?? [])),
     signal
   });
   if (results.data.length === 0) throw new Error(t('alert.noData'));

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -258,26 +258,32 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
   return result;
 };
 const { t } = useI18n();
+// noPropertyData is used to minimize the JSON sent to Backend: the JSON won't
+// specify a `data` property for an entity without property data.
+const noPropertyData = { toJSON: () => undefined };
 const rowToEntity = (extraProperties) => (values, columns) => {
   let label;
   const data = Object.create(null);
+  let hasProperty = false;
   const extraData = extraProperties.size !== 0 ? Object.create(null) : undefined;
   for (const [i, value] of values.entries()) {
     if (value === '') continue; // eslint-disable-line no-continue
 
     const column = columns[i];
-    if (column === 'label')
+    if (column === 'label') {
       label = value;
-    else if (dataset.propertyMap.has(column))
+    } else if (dataset.propertyMap.has(column)) {
       data[column] = value;
-    else if (extraProperties.has(column))
+      hasProperty = true;
+    } else if (extraProperties.has(column)) {
       extraData[column] = value;
+    }
   }
 
   if (label == null || /^\s+$/.test(label))
     throw new Error(t('alert.blankLabel'));
 
-  return { label, data, extra: extraData };
+  return { label, data: hasProperty ? data : noPropertyData, extra: extraData };
 };
 const { i18n: globalI18n, redAlert } = inject('container');
 const parseEntities = async (file, headerResults, extraProperties, signal) => {
@@ -396,11 +402,9 @@ const propertiesToCreate = computed(() =>
 const { request, awaitingResponse: uploading } = useRequest();
 const uploadProgress = ref(0);
 const upload = () => {
-  const entitiesToSend = csvEntities.value.map(entity => {
-    const result = { label: entity.label };
-    if (Object.keys(entity.data).length !== 0) result.data = entity.data;
-    return result;
-  });
+  const entitiesToSend = csvEntities.value.map(entity => (entity.extra == null
+    ? entity
+    : { label: entity.label, data: entity.data }));
   request({
     method: 'POST',
     url: apiPaths.entities(dataset.projectId, dataset.name),

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -379,7 +379,7 @@ const showWarningRows = (range) => {
 };
 watch(csvEntities, (value) => { if (value == null) warningRows.value = null; });
 
-// Creating new properties
+// CREATING NEW PROPERTIES
 const toggleExtraProperty = (name, selected) => {
   if (selected)
     selectedProperties.add(name);

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -38,8 +38,8 @@ except according to the terms contained in the LICENSE file.
           </div>
           <div class="panel-body">
             <entity-upload-table :ref="setTable(1)" :entities="csvSlice"
-              :row-index="csvRow" :page-size="csvPage.size"
-              :highlighted="warningRows"/>
+              :extra-properties="propertiesToCreate" :row-index="csvRow"
+              :page-size="csvPage.size" :highlighted="warningRows"/>
             <pagination v-if="csvEntities != null" v-model:page="csvPage.page"
               v-model:size="csvPage.size" :count="csvEntities.length"
               :size-options="pageSizeOptions"/>
@@ -49,7 +49,8 @@ except according to the terms contained in the LICENSE file.
         <entity-upload-errors v-if="errors != null" v-bind="errors"
           :delimiter="fileMetadata.delimiter"/>
         <entity-upload-warnings v-if="warnings != null" v-bind="warnings"
-          :filename="fileMetadata.name" @rows="showWarningRows"/>
+          :filename="fileMetadata.name" @rows="showWarningRows"
+          @toggle-extra="toggleExtraProperty"/>
 
         <entity-upload-file-select :disabled="parsing || uploading"
           :parsing="parsing" @change="selectFile"/>
@@ -171,6 +172,7 @@ const csvEntities = shallowRef(null);
 const fileMetadata = shallowRef(null);
 const errors = shallowRef(null);
 const warnings = shallowRef(null);
+const selectedProperties = reactive(new Set());
 const parsing = ref(false);
 // Function to abort parsing in progress
 let abortParse = noop;
@@ -212,6 +214,7 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
     warningDetails.systemProperties = [];
     warningDetails.invalidProperties = [];
     warningDetails.caseMismatch = [];
+    warningDetails.extraProperties = [];
     for (const column of columnSet) {
       if (column === 'label') continue; // eslint-disable-line no-continue
       if (column.startsWith('__') || column === 'name') {
@@ -220,18 +223,12 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
         warningDetails.invalidProperties.push(column);
       } else {
         const property = lowercaseProperties.get(column.toLowerCase());
-        if (property != null && column !== property)
+        if (property == null)
+          warningDetails.extraProperties.push(column);
+        else if (column !== property)
           warningDetails.caseMismatch.push({ column, property });
       }
     }
-
-    errorDetails.unknownProperty = columnSet.size !==
-      dataset.properties.length -
-      warningDetails.missingProperties.length +
-      warningDetails.systemProperties.length +
-      warningDetails.invalidProperties.length +
-      warningDetails.caseMismatch.length +
-      (hasLabel ? 1 : 0);
   }
 
   // Normalize detail objects, adding a `count` property.
@@ -261,38 +258,32 @@ const validateHeader = ({ columns, errors: papaErrors }) => {
   return result;
 };
 const { t } = useI18n();
-// noPropertyData is used to minimize the JSON sent to Backend: the JSON won't
-// specify a `data` property for an entity without property data.
-const noPropertyData = { toJSON: () => undefined };
-const rowToEntity = (values, columns) => {
-  const obj = Object.create(null);
-  let hasProperty = false;
+const rowToEntity = (extraProperties) => (values, columns) => {
+  let label;
+  const data = Object.create(null);
+  const extraData = extraProperties.size !== 0 ? Object.create(null) : undefined;
   for (const [i, value] of values.entries()) {
     if (value === '') continue; // eslint-disable-line no-continue
 
     const column = columns[i];
-    if (column === 'label') {
-      obj.label = value;
-    } else if (dataset.propertyMap.has(column)) {
-      obj[column] = value;
-      hasProperty = true;
-    }
+    if (column === 'label')
+      label = value;
+    else if (dataset.propertyMap.has(column))
+      data[column] = value;
+    else if (extraProperties.has(column))
+      extraData[column] = value;
   }
-  const { label } = obj;
+
   if (label == null || /^\s+$/.test(label))
     throw new Error(t('alert.blankLabel'));
-  if (hasProperty) {
-    delete obj.label;
-    return { label, data: obj };
-  }
-  obj.data = noPropertyData;
-  return obj;
+
+  return { label, data, extra: extraData };
 };
 const { i18n: globalI18n, redAlert } = inject('container');
-const parseEntities = async (file, headerResults, signal) => {
+const parseEntities = async (file, headerResults, extraProperties, signal) => {
   const results = await parseCSV(globalI18n, file, headerResults.columns, {
     delimiter: headerResults.meta.delimiter,
-    transformRow: rowToEntity,
+    transformRow: rowToEntity(new Set(extraProperties)),
     signal
   });
   if (results.data.length === 0) throw new Error(t('alert.noData'));
@@ -304,6 +295,7 @@ const selectFile = (file) => {
   fileMetadata.value = null;
   errors.value = null;
   warnings.value = null;
+  selectedProperties.clear();
 
   const abortController = new AbortController();
   abortParse = () => { abortController.abort(); };
@@ -329,7 +321,8 @@ const selectFile = (file) => {
         return Promise.resolve();
       }
 
-      return parseEntities(file, headerResults, signal)
+      const extraProperties = validation.warnings?.extraProperties;
+      return parseEntities(file, headerResults, extraProperties, signal)
         .then(results => {
           csvEntities.value = results.data;
 
@@ -356,6 +349,8 @@ const selectFile = (file) => {
     })
     .catch(noop);
 };
+onBeforeUnmount(() => { abortParse(); });
+
 watch(() => props.state, (state) => {
   if (state) return;
   abortParse();
@@ -363,8 +358,8 @@ watch(() => props.state, (state) => {
   fileMetadata.value = null;
   errors.value = null;
   warnings.value = null;
+  selectedProperties.clear();
 });
-onBeforeUnmount(() => { abortParse(); });
 
 const csvPage = reactive({ page: 0, size: defaultPageSize });
 const csvRow = computed(() =>
@@ -384,15 +379,27 @@ const showWarningRows = (range) => {
 };
 watch(csvEntities, (value) => { if (value == null) warningRows.value = null; });
 
+// Creating new properties
+const toggleExtraProperty = (name, selected) => {
+  if (selected)
+    selectedProperties.add(name);
+  else
+    selectedProperties.delete(name);
+};
+const propertiesToCreate = computed(() =>
+  warnings.value?.extraProperties?.filter(name => selectedProperties.has(name)));
+
 const { request, awaitingResponse: uploading } = useRequest();
 const uploadProgress = ref(0);
 const upload = () => {
+  const entitiesToSend = csvEntities.value.map(entity =>
+    (Object.keys(entity.data).length !== 0 ? entity : { label: entity.label }));
   request({
     method: 'POST',
     url: apiPaths.entities(dataset.projectId, dataset.name),
     data: {
       source: pick(['name', 'size'], fileMetadata.value),
-      entities: csvEntities.value
+      entities: entitiesToSend
     },
     onUploadProgress: (event) => { uploadProgress.value = event.progress ?? 0; }
   })

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -392,8 +392,11 @@ const propertiesToCreate = computed(() =>
 const { request, awaitingResponse: uploading } = useRequest();
 const uploadProgress = ref(0);
 const upload = () => {
-  const entitiesToSend = csvEntities.value.map(entity =>
-    (Object.keys(entity.data).length !== 0 ? entity : { label: entity.label }));
+  const entitiesToSend = csvEntities.value.map(entity => {
+    const result = { label: entity.label };
+    if (Object.keys(entity.data).length !== 0) result.data = entity.data;
+    return result;
+  });
   request({
     method: 'POST',
     url: apiPaths.entities(dataset.projectId, dataset.name),

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -386,6 +386,10 @@ const toggleExtraProperty = (name, selected) => {
   else
     selectedProperties.delete(name);
 };
+// Because selectedProperties persists from one file selection to the next, it
+// is not necessarily a subset of warnings.value.extraProperties. Either list
+// may include properties that the other does not. propertiesToCreate represents
+// the intersection of the two lists.
 const propertiesToCreate = computed(() =>
   warnings.value?.extraProperties?.filter(name => selectedProperties.has(name)));
 

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -263,9 +263,9 @@ const { t } = useI18n();
 const noPropertyData = { toJSON: () => undefined };
 const rowToEntity = (extraProperties) => (values, columns) => {
   let label;
-  const data = Object.create(null);
+  const data = dataset.properties.length !== 0 ? Object.create(null) : null;
   let hasProperty = false;
-  const extraData = extraProperties.size !== 0 ? Object.create(null) : undefined;
+  const extraData = extraProperties.size !== 0 ? Object.create(null) : null;
   for (const [i, value] of values.entries()) {
     if (value === '') continue; // eslint-disable-line no-continue
 
@@ -283,7 +283,9 @@ const rowToEntity = (extraProperties) => (values, columns) => {
   if (label == null || /^\s+$/.test(label))
     throw new Error(t('alert.blankLabel'));
 
-  return { label, data: hasProperty ? data : noPropertyData, extra: extraData };
+  const result = { label, data: hasProperty ? data : noPropertyData };
+  if (extraData != null) result.extra = extraData;
+  return result;
 };
 const { i18n: globalI18n, redAlert } = inject('container');
 const parseEntities = async (file, headerResults, extraProperties, signal) => {

--- a/apps/central/src/components/entity/upload/alert.vue
+++ b/apps/central/src/components/entity/upload/alert.vue
@@ -68,6 +68,7 @@ const { formatRange } = useI18nUtils();
   // Title
   > :first-child {
     @include line-clamp(2);
+    margin-bottom: 5px;
 
     // Icon
     > :first-child { margin-right: $margin-right-icon; }

--- a/apps/central/src/components/entity/upload/errors.vue
+++ b/apps/central/src/components/entity/upload/errors.vue
@@ -26,12 +26,6 @@
         <p>{{ $t('missingLabel.description') }}</p>
       </template>
     </entity-upload-alert>
-    <entity-upload-alert v-if="unknownProperty" type="danger">
-      <template #title>Unknown property found in header row</template>
-      <template #body>
-        <p>{{ $t('unknownProperty') }}</p>
-      </template>
-    </entity-upload-alert>
     <entity-upload-alert v-if="duplicateColumns != null" type="danger">
       <template #title>{{ $t('duplicateColumn.title') }}</template>
       <template #body>
@@ -84,7 +78,6 @@ const props = defineProps({
   // Errors about the column header
   invalidQuotes: Boolean,
   missingLabel: Boolean,
-  unknownProperty: Boolean,
   duplicateColumns: Array,
   emptyColumn: Boolean,
 
@@ -123,8 +116,6 @@ const formattedDelimiter = computed(() => formatCSVDelimiter(props.delimiter));
       "title": "A {label} property is required",
       "description": "The label indicates the name to use for each Entity throughout Central and elsewhere."
     },
-    // @transifexKey component.EntityUploadHeaderErrors.suggestions.unknownProperty
-    "unknownProperty": "If you want to add properties to this Entity List, you can do so in the Entity Properties section on the Overview page of this Entity List, or you can upload and publish a Form that references the property.",
     "duplicateColumn": {
       "title": "Duplicate column headers",
       "description": "Each column must have a unique header.",

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -6,7 +6,10 @@
       </label>
     </div>
     <div v-for="name of properties" :key="name" class="checkbox">
-      <label><input type="checkbox" :value="name">{{ name }}</label>
+      <label>
+        <input type="checkbox" :value="name">
+        <span v-tooltip.text>{{ name }}</span>
+      </label>
     </div>
   </div>
 </template>
@@ -38,7 +41,10 @@ const toggle = (event) => {
 </script>
 
 <style lang="scss">
+@import '../../../assets/scss/mixins';
+
 #entity-upload-extra-properties {
+  label { @include text-overflow-ellipsis; }
 }
 </style>
 

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -66,8 +66,8 @@ const toggle = (event) => {
 {
   "en": {
     "action": {
-      // This is the text of a button that allows the user to select all
-      // columns.
+      // This is the text of a button that allows the user to select all the
+      // columns of a table.
       "selectAll": "Select all"
     }
   }

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -31,8 +31,10 @@ const toggle = (event) => {
   const { checked } = target;
   if (target.dataset.selectAll === 'true') {
     for (const input of event.currentTarget.querySelectorAll('input[value]')) {
-      input.checked = checked;
-      emit('toggle', input.value, checked);
+      if (input.checked !== checked) {
+        input.checked = checked;
+        emit('toggle', input.value, checked);
+      }
     }
   } else {
     emit('toggle', target.value, checked);

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -44,6 +44,16 @@ const toggle = (event) => {
 @import '../../../assets/scss/mixins';
 
 #entity-upload-extra-properties {
+  padding-inline: 8px;
+
+  .checkbox {
+    margin-block: 0;
+    padding-block: 3px;
+    padding-left: 10px;
+
+    &:first-child { padding-left: 0; }
+  }
+
   label { @include text-overflow-ellipsis; }
 }
 </style>

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -44,6 +44,8 @@ const toggle = (event) => {
 @import '../../../assets/scss/mixins';
 
 #entity-upload-extra-properties {
+  max-height: 350px;
+  overflow-y: auto;
   padding-inline: 8px;
 
   .checkbox {

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -1,0 +1,55 @@
+<template>
+  <div id="entity-upload-extra-properties" @change="toggle">
+    <div v-if="properties.length !== 1" class="checkbox">
+      <label>
+        <input type="checkbox" data-select-all="true">{{ $t('action.selectAll') }}
+      </label>
+    </div>
+    <div v-for="name of properties" :key="name" class="checkbox">
+      <label><input type="checkbox" :value="name">{{ name }}</label>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineOptions({
+  name: 'EntityUploadExtraProperties'
+});
+defineProps({
+  properties: {
+    type: Array,
+    required: true
+  }
+});
+const emit = defineEmits(['toggle']);
+
+const toggle = (event) => {
+  const { target } = event;
+  const { checked } = target;
+  if (target.dataset.selectAll === 'true') {
+    for (const input of event.currentTarget.querySelectorAll('input[value]')) {
+      input.checked = checked;
+      emit('toggle', input.value, checked);
+    }
+  } else {
+    emit('toggle', target.value, checked);
+  }
+};
+</script>
+
+<style lang="scss">
+#entity-upload-extra-properties {
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    "action": {
+      // This is the text of a button that allows the user to select all
+      // columns.
+      "selectAll": "Select all"
+    }
+  }
+}
+</i18n>

--- a/apps/central/src/components/entity/upload/table.vue
+++ b/apps/central/src/components/entity/upload/table.vue
@@ -19,6 +19,11 @@ except according to the terms contained in the LICENSE file.
           <th v-for="{ name } of dataset.properties" :key="name">
             <div v-tooltip.text>{{ name }}</div>
           </th>
+          <template v-if="extraProperties != null">
+            <th v-for="name of extraProperties" :key="name">
+              <div v-tooltip.text>{{ name }}</div>
+            </th>
+          </template>
         </tr>
       </thead>
       <tbody v-if="entities != null && entities.length !== 0"
@@ -32,6 +37,11 @@ except according to the terms contained in the LICENSE file.
           <td v-for="{ name } of dataset.properties" :key="name">
             <div v-tooltip.text>{{ entity.data[name] }}</div>
           </td>
+          <template v-if="extraProperties != null">
+            <td v-for="name of extraProperties" :key="name">
+              <div v-tooltip.text>{{ entity.extra[name] }}</div>
+            </td>
+          </template>
         </tr>
       </tbody>
     </table>
@@ -49,6 +59,7 @@ defineOptions({
 });
 const props = defineProps({
   entities: Array,
+  extraProperties: Array,
   // The 0-indexed row number of the first row of the table
   rowIndex: Number,
   pageSize: {

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -65,6 +65,18 @@ except according to the terms contained in the LICENSE file.
         <p><i18n-list :list="missingProperties"/></p>
       </template>
     </entity-upload-alert>
+
+    <!-- Data warnings -->
+    <entity-upload-alert v-if="raggedRows != null" type="warning"
+      :ranges="raggedRows" @rows="$emit('rows', $event)">
+      <template #title>{{ $t('row.raggedRows') }}</template>
+    </entity-upload-alert>
+    <entity-upload-alert v-if="largeCell != null" type="warning"
+      :ranges="[[largeCell, largeCell]]" @rows="$emit('rows', $event)">
+      <template #title>{{ $t('row.largeCell') }}</template>
+    </entity-upload-alert>
+
+    <!-- Extra properties -->
     <entity-upload-alert v-if="extraProperties != null" type="warning">
       <template #title>
         <template v-if="extraProperties.length === 1">
@@ -86,16 +98,6 @@ except according to the terms contained in the LICENSE file.
         <entity-upload-extra-properties :properties="extraProperties"
           @toggle="toggleExtraProperty"/>
       </template>
-    </entity-upload-alert>
-
-    <!-- Data warnings -->
-    <entity-upload-alert v-if="raggedRows != null" type="warning"
-      :ranges="raggedRows" @rows="$emit('rows', $event)">
-      <template #title>{{ $t('row.raggedRows') }}</template>
-    </entity-upload-alert>
-    <entity-upload-alert v-if="largeCell != null" type="warning"
-      :ranges="[[largeCell, largeCell]]" @rows="$emit('rows', $event)">
-      <template #title>{{ $t('row.largeCell') }}</template>
     </entity-upload-alert>
   </div>
 </template>

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -77,10 +77,10 @@ except according to the terms contained in the LICENSE file.
       <template #body>
         <p>
           <template v-if="extraProperties.length === 1">
-            {{ $t('extraProperties.title.one') }}
+            {{ $t('extraProperties.description.one') }}
           </template>
           <template v-else>
-            {{ $t('extraProperties.title.multiple') }}
+            {{ $t('extraProperties.description.multiple') }}
           </template>
         </p>
         <entity-upload-extra-properties :properties="extraProperties"

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -188,7 +188,7 @@ const toggleExtraProperty = (property, checked) => {
     "extraProperties": {
       "title": {
         "one": "Column doesn’t match existing properties",
-        "multiple": "These columns don’t match existing properties",
+        "multiple": "These columns don’t match existing properties"
       },
       "description": {
         "one": "Select the column to create a new property, otherwise it will be ignored.",

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -65,6 +65,28 @@ except according to the terms contained in the LICENSE file.
         <p><i18n-list :list="missingProperties"/></p>
       </template>
     </entity-upload-alert>
+    <entity-upload-alert v-if="extraProperties != null" type="warning">
+      <template #title>
+        <template v-if="extraProperties.length === 1">
+          {{ $t('extraProperties.title.one') }}
+        </template>
+        <template v-else>
+          {{ $t('extraProperties.title.multiple') }}
+        </template>
+      </template>
+      <template #body>
+        <p>
+          <template v-if="extraProperties.length === 1">
+            {{ $t('extraProperties.title.one') }}
+          </template>
+          <template v-else>
+            {{ $t('extraProperties.title.multiple') }}
+          </template>
+        </p>
+        <entity-upload-extra-properties :properties="extraProperties"
+          @toggle="toggleExtraProperty"/>
+      </template>
+    </entity-upload-alert>
 
     <!-- Data warnings -->
     <entity-upload-alert v-if="raggedRows != null" type="warning"
@@ -80,6 +102,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import EntityUploadAlert from './alert.vue';
+import EntityUploadExtraProperties from './extra-properties.vue';
 import I18nList from '../../i18n/list.vue';
 import SentenceSeparator from '../../sentence-separator.vue';
 
@@ -101,12 +124,17 @@ defineProps({
   caseMismatch: Array,
   invalidProperties: Array,
   missingProperties: Array,
+  extraProperties: Array,
 
   // Data warnings (below the column header)
   raggedRows: Array,
   largeCell: Number
 });
-defineEmits(['rows']);
+const emit = defineEmits(['rows', 'toggle-extra']);
+
+const toggleExtraProperty = (property, checked) => {
+  emit('toggle-extra', property, checked);
+};
 </script>
 
 <style lang="scss">
@@ -154,6 +182,17 @@ defineEmits(['rows']);
       "title": "Property not found in file | Properties not found in file",
       // "Property" refers to an Entity property.
       "description": "This property will be left empty. | These properties will be left empty."
+    },
+    "extraProperties": {
+      "title": {
+        "one": "Column doesn’t match existing properties",
+        "multiple": "These columns don’t match existing properties",
+      },
+      "description": {
+        "one": "Select the column to create a new property, otherwise it will be ignored.",
+        // "Ones" refers to "columns".
+        "multiple": "Select which ones to create, otherwise they will be ignored."
+      }
     },
     // "Property" refers to an Entity property.
     "propertiesIgnored": "This property will be ignored. | These properties will be ignored.",

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -658,10 +658,18 @@ describe('EntityUpload', () => {
     it('shows selected properties in the table', async () => {
       const modal = await showModal();
       await selectFile(modal, extraCSV);
+
+      const tables = modal.findAllComponents(EntityUploadTable);
+      tables.length.should.equal(2);
+      const table = tables[1];
+      table.props().extraProperties.should.eql([]);
+
       const input = modal.get('#entity-upload-extra-properties .checkbox:nth-child(2) input');
       await input.setChecked();
-      const tables = modal.findAllComponents(EntityUploadTable);
-      tables[1].props().extraProperties.should.eql(['circumference']);
+      table.props().extraProperties.should.eql(['circumference']);
+
+      await input.setChecked(false);
+      table.props().extraProperties.should.eql([]);
     });
 
     it('does not send properties that were not selected', () =>

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -152,10 +152,9 @@ describe('EntityUpload', () => {
       const errors = modal.getComponent(EntityUploadErrors).props();
       errors.should.include({
         delimiter: ',',
-        count: 4,
+        count: 3,
         invalidQuotes: false,
         missingLabel: true,
-        unknownProperty: true,
         emptyColumn: true
       });
       errors.duplicateColumns.should.eql(['foo']);
@@ -163,7 +162,7 @@ describe('EntityUpload', () => {
 
     it('uses the delimiter from the file', async () => {
       const modal = await showModal();
-      const csv = createCSV('label;height;circumference\ndogwood;1;2');
+      const csv = createCSV('height;circumference\n1;2');
       await selectFile(modal, csv);
       modal.getComponent(EntityUploadErrors).props().delimiter.should.equal(';');
     });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -638,4 +638,51 @@ describe('EntityUpload', () => {
         }
       }]);
   });
+
+  describe('extra properties', () => {
+    beforeEach(() => {
+      testData.extendedDatasets.createPast(1, {
+        properties: [{ name: 'height' }]
+      });
+    });
+
+    const extraCSV = createCSV('label,height,circumference,species\ndogwood,1,2,dogwood\nelm');
+
+    it('shows a warning if there are extra properties', async () => {
+      const modal = await showModal();
+      await selectFile(modal, extraCSV);
+      const warnings = modal.getComponent(EntityUploadWarnings).props();
+      warnings.extraProperties.should.eql(['circumference', 'species']);
+    });
+
+    it('shows selected properties in the table', async () => {
+      const modal = await showModal();
+      await selectFile(modal, extraCSV);
+      const input = modal.get('#entity-upload-extra-properties .checkbox:nth-child(2) input');
+      await input.setChecked();
+      const tables = modal.findAllComponents(EntityUploadTable);
+      tables[1].props().extraProperties.should.eql(['circumference']);
+    });
+
+    it('does not send properties that were not selected', () =>
+      showModal()
+        .complete()
+        .request(async (modal) => {
+          await selectFile(modal, extraCSV);
+          return modal.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .respondWithProblem()
+        .testRequests([{
+          method: 'POST',
+          url: '/v1/projects/1/datasets/trees/entities',
+          data: {
+            source: { name: 'my_data.csv', size: 58 },
+            entities: [
+              { label: 'dogwood', data: { height: '1' } },
+              // Don't bother sending an empty `data` object.
+              { label: 'elm' }
+            ]
+          }
+        }]));
+  });
 });

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -27,7 +27,7 @@ describe('EntityUploadExtraProperties', () => {
   });
 
   describe('select all', () => {
-    it('does not show the checkbox for a single property', () => {
+    it('does not show the checkbox if there is only a single property', () => {
       const component = mountComponent({
         props: { properties: ['foo'] }
       });

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -1,0 +1,58 @@
+import EntityUploadExtraProperties from '../../../../src/components/entity/upload/extra-properties.vue';
+
+import { mount } from '../../../util/lifecycle';
+
+const mountComponent = (options) => mount(EntityUploadExtraProperties, options);
+
+describe('EntityUploadExtraProperties', () => {
+  it('shows a checkbox for each property', () => {
+    const component = mountComponent({
+      props: { properties: ['foo', 'bar'] }
+    });
+    const text = component.findAll('.checkbox').map(div => div.text());
+    text.should.eql(['Select all', 'foo', 'bar']);
+  });
+
+  it('emits a toggle event when a property is checked or unchecked', async () => {
+    const component = mountComponent({
+      props: { properties: ['foo', 'bar'] }
+    });
+    const checkbox = component.get('.checkbox:nth-child(2)');
+    checkbox.text().should.equal('foo');
+    await checkbox.get('input').setChecked();
+    await checkbox.get('input').setChecked(false);
+    component.emitted().toggle.should.eql([['foo', true], ['foo', false]]);
+  });
+
+  describe('select all', () => {
+    it('does not show the checkbox for a single property', () => {
+      const component = mountComponent({
+        props: { properties: ['foo'] }
+      });
+      const checkboxes = component.findAll('.checkbox');
+      checkboxes.length.should.equal(1);
+      checkboxes[0].text().should.equal('foo');
+    });
+
+    it('toggles each property', async () => {
+      const component = mountComponent({
+        props: { properties: ['foo', 'bar'] }
+      });
+      const inputs = component.findAll('input');
+      inputs.length.should.equal(3);
+
+      await inputs[0].setChecked();
+      inputs[1].element.checked.should.be.true;
+      inputs[2].element.checked.should.be.true;
+      component.emitted().toggle.should.eql([['foo', true], ['bar', true]]);
+
+      await inputs[0].setChecked(false);
+      inputs[1].element.checked.should.be.false;
+      inputs[2].element.checked.should.be.false;
+      component.emitted().toggle.should.eql([
+        ['foo', true], ['bar', true],
+        ['foo', false], ['bar', false]
+      ]);
+    });
+  });
+});

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -5,12 +5,14 @@ import { mount } from '../../../util/lifecycle';
 const mountComponent = (options) => mount(EntityUploadExtraProperties, options);
 
 describe('EntityUploadExtraProperties', () => {
-  it('shows a checkbox for each property', () => {
+  it('shows a checkbox for each property', async () => {
     const component = mountComponent({
-      props: { properties: ['foo', 'bar'] }
+      props: { properties: ['circumference', 'species'] }
     });
-    const text = component.findAll('.checkbox').map(div => div.text());
-    text.should.eql(['Select all', 'foo', 'bar']);
+    const checkboxes = component.findAll('.checkbox');
+    const text = checkboxes.map(div => div.text());
+    text.should.eql(['Select all', 'circumference', 'species']);
+    await checkboxes[1].get('span').should.have.textTooltip();
   });
 
   it('emits a toggle event when a property is checked or unchecked', async () => {

--- a/apps/central/test/components/entity/upload/table.spec.js
+++ b/apps/central/test/components/entity/upload/table.spec.js
@@ -6,8 +6,6 @@ import testData from '../../../data';
 import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
 const mountComponent = (options = {}) => {
-  if (options.props?.entities != null)
-    throw new Error('entities prop not allowed. Use the rowIndex prop instead.');
   const mergedOptions = mergeMountOptions(options, {
     props: { pageSize: 5 },
     container: {
@@ -15,15 +13,14 @@ const mountComponent = (options = {}) => {
     }
   });
   const { props } = mergedOptions;
-  if (testData.extendedEntities.size !== 0) {
+  if (props.entities == null && testData.extendedEntities.size !== 0) {
     if (props.rowIndex == null) props.rowIndex = 0;
     props.entities = testData.extendedEntities.sorted()
       .reverse()
       .slice(props.rowIndex, props.rowIndex + props.pageSize)
       .map(entity => pick(['label', 'data'], entity.currentVersion));
-  } else {
-    props.rowIndex = -1;
   }
+  if (props.rowIndex == null) props.rowIndex = props.entities != null ? 0 : -1;
   return mount(EntityUploadTable, mergedOptions);
 };
 
@@ -81,6 +78,34 @@ describe('EntityUploadTable', () => {
     const divs = td.slice(2).map(wrapper => wrapper.get('div'));
     divs[0].text().should.equal('123456');
     divs[1].text().should.equal('999');
+    await divs[0].should.have.textTooltip();
+  });
+
+  it('shows extra properties in the CSV data', async () => {
+    testData.extendedDatasets.createPast(1, {
+      properties: [{ name: 'height' }]
+    });
+    const component = mountComponent({
+      props: {
+        entities: [{
+          label: 'dogwood',
+          data: { height: '1' },
+          extra: { circumference: '123456', species: 'dogwood' }
+        }],
+        extraProperties: ['circumference', 'species']
+      }
+    });
+
+    const th = component.findAll('th');
+    const thText = th.map(wrapper => wrapper.text());
+    thText.should.eql(['Row', 'label', 'height', 'circumference', 'species']);
+    await th[3].get('div').should.have.textTooltip();
+
+    const td = component.findAll('td');
+    td.length.should.equal(5);
+    const divs = td.slice(3).map(wrapper => wrapper.get('div'));
+    divs[0].text().should.equal('123456');
+    divs[1].text().should.equal('dogwood');
     await divs[0].should.have.textTooltip();
   });
 

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -1,6 +1,7 @@
 import { nextTick } from 'vue';
 
 import EntityUploadAlert from '../../../../src/components/entity/upload/alert.vue';
+import EntityUploadExtraProperties from '../../../../src/components/entity/upload/extra-properties.vue';
 import EntityUploadWarnings from '../../../../src/components/entity/upload/warnings.vue';
 
 import { mergeMountOptions, mount } from '../../../util/lifecycle';
@@ -76,6 +77,19 @@ describe('EntityUploadWarnings', () => {
     p.length.should.equal(3);
     p[0].text().should.equal('Properties not found in file');
     p[2].text().should.equal('foo, bar');
+  });
+
+  it('shows a warning for unknown properties', () => {
+    const component = mountComponent({
+      props: { extraProperties: ['foo', 'bar'] }
+    });
+
+    const p = component.getComponent(EntityUploadAlert).findAll('p');
+    p.length.should.equal(2);
+    p[0].text().should.equal('These columns don’t match existing properties');
+
+    const extraComponent = component.getComponent(EntityUploadExtraProperties);
+    expect(extraComponent.props().properties).to.eql(['foo', 'bar']);
   });
 
   it('shows a warning for ragged rows', () => {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2883,6 +2883,14 @@
         }
       }
     },
+    "EntityUploadExtraProperties": {
+      "action": {
+        "selectAll": {
+          "string": "Select all",
+          "developer_comment": "This is the text of a button that allows the user to select all columns."
+        }
+      }
+    },
     "EntityUploadFileSelect": {
       "text": {
         "full": {
@@ -2896,13 +2904,6 @@
       },
       "parsing": {
         "string": "Reading data…"
-      }
-    },
-    "EntityUploadHeaderErrors": {
-      "suggestions": {
-        "unknownProperty": {
-          "string": "If you want to add properties to this Entity List, you can do so in the Entity Properties section on the Overview page of this Entity List, or you can upload and publish a Form that references the property."
-        }
       }
     },
     "EntityUploadHeaderReview": {
@@ -2959,6 +2960,25 @@
         "description": {
           "string": "{count, plural, one {This property will be left empty.} other {These properties will be left empty.}}",
           "developer_comment": "\"Property\" refers to an Entity property."
+        }
+      },
+      "extraProperties": {
+        "title": {
+          "one": {
+            "string": "Column doesn’t match existing properties"
+          },
+          "multiple": {
+            "string": "These columns don’t match existing properties"
+          }
+        },
+        "description": {
+          "one": {
+            "string": "Select the column to create a new property, otherwise it will be ignored."
+          },
+          "multiple": {
+            "string": "Select which ones to create, otherwise they will be ignored.",
+            "developer_comment": "\"Ones\" refers to \"columns\"."
+          }
         }
       },
       "propertiesIgnored": {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2887,7 +2887,7 @@
       "action": {
         "selectAll": {
           "string": "Select all",
-          "developer_comment": "This is the text of a button that allows the user to select all columns."
+          "developer_comment": "This is the text of a button that allows the user to select all the columns of a table."
         }
       }
     },


### PR DESCRIPTION
This PR makes progress on getodk/central#1786. It's the first PR for the issue, but it doesn't fully complete it: there will be follow-up PRs. This PR does the following:

- Removes the error when there is an unknown property.
- Instead, it shows a warning.
- The warning lists the specific unknown properties (i.e., it doesn't just say, "there is some unknown property").
- It allows the user to select one or more unknown properties.
- It allows the user to select all unknown properties at once via a "Select all" checkbox.
- Selecting a property shows it in the second table (the table for the CSV data).
- However, the property is not yet actually included in the request. Frontend doesn't create the new property, and it doesn't send the property's entity data to Backend as part of the upload request. That'll come in a follow-up PR.
- In a follow-up PR, I'll also make the modal remember the property selection even as the user moves from one file selection to the next (up until the modal is closed entirely). In this PR, the property selection is reset whenever a file is selected.

#### What has been done to verify that this works as intended?

New tests. I also tried it out locally.

#### Why is this the best possible solution? Were any other approaches considered?

One change I made was to `rowToEntity()`, which converts a row/array of CSV values to an entity object. Previously, the resulting entity object was optimized for transport. For example, if its `data` object was empty, it would get a `toJSON` property that would remove it from the payload sent to Backend. However, things get more complicated now that extra properties can be selected/added after the CSV is parsed. That means that the entity objects we parse may differ from the ones we ultimately send to Backend. For that reason, it makes less sense to try to optimize them for transport at parse time.

In this PR, I've gone ahead and removed some of those optimizations, with the thought that if there is a degradation in performance, that's likely something that we'll notice during testing. However, now I'm leaning toward adding back modified versions of those optimizations in a follow-up PR. Those modified optimizations would take place at the time of the request rather than at parse time.