### PR TITLE
Make EntityUpload inert during request

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     backdrop @hide="$emit('hide')" @mutate="resizeColumnIfShown">
     <template #title>{{ $t('title') }}</template>
     <template #body>
-      <div :class="{ backdrop: uploading }">
+      <div :class="{ backdrop: uploading }" :inert="uploading">
         <p class="entity-upload-section-title">{{ $t('currentEntities') }}</p>
         <div class="entity-upload-table-container">
           <entity-upload-table :ref="setTable(0)"

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -408,7 +408,7 @@ describe('EntityUpload', () => {
       })
       .beforeAnyResponse(modal => {
         modal.getComponent(EntityUploadFileSelect).props().disabled.should.be.true;
-        modal.find('.backdrop').exists().should.be.true;
+        should.exist(modal.get('.backdrop').attributes().inert);
 
         const popup = modal.getComponent(EntityUploadPopup);
         popup.props().filename.should.equal('my_data.csv');


### PR DESCRIPTION
This PR supports work on getodk/central#1786.

While requests are in progress, we don't want the user to select or deselect unknown/extra properties: doing so could affect the requests that are sent. To a large extent, selecting/deselecting them is already not possible, because we place a backdrop over the modal during the requests. However, prior to this PR, I think users could reach the checkboxes using the Tab key or a screen reader. This PR ensures that the user cannot interact with the checkboxes even in those cases. To be clear, I'm not really worried that users will actively attempt to undermine these requests. I just want it to be clear to all users which controls are disabled or not.

#### What has been done to verify that this works as intended?

I updated a test.

#### Why is this the best possible solution? Were any other approaches considered?

I added `inert` to the `.backdrop` covering the modal content (which is an ancestor element). That should prevent interactions with any descendant element of `.backdrop`, both the checkboxes in `EntityUploadExtraProperties` and any other controls (e.g., for pagination).

An alternative is that I could have used the `disabled` prop of `EntityUploadExtraProperties` to specifically disable just the checkboxes during the request. That's what I first thought about doing. However, I feel like `inert` is a more general approach. I also thought it might be a simpler code change.