### PR TITLE
feat(web-forms#461): enforce single submission on public access links

### DIFF
--- a/.changeset/busy-trees-open.md
+++ b/.changeset/busy-trees-open.md
@@ -1,0 +1,6 @@
+---
+"@getodk/web-forms": minor
+"@getodk/forms": minor
+---
+
+Added the ability to enforce single submissions to public access links.

--- a/.changeset/busy-trees-open.md
+++ b/.changeset/busy-trees-open.md
@@ -1,5 +1,4 @@
 ---
-"@getodk/web-forms": minor
 "@getodk/forms": minor
 ---
 

--- a/apps/forms/src/components/enketo-iframe.vue
+++ b/apps/forms/src/components/enketo-iframe.vue
@@ -101,7 +101,7 @@ const setEnketoSrc = () => {
 
   // we no longer render Enketo for Edit Submission from central-frontend.
   const enketoId = props.enketoId ?? props.form.enketoId;
-  if (enketoId === props.form.enketoOnceId) {
+  if (props.form.once) {
     lastSubmitted(enketoId)
       .then(result => {
         if (result) {

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -11,6 +11,7 @@ import Location from '../utils/location';
 import { getDeviceId } from '../utils/device-id';
 import { hideSpinner } from '../utils/spinner';
 import { deleteLastSaved, getLastSaved, setLastSaved } from '../utils/last-saved';
+import { hasSubmitted, setSubmitted } from '../utils/once-store';
 defineOptions({
   name: 'WebFormRenderer'
 });
@@ -37,7 +38,7 @@ interface PostPrimaryInstanceParams {
   deviceID?: string | undefined;
 }
 
-let clearForm:Function;
+let clearForm: Function;
 let submissionData: SubmissionData;
 
 const submissionResult:any = {};
@@ -97,7 +98,7 @@ const postPrimaryInstance = async (file:File) => {
   }
 };
 
-const isProblem = (data:any) => {
+const isProblem = (data: any) => {
   return data != null &&
     typeof data === 'object' &&
     typeof data.code === 'number' &&
@@ -138,6 +139,10 @@ const handleResult = () => {
 
   // Success handler
   if (submissionResult.primaryInstanceResult.success && attachmentResultArr.every(r => r.success)) {
+
+    if (props.form.once && props.form.enketoOnceId) {
+      setSubmitted(props.form.enketoOnceId);
+    }
 
     clearForm();
 
@@ -246,7 +251,11 @@ const webFormLoaded = () => {
 };
 
 const updateLastSaved = (hasLastSaved) => {
-  if (!isEdit.value && !props.form.draft && submissionResult.primaryInstanceResult.success) {
+  if (!isEdit.value
+    && !props.form.draft
+    && submissionResult.primaryInstanceResult.success
+    && !props.form.once
+  ) {
     if (hasLastSaved) {
       setLastSaved(props.form.projectId, props.form.xmlFormId, submissionData.instanceFile);
     } else {
@@ -301,6 +310,11 @@ const editInstanceOptions = computed(() => {
 });
 
 onMounted(async () => {
+  if (props.form.once && props.form.enketoOnceId && hasSubmitted(props.form.enketoOnceId)) {
+    visibleModal.value = { type: 'thankYouModal', hideable: false };
+    webFormLoaded(); // hide the spinner
+    return;
+  }
   if (!isEdit.value && !props.form.draft) {
     lastSavedXml.value = await getLastSaved(props.form.projectId, props.form.xmlFormId);
   }

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -88,6 +88,9 @@ const postPrimaryInstance = async (file:File) => {
   try {
     const response = await fetch(url, { body: file, headers, method });
     if (response.ok) {
+      if (props.form.once && props.form.enketoOnceId) {
+        setSubmitted(props.form.enketoOnceId);
+      }
       const data = await response.json();
       return { success: true, data };
     }
@@ -139,10 +142,6 @@ const handleResult = () => {
 
   // Success handler
   if (submissionResult.primaryInstanceResult.success && attachmentResultArr.every(r => r.success)) {
-
-    if (props.form.once && props.form.enketoOnceId) {
-      setSubmitted(props.form.enketoOnceId);
-    }
 
     clearForm();
 

--- a/apps/forms/src/utils/api.ts
+++ b/apps/forms/src/utils/api.ts
@@ -12,6 +12,7 @@ export interface Form {
   draft: boolean;
   webformsEnabled: boolean;
   attachments: Attachment[];
+  once: boolean;
 }
 
 export interface Project {
@@ -129,14 +130,17 @@ const getForm = async (url: string, draft: boolean, st?: string | null): Promise
     draft: !result.publishedAt,
     enketoOnceId: result.enketoOnceId,
     webformsEnabled: !!result.webformsEnabled,
-    attachments
+    attachments,
+    once: false,
   };
 };
 
 export const getFormByEnketoId = async (enketoId: string, st?: string | null): Promise<Form> => {
   const qs = queryString({ st });
   const url = `/v1/form-links/${enketoId}/form${qs}`;
-  return getForm(url, false, st);
+  const form = await getForm(url, false, st);
+  form.once = enketoId === form.enketoOnceId;
+  return form;
 };
 
 export const getFormByFormId = async (projectId: number, formId: string, draft: boolean, st?: string | null): Promise<Form> => {

--- a/apps/forms/src/utils/once-store.ts
+++ b/apps/forms/src/utils/once-store.ts
@@ -1,0 +1,20 @@
+const ONCE_KEY_PREFIX = 'odk-once-';
+
+const getKey = (enketoOnceId: string) => ONCE_KEY_PREFIX + enketoOnceId;
+
+export const hasSubmitted = (enketoOnceId: string): boolean => {
+  try {
+    return !!localStorage.getItem(getKey(enketoOnceId));
+  } catch {
+    // localStorage not available
+    return false;
+  }
+};
+
+export const setSubmitted = (enketoOnceId: string) => {
+  try {
+    localStorage.setItem(getKey(enketoOnceId), 'true');
+  } catch {
+    // localStorage not available
+  }
+};

--- a/apps/forms/test/utils/api.spec.ts
+++ b/apps/forms/test/utils/api.spec.ts
@@ -101,11 +101,13 @@ describe('Test api utility', () => {
       name: 'Simple',
       xmlFormId: 'simple',
       enketoId: 'abcdef',
+      enketoOnceId: 'singlesubmissiononly',
       projectId: 5,
       state: 'open',
       draft: false,
       webformsEnabled: false,
-      attachments: [ { name: 'myfile.png' } ]
+      attachments: [ { name: 'myfile.png' } ],
+      once: false,
     };
     
     const stubFormFetch = () => {
@@ -115,6 +117,7 @@ describe('Test api utility', () => {
         name: 'Simple',
         version: '2.1',
         enketoId: 'abcdef',
+        enketoOnceId: 'singlesubmissiononly',
         hash: '51a93eab3a1974dbffc4c7913fa5a16a',
         keyId: 3,
         state: 'open',
@@ -208,6 +211,14 @@ describe('Test api utility', () => {
         expect(actual).toEqual(expectedForm);
         expect(fetch).toHaveBeenCalledTimes(2);
         expect(fetch).toHaveBeenCalledWith('/v1/form-links/abc/form?st=zyx');
+      });
+
+      it('single submission', async () => {
+        stubFormFetch();
+        const actual = await getFormByEnketoId('singlesubmissiononly', 'zyx');
+        expect(actual).toEqual({ ...expectedForm, once: true });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith('/v1/form-links/singlesubmissiononly/form?st=zyx');
       });
 
       it('handles central errors', async () => {

--- a/apps/forms/test/utils/api.spec.ts
+++ b/apps/forms/test/utils/api.spec.ts
@@ -217,7 +217,7 @@ describe('Test api utility', () => {
         stubFormFetch();
         const actual = await getFormByEnketoId('singlesubmissiononly', 'zyx');
         expect(actual).toEqual({ ...expectedForm, once: true });
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledTimes(2);
         expect(fetch).toHaveBeenCalledWith('/v1/form-links/singlesubmissiononly/form?st=zyx');
       });
 

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -115,7 +115,6 @@ test.describe('ODK Web Forms', () => {
     await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible();
     await page.reload();
     await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible();
-    await expect(page.getByText('You have already completed this survey.')).toBeVisible();
   });
 
   test('binds last-saved instance for multiple submissions', async ({ page }) => {

--- a/e2e-tests/tests/web-forms.spec.js
+++ b/e2e-tests/tests/web-forms.spec.js
@@ -106,6 +106,18 @@ test.describe('ODK Web Forms', () => {
     await expect(page.getByRole('heading', { name: 'Successful' })).toBeVisible();
   });
 
+  test('restrict multiple submission for single submission public link', async ({ page }) => {
+    const singleSubPublicLink = await backendClient.createPublicLink(publishedForm.xmlFormId, true);
+    await page.goto(`${appUrl}/-/single/${publishedForm.enketoOnceId}?st=${singleSubPublicLink.token}`);
+    await expect(page.getByRole('heading', { name: publishedForm.name })).toBeVisible();
+    await page.getByLabel('First Name').fill('John Doe');
+    await page.getByRole('button', { name: 'send' }).click();
+    await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible();
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible();
+    await expect(page.getByText('You have already completed this survey.')).toBeVisible();
+  });
+
   test('binds last-saved instance for multiple submissions', async ({ page }) => {
     const form = await backendClient.createForm(FORM_TEMPLATES.lastsaved);
     await login(page);

--- a/packages/web-forms/README.md
+++ b/packages/web-forms/README.md
@@ -311,7 +311,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
   <summary>
 
 <!-- prettier-ignore -->
-##### Misc<br/>🟩🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 33\%
+##### Misc<br/>🟩🟩🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜ 44\%
 
   </summary>
   <br/>
@@ -321,7 +321,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
 | [last saved instance](https://github.com/getodk/web-forms/issues/306)            |    ✅    |
 | [defaults from query parameters](https://github.com/getodk/web-forms/issues/464) |    ✅    |
 | multi-form app-like experience                                                   |          |
-| [prevent multiple submissions](https://github.com/getodk/web-forms/issues/461)   |          |
+| [prevent multiple submissions](https://github.com/getodk/web-forms/issues/461)   |    ✅    |
 | configure end of form experience                                                 |          |
 | save as draft                                                                    |          |
 | offline entities                                                                 |          |

--- a/packages/web-forms/feature-matrix.json
+++ b/packages/web-forms/feature-matrix.json
@@ -218,7 +218,7 @@
     "[last saved instance](https://github.com/getodk/web-forms/issues/306)": "✅",
     "[defaults from query parameters](https://github.com/getodk/web-forms/issues/464)": "✅",
     "multi-form app-like experience": "",
-    "[prevent multiple submissions](https://github.com/getodk/web-forms/issues/461)": "",
+    "[prevent multiple submissions](https://github.com/getodk/web-forms/issues/461)": "✅",
     "configure end of form experience": "",
     "save as draft": "",
     "offline entities": "",


### PR DESCRIPTION
Closes getodk/web-forms#461

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual testing
e2e test added

#### Why is this the best possible solution? Were any other approaches considered?

The implementation is quite simple. The only bit I really debated was whether to use cookies (like Enketo does) or local storage. I chose local storage because of the better API.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.