### PR TITLE
Disable EntityUploadExtraProperties if CSV file has error

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -49,10 +49,12 @@ except according to the terms contained in the LICENSE file.
         <entity-upload-errors v-if="errors != null" v-bind="errors"
           :delimiter="fileMetadata.delimiter"/>
         <entity-upload-warnings v-if="warnings != null" v-bind="warnings"
-          :filename="fileMetadata.name" @rows="showWarningRows">
+          :filename="fileMetadata.name" :errors="errors?.count"
+          @rows="showWarningRows">
           <template #extra-properties>
             <entity-upload-extra-properties :properties="warnings.extraProperties"
-              :selected="selectedProperties" @toggle="toggleExtraProperty"/>
+              :selected="selectedProperties" :disabled="errors != null"
+              @toggle="toggleExtraProperty"/>
           </template>
         </entity-upload-warnings>
 

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -49,7 +49,7 @@ except according to the terms contained in the LICENSE file.
         <entity-upload-errors v-if="errors != null" v-bind="errors"
           :delimiter="fileMetadata.delimiter"/>
         <entity-upload-warnings v-if="warnings != null" v-bind="warnings"
-          :filename="fileMetadata.name" :errors="errors?.count"
+          :filename="fileMetadata.name" :has-error="errors != null"
           @rows="showWarningRows">
           <template #extra-properties>
             <entity-upload-extra-properties :properties="warnings.extraProperties"

--- a/apps/central/src/components/entity/upload/errors.vue
+++ b/apps/central/src/components/entity/upload/errors.vue
@@ -70,6 +70,7 @@ const props = defineProps({
     type: String,
     required: true
   },
+  // Number of errors
   count: {
     type: Number,
     required: true

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -1,14 +1,16 @@
 <template>
   <div id="entity-upload-extra-properties" @change="toggle">
-    <div v-if="properties.length !== 1" class="checkbox">
+    <div v-if="properties.length !== 1" class="checkbox" :class="{ disabled }">
       <label>
-        <input type="checkbox" :checked="selectedAll" data-select-all="true">
+        <input type="checkbox" :checked="selectedAll" :disabled="disabled"
+          data-select-all="true">
         <span>{{ $t('action.selectAll') }}</span>
       </label>
     </div>
-    <div v-for="name of properties" :key="name" class="checkbox">
+    <div v-for="name of properties" :key="name" class="checkbox" :class="{ disabled }">
       <label>
-        <input type="checkbox" :value="name" :checked="selected.has(name)">
+        <input type="checkbox" :value="name" :checked="selected.has(name)"
+          :disabled="disabled">
         <span v-tooltip.text>{{ name }}</span>
       </label>
     </div>
@@ -29,7 +31,8 @@ const props = defineProps({
   selected: {
     type: Set,
     required: true
-  }
+  },
+  disabled: Boolean
 });
 const emit = defineEmits(['toggle']);
 

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -202,7 +202,7 @@ defineEmits(['rows']);
         "multiple": "Select which ones to create, otherwise they will be ignored."
       },
       "error": {
-        "one": "Once you’ve fixed all errors, you’ll be able to choose whether to create a new property.",
+        "one": "Once you’ve fixed all errors, you’ll be able to select the column.",
         // "Ones" refers to "columns".
         "multiple": "Once you’ve fixed all errors, you’ll be able to select which ones to create."
       }

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -88,11 +88,21 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template #body>
         <p>
-          <template v-if="extraProperties.length === 1">
-            {{ $t('extraProperties.description.one') }}
+          <template v-if="errors === 0">
+            <template v-if="extraProperties.length === 1">
+              {{ $t('extraProperties.description.one') }}
+            </template>
+            <template v-else>
+              {{ $t('extraProperties.description.multiple') }}
+            </template>
           </template>
           <template v-else>
-            {{ $t('extraProperties.description.multiple') }}
+            <template v-if="extraProperties.length === 1">
+              {{ $tc('extraProperties.error.one', errors) }}
+            </template>
+            <template v-else>
+              {{ $tc('extraProperties.error.multiple', errors) }}
+            </template>
           </template>
         </p>
         <slot name="extra-properties"></slot>
@@ -114,9 +124,15 @@ defineProps({
     type: String,
     required: true
   },
+  // Number of warnings
   count: {
     type: Number,
     required: true
+  },
+  // Number of errors
+  errors: {
+    type: Number,
+    default: 0
   },
 
   // Column header warnings
@@ -188,6 +204,11 @@ defineEmits(['rows']);
         "one": "Select the column to create a new property, otherwise it will be ignored.",
         // "Ones" refers to "columns".
         "multiple": "Select which ones to create, otherwise they will be ignored."
+      },
+      "error": {
+        "one": "Once you’ve fixed the error, you’ll be able to choose whether to create a new property. | Once you’ve fixed the errors, you’ll be able to choose whether to create a new property.",
+        // "Ones" refers to "columns".
+        "multiple": "Once you’ve fixed the error, you’ll be able to select which ones to create. | Once you’ve fixed the errors, you’ll be able to select which ones to create."
       }
     },
     // "Property" refers to an Entity property.

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -88,7 +88,7 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template #body>
         <p>
-          <template v-if="errors === 0">
+          <template v-if="!hasError">
             <template v-if="extraProperties.length === 1">
               {{ $t('extraProperties.description.one') }}
             </template>
@@ -98,10 +98,10 @@ except according to the terms contained in the LICENSE file.
           </template>
           <template v-else>
             <template v-if="extraProperties.length === 1">
-              {{ $tc('extraProperties.error.one', errors) }}
+              {{ $t('extraProperties.error.one') }}
             </template>
             <template v-else>
-              {{ $tc('extraProperties.error.multiple', errors) }}
+              {{ $t('extraProperties.error.multiple') }}
             </template>
           </template>
         </p>
@@ -129,11 +129,7 @@ defineProps({
     type: Number,
     required: true
   },
-  // Number of errors
-  errors: {
-    type: Number,
-    default: 0
-  },
+  hasError: Boolean,
 
   // Column header warnings
   systemProperties: Array,
@@ -206,9 +202,9 @@ defineEmits(['rows']);
         "multiple": "Select which ones to create, otherwise they will be ignored."
       },
       "error": {
-        "one": "Once you’ve fixed the error, you’ll be able to choose whether to create a new property. | Once you’ve fixed the errors, you’ll be able to choose whether to create a new property.",
+        "one": "Once you’ve fixed all errors, you’ll be able to choose whether to create a new property.",
         // "Ones" refers to "columns".
-        "multiple": "Once you’ve fixed the error, you’ll be able to select which ones to create. | Once you’ve fixed the errors, you’ll be able to select which ones to create."
+        "multiple": "Once you’ve fixed all errors, you’ll be able to select which ones to create."
       }
     },
     // "Property" refers to an Entity property.

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -737,6 +737,8 @@ describe('EntityUpload', () => {
       const modal = await showModal();
       await selectFile(modal, createCSV('height,circumference\n1,2'));
       modal.findComponent(EntityUploadErrors).exists().should.be.true;
+      modal.getComponent(EntityUploadWarnings).props().hasError.should.be.true;
+
       const extraComponent = modal.getComponent(EntityUploadExtraProperties);
       expect(extraComponent.props().properties).to.eql(['circumference']);
       extraComponent.props().disabled.should.be.true;

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -733,6 +733,15 @@ describe('EntityUpload', () => {
       getTableExtra().should.eql([]);
     });
 
+    it('disables selection if there is an error', async () => {
+      const modal = await showModal();
+      await selectFile(modal, createCSV('height,circumference\n1,2'));
+      modal.findComponent(EntityUploadErrors).exists().should.be.true;
+      const extraComponent = modal.getComponent(EntityUploadExtraProperties);
+      expect(extraComponent.props().properties).to.eql(['circumference']);
+      extraComponent.props().disabled.should.be.true;
+    });
+
     it('does not send properties that were not selected', () =>
       showModal()
         .complete()

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -36,6 +36,17 @@ describe('EntityUploadExtraProperties', () => {
     });
   });
 
+  it('disables checkboxes if the disabled prop is true', () => {
+    const component = mountComponent({
+      props: { properties: ['foo', 'bar'], disabled: true }
+    });
+    const checkboxes = component.findAll('.checkbox');
+    for (const checkbox of checkboxes) {
+      checkbox.classes('disabled').should.be.true;
+      checkbox.get('input').element.disabled.should.be.true;
+    }
+  });
+
   it('emits a toggle event when a property is checked', async () => {
     const component = mountComponent({
       props: { properties: ['foo', 'bar'] }

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -41,6 +41,7 @@ describe('EntityUploadExtraProperties', () => {
       props: { properties: ['foo', 'bar'], disabled: true }
     });
     const checkboxes = component.findAll('.checkbox');
+    checkboxes.length.should.equal(3);
     for (const checkbox of checkboxes) {
       checkbox.classes('disabled').should.be.true;
       checkbox.get('input').element.disabled.should.be.true;

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -91,11 +91,11 @@ describe('EntityUploadWarnings', () => {
 
     it('shows different text if there are errors', () => {
       const component = mountComponent({
-        props: { extraProperties: ['foo', 'bar'], errors: 2 }
+        props: { extraProperties: ['foo', 'bar'], hasError: true }
       });
       const warning = component.getComponent(EntityUploadAlert);
       const text = warning.get('p:nth-child(2)').text();
-      text.should.startWith('Once you’ve fixed the errors, you’ll be able to select');
+      text.should.startWith('Once you’ve fixed all errors, you’ll be able to select');
     });
   });
 

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -78,13 +78,25 @@ describe('EntityUploadWarnings', () => {
     p[2].text().should.equal('foo, bar');
   });
 
-  it('shows a warning for unknown properties', () => {
-    const component = mountComponent({
-      props: { extraProperties: ['foo', 'bar'] }
+  describe('unknown properties', () => {
+    it('shows a warning for unknown properties', () => {
+      const component = mountComponent({
+        props: { extraProperties: ['foo', 'bar'] }
+      });
+      const p = component.getComponent(EntityUploadAlert).findAll('p');
+      p.length.should.equal(2);
+      p[0].text().should.equal('These columns don’t match existing properties');
+      p[1].text().should.startWith('Select which ones to create');
     });
-    const p = component.getComponent(EntityUploadAlert).findAll('p');
-    p.length.should.equal(2);
-    p[0].text().should.equal('These columns don’t match existing properties');
+
+    it('shows different text if there are errors', () => {
+      const component = mountComponent({
+        props: { extraProperties: ['foo', 'bar'], errors: 2 }
+      });
+      const warning = component.getComponent(EntityUploadAlert);
+      const text = warning.get('p:nth-child(2)').text();
+      text.should.startWith('Once you’ve fixed the errors, you’ll be able to select');
+    });
   });
 
   it('shows a warning for ragged rows', () => {

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -78,8 +78,8 @@ describe('EntityUploadWarnings', () => {
     p[2].text().should.equal('foo, bar');
   });
 
-  describe('unknown properties', () => {
-    it('shows a warning for unknown properties', () => {
+  describe('unknown (extra) properties', () => {
+    it('shows a warning', () => {
       const component = mountComponent({
         props: { extraProperties: ['foo', 'bar'] }
       });
@@ -89,7 +89,7 @@ describe('EntityUploadWarnings', () => {
       p[1].text().should.startWith('Select which ones to create');
     });
 
-    it('shows different text if there are errors', () => {
+    it('shows different text if there is an error', () => {
       const component = mountComponent({
         props: { extraProperties: ['foo', 'bar'], hasError: true }
       });

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2979,6 +2979,15 @@
             "string": "Select which ones to create, otherwise they will be ignored.",
             "developer_comment": "\"Ones\" refers to \"columns\"."
           }
+        },
+        "error": {
+          "one": {
+            "string": "{count, plural, one {Once you’ve fixed the error, you’ll be able to choose whether to create a new property.} other {Once you’ve fixed the errors, you’ll be able to choose whether to create a new property.}}"
+          },
+          "multiple": {
+            "string": "{count, plural, one {Once you’ve fixed the error, you’ll be able to select which ones to create.} other {Once you’ve fixed the errors, you’ll be able to select which ones to create.}}",
+            "developer_comment": "\"Ones\" refers to \"columns\"."
+          }
         }
       },
       "propertiesIgnored": {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2982,10 +2982,10 @@
         },
         "error": {
           "one": {
-            "string": "{count, plural, one {Once you’ve fixed the error, you’ll be able to choose whether to create a new property.} other {Once you’ve fixed the errors, you’ll be able to choose whether to create a new property.}}"
+            "string": "Once you’ve fixed all errors, you’ll be able to choose whether to create a new property."
           },
           "multiple": {
-            "string": "{count, plural, one {Once you’ve fixed the error, you’ll be able to select which ones to create.} other {Once you’ve fixed the errors, you’ll be able to select which ones to create.}}",
+            "string": "Once you’ve fixed all errors, you’ll be able to select which ones to create.",
             "developer_comment": "\"Ones\" refers to \"columns\"."
           }
         }

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2982,7 +2982,7 @@
         },
         "error": {
           "one": {
-            "string": "Once you’ve fixed all errors, you’ll be able to choose whether to create a new property."
+            "string": "Once you’ve fixed all errors, you’ll be able to select the column."
           },
           "multiple": {
             "string": "Once you’ve fixed all errors, you’ll be able to select which ones to create.",


### PR DESCRIPTION
This PR makes progress on getodk/central#1786. The Figma design shows that if the CSV file has an error, the checkboxes in `EntityUploadExtraProperties` should be disabled. Further, the text above the checkboxes should be a little different.

#### What has been done to verify that this works as intended?

New tests.