### PR TITLE
Features: Submission XML

### DIFF
--- a/.changeset/kind-ravens-stay.md
+++ b/.changeset/kind-ravens-stay.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": patch
+---
+
+Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)

--- a/apps/central/src/components/form-version/list.vue
+++ b/apps/central/src/components/form-version/list.vue
@@ -14,7 +14,7 @@ except according to the terms contained in the LICENSE file.
     <form-version-table @view-xml="viewXml.show()"/>
     <loading :state="formVersions.initiallyLoading"/>
 
-    <form-version-view-xml v-bind="viewXml" @hide="viewXml.hide()"/>
+    <xml-viewer v-bind="viewXml" :xml="formVersionXml.data" :loading="formVersionXml.awaitingResponse" @hide="viewXml.hide()"/>
   </div>
 </template>
 
@@ -34,7 +34,7 @@ export default {
   name: 'FormVersionList',
   components: {
     FormVersionTable,
-    FormVersionViewXml: defineAsyncComponent(loadAsync('FormVersionViewXml')),
+    XmlViewer: defineAsyncComponent(loadAsync('XmlViewer')),
     Loading
   },
   props: {
@@ -48,12 +48,12 @@ export default {
     }
   },
   setup() {
-    const { formVersions } = useRequestData();
-    return { formVersions };
+    const { formVersions, formVersionXml } = useRequestData();
+    return { formVersions, formVersionXml };
   },
   data() {
     return {
-      viewXml: modalData('FormVersionViewXml')
+      viewXml: modalData('XmlViewer')
     };
   },
   created() {

--- a/apps/central/src/components/form/edit/def.vue
+++ b/apps/central/src/components/form/edit/def.vue
@@ -33,7 +33,7 @@ except according to the terms contained in the LICENSE file.
     </template>
   </form-edit-section>
 
-  <form-version-view-xml v-bind="viewXml" @hide="viewXml.hide()"/>
+  <xml-viewer v-bind="viewXml" :xml="formVersionXml.data" :loading="formVersionXml.awaitingResponse" @hide="viewXml.hide()"/>
 </template>
 
 <script setup>
@@ -54,14 +54,14 @@ defineOptions({
 });
 
 const emits = defineEmits(['afterUpload']);
-const { form, resourceView } = useRequestData();
+const { form, formVersionXml, resourceView } = useRequestData();
 const formDraft = resourceView('formDraft', (data) => data.get());
 
 const changed = computed(() =>
   form.dataExists && form.publishedAt != null && formDraft.hash !== form.hash);
 
-const FormVersionViewXml = defineAsyncComponent(loadAsync('FormVersionViewXml'));
-const viewXml = modalData('FormVersionViewXml');
+const XmlViewer = defineAsyncComponent(loadAsync('XmlViewer'));
+const viewXml = modalData('XmlViewer');
 
 const afterUpload = () => {
   emits('afterUpload');

--- a/apps/central/src/components/submission/data.vue
+++ b/apps/central/src/components/submission/data.vue
@@ -1,0 +1,72 @@
+<!--
+Copyright 2025 ODK Central Developers
+See the NOTICE file at the top-level directory of this distribution and at
+https://github.com/getodk/central-frontend/blob/master/NOTICE.
+
+This file is part of ODK Central. It is subject to the license terms in
+the LICENSE file found in the top-level directory of this distribution and at
+https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
+including this file, may be copied, modified, propagated, or distributed
+except according to the terms contained in the LICENSE file.
+-->
+<template>
+  <dl v-if="fields.dataExists && submission.dataExists" class="submission-data">
+    <div v-for="field of fields.selectable" :key="field.path">
+      <dl-data :value="field.binary !== true ? formatValue(submission.data, field, $i18n) : null">
+        <template #name>
+          <span v-if="field.path === mappedFieldPath" class="icon-check-circle mapped-field-icon"
+            v-tooltip.sr-only></span>
+          <span v-tooltip.no-aria="field.header" class="field-name">{{ field.name }}</span>
+          <span v-if="field.path === mappedFieldPath" class="sr-only">&nbsp;{{ $t('mappedField') }}</span>
+        </template>
+        <template v-if="field.binary === true && getValue(submission.data, field) != null"
+          #value>
+          <submission-attachment-link :project-id="projectId"
+            :xml-form-id="xmlFormId" :instance-id="instanceId"
+            :attachment-name="getValue(submission.data, field)"/>
+        </template>
+      </dl-data>
+    </div>
+  </dl>
+</template>
+
+<script setup>
+import DlData from '../dl-data.vue';
+import SubmissionAttachmentLink from './attachment-link.vue';
+
+import { getValue, formatValue } from '../../util/submission';
+import { useRequestData } from '../../request-data';
+
+defineOptions({
+  name: 'SubmissionData'
+});
+defineProps({
+  projectId: String,
+  xmlFormId: String,
+  instanceId: String,
+  mappedFieldPath: String
+});
+
+const { fields, submission } = useRequestData();
+</script>
+
+<style lang="scss">
+@import '../../assets/scss/variables';
+
+.submission-data {
+  .mapped-field-icon {
+    margin-right: 2px;
+    color: $color-success;
+  }
+}
+</style>
+
+<i18n lang="json5">
+{
+  "en": {
+    // @transifexKey component.SubmissionMapPopup.mappedField
+    // Message of the tooltip of checkmark icon, which is shown next of the fieldname that is used to plot pins on the map
+    "mappedField": "Map references this field"
+  }
+}
+</i18n>

--- a/apps/central/src/components/submission/data.vue
+++ b/apps/central/src/components/submission/data.vue
@@ -1,14 +1,3 @@
-<!--
-Copyright 2025 ODK Central Developers
-See the NOTICE file at the top-level directory of this distribution and at
-https://github.com/getodk/central-frontend/blob/master/NOTICE.
-
-This file is part of ODK Central. It is subject to the license terms in
-the LICENSE file found in the top-level directory of this distribution and at
-https://www.apache.org/licenses/LICENSE-2.0. No part of ODK Central,
-including this file, may be copied, modified, propagated, or distributed
-except according to the terms contained in the LICENSE file.
--->
 <template>
   <dl v-if="fields.dataExists && submission.dataExists" class="submission-data">
     <div v-for="field of fields.selectable" :key="field.path">

--- a/apps/central/src/components/submission/def-dropdown.vue
+++ b/apps/central/src/components/submission/def-dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <dropdown class="submission-def-dropdown btn-group">
+  <dropdown class="submission-def-dropdown">
     <template #toggle="{ toggle, attrs }">
       <button type="button" class="btn btn-default"
         v-bind="attrs" @click="toggle">
@@ -21,35 +21,34 @@
   </dropdown>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue';
+
 import Dropdown from '../dropdown.vue';
 
 import { apiPaths } from '../../util/request';
 
-export default {
-  name: 'SubmissionDefDropdown',
-  components: { Dropdown },
-  props: {
-    projectId: {
-      type: String,
-      required: true
-    },
-    xmlFormId: {
-      type: String,
-      required: true
-    },
-    instanceId: {
-      type: String,
-      required: true
-    }
+defineOptions({ name: 'SubmissionDefDropdown' });
+
+const props = defineProps({
+  projectId: {
+    type: String,
+    required: true
   },
-  emits: ['view-xml'],
-  computed: {
-    xmlPath() {
-      return apiPaths.submissionXml(this.projectId, this.xmlFormId, this.instanceId);
-    }
+  xmlFormId: {
+    type: String,
+    required: true
+  },
+  instanceId: {
+    type: String,
+    required: true
   }
-};
+});
+
+defineEmits(['view-xml']);
+
+const xmlPath = computed(() =>
+  apiPaths.submissionXml(props.projectId, props.xmlFormId, props.instanceId));
 </script>
 
 <i18n lang="json5">

--- a/apps/central/src/components/submission/def-dropdown.vue
+++ b/apps/central/src/components/submission/def-dropdown.vue
@@ -1,0 +1,67 @@
+<template>
+  <dropdown class="submission-def-dropdown btn-group">
+    <template #toggle="{ toggle, attrs }">
+      <button type="button" class="btn btn-default"
+        v-bind="attrs" @click="toggle">
+        <span class="icon-code"></span>
+        <span>{{ $t('action.def') }}</span>
+        <span class="caret"></span>
+      </button>
+    </template>
+    <template #menu>
+      <li>
+        <a href="#" @click.prevent="$emit('view-xml')">{{ $t('action.viewXml') }}</a>
+      </li>
+      <li>
+        <a :href="xmlPath" :download="`${instanceId}.xml`">
+          {{ $t('action.downloadXml') }}
+        </a>
+      </li>
+    </template>
+  </dropdown>
+</template>
+
+<script>
+import Dropdown from '../dropdown.vue';
+
+import { apiPaths } from '../../util/request';
+
+export default {
+  name: 'SubmissionDefDropdown',
+  components: { Dropdown },
+  props: {
+    projectId: {
+      type: String,
+      required: true
+    },
+    xmlFormId: {
+      type: String,
+      required: true
+    },
+    instanceId: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ['view-xml'],
+  computed: {
+    xmlPath() {
+      return apiPaths.submissionXml(this.projectId, this.xmlFormId, this.instanceId);
+    }
+  }
+};
+</script>
+
+<i18n lang="json5">
+{
+  "en": {
+    "action": {
+      // @transifexKey component.FormVersionDefDropdown.action.def
+      "def": "Definition",
+      // @transifexKey component.FormVersionDefDropdown.action.viewXml
+      "viewXml": "View XML in browser",
+      "downloadXml": "Download XML"
+    }
+  }
+}
+</i18n>

--- a/apps/central/src/components/submission/map-popup.vue
+++ b/apps/central/src/components/submission/map-popup.vue
@@ -39,25 +39,8 @@ except according to the terms contained in the LICENSE file.
             </template>
           </i18n-t>
         </div>
-        <dl>
-          <div v-for="field of fields.selectable" :key="field.path">
-            <dl-data
-              :value="field.binary !== true ? formatValue(submission.data, field, $i18n) : null">
-              <template #name>
-                <span v-if="field.path === fieldpath" class="icon-check-circle mapped-field-icon"
-                  v-tooltip.sr-only></span>
-                <span v-tooltip.no-aria="field.header" class="field-name">{{ field.name }}</span>
-                <span v-if="field.path === fieldpath" class="sr-only">&nbsp;{{ $t('mappedField') }}</span>
-              </template>
-              <template v-if="field.binary === true && getValue(submission.data, field) != null"
-                #value>
-                <submission-attachment-link :project-id="projectId"
-                  :xml-form-id="xmlFormId" :instance-id="instanceId"
-                  :attachment-name="getValue(submission.data, field)"/>
-              </template>
-            </dl-data>
-          </div>
-        </dl>
+        <submission-data :project-id="projectId" :xml-form-id="xmlFormId"
+          :instance-id="instanceId" :mapped-field-path="fieldpath"/>
       </div>
     </template>
     <template #footer>
@@ -73,16 +56,14 @@ import { computed, useTemplateRef, watch } from 'vue';
 import { last } from 'ramda';
 
 import DateTime from '../date-time.vue';
-import DlData from '../dl-data.vue';
 import Loading from '../loading.vue';
 import MapPopup from '../map/popup.vue';
 import SubmissionActions from './actions.vue';
-import SubmissionAttachmentLink from './attachment-link.vue';
+import SubmissionData from './data.vue';
 import SubmissionReviewState from './review-state.vue';
 
 import useSubmission from '../../request-data/submission';
 import { apiPaths } from '../../util/request';
-import { getValue, formatValue } from '../../util/submission';
 import { useRequestData } from '../../request-data';
 
 defineOptions({
@@ -181,11 +162,6 @@ const handleActions = (event) => {
     color: $color-warning;
     margin-right: $margin-right-icon;
   }
-
-  .mapped-field-icon {
-    margin-right: 2px;
-    color: $color-success;
-  }
 }
 </style>
 
@@ -196,8 +172,6 @@ const handleActions = (event) => {
     "submissionDetails": "Submission Details",
     // {field} is the name of a Form field.
     "missingField": "This Submission was mapped using {field}, which isn’t in the published Form version.",
-    // Message of the tooltip of checkmark icon, which is shown next of the fieldname that is used to plot pins on the map
-    "mappedField": "Map references this field"
   }
 }
 </i18n>

--- a/apps/central/src/components/submission/show.vue
+++ b/apps/central/src/components/submission/show.vue
@@ -52,6 +52,7 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import Breadcrumbs from '../breadcrumbs.vue';
@@ -65,13 +66,13 @@ import SubmissionData from './data.vue';
 import SubmissionDefDropdown from './def-dropdown.vue';
 import SubmissionUpdateReviewState from './update-review-state.vue';
 import SubmissionDelete from './delete.vue';
-import XmlViewer from '../xml-viewer.vue';
 
 import useFields from '../../request-data/fields';
 import useRoutes from '../../composables/routes';
 import useRequest from '../../composables/request';
 import useSubmission from '../../request-data/submission';
 import { apiPaths } from '../../util/request';
+import { loadAsync } from '../../util/load-async';
 import { modalData, setDocumentTitle } from '../../util/reactivity';
 import { useRequestData } from '../../request-data';
 import { noop } from '../../util/util';
@@ -90,7 +91,7 @@ export default {
     SubmissionDefDropdown,
     SubmissionDelete,
     SubmissionUpdateReviewState,
-    XmlViewer
+    XmlViewer: defineAsyncComponent(loadAsync('XmlViewer')),
   },
   inject: ['alert'],
   props: {
@@ -232,8 +233,15 @@ export default {
 </script>
 
 <style lang="scss">
-  #submission-show .page-section-heading {
-    font-size: 24px;
+  #submission-show {
+    .page-section-heading {
+      font-size: 24px;
+    }
+
+    .submission-data {
+      max-height: 510px;
+      overflow-y: auto;
+    }
   }
 
   #submission-data-section .page-section-heading {

--- a/apps/central/src/components/submission/show.vue
+++ b/apps/central/src/components/submission/show.vue
@@ -23,6 +23,9 @@ except according to the terms contained in the LICENSE file.
           <page-section id="submission-data-section">
             <template #heading>
               <span>{{ $t('common.data') }}</span>
+              <submission-def-dropdown :project-id="projectId"
+                :xml-form-id="xmlFormId" :instance-id="instanceId"
+                @view-xml="viewXml"/>
             </template>
             <template #body>
               <submission-data :project-id="projectId" :xml-form-id="xmlFormId"
@@ -43,6 +46,8 @@ except according to the terms contained in the LICENSE file.
     <submission-delete v-bind="deleteModal" :submission="submission"
       :awaiting-response="awaitingResponse" @hide="deleteModal.hide()"
       @delete="requestDelete"/>
+    <xml-viewer v-bind="viewXmlModal" :xml="submissionXml.data"
+      :loading="submissionXml.awaitingResponse" @hide="viewXmlModal.hide()"/>
   </div>
 </template>
 
@@ -57,8 +62,10 @@ import PageSection from '../page/section.vue';
 import SubmissionActivity from './activity.vue';
 import SubmissionBasicDetails from './basic-details.vue';
 import SubmissionData from './data.vue';
+import SubmissionDefDropdown from './def-dropdown.vue';
 import SubmissionUpdateReviewState from './update-review-state.vue';
 import SubmissionDelete from './delete.vue';
+import XmlViewer from '../xml-viewer.vue';
 
 import useFields from '../../request-data/fields';
 import useRoutes from '../../composables/routes';
@@ -80,8 +87,10 @@ export default {
     SubmissionActivity,
     SubmissionBasicDetails,
     SubmissionData,
+    SubmissionDefDropdown,
     SubmissionDelete,
-    SubmissionUpdateReviewState
+    SubmissionUpdateReviewState,
+    XmlViewer
   },
   inject: ['alert'],
   props: {
@@ -99,11 +108,12 @@ export default {
     }
   },
   setup() {
-    const { project, form, resourceStates } = useRequestData();
+    const { project, form, createResource, resourceStates } = useRequestData();
     const { request, awaitingResponse } = useRequest();
 
     const { submission, submissionVersion, audits, comments, diffs } = useSubmission();
     const fields = useFields();
+    const submissionXml = createResource('submissionXml');
 
     const { t } = useI18n();
     setDocumentTitle(() => (submission.dataExists
@@ -113,8 +123,8 @@ export default {
     const { formPath, projectPath } = useRoutes();
     return {
       project, form, submission, submissionVersion, audits, comments, diffs, fields,
-      request, awaitingResponse, ...resourceStates([project, form, submission]),
-      reviewModal: modalData(), deleteModal: modalData(),
+      submissionXml, request, awaitingResponse, ...resourceStates([project, form, submission]),
+      reviewModal: modalData(), deleteModal: modalData(), viewXmlModal: modalData(),
       formPath, projectPath
     };
   },
@@ -199,6 +209,11 @@ export default {
       this.alert.success(this.$t('alert.updateReviewState'));
       this.submission.__system.reviewState = reviewState;
     },
+    viewXml() {
+      this.viewXmlModal.show();
+      const url = apiPaths.submissionXml(this.projectId, this.xmlFormId, this.instanceId);
+      this.submissionXml.request({ url }).catch(noop);
+    },
     requestDelete([{ __id: instanceId }]) {
       this.request({
         method: 'DELETE',
@@ -219,6 +234,12 @@ export default {
 <style lang="scss">
   #submission-show .page-section-heading {
     font-size: 24px;
+  }
+
+  #submission-data-section .page-section-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 </style>
 

--- a/apps/central/src/components/submission/show.vue
+++ b/apps/central/src/components/submission/show.vue
@@ -20,6 +20,15 @@ except according to the terms contained in the LICENSE file.
       <div v-show="dataExists" class="row">
         <div class="col-xs-4">
           <submission-basic-details/>
+          <page-section id="submission-data-section">
+            <template #heading>
+              <span>{{ $t('common.data') }}</span>
+            </template>
+            <template #body>
+              <submission-data :project-id="projectId" :xml-form-id="xmlFormId"
+                :instance-id="instanceId"/>
+            </template>
+          </page-section>
         </div>
         <div class="col-xs-8">
           <submission-activity :project-id="projectId" :xml-form-id="xmlFormId"
@@ -44,8 +53,10 @@ import Breadcrumbs from '../breadcrumbs.vue';
 import Loading from '../loading.vue';
 import PageBody from '../page/body.vue';
 import PageHead from '../page/head.vue';
+import PageSection from '../page/section.vue';
 import SubmissionActivity from './activity.vue';
 import SubmissionBasicDetails from './basic-details.vue';
+import SubmissionData from './data.vue';
 import SubmissionUpdateReviewState from './update-review-state.vue';
 import SubmissionDelete from './delete.vue';
 
@@ -65,8 +76,10 @@ export default {
     Loading,
     PageBody,
     PageHead,
+    PageSection,
     SubmissionActivity,
     SubmissionBasicDetails,
+    SubmissionData,
     SubmissionDelete,
     SubmissionUpdateReviewState
   },
@@ -163,7 +176,7 @@ export default {
             this.projectId,
             this.xmlFormId,
             this.instanceId,
-            { $select: '__id,__system,meta' }
+            { $wkt: true }
           )
         }),
         this.submissionVersion.request({

--- a/apps/central/src/components/xml-viewer.vue
+++ b/apps/central/src/components/xml-viewer.vue
@@ -10,18 +10,18 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 -->
 
-<!-- We show the XForm XML in a modal rather than showing it in a new tab and
+<!-- We show the XML in a modal rather than showing it in a new tab and
 trying to leverage browsers' ability to render XML as a tree. That's because
 rather than rendering an XForm as an XML tree, the browser will render it as
 XHTML, because XForms include the XHTML namespace. There doesn't seem to be a
 way to force browsers to render the XML as a tree, so we format it ourselves.
 Somewhat related: https://support.google.com/chrome/thread/10921150?hl=en -->
 <template>
-  <modal id="form-version-view-xml" :state="state" hideable backdrop
+  <modal id="xml-viewer" :state="state" hideable backdrop
     @hide="$emit('hide')">
     <template #title>{{ $t('title') }}</template>
     <template #body>
-      <pre><spinner :state="formVersionXml.initiallyLoading"/><code>{{ formattedXml }}</code></pre>
+      <pre><spinner :state="loading"/><code>{{ formattedXml }}</code></pre>
       <div class="modal-actions">
         <button type="button" class="btn btn-primary" @click="$emit('hide')">
           {{ $t('action.close') }}
@@ -31,51 +31,46 @@ Somewhat related: https://support.google.com/chrome/thread/10921150?hl=en -->
   </modal>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue';
 // xml-formatter suggests using dist/browser/xml-formatter.js in the browser,
 // but I wasn't able to get that to work -- maybe because we use webpack?
 // Importing this way seems to work and also results in a small bundle.
 import formatXml from 'xml-formatter';
 
-import Modal from '../modal.vue';
-import Spinner from '../spinner.vue';
+import Modal from './modal.vue';
+import Spinner from './spinner.vue';
 
-import { useRequestData } from '../../request-data';
+defineOptions({
+  name: 'XmlViewer'
+});
 
-export default {
-  name: 'FormVersionViewXml',
-  components: { Modal, Spinner },
-  props: {
-    state: {
-      type: Boolean,
-      default: false
-    }
+const props = defineProps({
+  state: {
+    type: Boolean,
+    default: false
   },
-  emits: ['hide'],
-  setup() {
-    const { formVersionXml } = useRequestData();
-    return { formVersionXml };
+  xml: {
+    type: String,
+    default: null
   },
-  computed: {
-    // XSLT might be a way to implement this without a dependency, but Firefox
-    // doesn't seem to support the `indent` attribute of <xsl:output>:
-    // https://stackoverflow.com/questions/376373/pretty-printing-xml-with-javascript
-    formattedXml() {
-      return this.formVersionXml.dataExists
-        ? formatXml(this.formVersionXml.data, { collapseContent: true })
-        : '';
-    }
-  },
-  watch: {
-    state(state) {
-      if (!state) this.formVersionXml.reset();
-    }
+  loading: {
+    type: Boolean,
+    default: false
   }
-};
+});
+
+defineEmits(['hide']);
+
+// XSLT might be a way to implement this without a dependency, but Firefox
+// doesn't seem to support the `indent` attribute of <xsl:output>:
+// https://stackoverflow.com/questions/376373/pretty-printing-xml-with-javascript
+const formattedXml = computed(() =>
+  (props.xml != null ? formatXml(props.xml, { collapseContent: true }) : ''));
 </script>
 
 <style lang="scss">
-#form-version-view-xml {
+#xml-viewer {
   pre {
     min-height: 120px;
     // 129px is the height of the modal, not including the <pre> element. The
@@ -91,6 +86,7 @@ export default {
 <i18n lang="json5">
 {
   "en": {
+    // @transifexKey component.FormVersionViewXml.title
     // This is the title at the top of a pop-up.
     "title": "View XML"
   }

--- a/apps/central/src/util/load-async.js
+++ b/apps/central/src/util/load-async.js
@@ -105,8 +105,8 @@ const loaders = new Map()
   .set('FormVersionList', loader(() => import(
     '../components/form-version/list.vue'
   )))
-  .set('FormVersionViewXml', loader(() => import(
-    '../components/form-version/view-xml.vue'
+  .set('XmlViewer', loader(() => import(
+    '../components/xml-viewer.vue'
   )))
   .set('GeojsonMapDevTools', loader(() => import(
     '../components/geojson-map/dev-tools.vue'

--- a/apps/central/test/components/form-version/row.spec.js
+++ b/apps/central/test/components/form-version/row.spec.js
@@ -3,7 +3,7 @@ import EnketoPreview from '../../../src/components/enketo/preview.vue';
 import FormVersionDefDropdown from '../../../src/components/form-version/def-dropdown.vue';
 import FormVersionRow from '../../../src/components/form-version/row.vue';
 import FormVersionString from '../../../src/components/form-version/string.vue';
-import FormVersionViewXml from '../../../src/components/form-version/view-xml.vue';
+import XmlViewer from '../../../src/components/xml-viewer.vue';
 import TimeAndUser from '../../../src/components/time-and-user.vue';
 
 import testData from '../../data';
@@ -89,7 +89,7 @@ describe('FormVersionRow', () => {
   it('toggles the "View XML" modal', () => {
     testData.extendedForms.createPast(1);
     return load('/projects/1/forms/f/versions', { root: false }).testModalToggles({
-      modal: FormVersionViewXml,
+      modal: XmlViewer,
       show: '.form-version-row .form-version-def-dropdown a',
       hide: '.btn-primary',
       respond: (series) => series.respondWithData(() => '<x/>')

--- a/apps/central/test/components/form-version/view-xml.spec.js
+++ b/apps/central/test/components/form-version/view-xml.spec.js
@@ -1,17 +1,11 @@
-import FormVersionViewXml from '../../../src/components/form-version/view-xml.vue';
+import XmlViewer from '../../../src/components/xml-viewer.vue';
 
 import { mount } from '../../util/lifecycle';
-import { testRequestData } from '../../util/request-data';
 
 describe('FormVersionViewXml', () => {
   it('formats the XML', () => {
-    const modal = mount(FormVersionViewXml, {
-      props: { state: true },
-      container: {
-        requestData: testRequestData(['formVersionXml'], {
-          formVersionXml: '<x><y/></x>'
-        })
-      }
+    const modal = mount(XmlViewer, {
+      props: { state: true, xml: '<x><y/></x>' }
     });
     modal.get('code').text().should.equal('<x>\r\n    <y/>\r\n</x>');
   });

--- a/apps/central/test/components/form-version/view-xml.spec.js
+++ b/apps/central/test/components/form-version/view-xml.spec.js
@@ -9,4 +9,11 @@ describe('FormVersionViewXml', () => {
     });
     modal.get('code').text().should.equal('<x>\r\n    <y/>\r\n</x>');
   });
+
+  it('shows a spinner when loading', () => {
+    const modal = mount(XmlViewer, {
+      props: { state: true, loading: true }
+    });
+    modal.get('.spinner').should.be.visible();
+  });
 });

--- a/apps/central/test/components/form/edit/def.spec.js
+++ b/apps/central/test/components/form/edit/def.spec.js
@@ -1,6 +1,6 @@
 import FormEditDef from '../../../../src/components/form/edit/def.vue';
 import FormVersionString from '../../../../src/components/form-version/string.vue';
-import FormVersionViewXml from '../../../../src/components/form-version/view-xml.vue';
+import XmlViewer from '../../../../src/components/xml-viewer.vue';
 
 import testData from '../../../data';
 import { load } from '../../../util/http';
@@ -48,7 +48,7 @@ describe('FormEditDef', () => {
   it('toggles the "View XML" modal', () => {
     testData.extendedForms.createPast(1, { draft: true });
     return load('/projects/1/forms/f/draft', { root: false }).testModalToggles({
-      modal: FormVersionViewXml,
+      modal: XmlViewer,
       show: '.form-version-def-dropdown a',
       hide: '.btn-primary',
       respond: (series) => series.respondWithData(() => '<x/>')

--- a/apps/central/test/components/submission/activity.spec.js
+++ b/apps/central/test/components/submission/activity.spec.js
@@ -46,7 +46,7 @@ describe('SubmissionActivity', () => {
     return load("/projects/1/forms/a%20b/submissions/'c%20d'").testRequests([
       { url: '/v1/projects/1', extended: true },
       { url: '/v1/projects/1/forms/a%20b', extended: false },
-      { url: "/v1/projects/1/forms/a%20b.svc/Submissions('''c%20d''')?%24select=__id%2C__system%2Cmeta" },
+      { url: "/v1/projects/1/forms/a%20b.svc/Submissions('''c%20d''')?%24wkt=true" },
       { url: "/v1/projects/1/forms/a%20b/submissions/'c%20d'/versions/'c%20d'" },
       { url: '/v1/projects/1/forms/a%20b/fields' },
       { url: "/v1/projects/1/forms/a%20b/submissions/'c%20d'/audits", extended: true },

--- a/apps/central/test/components/submission/data.spec.js
+++ b/apps/central/test/components/submission/data.spec.js
@@ -1,0 +1,118 @@
+import DlData from '../../../src/components/dl-data.vue';
+import SubmissionAttachmentLink from '../../../src/components/submission/attachment-link.vue';
+import SubmissionData from '../../../src/components/submission/data.vue';
+
+import useFields from '../../../src/request-data/fields';
+import useSubmission from '../../../src/request-data/submission';
+
+import testData from '../../data';
+import { mergeMountOptions, mount } from '../../util/lifecycle';
+import { mockLogin } from '../../util/session';
+import { testRequestData } from '../../util/request-data';
+
+const mountOptions = (options = undefined) => {
+  const form = testData.extendedForms.last();
+  const submission = testData.submissionOData();
+  return mergeMountOptions(options, {
+    props: {
+      projectId: '1',
+      xmlFormId: form.xmlFormId,
+      instanceId: testData.extendedSubmissions.last().instanceId
+    },
+    container: {
+      requestData: testRequestData([useFields, useSubmission], {
+        fields: form._fields,
+        submission
+      })
+    }
+  });
+};
+
+describe('SubmissionData', () => {
+  beforeEach(() => {
+    mockLogin();
+    testData.extendedForms.createPast(1, {
+      xmlFormId: 'a b',
+      fields: [
+        testData.fields.group('/names'),
+        testData.fields.string('/names/first_name'),
+        testData.fields.geopoint('/p1'),
+        testData.fields.geopoint('/p2')
+      ],
+      submissions: 1
+    });
+    testData.extendedSubmissions.createPast(1, {
+      instanceId: 'c d',
+      reviewState: 'hasIssues',
+      meta: { instanceName: 'Some instance' },
+      names: { first_name: 'Someone' },
+      p1: 'POINT (1 1)',
+      p2: 'POINT (2 2)'
+    });
+  });
+
+  it('shows form-field data', () => {
+    const component = mount(SubmissionData, mountOptions());
+    const pairs = component.findAllComponents(DlData);
+    const names = pairs.map(pair => pair.get('dt .field-name').text());
+    names.should.eql(['first_name', 'p1', 'p2']);
+
+    const values = pairs.map(pair => pair.props().value);
+    values.should.eql(['Someone', 'POINT (1 1)', 'POINT (2 2)']);
+  });
+
+  it('formats form-field data', () => {
+    testData.extendedForms.createPast(1, {
+      xmlFormId: 'f',
+      fields: [
+        testData.fields.int('/i1'),
+        testData.fields.int('/i2'),
+        testData.fields.binary('/b1'),
+        testData.fields.binary('/b2'),
+        testData.fields.geopoint('/p1')
+      ]
+    });
+    testData.extendedSubmissions.createPast(1, {
+      instanceId: 's',
+      i1: 1000,
+      i2: null,
+      b1: 'foo.jpg',
+      b2: null,
+      p1: 'POINT (1 1)'
+    });
+    const component = mount(SubmissionData, mountOptions());
+    const dd = component.findAll('.dl-data-dd');
+    dd.length.should.equal(5);
+
+    dd[0].text().should.equal('1,000');
+    dd[1].text().should.equal('(empty)');
+
+    dd[2].getComponent(SubmissionAttachmentLink).props().should.include({
+      projectId: '1',
+      xmlFormId: 'f',
+      draft: false,
+      instanceId: 's',
+      attachmentName: 'foo.jpg',
+      deleted: false
+    });
+    dd[2].text().should.equal('');
+
+    dd[3].findComponent(SubmissionAttachmentLink).exists().should.be.false;
+    dd[3].text().should.equal('(empty)');
+  });
+
+  it('shows a tooltip above name of form field with its full column header', async () => {
+    const component = mount(SubmissionData, mountOptions());
+    const name = component.getComponent(DlData).get('dt .field-name');
+    name.text().should.equal('first_name');
+    await name.should.have.tooltip('names-first_name');
+  });
+
+  it('shows checkmark for the mapped field', () => {
+    const component = mount(SubmissionData, mountOptions({
+      props: { mappedFieldPath: '/p1' }
+    }));
+    const pair = component.findAllComponents(DlData)[1];
+    pair.find('.icon-check-circle').exists().should.be.true;
+  });
+});

--- a/apps/central/test/components/submission/def-dropdown.spec.js
+++ b/apps/central/test/components/submission/def-dropdown.spec.js
@@ -1,0 +1,27 @@
+import SubmissionDefDropdown from '../../../src/components/submission/def-dropdown.vue';
+
+import { mount } from '../../util/lifecycle';
+
+const mountComponent = (props = {}) => mount(SubmissionDefDropdown, {
+  props: {
+    projectId: '1',
+    xmlFormId: 'a b',
+    instanceId: 's',
+    ...props
+  }
+});
+
+describe('SubmissionDefDropdown', () => {
+  it('emits a view-xml event', async () => {
+    const dropdown = mountComponent();
+    await dropdown.get('a').trigger('click');
+    dropdown.emitted('view-xml').length.should.equal(1);
+  });
+
+  it('has the correct attributes for download button', () => {
+    const dropdown = mountComponent();
+    const { href, download } = dropdown.findAll('a')[1].attributes();
+    href.should.equal('/v1/projects/1/forms/a%20b/submissions/s.xml');
+    download.should.equal('s.xml');
+  });
+});

--- a/apps/central/test/components/submission/map-popup.spec.js
+++ b/apps/central/test/components/submission/map-popup.spec.js
@@ -3,7 +3,6 @@ import { T } from 'ramda';
 import DateTime from '../../../src/components/date-time.vue';
 import DlData from '../../../src/components/dl-data.vue';
 import GeojsonMap from '../../../src/components/geojson-map.vue';
-import SubmissionAttachmentLink from '../../../src/components/submission/attachment-link.vue';
 import SubmissionDelete from '../../../src/components/submission/delete.vue';
 import SubmissionMapPopup from '../../../src/components/submission/map-popup.vue';
 import SubmissionReviewState from '../../../src/components/submission/review-state.vue';
@@ -133,73 +132,6 @@ describe('SubmissionMapPopup', () => {
         dd[1].getComponent(DateTime).props().iso.should.equal(createdAt);
       }));
 
-  it('shows form-field data', () =>
-    mockHttp()
-      .mount(SubmissionMapPopup, mountOptions())
-      .respondWithData(testData.submissionOData)
-      .afterResponse(async (component) => {
-        const pairs = component.findAllComponents(DlData);
-        const names = pairs.map(pair => pair.get('dt .field-name').text());
-        names.should.eql(['first_name', 'p1', 'p2']);
-
-        const values = pairs.map(pair => pair.props().value);
-        values.should.eql(['Someone', 'POINT (1 1)', 'POINT (2 2)']);
-      }));
-
-  it('formats form-field data', () => {
-    testData.extendedForms.createPast(1, {
-      xmlFormId: 'f',
-      fields: [
-        testData.fields.int('/i1'),
-        testData.fields.int('/i2'),
-        testData.fields.binary('/b1'),
-        testData.fields.binary('/b2'),
-        testData.fields.geopoint('/p1')
-      ]
-    });
-    testData.extendedSubmissions.createPast(1, {
-      instanceId: 's',
-      i1: 1000,
-      i2: null,
-      b1: 'foo.jpg',
-      b2: null,
-      p1: 'POINT (1 1)'
-    });
-    return mockHttp()
-      .mount(SubmissionMapPopup, mountOptions())
-      .respondWithData(testData.submissionOData)
-      .afterResponse(async (component) => {
-        const dd = component.findAll('.dl-data-dd');
-        dd.length.should.equal(5);
-
-        dd[0].text().should.equal('1,000');
-        dd[1].text().should.equal('(empty)');
-
-        dd[2].getComponent(SubmissionAttachmentLink).props().should.eql({
-          projectId: '1',
-          xmlFormId: 'f',
-          draft: false,
-          instanceId: 's',
-          attachmentName: 'foo.jpg',
-          deleted: false
-        });
-        dd[2].text().should.equal('');
-
-        dd[3].findComponent(SubmissionAttachmentLink).exists().should.be.false;
-        dd[3].text().should.equal('(empty)');
-      });
-  });
-
-  it('shows a tooltip above name of form field with its full column header', () =>
-    mockHttp()
-      .mount(SubmissionMapPopup, mountOptions())
-      .respondWithData(testData.submissionOData)
-      .afterResponse(async (component) => {
-        const name = component.getComponent(DlData).get('dt span');
-        name.text().should.equal('first_name');
-        await name.should.have.tooltip('names-first_name');
-      }));
-
   it('shows a warning if geo field is not in current version of form', () =>
     mockHttp()
       .mount(SubmissionMapPopup, mountOptions({
@@ -242,15 +174,6 @@ describe('SubmissionMapPopup', () => {
         const pair = component.findAllComponents(DlData)[1];
         pair.get('dt .field-name').text().should.equal('p1');
         pair.props().value.should.equal('POINT (3 3)');
-      }));
-
-  it('shows checkmark for the mapped field', () =>
-    mockHttp()
-      .mount(SubmissionMapPopup, mountOptions())
-      .respondWithData(testData.submissionOData)
-      .afterResponse(async (component) => {
-        const pair = component.findAllComponents(DlData)[1];
-        pair.find('.icon-check-circle').exists().should.be.true;
       }));
 
   describe('review button', () => {

--- a/apps/central/test/components/submission/show.spec.js
+++ b/apps/central/test/components/submission/show.spec.js
@@ -181,4 +181,23 @@ describe('SubmissionShow', () => {
         });
     });
   });
+
+  describe('view xml', () => {
+    it('sends the correct request after clicking view xml', () => {
+      testData.extendedSubmissions.createPast(1, { instanceId: 's' });
+      return load('/projects/1/forms/f/submissions/s', { root: false })
+        .complete()
+        .request(async (component) => {
+          await component.get('.submission-def-dropdown button').trigger('click');
+          return component.get('.submission-def-dropdown a').trigger('click');
+        })
+        .respondWithData(() => '<submission/>')
+        .testRequests([{
+          url: '/v1/projects/1/forms/f/submissions/s.xml'
+        }])
+        .afterResponse(component => {
+          component.get('#xml-viewer code').text().should.equal('<submission/>');
+        });
+    });
+  });
 });

--- a/apps/central/test/components/submission/show.spec.js
+++ b/apps/central/test/components/submission/show.spec.js
@@ -1,5 +1,6 @@
 import NotFound from '../../../src/components/not-found.vue';
 import Breadcrumbs from '../../../src/components/breadcrumbs.vue';
+import SubmissionData from '../../../src/components/submission/data.vue';
 import SubmissionDelete from '../../../src/components/submission/delete.vue';
 
 import testData from '../../data';
@@ -65,6 +66,25 @@ describe('SubmissionShow', () => {
       root: false
     });
     component.get('#page-head-title').text().should.equal('s');
+  });
+
+  it('renders the SubmissionData component', async () => {
+    testData.extendedForms.createPast(1, {
+      xmlFormId: 'a',
+      fields: [
+        testData.fields.string('/name'),
+        testData.fields.string('/age'),
+      ],
+      submissions: 1
+    });
+    testData.extendedSubmissions.createPast(1, {
+      instanceId: 's',
+      name: 'Alice',
+      age: '30'
+    });
+    const component = await load('/projects/1/forms/a/submissions/s', { root: false });
+    component.findComponent(SubmissionData).exists().should.be.true;
+    component.findAll('.dl-data-dd').map(dd => dd.text()).should.eql(['Alice', '30']);
   });
 
   describe('delete', () => {

--- a/apps/central/test/util/http/data.js
+++ b/apps/central/test/util/http/data.js
@@ -1,5 +1,3 @@
-import { pick } from 'ramda';
-
 import useForm from '../../../src/request-data/form';
 import useProject from '../../../src/request-data/project';
 import useDatasets from '../../../src/request-data/datasets';
@@ -215,7 +213,7 @@ const responsesByComponent = {
     form: () => testData.extendedForms.last(),
     submission: () => {
       const odata = testData.submissionOData();
-      const selected = odata.value.map(pick(['__id', '__system', 'meta']));
+      const selected = odata.value;
       return { ...odata, value: selected };
     },
     submissionVersion: () => ({}),

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -5261,6 +5261,14 @@
         }
       }
     },
+    "SubmissionDefDropdown": {
+      "action": {
+        "downloadXml": {
+          "string": "Download XML",
+          "developer_comment": "This is the text for an action, for example, the text of a button."
+        }
+      }
+    },
     "SubmissionDelete": {
       "title": {
         "string": "Delete Submission",


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1707


https://github.com/user-attachments/assets/b25eda72-9e04-4575-80b9-139de9a36e9c

cc @nicoleorlowski 

#### What has been done to verify that this works as intended?

Added tests and manual verification

#### Why is this the best possible solution? Were any other approaches considered?

- To show submission data
  - Extracted `dl` from MapPopup into a new SubmissionData component so that it can be reused in map and submission detail page
- To show submission xml
  - Reused existing FormVersionXml component, made it bit general so that any XML can be show, renamed it to XmlViewer

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

The definition button on Form Edit page and Form Version page should also be tested with this.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No