### PR TITLE
Update warning colors

### DIFF
--- a/apps/central/src/assets/scss/_variables.scss
+++ b/apps/central/src/assets/scss/_variables.scss
@@ -43,8 +43,8 @@ $color-info: #31708f;
 $color-info-light: #d9edf7;
 $color-info-dark: darken($color-info, 10%);
 $color-warning: #f29e00;
-$color-warning-light: #f5c93b;
-$color-warning-dark: #e06f0b;
+$color-warning-light: #F5E9D9;
+$color-warning-dark: #BF6A02;
 $color-danger: #de2a11;
 $color-danger-lighter: #dd5454; // Between $color-danger and $color-danger-light
 $color-danger-light: #ffe6e6;


### PR DESCRIPTION
This PR makes progress on getodk/central#1904. It updates two Sass variables related to the color of warnings:

Variable | Old color | New color
:-- | :-- | :--
`$color-warning-light` | `#f5c93b` | `#F5E9D9`
`$color-warning-dark` | `#e06f0b` | `#BF6A02`

I checked with Nicole, and the intention is to use these new colors across Frontend, not just in the `EntityUpload` modal.

#### What has been done to verify that this works as intended?

I tried out the new colors locally.

#### Why is this the best possible solution? Were any other approaches considered?

I searched for current uses of `$color-warning-light` and `$color-warning-dark`. For none of them did it strike me that these color changes would be problematic.

One thing I wondered was whether to change `$color-warning` or `$color-warning-dark`. For errors ("danger"), there are several places where we use `$color-danger-light` for the background color and `$color-danger` for the text — not `$color-danger-dark`. Yet for `EntityUpload`, we use `$color-warning-light` and `$color-warning-dark` — not `$color-warning`. So consistency would suggest changing `$color-warning` and using that in `EntityUpload` instead of `$color-warning-dark`.

However, ultimately I decided to change `$color-warning-dark` instead of `$color-warning`. The new color is darker than the current `$color-warning-dark`, so I didn't think it made sense to update `$color-warning`. That would have made it darker than `$color-warning-dark`.

One other thing I did was search the codebase for the new colors. I wanted to make sure they weren't already in use in some component.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Just color changes. If there are any places where the new colors really don't work, hopefully we'll discover that during regression testing.