### PR TITLE
fix(web-forms#886): allow commas as decimal places

### DIFF
--- a/.changeset/curly-badgers-yawn.md
+++ b/.changeset/curly-badgers-yawn.md
@@ -1,0 +1,7 @@
+---
+"@getodk/xpath": patch
+"@getodk/web-forms": patch
+"@getodk/xforms-engine": patch
+---
+
+Fixed a bug where using commas for decimal places returned an invalid number.

--- a/packages/xpath/src/evaluations/StringEvaluation.ts
+++ b/packages/xpath/src/evaluations/StringEvaluation.ts
@@ -2,8 +2,6 @@ import type { XPathNode } from '../adapter/interface/XPathNode.ts';
 import type { LocationPathEvaluation } from './LocationPathEvaluation.ts';
 import { ValueEvaluation } from './ValueEvaluation.ts';
 
-const parseNumber = (value: string) => Number(value.replace(',', '.'));
-
 export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'STRING'> {
   readonly type = 'STRING';
   readonly nodes = null;
@@ -20,7 +18,7 @@ export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'S
     super();
 
     this.booleanValue = !isEmpty;
-    this.numberValue = isEmpty ? NaN : parseNumber(value);
+    this.numberValue = isEmpty ? NaN : Number(value);
     this.stringValue = value;
 
     const numberFunction = context.functions.getDefaultImplementation('number');
@@ -28,7 +26,7 @@ export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'S
     if (isEmpty) {
       this.numberValue = NaN;
     } else if (numberFunction === null) {
-      this.numberValue = parseNumber(value);
+      this.numberValue = Number(value);
     } else {
       try {
         this.numberValue = numberFunction
@@ -39,7 +37,7 @@ export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'S
           ])
           .toNumber();
       } catch {
-        this.numberValue = parseNumber(value);
+        this.numberValue = Number(value);
       }
     }
   }

--- a/packages/xpath/src/evaluations/StringEvaluation.ts
+++ b/packages/xpath/src/evaluations/StringEvaluation.ts
@@ -2,6 +2,8 @@ import type { XPathNode } from '../adapter/interface/XPathNode.ts';
 import type { LocationPathEvaluation } from './LocationPathEvaluation.ts';
 import { ValueEvaluation } from './ValueEvaluation.ts';
 
+const parseNumber = (value: string) => Number(value.replace(',', '.'));
+
 export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'STRING'> {
   readonly type = 'STRING';
   readonly nodes = null;
@@ -18,7 +20,7 @@ export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'S
     super();
 
     this.booleanValue = !isEmpty;
-    this.numberValue = isEmpty ? NaN : Number(value);
+    this.numberValue = isEmpty ? NaN : parseNumber(value);
     this.stringValue = value;
 
     const numberFunction = context.functions.getDefaultImplementation('number');
@@ -26,7 +28,7 @@ export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'S
     if (isEmpty) {
       this.numberValue = NaN;
     } else if (numberFunction === null) {
-      this.numberValue = Number(value);
+      this.numberValue = parseNumber(value);
     } else {
       try {
         this.numberValue = numberFunction
@@ -37,7 +39,7 @@ export class StringEvaluation<T extends XPathNode> extends ValueEvaluation<T, 'S
           ])
           .toNumber();
       } catch {
-        this.numberValue = Number(value);
+        this.numberValue = parseNumber(value);
       }
     }
   }

--- a/packages/xpath/src/functions/xforms/node-set.ts
+++ b/packages/xpath/src/functions/xforms/node-set.ts
@@ -389,7 +389,7 @@ export const randomize = new NodeSetFunction(
     if (seedExpression === undefined) return seededRandomize(nodes);
 
     const seed = seedExpression.evaluate(context);
-    const asNumber = seed.toNumber(); // TODO: There are some peculiarities to address: https://github.com/getodk/web-forms/issues/240
+    const asNumber = seed.toNumber();
     let finalSeed: bigint | number | undefined;
     if (Number.isNaN(asNumber)) {
       // Specific behaviors for when a seed value is not interpretable as numeric.

--- a/packages/xpath/src/functions/xforms/number.ts
+++ b/packages/xpath/src/functions/xforms/number.ts
@@ -40,6 +40,10 @@ export const log10 = mathAlias('log10');
 export const max = mathNAlias('max');
 export const min = mathNAlias('min');
 
+const parseCommaDecimal = (value: string): number => {
+  return Number(value.replace(',', '.'));
+};
+
 /**
  * Overrides the standard XPath 1.0 (fn namespaced) `number` in an
  * {@link XFormsXPathEvaluator}. This supports various date/datetime
@@ -72,6 +76,9 @@ export const number = new FunctionImplementation(
           booleanValue: true,
           stringValue: String(Math.floor(dateTime.epochMilliseconds / DAY_MILLISECONDS)),
         });
+      }
+      if (stringValue.includes(',')) {
+        return new NumberEvaluation(context, parseCommaDecimal(stringValue));
       }
     }
 

--- a/packages/xpath/test/xforms/number.test.ts
+++ b/packages/xpath/test/xforms/number.test.ts
@@ -56,6 +56,9 @@ describe('#number()', () => {
       { expression: 'number("1.1   ")', expected: 1.1 },
       { expression: 'number("1.1   \n ")', expected: 1.1 },
       { expression: 'number("  1.1 \n\r\n  ")', expected: 1.1 },
+      { expression: 'number(",112")', expected: 0.112 },
+      { expression: 'number("11,12")', expected: 11.12 },
+      { expression: 'number("0x12")', expected: 18 }, // not supported by JavaRosa
     ].forEach(({ expression, expected }) => {
       it(`${expression} should be ${expected}`, () => {
         testContext.assertNumberValue(expression, expected);

--- a/packages/xpath/test/xforms/sum.test.ts
+++ b/packages/xpath/test/xforms/sum.test.ts
@@ -65,6 +65,20 @@ describe('#sum()', () => {
     testContext.assertNumberValue('sum(/root/item)', 100);
   });
 
+  it('sum of decimals', () => {
+    testContext = createXFormsTestContext(`
+      <root id="root">
+        <item>-10.6</item>
+        <item>11,3</item>
+        <item>99.2</item>
+      </root>`);
+
+    const contextNode = testContext.document.getElementById('root');
+
+    testContext.assertNumberValue('sum(*)', 99.9, { contextNode });
+    testContext.assertNumberValue('sum(/root/item)', 99.9);
+  });
+
   it('sum trims string input', () => {
     testContext = createXFormsTestContext(`
       <root id="root">


### PR DESCRIPTION
Closes getodk/web-forms#886
Closes getodk/web-forms#240

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Unit test.
Manual test.
Comparison with Collect for...

```
number(1)
number('1')
number(1.2)
number('1.2')
number('1,23')
number('0x12')
number('abc')
number('   13   ')
number('.56')
```

The two implementations match in all cases except the hexadecimal `0x12` which WF parses to 18 but JavaRosa returns NaN. I'm comfortable that this is enough of an edge case to ignore.

#### Why is this the best possible solution? Were any other approaches considered?

This mostly matches the implementation in Collect.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Allows entering numbers with commas for decimals.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.