### PR TITLE
EntityUpload: remember selection of extra properties

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -49,8 +49,12 @@ except according to the terms contained in the LICENSE file.
         <entity-upload-errors v-if="errors != null" v-bind="errors"
           :delimiter="fileMetadata.delimiter"/>
         <entity-upload-warnings v-if="warnings != null" v-bind="warnings"
-          :filename="fileMetadata.name" @rows="showWarningRows"
-          @toggle-extra="toggleExtraProperty"/>
+          :filename="fileMetadata.name" @rows="showWarningRows">
+          <template #extra-properties>
+            <entity-upload-extra-properties :properties="warnings.extraProperties"
+              :selected="selectedProperties" @toggle="toggleExtraProperty"/>
+          </template>
+        </entity-upload-warnings>
 
         <entity-upload-file-select :disabled="parsing || uploading"
           :parsing="parsing" @change="selectFile"/>
@@ -77,6 +81,7 @@ import { pick } from 'ramda';
 import { useI18n } from 'vue-i18n';
 
 import EntityUploadErrors from './upload/errors.vue';
+import EntityUploadExtraProperties from './upload/extra-properties.vue';
 import EntityUploadFileSelect from './upload/file-select.vue';
 import EntityUploadPopup from './upload/popup.vue';
 import EntityUploadTable from './upload/table.vue';
@@ -303,7 +308,6 @@ const selectFile = (file) => {
   fileMetadata.value = null;
   errors.value = null;
   warnings.value = null;
-  selectedProperties.clear();
 
   const abortController = new AbortController();
   abortParse = () => { abortController.abort(); };

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -2,12 +2,13 @@
   <div id="entity-upload-extra-properties" @change="toggle">
     <div v-if="properties.length !== 1" class="checkbox">
       <label>
-        <input type="checkbox" data-select-all="true">{{ $t('action.selectAll') }}
+        <input type="checkbox" :checked="selectedAll" data-select-all="true">
+        <span>{{ $t('action.selectAll') }}</span>
       </label>
     </div>
     <div v-for="name of properties" :key="name" class="checkbox">
       <label>
-        <input type="checkbox" :value="name">
+        <input type="checkbox" :value="name" :checked="selected.has(name)">
         <span v-tooltip.text>{{ name }}</span>
       </label>
     </div>
@@ -15,29 +16,35 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
 defineOptions({
   name: 'EntityUploadExtraProperties'
 });
-defineProps({
+const props = defineProps({
   properties: {
     type: Array,
+    required: true
+  },
+  selected: {
+    type: Set,
     required: true
   }
 });
 const emit = defineEmits(['toggle']);
 
+const selectedAll = computed(() =>
+  props.properties.every(name => props.selected.has(name)));
+
 const toggle = (event) => {
-  const { target } = event;
-  const { checked } = target;
-  if (target.dataset.selectAll === 'true') {
-    for (const input of event.currentTarget.querySelectorAll('input[value]')) {
-      if (input.checked !== checked) {
-        input.checked = checked;
-        emit('toggle', input.value, checked);
-      }
+  const input = event.target;
+  const { checked } = input;
+  if (input.dataset.selectAll === 'true') {
+    for (const name of props.properties) {
+      if (props.selected.has(name) !== checked) emit('toggle', name, checked);
     }
   } else {
-    emit('toggle', target.value, checked);
+    emit('toggle', input.value, checked);
   }
 };
 </script>

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -95,8 +95,7 @@ except according to the terms contained in the LICENSE file.
             {{ $t('extraProperties.description.multiple') }}
           </template>
         </p>
-        <entity-upload-extra-properties :properties="extraProperties"
-          @toggle="toggleExtraProperty"/>
+        <slot name="extra-properties"></slot>
       </template>
     </entity-upload-alert>
   </div>
@@ -104,7 +103,6 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import EntityUploadAlert from './alert.vue';
-import EntityUploadExtraProperties from './extra-properties.vue';
 import I18nList from '../../i18n/list.vue';
 import SentenceSeparator from '../../sentence-separator.vue';
 
@@ -132,11 +130,7 @@ defineProps({
   raggedRows: Array,
   largeCell: Number
 });
-const emit = defineEmits(['rows', 'toggle-extra']);
-
-const toggleExtraProperty = (property, checked) => {
-  emit('toggle-extra', property, checked);
-};
+defineEmits(['rows']);
 </script>
 
 <style lang="scss">

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -648,6 +648,11 @@ describe('EntityUpload', () => {
     });
 
     const extraCSV = createCSV('label,height,circumference,species\ndogwood,1,2,dogwood\nelm');
+    const toggleExtra = (modal, name, checked = true) => {
+      const input = modal.get(`#entity-upload-extra-properties input[value="${name}"]`);
+      input.element.checked.should.equal(!checked);
+      return input.setChecked(checked);
+    };
 
     it('shows a warning if there are extra properties', async () => {
       const modal = await showModal();
@@ -677,12 +682,6 @@ describe('EntityUpload', () => {
 
     it('remembers the property selection until the modal is hidden', async () => {
       const modal = await showModal();
-      // Checks or unchecks the first property.
-      const toggleFirst = (checked = true) => {
-        const input = modal.get('#entity-upload-extra-properties .checkbox:nth-child(2) input');
-        input.element.checked.should.equal(!checked);
-        return input.setChecked(checked);
-      };
       const getSelected = () => {
         const { selected } = modal.getComponent(EntityUploadExtraProperties).props();
         return [...selected];
@@ -698,36 +697,60 @@ describe('EntityUpload', () => {
       };
 
       await selectFile(modal, extraCSV);
-      await toggleFirst();
+      await toggleExtra(modal, 'circumference');
 
-      const secondCSV = createCSV('label,height,foo,bar\ndogwood,1,x,y');
-      await selectFile(modal, secondCSV);
+      // Select a .csv file with a `circumference` property like extraCSV, but
+      // without `species`.
+      await selectFile(modal, createCSV('label,circumference\ndogwood,1'));
+      // The selection of `circumference` should be remembered.
       getSelected().should.eql(['circumference']);
+      getChecked().should.eql(['circumference']);
+      getTableExtra().should.eql(['circumference']);
+
+      // A .csv file without `circumference` or `species`, but instead two other
+      // extra properties: `foo` and `bar`.
+      const foobarCSV = createCSV('label,height,foo,bar\ndogwood,1,x,y');
+      await selectFile(modal, foobarCSV);
+      // Under the hood, the selection of `circumference` should still be
+      // remembered.
+      getSelected().should.eql(['circumference']);
+      // However, the selection is not visible in the UI.
       getChecked().should.eql([]);
       getTableExtra().should.eql([]);
-      await toggleFirst();
+      await toggleExtra(modal, 'foo');
 
+      // Select extraCSV again. We should see that the selection of
+      // `circumference` has been remembered. The selection of `foo` should be
+      // remembered under the hood.
       await selectFile(modal, extraCSV);
       getSelected().should.eql(['circumference', 'foo']);
       getChecked().should.eql(['circumference']);
       getTableExtra().should.eql(['circumference']);
 
-      await selectFile(modal, secondCSV);
+      // Select foobarCSV again. We should see that the selection of `foo` has
+      // been remembered.
+      await selectFile(modal, foobarCSV);
       getSelected().should.eql(['circumference', 'foo']);
       getChecked().should.eql(['foo']);
       getTableExtra().should.eql(['foo']);
-      await toggleFirst(false);
+      await toggleExtra(modal, 'foo', false);
 
+      // Select foobarCSV again (after temporarily swapping it out). We should
+      // see that the deselection of `foo` has been remembered.
       await selectFile(modal, extraCSV);
-      await selectFile(modal, secondCSV);
+      await selectFile(modal, foobarCSV);
+      // Under the hood, the selection of `circumference` should still be
+      // remembered.
       getSelected().should.eql(['circumference']);
       getChecked().should.eql([]);
       getTableExtra().should.eql([]);
 
+      // Hide the modal.
       await modal.setProps({ state: false });
       await modal.setProps({ state: true });
 
       await selectFile(modal, extraCSV);
+      // The selection of `circumference` should no longer be remembered.
       getSelected().should.eql([]);
       getChecked().should.eql([]);
       getTableExtra().should.eql([]);

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -4,6 +4,7 @@ import { T } from 'ramda';
 import EntityFilters from '../../../src/components/entity/filters.vue';
 import EntityUpload from '../../../src/components/entity/upload.vue';
 import EntityUploadErrors from '../../../src/components/entity/upload/errors.vue';
+import EntityUploadExtraProperties from '../../../src/components/entity/upload/extra-properties.vue';
 import EntityUploadFileSelect from '../../../src/components/entity/upload/file-select.vue';
 import EntityUploadPopup from '../../../src/components/entity/upload/popup.vue';
 import EntityUploadTable from '../../../src/components/entity/upload/table.vue';
@@ -39,7 +40,7 @@ const parseFilterTime = (filter) => {
 };
 const createCSV = (text = 'label\ndogwood') => new File([text], 'my_data.csv');
 const selectFile = async (modal, file = createCSV()) => {
-  await setFiles(modal.get('input'), [file]);
+  await setFiles(modal.get('input[type="file"]'), [file]);
   return waitUntil(() => !modal.vm.parsing);
 };
 const getTables = (modal) => {
@@ -653,6 +654,8 @@ describe('EntityUpload', () => {
       await selectFile(modal, extraCSV);
       const warnings = modal.getComponent(EntityUploadWarnings).props();
       warnings.extraProperties.should.eql(['circumference', 'species']);
+      const extraComponent = modal.getComponent(EntityUploadExtraProperties);
+      expect(extraComponent.props().properties).to.eql(['circumference', 'species']);
     });
 
     it('shows selected properties in the table', async () => {
@@ -670,6 +673,64 @@ describe('EntityUpload', () => {
 
       await input.setChecked(false);
       table.props().extraProperties.should.eql([]);
+    });
+
+    it('remembers the property selection until the modal is hidden', async () => {
+      const modal = await showModal();
+      // Checks or unchecks the first property.
+      const toggleFirst = (checked = true) => {
+        const input = modal.get('#entity-upload-extra-properties .checkbox:nth-child(2) input');
+        input.element.checked.should.equal(!checked);
+        return input.setChecked(checked);
+      };
+      const getSelected = () => {
+        const { selected } = modal.getComponent(EntityUploadExtraProperties).props();
+        return [...selected];
+      };
+      const getChecked = () => {
+        const checked = modal.findAll('#entity-upload-extra-properties .checkbox:has(input:checked)');
+        return checked.map(div => div.text());
+      };
+      const getTableExtra = () => {
+        const tables = modal.findAllComponents(EntityUploadTable);
+        tables.length.should.equal(2);
+        return tables[1].props().extraProperties ?? [];
+      };
+
+      await selectFile(modal, extraCSV);
+      await toggleFirst();
+
+      const secondCSV = createCSV('label,height,foo,bar\ndogwood,1,x,y');
+      await selectFile(modal, secondCSV);
+      getSelected().should.eql(['circumference']);
+      getChecked().should.eql([]);
+      getTableExtra().should.eql([]);
+      await toggleFirst();
+
+      await selectFile(modal, extraCSV);
+      getSelected().should.eql(['circumference', 'foo']);
+      getChecked().should.eql(['circumference']);
+      getTableExtra().should.eql(['circumference']);
+
+      await selectFile(modal, secondCSV);
+      getSelected().should.eql(['circumference', 'foo']);
+      getChecked().should.eql(['foo']);
+      getTableExtra().should.eql(['foo']);
+      await toggleFirst(false);
+
+      await selectFile(modal, extraCSV);
+      await selectFile(modal, secondCSV);
+      getSelected().should.eql(['circumference']);
+      getChecked().should.eql([]);
+      getTableExtra().should.eql([]);
+
+      await modal.setProps({ state: false });
+      await modal.setProps({ state: true });
+
+      await selectFile(modal, extraCSV);
+      getSelected().should.eql([]);
+      getChecked().should.eql([]);
+      getTableExtra().should.eql([]);
     });
 
     it('does not send properties that were not selected', () =>
@@ -692,5 +753,7 @@ describe('EntityUpload', () => {
             ]
           }
         }]));
+
+    it('does not create properties that were selected, but are not in current CSV');
   });
 });

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -1,8 +1,11 @@
 import EntityUploadExtraProperties from '../../../../src/components/entity/upload/extra-properties.vue';
 
-import { mount } from '../../../util/lifecycle';
+import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
-const mountComponent = (options) => mount(EntityUploadExtraProperties, options);
+const mountComponent = (options) =>
+  mount(EntityUploadExtraProperties, mergeMountOptions(options, {
+    props: { selected: new Set() }
+  }));
 
 describe('EntityUploadExtraProperties', () => {
   it('shows a checkbox for each property', async () => {
@@ -15,15 +18,38 @@ describe('EntityUploadExtraProperties', () => {
     await checkboxes[1].get('span').should.have.textTooltip();
   });
 
-  it('emits a toggle event when a property is checked or unchecked', async () => {
+  describe('selected prop', () => {
+    it('sets the initial state of the checkboxes', () => {
+      const component = mountComponent({
+        props: { properties: ['foo', 'bar'], selected: new Set(['foo']) }
+      });
+      const checked = component.findAll('input').map(input => input.element.checked);
+      checked.should.eql([false, true, false]);
+    });
+
+    it('checks "Select all" if all properties are selected', () => {
+      const component = mountComponent({
+        props: { properties: ['foo', 'bar'], selected: new Set(['foo', 'bar']) }
+      });
+      const checked = component.findAll('input').map(input => input.element.checked);
+      checked.should.eql([true, true, true]);
+    });
+  });
+
+  it('emits a toggle event when a property is checked', async () => {
     const component = mountComponent({
       props: { properties: ['foo', 'bar'] }
     });
-    const checkbox = component.get('.checkbox:nth-child(2)');
-    checkbox.text().should.equal('foo');
-    await checkbox.get('input').setChecked();
-    await checkbox.get('input').setChecked(false);
-    component.emitted().toggle.should.eql([['foo', true], ['foo', false]]);
+    await component.get('input[value="foo"]').setChecked();
+    component.emitted().toggle.should.eql([['foo', true]]);
+  });
+
+  it('emits a toggle event when a property is unchecked', async () => {
+    const component = mountComponent({
+      props: { properties: ['foo', 'bar'], selected: new Set(['foo']) }
+    });
+    await component.get('input[value="foo"]').setChecked(false);
+    component.emitted().toggle.should.eql([['foo', false]]);
   });
 
   describe('select all', () => {
@@ -36,25 +62,23 @@ describe('EntityUploadExtraProperties', () => {
       checkboxes[0].text().should.equal('foo');
     });
 
-    it('toggles each property', async () => {
+    it('selects every unselected property', async () => {
       const component = mountComponent({
-        props: { properties: ['foo', 'bar'] }
+        props: { properties: ['foo', 'bar', 'baz'], selected: new Set(['baz']) }
       });
-      const inputs = component.findAll('input');
-      inputs.length.should.equal(3);
-
-      await inputs[0].setChecked();
-      inputs[1].element.checked.should.be.true;
-      inputs[2].element.checked.should.be.true;
+      await component.get('input').setChecked();
       component.emitted().toggle.should.eql([['foo', true], ['bar', true]]);
+    });
 
-      await inputs[0].setChecked(false);
-      inputs[1].element.checked.should.be.false;
-      inputs[2].element.checked.should.be.false;
-      component.emitted().toggle.should.eql([
-        ['foo', true], ['bar', true],
-        ['foo', false], ['bar', false]
-      ]);
+    it('deselects every property', async () => {
+      const component = mountComponent({
+        props: {
+          properties: ['foo', 'bar'],
+          selected: new Set(['foo', 'bar'])
+        }
+      });
+      await component.get('input').setChecked(false);
+      component.emitted().toggle.should.eql([['foo', false], ['bar', false]]);
     });
   });
 });

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -1,7 +1,6 @@
 import { nextTick } from 'vue';
 
 import EntityUploadAlert from '../../../../src/components/entity/upload/alert.vue';
-import EntityUploadExtraProperties from '../../../../src/components/entity/upload/extra-properties.vue';
 import EntityUploadWarnings from '../../../../src/components/entity/upload/warnings.vue';
 
 import { mergeMountOptions, mount } from '../../../util/lifecycle';
@@ -83,13 +82,9 @@ describe('EntityUploadWarnings', () => {
     const component = mountComponent({
       props: { extraProperties: ['foo', 'bar'] }
     });
-
     const p = component.getComponent(EntityUploadAlert).findAll('p');
     p.length.should.equal(2);
     p[0].text().should.equal('These columns don’t match existing properties');
-
-    const extraComponent = component.getComponent(EntityUploadExtraProperties);
-    expect(extraComponent.props().properties).to.eql(['foo', 'bar']);
   });
 
   it('shows a warning for ragged rows', () => {


### PR DESCRIPTION
This PR makes progress on getodk/central#1786. Right now, the selection of new properties in `EntityUploadExtraProperties` is not persisted when the user selects a new file. This PR makes it so that the selection is remembered up until the user closes the modal. Doing so makes it easier for the user to iterate on the upload file if there are errors or warnings.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

We already store the user's `selectedProperties`. Now we won't clear them on file select.

We'll pass `selectedProperties` to `EntityUploadExtraProperties` via its new `selected` prop. In some ways, we're actually able to simplify `EntityUploadExtraProperties` by adding this prop.

However, it's not convenient that in order for `selected` to reach `EntityUploadExtraProperties`, it has to go through the intermediary `EntityUploadWarnings` component first. This PR makes that easier by having the `EntityUpload` modal component render `EntityUploadExtraProperties` directly. That way, the modal can pass it props directly and handle events directly. There's no need for `EntityUploadWarnings` to get involved in the communication between the two components. `EntityUploadWarnings` still needs to contain `EntityUploadExtraProperties`, but it can be passed it as a slot rather than handling its rendering itself.