### PR TITLE
feat(web-forms#515): add quick appearance

### DIFF
--- a/.changeset/six-cars-follow.md
+++ b/.changeset/six-cars-follow.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": minor
+---
+
+Added support for `quick` appearance.

--- a/packages/web-forms/README.md
+++ b/packages/web-forms/README.md
@@ -60,7 +60,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
   <summary>
 
 <!-- prettier-ignore -->
-##### Appearances<br/>🟩🟩🟩🟩🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜ 54\%
+##### Appearances<br/>🟩🟩🟩🟩🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜ 56\%
 
   </summary>
   <br/>
@@ -96,7 +96,7 @@ This section is auto generated. Please update `feature-matrix.json` and then run
 | hide-input                                                      |          |
 | minimal                                                         |    ✅    |
 | search / autocomplete                                           |    ✅    |
-| [quick](https://github.com/getodk/web-forms/issues/515)         |          |
+| [quick](https://github.com/getodk/web-forms/issues/515)         |    ✅    |
 | columns-pack                                                    |    ✅    |
 | columns                                                         |    ✅    |
 | columns-n                                                       |    ✅    |

--- a/packages/web-forms/feature-matrix.json
+++ b/packages/web-forms/feature-matrix.json
@@ -65,7 +65,7 @@
     "hide-input": "",
     "minimal": "✅",
     "search / autocomplete": "✅",
-    "[quick](https://github.com/getodk/web-forms/issues/515)": "",
+    "[quick](https://github.com/getodk/web-forms/issues/515)": "✅",
     "columns-pack": "✅",
     "columns": "✅",
     "columns-n": "✅",

--- a/packages/web-forms/src/components/common/LikertWidget.vue
+++ b/packages/web-forms/src/components/common/LikertWidget.vue
@@ -12,7 +12,7 @@ defineEmits(['change']);
 
 <template>
 	<div class="likert">
-		<RadioButton :question="question" @change="$emit('change')" />
+		<RadioButton :question="question" @change="$emit('change', $event)" />
 	</div>
 </template>
 

--- a/packages/web-forms/src/components/common/RadioButton.vue
+++ b/packages/web-forms/src/components/common/RadioButton.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import TextMedia from '@getodk/web-forms/components/common/TextMedia.vue';
 import { selectOptionId } from '@getodk/web-forms/lib/format/ids.ts';
+import { advanceIfQuick } from '@getodk/web-forms/lib/pagination/pagination.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import RadioButton from 'primevue/radiobutton';
 
@@ -16,6 +17,7 @@ const selectValue = (value: string) => {
 		return;
 	}
 	props.question.selectValue(value);
+	advanceIfQuick(props.question);
 };
 </script>
 

--- a/packages/web-forms/src/components/common/RadioButton.vue
+++ b/packages/web-forms/src/components/common/RadioButton.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import TextMedia from '@getodk/web-forms/components/common/TextMedia.vue';
 import { selectOptionId } from '@getodk/web-forms/lib/format/ids.ts';
-import { advanceIfQuick } from '@getodk/web-forms/lib/pagination/pagination.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import RadioButton from 'primevue/radiobutton';
 
@@ -9,16 +8,8 @@ interface RadioButtonProps {
 	readonly question: SelectNode;
 }
 
-defineEmits(['update:modelValue', 'change']);
-const props = defineProps<RadioButtonProps>();
-
-const selectValue = (value: string) => {
-	if (props.question.appearances.label) {
-		return;
-	}
-	props.question.selectValue(value);
-	advanceIfQuick(props.question);
-};
+defineEmits(['change']);
+defineProps<RadioButtonProps>();
 </script>
 
 <template>
@@ -39,8 +30,7 @@ const selectValue = (value: string) => {
 			:name="question.nodeId"
 			:disabled="question.currentState.readonly"
 			:model-value="question.currentState.value[0]"
-			@update:model-value="selectValue"
-			@change="$emit('change')"
+			@change="$emit('change', option.value)"
 		/>
 		<TextMedia :label="option.label" :audio-icons-only="question.currentState.isSelectWithImages" />
 	</label>

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -5,7 +5,6 @@ import { computed, inject } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
 import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
-import { advanceIfQuick } from '@getodk/web-forms/lib/pagination/pagination.ts';
 
 interface SearchableDropdownProps {
 	readonly question: SelectNode;
@@ -17,7 +16,7 @@ const props = defineProps<SearchableDropdownProps>();
 
 const DEFAULT_PRIMEVUE_ITEM_HEIGHT = 38;
 
-defineEmits(['update:modelValue', 'change']);
+defineEmits(['change']);
 
 const options = computed(() => {
 	return props.question.currentState.valueOptions.map((option) => {
@@ -46,11 +45,6 @@ const selectedLabel = computed(() => {
 	const option = props.question.getValueOption(value);
 	return option?.label.formatted;
 });
-
-const selectValue = (value: string) => {
-	props.question.selectValue(value);
-	advanceIfQuick(props.question);
-};
 </script>
 
 <template>
@@ -66,8 +60,7 @@ const selectValue = (value: string) => {
 		option-label="search"
 		option-value="value"
 		:virtual-scroller-options="virtualScrollerOptions"
-		@update:model-value="selectValue"
-		@change="$emit('change')"
+		@change="$emit('change', $event.value)"
 	>
 		<template #option="slotProps">
 			<MarkdownBlock v-for="elem in slotProps.option.label" :key="elem.id" :elem="elem" />

--- a/packages/web-forms/src/components/common/SearchableDropdown.vue
+++ b/packages/web-forms/src/components/common/SearchableDropdown.vue
@@ -5,6 +5,7 @@ import { computed, inject } from 'vue';
 import MarkdownBlock from './MarkdownBlock.vue';
 import { TRANSLATE } from '@getodk/web-forms/lib/constants/injection-keys.ts';
 import type { Translate } from '@getodk/web-forms/lib/locale/useLocale.ts';
+import { advanceIfQuick } from '@getodk/web-forms/lib/pagination/pagination.ts';
 
 interface SearchableDropdownProps {
 	readonly question: SelectNode;
@@ -48,6 +49,7 @@ const selectedLabel = computed(() => {
 
 const selectValue = (value: string) => {
 	props.question.selectValue(value);
+	advanceIfQuick(props.question);
 };
 </script>
 

--- a/packages/web-forms/src/components/form-elements/select/Select1Control.vue
+++ b/packages/web-forms/src/components/form-elements/select/Select1Control.vue
@@ -8,7 +8,6 @@ import RadioButton from '@getodk/web-forms/components/common/RadioButton.vue';
 import SearchableDropdown from '@getodk/web-forms/components/common/SearchableDropdown.vue';
 import ValidationMessage from '@getodk/web-forms/components/common/ValidationMessage.vue';
 import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
-import { advanceIfQuick } from '@getodk/web-forms/lib/pagination/pagination.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import { MODES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import { computed, ref, watchEffect } from 'vue';
@@ -30,7 +29,20 @@ const savedFeatureValue = computed(() => {
 	return props.question.currentState.valueOptions.find((option) => option.value === value);
 });
 
-const saveMapSelection = (value: string | undefined) => {
+const advanceIfQuick = (question: SelectNode) => {
+	const { appearances } = question;
+	const isQuick = appearances.quick || appearances.quickcompact;
+	const isValid = question.validationState.violation == null;
+
+	if (isQuick && !appearances.likert && isValid) {
+		question.root.nextPage();
+	}
+};
+
+const saveSelection = (value: string | undefined) => {
+	if (props.question.appearances.label) {
+		return;
+	}
 	props.question.selectValue(value ?? '');
 	advanceIfQuick(props.question);
 };
@@ -55,12 +67,14 @@ watchEffect(() => {
 	<SearchableDropdown
 		v-if="question.appearances.autocomplete || question.appearances.minimal"
 		:question="question"
+		@change="saveSelection"
 	/>
 
 	<LikertWidget
 		v-else-if="question.appearances.likert"
 		:class="{ 'select-with-images': isSelectWithImages }"
 		:question="question"
+		@change="saveSelection"
 	/>
 
 	<AsyncMap
@@ -69,7 +83,7 @@ watchEffect(() => {
 		:mode="MODES.SELECT"
 		:saved-feature-value="savedFeatureValue"
 		:disabled="question.currentState.readonly"
-		@save="saveMapSelection"
+		@save="saveSelection"
 	/>
 
 	<FieldListTable
@@ -81,7 +95,7 @@ watchEffect(() => {
 			<ControlText :question="question" />
 		</template>
 		<template #default>
-			<RadioButton :question="question" />
+			<RadioButton :question="question" @change="saveSelection" />
 		</template>
 	</FieldListTable>
 
@@ -90,7 +104,7 @@ watchEffect(() => {
 		:class="{ 'select-with-images': isSelectWithImages }"
 		:appearances="question.appearances"
 	>
-		<RadioButton :question="question" />
+		<RadioButton :question="question" @change="saveSelection" />
 	</ColumnarAppearance>
 
 	<template v-else>
@@ -101,7 +115,7 @@ watchEffect(() => {
 			/>
 		</template>
 		<div class="default-appearance">
-			<RadioButton :question="question" />
+			<RadioButton :question="question" @change="saveSelection" />
 		</div>
 	</template>
 

--- a/packages/web-forms/src/components/form-elements/select/Select1Control.vue
+++ b/packages/web-forms/src/components/form-elements/select/Select1Control.vue
@@ -8,6 +8,7 @@ import RadioButton from '@getodk/web-forms/components/common/RadioButton.vue';
 import SearchableDropdown from '@getodk/web-forms/components/common/SearchableDropdown.vue';
 import ValidationMessage from '@getodk/web-forms/components/common/ValidationMessage.vue';
 import ControlText from '@getodk/web-forms/components/form-elements/ControlText.vue';
+import { advanceIfQuick } from '@getodk/web-forms/lib/pagination/pagination.ts';
 import type { SelectNode } from '@getodk/xforms-engine';
 import { MODES } from '@getodk/web-forms/components/common/map/getModeConfig.ts';
 import { computed, ref, watchEffect } from 'vue';
@@ -28,6 +29,11 @@ const savedFeatureValue = computed(() => {
 	const value = props.question.currentState.value?.[0];
 	return props.question.currentState.valueOptions.find((option) => option.value === value);
 });
+
+const saveMapSelection = (value: string | undefined) => {
+	props.question.selectValue(value ?? '');
+	advanceIfQuick(props.question);
+};
 
 watchEffect(() => {
 	const appearances = [...props.question.appearances];
@@ -63,7 +69,7 @@ watchEffect(() => {
 		:mode="MODES.SELECT"
 		:saved-feature-value="savedFeatureValue"
 		:disabled="question.currentState.readonly"
-		@save="(value) => question.selectValue(value ?? '')"
+		@save="saveMapSelection"
 	/>
 
 	<FieldListTable

--- a/packages/web-forms/src/lib/pagination/pagination.ts
+++ b/packages/web-forms/src/lib/pagination/pagination.ts
@@ -1,4 +1,8 @@
-import type { AnyControlNode, RepeatRangeUncontrolledNode, SelectNode } from '@getodk/xforms-engine';
+import type {
+  AnyControlNode,
+  RepeatRangeUncontrolledNode,
+  SelectNode,
+} from '@getodk/xforms-engine';
 
 export const isOnCurrentPage = (node: AnyControlNode | RepeatRangeUncontrolledNode): boolean => {
   if (!node.root.isPaginated) {
@@ -10,7 +14,10 @@ export const isOnCurrentPage = (node: AnyControlNode | RepeatRangeUncontrolledNo
 
 export const advanceIfQuick = (question: SelectNode) => {
   const { appearances } = question;
-  if ((appearances.quick || appearances.quickcompact) && !appearances.label && !appearances.likert) {
+  const isQuick = appearances.quick || appearances.quickcompact;
+  const supportsAutoAdvance = !appearances.label && !appearances.likert;
+
+  if (isQuick && supportsAutoAdvance) {
     question.root.nextPage();
   }
 };

--- a/packages/web-forms/src/lib/pagination/pagination.ts
+++ b/packages/web-forms/src/lib/pagination/pagination.ts
@@ -1,4 +1,4 @@
-import type { AnyControlNode, RepeatRangeUncontrolledNode } from '@getodk/xforms-engine';
+import type { AnyControlNode, RepeatRangeUncontrolledNode, SelectNode } from '@getodk/xforms-engine';
 
 export const isOnCurrentPage = (node: AnyControlNode | RepeatRangeUncontrolledNode): boolean => {
   if (!node.root.isPaginated) {
@@ -6,4 +6,11 @@ export const isOnCurrentPage = (node: AnyControlNode | RepeatRangeUncontrolledNo
   }
   const currentPage = node.root.currentState.currentPage;
   return currentPage != null && node.currentState.pageBoundary === currentPage;
+};
+
+export const advanceIfQuick = (question: SelectNode) => {
+  const { appearances } = question;
+  if ((appearances.quick || appearances.quickcompact) && !appearances.label && !appearances.likert) {
+    question.root.nextPage();
+  }
 };

--- a/packages/web-forms/src/lib/pagination/pagination.ts
+++ b/packages/web-forms/src/lib/pagination/pagination.ts
@@ -1,8 +1,4 @@
-import type {
-  AnyControlNode,
-  RepeatRangeUncontrolledNode,
-  SelectNode,
-} from '@getodk/xforms-engine';
+import type { AnyControlNode, RepeatRangeUncontrolledNode } from '@getodk/xforms-engine';
 
 export const isOnCurrentPage = (node: AnyControlNode | RepeatRangeUncontrolledNode): boolean => {
   if (!node.root.isPaginated) {
@@ -10,15 +6,4 @@ export const isOnCurrentPage = (node: AnyControlNode | RepeatRangeUncontrolledNo
   }
   const currentPage = node.root.currentState.currentPage;
   return currentPage != null && node.currentState.pageBoundary === currentPage;
-};
-
-export const advanceIfQuick = (question: SelectNode) => {
-  const { appearances } = question;
-  const isQuick = appearances.quick || appearances.quickcompact;
-  const supportsAutoAdvance = !appearances.label && !appearances.likert;
-  const isValid = question.validationState.violation == null;
-
-  if (isQuick && supportsAutoAdvance && isValid) {
-    question.root.nextPage();
-  }
 };

--- a/packages/web-forms/src/lib/pagination/pagination.ts
+++ b/packages/web-forms/src/lib/pagination/pagination.ts
@@ -16,8 +16,9 @@ export const advanceIfQuick = (question: SelectNode) => {
   const { appearances } = question;
   const isQuick = appearances.quick || appearances.quickcompact;
   const supportsAutoAdvance = !appearances.label && !appearances.likert;
+  const isValid = question.validationState.violation == null;
 
-  if (isQuick && supportsAutoAdvance) {
+  if (isQuick && supportsAutoAdvance && isValid) {
     question.root.nextPage();
   }
 };

--- a/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
@@ -411,5 +411,17 @@ describe('SelectControl', () => {
       expect(ratingNode.currentState.value[0]).toBe('1');
       expect(root.currentState.currentPage).toBe(ratingNode.currentState.pageBoundary);
     });
+
+    it('does not advance when the answer violates a constraint', async () => {
+      const spiceNode = getSelectNodeByReference(root, '/data/spice');
+      root.setCurrentPage(spiceNode.currentState.pageBoundary);
+      const component = mountComponent(spiceNode);
+      const violatingOption = component.find(`input[id="${spiceNode.nodeId}_ghost"]`);
+
+      await violatingOption.trigger('click');
+
+      expect(spiceNode.validationState.violation).not.toBeNull();
+      expect(root.currentState.currentPage).toBe(spiceNode.currentState.pageBoundary);
+    });
   });
 });

--- a/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
@@ -124,6 +124,16 @@ const getMenuItem = async (
   return menuItems.find((menuItem) => menuItem.text() === label) ?? null;
 };
 
+const selectOption = async (component: MountedComponent, node: SelectNode, option: string) => {
+  const radio = component.find(`input[id="${node.nodeId}_${option}"]`);
+  if (radio.exists()) {
+    return radio.trigger('click');
+  }
+  const menuItem = await getMenuItem(component, component.find(`.${SELECT_CLASS}`), option);
+  assert(menuItem != null);
+  return menuItem.trigger('mousedown');
+};
+
 describe('SelectControl', () => {
   describe('select1', () => {
     describe('no appearance (radio controls)', () => {
@@ -385,43 +395,80 @@ describe('SelectControl', () => {
 
   describe('quick appearance (auto-advance)', () => {
     let root: RootNode;
-    let fruitNode: SelectNode;
-    let ratingNode: SelectNode;
 
     beforeEach(async () => {
       root = await getReactiveForm('pagination-18-quick.xml');
-      fruitNode = getSelectNodeByReference(root, '/data/fruit');
-      ratingNode = getSelectNodeByReference(root, '/data/rating');
     });
 
-    it('advances to the next page when a quick select1 is answered', async () => {
-      const component = mountComponent(fruitNode);
-      const mango = component.find(`input[id="${fruitNode.nodeId}_mango"]`);
-      await mango.trigger('click');
+    it.each([
+      {
+        scenario: 'quick',
+        question: '/data/fruit',
+        tappedOption: 'mango',
+        questionOnNextPage: '/data/rating',
+      },
+      {
+        scenario: 'quickcompact',
+        question: '/data/color',
+        tappedOption: 'red',
+        questionOnNextPage: '/data/shape',
+      },
+      {
+        scenario: 'quick minimal (dropdown)',
+        question: '/data/veg',
+        tappedOption: 'carrot',
+        questionOnNextPage: '/data/color',
+      },
+    ])(
+      'advances to the next page when a $scenario select1 is tapped',
+      async ({ question, tappedOption, questionOnNextPage }) => {
+        const node = getSelectNodeByReference(root, question);
+        const nextNode = getSelectNodeByReference(root, questionOnNextPage);
+        root.setCurrentPage(node.currentState.pageBoundary);
+        const component = mountComponent(node);
 
-      expect(root.currentState.currentPage).toBe(ratingNode.currentState.pageBoundary);
-    });
+        await selectOption(component, node, tappedOption);
 
-    it('does not advance when a quick likert select1 is answered', async () => {
-      root.setCurrentPage(ratingNode.currentState.pageBoundary);
-      const component = mountComponent(ratingNode);
-      const firstRatingOption = component.find(`input[id="${ratingNode.nodeId}_1"]`);
-      await firstRatingOption.trigger('click');
+        expectSelectedValueState(node, tappedOption);
+        expect(root.currentState.currentPage).toBe(nextNode.currentState.pageBoundary);
+      }
+    );
 
-      expect(ratingNode.currentState.value[0]).toBe('1');
-      expect(root.currentState.currentPage).toBe(ratingNode.currentState.pageBoundary);
-    });
+    it.each([
+      {
+        scenario: 'likert',
+        question: '/data/rating',
+        tappedOption: '1',
+        expectedValue: '1',
+        expectsViolation: false,
+      },
+      {
+        scenario: 'label',
+        question: '/data/shape',
+        tappedOption: 'circle',
+        expectedValue: null,
+        expectsViolation: false,
+      },
+      {
+        scenario: 'constraint-violating',
+        question: '/data/spice',
+        tappedOption: 'ghost',
+        expectedValue: 'ghost',
+        expectsViolation: true,
+      },
+    ])(
+      'does not advance when a quick $scenario select1 is tapped',
+      async ({ question, tappedOption, expectedValue, expectsViolation }) => {
+        const node = getSelectNodeByReference(root, question);
+        root.setCurrentPage(node.currentState.pageBoundary);
+        const component = mountComponent(node);
 
-    it('does not advance when the answer violates a constraint', async () => {
-      const spiceNode = getSelectNodeByReference(root, '/data/spice');
-      root.setCurrentPage(spiceNode.currentState.pageBoundary);
-      const component = mountComponent(spiceNode);
-      const violatingOption = component.find(`input[id="${spiceNode.nodeId}_ghost"]`);
+        await selectOption(component, node, tappedOption);
 
-      await violatingOption.trigger('click');
-
-      expect(spiceNode.validationState.violation).not.toBeNull();
-      expect(root.currentState.currentPage).toBe(spiceNode.currentState.pageBoundary);
-    });
+        expectSelectedValueState(node, expectedValue);
+        expect(node.validationState.violation != null).toBe(expectsViolation);
+        expect(root.currentState.currentPage).toBe(node.currentState.pageBoundary);
+      }
+    );
   });
 });

--- a/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
+++ b/packages/web-forms/tests/components/form-elements/select/SelectControl.test.ts
@@ -382,4 +382,34 @@ describe('SelectControl', () => {
       expect(component.get('.validation-message').text()).toBe('validation_message.required.error');
     });
   });
+
+  describe('quick appearance (auto-advance)', () => {
+    let root: RootNode;
+    let fruitNode: SelectNode;
+    let ratingNode: SelectNode;
+
+    beforeEach(async () => {
+      root = await getReactiveForm('pagination-18-quick.xml');
+      fruitNode = getSelectNodeByReference(root, '/data/fruit');
+      ratingNode = getSelectNodeByReference(root, '/data/rating');
+    });
+
+    it('advances to the next page when a quick select1 is answered', async () => {
+      const component = mountComponent(fruitNode);
+      const mango = component.find(`input[id="${fruitNode.nodeId}_mango"]`);
+      await mango.trigger('click');
+
+      expect(root.currentState.currentPage).toBe(ratingNode.currentState.pageBoundary);
+    });
+
+    it('does not advance when a quick likert select1 is answered', async () => {
+      root.setCurrentPage(ratingNode.currentState.pageBoundary);
+      const component = mountComponent(ratingNode);
+      const firstRatingOption = component.find(`input[id="${ratingNode.nodeId}_1"]`);
+      await firstRatingOption.trigger('click');
+
+      expect(ratingNode.currentState.value[0]).toBe('1');
+      expect(root.currentState.currentPage).toBe(ratingNode.currentState.pageBoundary);
+    });
+  });
 });

--- a/packages/web-forms/tests/fixtures/pagination-18-quick.xml
+++ b/packages/web-forms/tests/fixtures/pagination-18-quick.xml
@@ -8,6 +8,9 @@
           <fruit/>
           <rating/>
           <spice/>
+          <veg/>
+          <color/>
+          <shape/>
           <comment/>
           <meta>
             <instanceID/>
@@ -17,6 +20,9 @@
       <bind nodeset="/data/fruit" type="string"/>
       <bind nodeset="/data/rating" type="string"/>
       <bind nodeset="/data/spice" type="string" constraint=". != 'ghost'"/>
+      <bind nodeset="/data/veg" type="string"/>
+      <bind nodeset="/data/color" type="string"/>
+      <bind nodeset="/data/shape" type="string"/>
       <bind nodeset="/data/comment" type="string"/>
       <bind nodeset="/data/meta/instanceID" type="string"/>
     </model>
@@ -36,6 +42,21 @@
       <label>Spice level?</label>
       <item><label>Mild</label><value>mild</value></item>
       <item><label>Ghost pepper</label><value>ghost</value></item>
+    </select1>
+    <select1 ref="/data/veg" appearance="quick minimal">
+      <label>Favorite vegetable?</label>
+      <item><label>carrot</label><value>carrot</value></item>
+      <item><label>potato</label><value>potato</value></item>
+    </select1>
+    <select1 ref="/data/color" appearance="quickcompact">
+      <label>Favorite color?</label>
+      <item><label>Red</label><value>red</value></item>
+      <item><label>Blue</label><value>blue</value></item>
+    </select1>
+    <select1 ref="/data/shape" appearance="quick label">
+      <label>Shape?</label>
+      <item><label>Circle</label><value>circle</value></item>
+      <item><label>Square</label><value>square</value></item>
     </select1>
     <input ref="/data/comment"><label>Any comment?</label></input>
   </h:body>

--- a/packages/web-forms/tests/fixtures/pagination-18-quick.xml
+++ b/packages/web-forms/tests/fixtures/pagination-18-quick.xml
@@ -7,6 +7,7 @@
         <data id="pg_18_quick">
           <fruit/>
           <rating/>
+          <spice/>
           <comment/>
           <meta>
             <instanceID/>
@@ -15,6 +16,7 @@
       </instance>
       <bind nodeset="/data/fruit" type="string"/>
       <bind nodeset="/data/rating" type="string"/>
+      <bind nodeset="/data/spice" type="string" constraint=". != 'ghost'"/>
       <bind nodeset="/data/comment" type="string"/>
       <bind nodeset="/data/meta/instanceID" type="string"/>
     </model>
@@ -29,6 +31,11 @@
       <label>Rating?</label>
       <item><label>1</label><value>1</value></item>
       <item><label>2</label><value>2</value></item>
+    </select1>
+    <select1 ref="/data/spice" appearance="quick">
+      <label>Spice level?</label>
+      <item><label>Mild</label><value>mild</value></item>
+      <item><label>Ghost pepper</label><value>ghost</value></item>
     </select1>
     <input ref="/data/comment"><label>Any comment?</label></input>
   </h:body>

--- a/packages/web-forms/tests/fixtures/pagination-18-quick.xml
+++ b/packages/web-forms/tests/fixtures/pagination-18-quick.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:head>
+    <h:title>18 Quick - auto-advance</h:title>
+    <model>
+      <instance>
+        <data id="pg_18_quick">
+          <fruit/>
+          <rating/>
+          <comment/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/fruit" type="string"/>
+      <bind nodeset="/data/rating" type="string"/>
+      <bind nodeset="/data/comment" type="string"/>
+      <bind nodeset="/data/meta/instanceID" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <select1 ref="/data/fruit" appearance="quick">
+      <label>Favorite fruit?</label>
+      <item><label>Cherry</label><value>cherry</value></item>
+      <item><label>Mango</label><value>mango</value></item>
+    </select1>
+    <select1 ref="/data/rating" appearance="quick likert">
+      <label>Rating?</label>
+      <item><label>1</label><value>1</value></item>
+      <item><label>2</label><value>2</value></item>
+    </select1>
+    <input ref="/data/comment"><label>Any comment?</label></input>
+  </h:body>
+</h:html>

--- a/packages/web-forms/tests/helpers.ts
+++ b/packages/web-forms/tests/helpers.ts
@@ -38,6 +38,7 @@ import paginationFieldlistRelevance from './fixtures/pagination-13-fieldlist-rel
 import paginationFieldlistOnRepeat from './fixtures/pagination-14-fieldlist-on-repeat.xml?raw';
 import paginationRepeatFixedCount from './fixtures/pagination-16-repeat-fixed-count.xml?raw';
 import paginationNestedRepeatFieldlist from './fixtures/pagination-17-nested-repeat-fieldlist.xml?raw';
+import paginationQuick from './fixtures/pagination-18-quick.xml?raw';
 
 import citiesGeoJson from './fixtures/attachments/cities.geojson?url';
 
@@ -81,6 +82,7 @@ const fixtures: Record<string, string> = {
   'pagination-14-fieldlist-on-repeat.xml': paginationFieldlistOnRepeat,
   'pagination-16-repeat-fixed-count.xml': paginationRepeatFixedCount,
   'pagination-17-nested-repeat-fieldlist.xml': paginationNestedRepeatFieldlist,
+  'pagination-18-quick.xml': paginationQuick,
 };
 
 const attachments: Record<string, string> = {

--- a/packages/xforms-engine/src/parse/body/appearance/selectAppearanceParser.ts
+++ b/packages/xforms-engine/src/parse/body/appearance/selectAppearanceParser.ts
@@ -23,12 +23,11 @@ export const selectAppearanceParser = new TokenListParser(
     'columns-pack',
     'autocomplete',
 
-    // TODO: these are `<select1>` only
+    // This parser is shared with <select>, but these tokens only make sense for <select1>.
     'likert',
     'quick',
     'quickcompact',
     'map',
-    // "quick map"
   ],
   {
     aliases: [{ fromAlias: 'search', toCanonical: 'autocomplete' }],


### PR DESCRIPTION
Closes https://github.com/getodk/web-forms/issues/515

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Compared with Collect. All cases with select and pagination were manually tested. Unit tests were added too.

#### Why is this the best possible solution? Were any other approaches considered?

Appearances are a client concern, so the implementation lives in the client, reusing the existing pagination API (nextPage)

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

In paginated forms, answering a `quick` select1 now auto-advances to the next page. No advance for `likert`/`label` variants or when the question has invalid answers. 

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No
