### PR TITLE
EntityUpload: create new properties and include their data in upload

### DIFF
--- a/apps/central/src/components/dataset/entities.vue
+++ b/apps/central/src/components/dataset/entities.vue
@@ -49,7 +49,7 @@ except according to the terms contained in the LICENSE file.
     </page-section>
 
     <entity-upload v-if="dataset.dataExists" v-bind="upload"
-      @hide="upload.hide()" @success="afterUpload"/>
+      @hide="hideUpload" @success="afterUpload"/>
     <entity-create v-if="dataset.dataExists" v-bind="create"
       @hide="create.hide()" @success="afterCreate"/>
     <odata-analyze v-bind="analyze" :odata-url="odataUrl" @hide="analyze.hide()"/>
@@ -98,6 +98,7 @@ export default {
       required: true
     }
   },
+  emits: ['fetch-dataset'],
   setup() {
     const { project, dataset } = useRequestData();
     const { deletedEntityCount } = useEntities();
@@ -140,13 +141,23 @@ export default {
     if (!this.deleted) this.fetchDeletedCount();
   },
   methods: {
-    afterUpload(count) {
+    hideUpload(createdProperty) {
+      this.upload.hide();
+      if (createdProperty) this.$emit('fetch-dataset', true);
+    },
+    afterUpload(entityCount, createdProperty) {
       this.upload.hide();
       this.alert.success(this.$t('alert.upload'));
+
+      if (createdProperty) {
+        this.$emit('fetch-dataset', true);
+      } else {
+        // Update dataset.entities so that the count in the OData loading
+        // message reflects the new entities.
+        this.dataset.entities += entityCount;
+      }
+
       this.$refs.list.reset();
-      // Update dataset.entities so that the count in the OData loading message
-      // reflects the new entities.
-      this.dataset.entities += count;
     },
     afterCreate() {
       this.create.hide();

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -484,7 +484,6 @@ watch([errors, warnings, csvEntities], () => {
 });
 
 const hide = () => { emit('hide', createdProperties.size !== 0); };
-
 watch(() => props.state, (state) => {
   if (state) return;
   abortParse();

--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -11,7 +11,7 @@ except according to the terms contained in the LICENSE file.
 -->
 <template>
   <modal id="entity-upload" :state="state" :hideable="!uploading" :persistent="true" size="full"
-    backdrop @hide="$emit('hide')" @mutate="resizeColumnIfShown">
+    backdrop @hide="hide" @mutate="resizeColumnIfShown">
     <template #title>{{ $t('title') }}</template>
     <template #body>
       <div :class="{ backdrop: uploading }">
@@ -53,8 +53,8 @@ except according to the terms contained in the LICENSE file.
           @rows="showWarningRows">
           <template #extra-properties>
             <entity-upload-extra-properties :properties="warnings.extraProperties"
-              :selected="selectedProperties" :disabled="errors != null"
-              @toggle="toggleExtraProperty"/>
+              :selected="selectedProperties" :created="createdProperties"
+              :disabled="errors != null" @toggle="toggleExtraProperty"/>
           </template>
         </entity-upload-warnings>
 
@@ -62,10 +62,12 @@ except according to the terms contained in the LICENSE file.
           :parsing="parsing" @change="selectFile"/>
       </div>
       <entity-upload-popup v-if="uploading" :filename="fileMetadata.name"
-        :count="csvEntities.length" :progress="uploadProgress"/>
+        :count="csvEntities.length"
+        :extra-properties="propertiesToCreate != null"
+        :progress="uploadProgress"/>
       <div ref="actions" class="modal-actions">
         <button type="button" class="btn btn-link" :aria-disabled="uploading"
-          @click="$emit('hide')">
+          @click="hide">
           {{ $t('action.cancel') }}
         </button>
         <button type="button" class="btn btn-primary"
@@ -110,6 +112,7 @@ const props = defineProps({
 const emit = defineEmits(['hide', 'success']);
 
 const { dataset, createResource } = useRequestData();
+const { request, awaitingResponse: uploading } = useRequest();
 
 const pageSizeOptions = [5, 10, 20, 50];
 const defaultPageSize = pageSizeOptions[0];
@@ -179,7 +182,6 @@ const csvEntities = shallowRef(null);
 const fileMetadata = shallowRef(null);
 const errors = shallowRef(null);
 const warnings = shallowRef(null);
-const selectedProperties = reactive(new Set());
 const parsing = ref(false);
 // Function to abort parsing in progress
 let abortParse = noop;
@@ -273,6 +275,7 @@ const rowToEntity = (extraProperties) => (values, columns) => {
   const data = dataset.properties.length !== 0 ? Object.create(null) : null;
   let hasProperty = false;
   const extraData = extraProperties.size !== 0 ? Object.create(null) : null;
+  let hasExtra = false;
   for (const [i, value] of values.entries()) {
     if (value === '') continue; // eslint-disable-line no-continue
 
@@ -284,6 +287,7 @@ const rowToEntity = (extraProperties) => (values, columns) => {
       hasProperty = true;
     } else if (extraProperties.has(column)) {
       extraData[column] = value;
+      hasExtra = true;
     }
   }
 
@@ -291,7 +295,7 @@ const rowToEntity = (extraProperties) => (values, columns) => {
     throw new Error(t('alert.blankLabel'));
 
   const result = { label, data: hasProperty ? data : noPropertyData };
-  if (extraData != null) result.extra = extraData;
+  if (hasExtra) result.extra = extraData;
   return result;
 };
 const { i18n: globalI18n, redAlert } = inject('container');
@@ -365,16 +369,6 @@ const selectFile = (file) => {
 };
 onBeforeUnmount(() => { abortParse(); });
 
-watch(() => props.state, (state) => {
-  if (state) return;
-  abortParse();
-  csvEntities.value = null;
-  fileMetadata.value = null;
-  errors.value = null;
-  warnings.value = null;
-  selectedProperties.clear();
-});
-
 const csvPage = reactive({ page: 0, size: defaultPageSize });
 const csvRow = computed(() =>
   (csvEntities.value != null ? csvPage.page * csvPage.size : -1));
@@ -394,6 +388,7 @@ const showWarningRows = (range) => {
 watch(csvEntities, (value) => { if (value == null) warningRows.value = null; });
 
 // CREATING NEW PROPERTIES
+const selectedProperties = reactive(new Set());
 const toggleExtraProperty = (name, selected) => {
   if (selected)
     selectedProperties.add(name);
@@ -404,26 +399,71 @@ const toggleExtraProperty = (name, selected) => {
 // is not necessarily a subset of warnings.value.extraProperties. Either list
 // may include properties that the other does not. propertiesToCreate represents
 // the intersection of the two lists.
-const propertiesToCreate = computed(() =>
-  warnings.value?.extraProperties?.filter(name => selectedProperties.has(name)));
+const propertiesToCreate = computed(() => {
+  const result = warnings.value?.extraProperties?.filter(name =>
+    selectedProperties.has(name));
+  return result != null && result.length !== 0 ? result : null;
+});
+const createdProperties = reactive(new Set());
+const createProperties = async () => {
+  if (propertiesToCreate.value == null) return;
+  for (const name of propertiesToCreate.value) {
+    if (createdProperties.has(name)) continue; // eslint-disable-line no-continue
+    await request({ // eslint-disable-line no-await-in-loop
+      method: 'POST',
+      url: apiPaths.datasetProperties(dataset.projectId, dataset.name),
+      data: { name }
+    });
+    createdProperties.add(name);
+  }
+};
+const mergeDataWithExtra = (entity) => {
+  if (entity.extra == null) return entity;
 
-const { request, awaitingResponse: uploading } = useRequest();
-const uploadProgress = ref(0);
+  if (propertiesToCreate.value == null)
+    return { label: entity.label, data: entity.data };
+
+  if (propertiesToCreate.value.length === warnings.value.extraProperties.length &&
+    entity.data === noPropertyData)
+    return { label: entity.label, data: entity.extra };
+
+  const merged = Object.create(null);
+  let hasExtra = false;
+  const extraData = entity.extra;
+  for (const name of propertiesToCreate.value) {
+    const value = extraData[name];
+    if (value != null) {
+      merged[name] = value;
+      hasExtra = true;
+    }
+  }
+  if (!hasExtra) return { label: entity.label, data: entity.data };
+  if (entity.data !== noPropertyData) Object.assign(merged, entity.data);
+  return { label: entity.label, data: merged };
+};
+
+// UPLOAD REQUEST
+const uploadProgress = ref(null);
 const upload = () => {
-  const entitiesToSend = csvEntities.value.map(entity => (entity.extra == null
-    ? entity
-    : { label: entity.label, data: entity.data }));
-  request({
-    method: 'POST',
-    url: apiPaths.entities(dataset.projectId, dataset.name),
-    data: {
-      source: pick(['name', 'size'], fileMetadata.value),
-      entities: entitiesToSend
-    },
-    onUploadProgress: (event) => { uploadProgress.value = event.progress ?? 0; }
-  })
-    .then(() => { emit('success', csvEntities.value.length); })
-    .finally(() => { uploadProgress.value = 0; })
+  createProperties()
+    .then(() => {
+      const entitiesToSend = warnings.value?.extraProperties == null
+        ? csvEntities.value
+        : csvEntities.value.map(mergeDataWithExtra);
+      uploadProgress.value = 0;
+      return request({
+        method: 'POST',
+        url: apiPaths.entities(dataset.projectId, dataset.name),
+        data: {
+          source: pick(['name', 'size'], fileMetadata.value),
+          entities: entitiesToSend
+        },
+        onUploadProgress: (event) => { uploadProgress.value = event.progress ?? 0; }
+      }).finally(() => { uploadProgress.value = null; });
+    })
+    .then(() => {
+      emit('success', csvEntities.value.length, createdProperties.size !== 0);
+    })
     .catch(noop);
 };
 
@@ -443,10 +483,18 @@ watch([errors, warnings, csvEntities], () => {
     nextTick(() => { actions.value.scrollIntoView(); });
 });
 
+const hide = () => { emit('hide', createdProperties.size !== 0); };
+
 watch(() => props.state, (state) => {
-  if (!state) {
-    for (const table of tables) table.resetScroll();
-  }
+  if (state) return;
+  abortParse();
+  csvEntities.value = null;
+  fileMetadata.value = null;
+  errors.value = null;
+  warnings.value = null;
+  selectedProperties.clear();
+  createdProperties.clear();
+  for (const table of tables) table.resetScroll();
 });
 </script>
 

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -10,7 +10,7 @@
         <span>{{ $t('action.selectAll') }}</span>
       </label>
       <p v-if="createdAll" :id="disabledMessageId('all')" class="sr-only">
-        {{ $t('created') }}
+        {{ $t('createdAll') }}
       </p>
     </div>
     <div v-for="(name, i) in properties" :key="name" class="checkbox"
@@ -99,7 +99,8 @@ const toggle = (event) => {
       // columns of a table.
       "selectAll": "Select all"
     },
-    "created": "This property was created in a previous upload attempt."
+    "created": "This property was created in a previous upload attempt.",
+    "createdAll": "All properties were created in a previous upload attempt."
   }
 }
 </i18n>

--- a/apps/central/src/components/entity/upload/extra-properties.vue
+++ b/apps/central/src/components/entity/upload/extra-properties.vue
@@ -1,18 +1,29 @@
 <template>
   <div id="entity-upload-extra-properties" @change="toggle">
-    <div v-if="properties.length !== 1" class="checkbox" :class="{ disabled }">
-      <label>
-        <input type="checkbox" :checked="selectedAll" :disabled="disabled"
+    <div v-if="properties.length !== 1" class="checkbox"
+      :class="{ disabled: disabled || createdAll }">
+      <label v-tooltip.sr-only>
+        <input type="checkbox" :checked="selectedAll"
+          :disabled="disabled || createdAll"
+          :aria-describedby="createdAll ? disabledMessageId('all') : null"
           data-select-all="true">
         <span>{{ $t('action.selectAll') }}</span>
       </label>
+      <p v-if="createdAll" :id="disabledMessageId('all')" class="sr-only">
+        {{ $t('created') }}
+      </p>
     </div>
-    <div v-for="name of properties" :key="name" class="checkbox" :class="{ disabled }">
-      <label>
+    <div v-for="(name, i) in properties" :key="name" class="checkbox"
+      :class="{ disabled: disabled || created.has(name) }">
+      <label v-tooltip.sr-only>
         <input type="checkbox" :value="name" :checked="selected.has(name)"
-          :disabled="disabled">
+          :disabled="disabled || created.has(name)"
+          :aria-describedby="created.has(name) ? disabledMessageId(i) : null">
         <span v-tooltip.text>{{ name }}</span>
       </label>
+      <p v-if="created.has(name)" :id="disabledMessageId(i)" class="sr-only">
+        {{ $t('created') }}
+      </p>
     </div>
   </div>
 </template>
@@ -32,12 +43,20 @@ const props = defineProps({
     type: Set,
     required: true
   },
+  created: {
+    type: Set,
+    required: true
+  },
   disabled: Boolean
 });
 const emit = defineEmits(['toggle']);
 
 const selectedAll = computed(() =>
   props.properties.every(name => props.selected.has(name)));
+const createdAll = computed(() =>
+  props.properties.every(name => props.created.has(name)));
+
+const disabledMessageId = (suffix) => `entity-upload-extra-properties-disabled-${suffix}`;
 
 const toggle = (event) => {
   const input = event.target;
@@ -79,7 +98,8 @@ const toggle = (event) => {
       // This is the text of a button that allows the user to select all the
       // columns of a table.
       "selectAll": "Select all"
-    }
+    },
+    "created": "This property was created in a previous upload attempt."
   }
 }
 </i18n>

--- a/apps/central/src/components/entity/upload/popup.vue
+++ b/apps/central/src/components/entity/upload/popup.vue
@@ -37,16 +37,19 @@ const props = defineProps({
     type: Number,
     required: true
   },
-  progress: {
-    type: Number,
-    required: true
-  }
+  extraProperties: Boolean,
+  progress: Number
 });
 
 const { t, n } = useI18n();
-const status = computed(() => (props.progress < 1
-  ? t('status.sending', { percentUploaded: n(props.progress, 'percent') })
-  : t('status.processing')));
+const status = computed(() => {
+  if (props.extraProperties && props.progress == null)
+    return t('status.creatingProperties');
+  const progress = props.progress ?? 0;
+  return progress < 1
+    ? t('status.sending', { percentUploaded: n(props.progress, 'percent') })
+    : t('status.processing');
+});
 </script>
 
 <style lang="scss">
@@ -87,6 +90,7 @@ const status = computed(() => (props.progress < 1
   "en": {
     "rowCount": "{count} data row found | {count} data rows found",
     "status": {
+      "creatingProperties": "Creating new properties…",
       // This text is shown while a file is being uploaded to the server.
       "sending": "Sending file… ({percentUploaded})",
       // This text is shown after a file has been uploaded to the server, but

--- a/apps/central/src/components/entity/upload/table.vue
+++ b/apps/central/src/components/entity/upload/table.vue
@@ -39,7 +39,7 @@ except according to the terms contained in the LICENSE file.
           </td>
           <template v-if="extraProperties != null">
             <td v-for="name of extraProperties" :key="name">
-              <div v-tooltip.text>{{ entity.extra[name] }}</div>
+              <div v-tooltip.text>{{ entity.extra?.[name] }}</div>
             </td>
           </template>
         </tr>

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -642,14 +642,30 @@ describe('EntityUpload', () => {
 
   describe('extra properties', () => {
     beforeEach(() => {
+      mockLogin();
       testData.extendedDatasets.createPast(1, {
         properties: [{ name: 'height' }]
       });
     });
 
-    const extraCSV = createCSV('label,height,circumference,species\ndogwood,1,2,dogwood\nelm');
-    const toggleExtra = (modal, name, checked = true) => {
-      const input = modal.get(`#entity-upload-extra-properties input[value="${name}"]`);
+    const extraCSV = createCSV([
+      // Two extra properties
+      ['label', 'height', 'circumference', 'species'],
+      // No properties missing
+      ['dogwood', '1', '2', 'dogwood'],
+      // All properties missing (both existing and extra)
+      ['elm'],
+      // Existing data properties missing
+      ['pine', '', '3', 'pine'],
+      // All extra properties missing
+      ['oak', '4'],
+      // One extra property missing
+      ['maple', '5', '6'],
+      // The other extra property missing
+      ['spruce', '7', '', 'spruce']
+    ].map(row => row.join(',')).join('\n'));
+    const toggleExtra = (component, name, checked = true) => {
+      const input = component.get(`#entity-upload-extra-properties input[value="${name}"]`);
       input.element.checked.should.equal(!checked);
       return input.setChecked(checked);
     };
@@ -667,17 +683,15 @@ describe('EntityUpload', () => {
       const modal = await showModal();
       await selectFile(modal, extraCSV);
 
-      const tables = modal.findAllComponents(EntityUploadTable);
-      tables.length.should.equal(2);
-      const table = tables[1];
-      table.props().extraProperties.should.eql([]);
+      const table = getTables(modal)[1];
+      should.not.exist(table.props().extraProperties);
 
       const input = modal.get('#entity-upload-extra-properties .checkbox:nth-child(2) input');
       await input.setChecked();
       table.props().extraProperties.should.eql(['circumference']);
 
       await input.setChecked(false);
-      table.props().extraProperties.should.eql([]);
+      should.not.exist(table.props().extraProperties);
     });
 
     it('remembers the property selection until the modal is hidden', async () => {
@@ -690,11 +704,8 @@ describe('EntityUpload', () => {
         const checked = modal.findAll('#entity-upload-extra-properties .checkbox:has(input:checked)');
         return checked.map(div => div.text());
       };
-      const getTableExtra = () => {
-        const tables = modal.findAllComponents(EntityUploadTable);
-        tables.length.should.equal(2);
-        return tables[1].props().extraProperties ?? [];
-      };
+      const getTableExtra = () =>
+        getTables(modal)[1].props().extraProperties ?? [];
 
       await selectFile(modal, extraCSV);
       await toggleExtra(modal, 'circumference');
@@ -767,7 +778,80 @@ describe('EntityUpload', () => {
       extraComponent.props().disabled.should.be.true;
     });
 
-    it('does not send properties that were not selected', () =>
+    it('sends all extra properties if all were selected', () =>
+      showModal()
+        .complete()
+        .request(async (modal) => {
+          await selectFile(modal, extraCSV);
+          await toggleExtra(modal, 'circumference');
+          await toggleExtra(modal, 'species');
+          return modal.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .respondWithSuccess()
+        .respondWithSuccess()
+        .respondWithProblem()
+        .testRequests([
+          {
+            method: 'POST',
+            url: '/v1/projects/1/datasets/trees/properties',
+            data: { name: 'circumference' }
+          },
+          {
+            method: 'POST',
+            url: '/v1/projects/1/datasets/trees/properties',
+            data: { name: 'species' }
+          },
+          {
+            method: 'POST',
+            url: '/v1/projects/1/datasets/trees/entities',
+            data: {
+              source: { name: 'my_data.csv', size: extraCSV.size },
+              entities: [
+                { label: 'dogwood', data: { circumference: '2', species: 'dogwood', height: '1' } },
+                { label: 'elm' },
+                { label: 'pine', data: { circumference: '3', species: 'pine' } },
+                { label: 'oak', data: { height: '4' } },
+                { label: 'maple', data: { circumference: '6', height: '5' } },
+                { label: 'spruce', data: { species: 'spruce', height: '7' } }
+              ]
+            }
+          }
+        ]));
+
+    it('does not send all extra properties if only some were selected', () =>
+      showModal()
+        .complete()
+        .request(async (modal) => {
+          await selectFile(modal, extraCSV);
+          await toggleExtra(modal, 'circumference');
+          return modal.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .respondWithSuccess()
+        .respondWithProblem()
+        .testRequests([
+          {
+            method: 'POST',
+            url: '/v1/projects/1/datasets/trees/properties',
+            data: { name: 'circumference' }
+          },
+          {
+            method: 'POST',
+            url: '/v1/projects/1/datasets/trees/entities',
+            data: {
+              source: { name: 'my_data.csv', size: extraCSV.size },
+              entities: [
+                { label: 'dogwood', data: { circumference: '2', height: '1' } },
+                { label: 'elm' },
+                { label: 'pine', data: { circumference: '3' } },
+                { label: 'oak', data: { height: '4' } },
+                { label: 'maple', data: { circumference: '6', height: '5' } },
+                { label: 'spruce', data: { height: '7' } }
+              ]
+            }
+          }
+        ]));
+
+    it('does not send extra properties if none were selected', () =>
       showModal()
         .complete()
         .request(async (modal) => {
@@ -779,15 +863,182 @@ describe('EntityUpload', () => {
           method: 'POST',
           url: '/v1/projects/1/datasets/trees/entities',
           data: {
-            source: { name: 'my_data.csv', size: 58 },
+            source: { name: 'my_data.csv', size: extraCSV.size },
             entities: [
               { label: 'dogwood', data: { height: '1' } },
-              // Don't bother sending an empty `data` object.
-              { label: 'elm' }
+              { label: 'elm' },
+              { label: 'pine' },
+              { label: 'oak', data: { height: '4' } },
+              { label: 'maple', data: { height: '5' } },
+              { label: 'spruce', data: { height: '7' } }
             ]
           }
         }]));
 
-    it('does not create properties that were selected, but are not in current CSV');
+    it('does not create properties that were selected, but are not in current CSV', () =>
+      showModal()
+        .complete()
+        .request(async (modal) => {
+          await selectFile(modal, createCSV('label,foo\ndogwood,x'));
+          await toggleExtra(modal, 'foo');
+          await selectFile(modal, extraCSV);
+          return modal.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .respondWithProblem()
+        .testRequests([{
+          method: 'POST',
+          url: '/v1/projects/1/datasets/trees/entities',
+          data: {
+            source: { name: 'my_data.csv', size: extraCSV.size },
+            entities: [
+              { label: 'dogwood', data: { height: '1' } },
+              { label: 'elm' },
+              { label: 'pine' },
+              { label: 'oak', data: { height: '4' } },
+              { label: 'maple', data: { height: '5' } },
+              { label: 'spruce', data: { height: '7' } }
+            ]
+          }
+        }]));
+
+    it('shows a popup during the request', () =>
+      showModal()
+        .complete()
+        .request(async (modal) => {
+          await selectFile(modal, extraCSV);
+          await toggleExtra(modal, 'circumference');
+          await toggleExtra(modal, 'species');
+          return modal.get('.modal-actions .btn-primary').trigger('click');
+        })
+        .beforeEachResponse((modal, config, i) => {
+          const popup = modal.getComponent(EntityUploadPopup);
+          popup.props().extraProperties.should.be.true;
+          if (i < 2)
+            should.not.exist(popup.props().progress);
+          else
+            popup.props().progress.should.equal(0);
+        })
+        .respondWithSuccess()
+        .respondWithSuccess()
+        .respondWithProblem());
+
+    describe('refreshing the list of properties', () => {
+      const upload = (names) => load('/projects/1/entity-lists/trees/entities')
+        .complete()
+        .request(async (component) => {
+          await component.get('#dataset-entities-upload-button').trigger('click');
+          const modal = component.getComponent(EntityUpload);
+          await selectFile(modal, extraCSV);
+          for (const name of names) await toggleExtra(modal, name);
+          return modal.get('.modal-actions .btn-primary').trigger('click');
+        });
+      const getCreated = (app) => {
+        const { created } = app.getComponent(EntityUploadExtraProperties).props();
+        return [...created];
+      };
+      const respondWithExtra = (names) => (series) => series.respondWithData(() => {
+        for (const name of names)
+          testData.extendedDatasets.addProperty(-1, name);
+        return testData.extendedDatasets.last();
+      });
+
+      it('updates the list of properties on success', () =>
+        upload(['circumference'])
+          .respondWithSuccess() // Property creation
+          .respondWithSuccess() // Upload
+          .modify(respondWithExtra(['circumference']))
+          .respondWithData(testData.entityOData)
+          .testRequests([
+            null,
+            null,
+            {
+              url: '/v1/projects/1/datasets/trees',
+              extended: true
+            },
+            {
+              url: ({ pathname }) => {
+                pathname.should.equal('/v1/projects/1/datasets/trees.svc/Entities');
+              }
+            }
+          ]));
+
+      it('handles an upload error after property creation', () =>
+        upload(['circumference'])
+          .respondWithSuccess() // Property creation
+          .respondWithProblem() // Upload
+          .afterResponses(app => {
+            getCreated(app).should.eql(['circumference']);
+
+            // Even though the entity list has a new property, that shouldn't be
+            // fully reflected in the modal yet. We want the modal to stay as
+            // similar/stable as possible over the course of this error case.
+            const th = getTables(app)[0].findAll('th').map(wrapper => wrapper.text());
+            th.should.eql(['Row', 'label', 'height']);
+          })
+          // Try to upload again. This time, it should only send the upload
+          // request.
+          .request(app =>
+            app.get('#entity-upload .modal-actions .btn-primary').trigger('click'))
+          .beforeEachResponse((_, { method, url }) => {
+            method.should.equal('POST');
+            url.should.equal('/v1/projects/1/datasets/trees/entities');
+          })
+          .respondWithProblem()
+          .complete()
+          // Select an additional property, then upload. It should send a
+          // request to create the additional property.
+          .request(async (app) => {
+            await toggleExtra(app, 'species');
+            return app.get('#entity-upload .modal-actions .btn-primary').trigger('click');
+          })
+          .beforeEachResponse((_, { method, url, data }, i) => {
+            method.should.equal('POST');
+            if (i === 0) {
+              url.should.equal('/v1/projects/1/datasets/trees/properties');
+              data.should.eql({ name: 'species' });
+            } else {
+              url.should.equal('/v1/projects/1/datasets/trees/entities');
+            }
+          })
+          .respondWithSuccess() // Property creation
+          .respondWithProblem() // Upload
+          .afterResponses(app => {
+            getCreated(app).should.eql(['circumference', 'species']);
+          })
+          // Try to upload once last time. This time, it will be successful.
+          .request(app =>
+            app.get('#entity-upload .modal-actions .btn-primary').trigger('click'))
+          .respondWithSuccess()
+          .modify(respondWithExtra(['circumference', 'species']))
+          .respondWithData(testData.entityOData)
+          .testRequests([
+            null,
+            {
+              url: '/v1/projects/1/datasets/trees',
+              extended: true
+            },
+            {
+              url: ({ pathname }) => {
+                pathname.should.equal('/v1/projects/1/datasets/trees.svc/Entities');
+              }
+            }
+          ]));
+
+      it('updates the list of properties if the modal is closed', () =>
+        upload(['circumference'])
+          .respondWithSuccess() // Property creation
+          .respondWithProblem() // Upload
+          .complete()
+          // Abandon the upload; just close the modal.
+          .request(app =>
+            app.get('#entity-upload .modal-actions .btn-link').trigger('click'))
+          .modify(respondWithExtra(['circumference']))
+          .testRequests([
+            {
+              url: '/v1/projects/1/datasets/trees',
+              extended: true
+            }
+          ]));
+    });
   });
 });

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -1038,7 +1038,22 @@ describe('EntityUpload', () => {
               url: '/v1/projects/1/datasets/trees',
               extended: true
             }
-          ]));
+          ])
+          // Open the modal again now that the list of properties has been
+          // updated. The modal should no longer remember that `circumference`
+          // was created. If the modal is closed, it should not update the list
+          // of properties again.
+          .afterResponse(async (app) => {
+            await app.get('#dataset-entities-upload-button').trigger('click');
+            const modal = app.getComponent(EntityUpload);
+            await selectFile(modal, extraCSV);
+            const warnings = modal.getComponent(EntityUploadWarnings);
+            // `circumference` is no longer in the list of extraProperties.
+            warnings.props().extraProperties.should.eql(['species']);
+            getCreated(modal).should.eql([]);
+          })
+          .testNoRequest(app =>
+            app.get('#entity-upload .modal-actions .btn-link').trigger('click')));
     });
   });
 });

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -4,7 +4,7 @@ import { mergeMountOptions, mount } from '../../../util/lifecycle';
 
 const mountComponent = (options) =>
   mount(EntityUploadExtraProperties, mergeMountOptions(options, {
-    props: { selected: new Set() }
+    props: { selected: new Set(), created: new Set() }
   }));
 
 describe('EntityUploadExtraProperties', () => {
@@ -46,6 +46,43 @@ describe('EntityUploadExtraProperties', () => {
       checkbox.classes('disabled').should.be.true;
       checkbox.get('input').element.disabled.should.be.true;
     }
+  });
+
+  describe('created prop', () => {
+    it('disables a property that has been created already', async () => {
+      const component = mountComponent({
+        props: {
+          properties: ['foo', 'bar'],
+          selected: new Set(['foo']),
+          created: new Set(['foo'])
+        }
+      });
+      const checkboxes = component.findAll('.checkbox');
+      const hasClass = checkboxes.map(checkbox => checkbox.classes('disabled'));
+      hasClass.should.eql([false, true, false]);
+      const disabled = checkboxes.map(checkbox => checkbox.get('input').element.disabled);
+      disabled.should.eql([false, true, false]);
+      checkboxes[1].get('input').should.have.ariaDescription(/^This property was created/);
+      await checkboxes[1].get('label').should.have.tooltip(/^This property was created/);
+    });
+
+    it('disables "Select all" if all properties have been created already', async () => {
+      const component = mountComponent({
+        props: {
+          properties: ['foo', 'bar'],
+          selected: new Set(['foo', 'bar']),
+          created: new Set(['foo', 'bar'])
+        }
+      });
+      const checkboxes = component.findAll('.checkbox');
+      checkboxes.length.should.equal(3);
+      for (const checkbox of checkboxes) {
+        checkbox.classes('disabled').should.be.true;
+        checkbox.get('input').element.disabled.should.be.true;
+      }
+      checkboxes[0].get('input').should.have.ariaDescription(/^This property was created/);
+      await checkboxes[0].get('label').should.have.tooltip(/^This property was created/);
+    });
   });
 
   it('emits a toggle event when a property is checked', async () => {

--- a/apps/central/test/components/entity/upload/extra-properties.spec.js
+++ b/apps/central/test/components/entity/upload/extra-properties.spec.js
@@ -80,8 +80,8 @@ describe('EntityUploadExtraProperties', () => {
         checkbox.classes('disabled').should.be.true;
         checkbox.get('input').element.disabled.should.be.true;
       }
-      checkboxes[0].get('input').should.have.ariaDescription(/^This property was created/);
-      await checkboxes[0].get('label').should.have.tooltip(/^This property was created/);
+      checkboxes[0].get('input').should.have.ariaDescription(/^All properties were created/);
+      await checkboxes[0].get('label').should.have.tooltip(/^All properties were created/);
     });
   });
 

--- a/apps/central/test/components/entity/upload/popup.spec.js
+++ b/apps/central/test/components/entity/upload/popup.spec.js
@@ -38,5 +38,13 @@ describe('EntityUploadPopup', () => {
       const text = component.get('#entity-upload-popup-status').text();
       text.should.equal('Processing file…');
     });
+
+    it('shows if new properties are being created', () => {
+      const component = mountComponent({
+        props: { extraProperties: true, progress: null }
+      });
+      const text = component.get('#entity-upload-popup-status').text();
+      text.should.equal('Creating new properties…');
+    });
   });
 });

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2892,6 +2892,9 @@
       },
       "created": {
         "string": "This property was created in a previous upload attempt."
+      },
+      "createdAll": {
+        "string": "All properties were created in a previous upload attempt."
       }
     },
     "EntityUploadFileSelect": {

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2889,6 +2889,9 @@
           "string": "Select all",
           "developer_comment": "This is the text of a button that allows the user to select all the columns of a table."
         }
+      },
+      "created": {
+        "string": "This property was created in a previous upload attempt."
       }
     },
     "EntityUploadFileSelect": {
@@ -2917,6 +2920,9 @@
         "string": "{count, plural, one {{count} data row found} other {{count} data rows found}}"
       },
       "status": {
+        "creatingProperties": {
+          "string": "Creating new properties…"
+        },
         "sending": {
           "string": "Sending file… ({percentUploaded})",
           "developer_comment": "This text is shown while a file is being uploaded to the server."


### PR DESCRIPTION
This PR makes progress on getodk/central#1786. Up until now, the user could see unknown/extra properties in their CSV file. They could select which ones to create. However, Frontend wouldn't actually send the requests to create the properties, and it wouldn't include the extra properties' data in the upload request to create new entities. This PR changes that, implementing the last main piece of getodk/central#1786.

#### What has been done to verify that this works as intended?

New tests. There were a couple of places in particular that I tried to make sure we had test coverage:

1. Verifying what data is sent to Backend; including the correct subset of extra properties and merging their data with the data for the existing entity properties
    - In particular, `mergeDataWithExtra()` has a lot of branches. I tried to cover them all in at least one test though.
2. Error cases
    - What if one property is created, but not another
    - What if properties are created, but then the subsequent upload fails

#### Why is this the best possible solution? Were any other approaches considered?

**Performance**

I'm a little concerned about the memory footprint associated with the definition `entitiesToSend`: the fact that we're creating a whole new array for the entity data to send to Backend (which, depending on the property selection, may differ from the entity data we've parsed from the CSV). For that reason, I've tried to make `mergeDataWithExtra()` as efficient as possible:

- Don't create the new array or call `mergeDataWithExtra()` if there aren't any extra properties
- Within `mergeDataWithExtra()`, don't create new objects or iterate over properties unless necessary. If there's a well-defined case that will be reasonably common where we can return early with a simpler result, do that instead of doing the full merge of the `data` and `extra` objects.
  - Example 1: `propertiesToCreate.value == null`. The user uploaded a file with extra properties, but then didn't select any. Just use the `data` object rather than creating a new object to merge `data` and `extra`.
  - Example 2: `propertiesToCreate.value.length === warnings.value.extraProperties.length &&
    entity.data === noPropertyData`. The user uploaded a file with extra properties, then selected all the properties. The file had one or more entities that didn't have any data for existing entity properties (perhaps because the entity list doesn't have any properties yet). I think this will be common if the user uploads their entity data right after creating the entity list (before explicitly creating any entity properties).

**Error cases**

I also thought about error cases. Hopefully they aren't too common, but I think they will definitely happen, so it's important to cover them. For example, getodk/central#691 is still a live issue. You could imagine a user attempting an upload, successfully creating their new properties, but then seeing the actual upload request fail. The end state is that the properties have been created, but their entities haven't been created yet (or at least so it seems).

What I've implemented is that 