### PR TITLE
Truncate tooltips after a certain number of lines

### DIFF
--- a/.changeset/wild-candles-sit.md
+++ b/.changeset/wild-candles-sit.md
@@ -1,0 +1,5 @@
+---
+"@getodk/central-frontend": minor
+---
+
+Truncate overflowing tooltips (getodk/central#2183)

--- a/apps/central/src/assets/scss/app.scss
+++ b/apps/central/src/assets/scss/app.scss
@@ -126,8 +126,9 @@ em { @include italic; }
   left: -1000px;
 }
 .tooltip-inner {
+  @include line-clamp(32);
   border-radius: 2px;
-  max-height: 100vh;
+  max-height: 95vh;
   overflow-wrap: break-word;
   padding-bottom: 2px;
   // Allow the text to have line breaks.


### PR DESCRIPTION
This PR closes getodk/central#2183. It truncates tooltips after 32 lines of text.

#### What has been done to verify that this works as intended?

I tried it out locally. I didn't write a new test, as it's just style changes.

#### Why is this the best possible solution? Were any other approaches considered?

I'm using the `line-clamp` mixin to truncate the tooltip after 32 lines of text. I chose the number 32 somewhat randomly. In local development, 30 visually looked a little too short, while 40 seemed too tall.

An alternative is that I could have just set `overflow: hidden;` The tooltip has a `max-height`, so `overflow: hidden;` would have been enough to prevent the content of the tooltip from overflowing the tooltip. However, I think the ellipsis is a nice indicator that the text of the tooltip is truncated.

I've also reduced the `max-height` from 100vh to 95vh. I don't think it works well for a tooltip to get super tall or to use the entire height of the viewport.