### PR TITLE
Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it

### DIFF
--- a/.changeset/bumpy-donuts-yell.md
+++ b/.changeset/bumpy-donuts-yell.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": patch
+---
+
+Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. [Central#1962](https://github.com/getodk/central/issues/1962)

--- a/.changeset/bumpy-donuts-yell.md
+++ b/.changeset/bumpy-donuts-yell.md
@@ -2,4 +2,4 @@
 "@getodk/central-frontend": patch
 ---
 
-Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. [Central#1962](https://github.com/getodk/central/issues/1962)
+Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962

--- a/apps/central/src/components/form/edit/draft-controls.vue
+++ b/apps/central/src/components/form/edit/draft-controls.vue
@@ -47,7 +47,7 @@ const abandonText = computed(() => (!form.dataExists
 <style lang="scss">
 #form-edit-draft-controls {
   text-align: center;
-  margin: 20px 0;
+  margin: 20px 0 100px 0;
 
   .title {
     font-size: 16px;


### PR DESCRIPTION
Closes https://github.com/getodk/central/issues/1962

<img width="1452" height="1007" alt="image" src="https://github.com/user-attachments/assets/fe14ca74-989a-4c19-a653-8805f5b1d27c" />
