### PR TITLE
Style lists in EntityUpload errors/warnings

### DIFF
--- a/apps/central/src/components/entity/upload/errors.vue
+++ b/apps/central/src/components/entity/upload/errors.vue
@@ -34,7 +34,7 @@
           <sentence-separator/>
           <span>{{ $tc('duplicateColumn.headersReused', duplicateColumns.length) }}</span>
         </p>
-        <p><i18n-list :list="duplicateColumns"/></p>
+        <entity-upload-property-list :names="duplicateColumns"/>
       </template>
     </entity-upload-alert>
     <entity-upload-alert v-if="emptyColumn" type="danger">
@@ -57,7 +57,7 @@
 import { computed } from 'vue';
 
 import EntityUploadAlert from './alert.vue';
-import I18nList from '../../i18n/list.vue';
+import EntityUploadPropertyList from './property-list.vue';
 import SentenceSeparator from '../../sentence-separator.vue';
 
 import { formatCSVDelimiter } from '../../../util/csv';

--- a/apps/central/src/components/entity/upload/property-list.vue
+++ b/apps/central/src/components/entity/upload/property-list.vue
@@ -1,8 +1,6 @@
 <template>
   <ul class="entity-upload-property-list">
-    <li v-for="name of names" :key="name">
-      <span v-tooltip.text>{{ name }}</span>
-    </li>
+    <li v-for="name of names" :key="name" v-tooltip.text>{{ name }}</li>
   </ul>
 </template>
 
@@ -32,13 +30,7 @@ defineProps({
   padding-left: 0;
 
   li {
-    // Needed for text-overflow-ellipsis.
-    overflow: hidden;
-  }
-
-  span {
     @include text-overflow-ellipsis;
-    display: inline-block;
     background-color: rgba(255, 255, 255, 0.5);
     border-radius: 20px;
     max-width: 275px;

--- a/apps/central/src/components/entity/upload/property-list.vue
+++ b/apps/central/src/components/entity/upload/property-list.vue
@@ -1,0 +1,48 @@
+<template>
+  <ul class="entity-upload-property-list">
+    <li v-for="name of names" :key="name">
+      <span v-tooltip.text>{{ name }}</span>
+    </li>
+  </ul>
+</template>
+
+<script setup>
+defineOptions({
+  name: 'EntityUploadPropertyList'
+});
+defineProps({
+  names: {
+    type: Array,
+    required: true
+  }
+});
+</script>
+
+<style lang="scss">
+@import '../../../assets/scss/mixins';
+
+.entity-upload-property-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  max-height: 135px;
+  overflow-y: auto;
+  margin-block: -2px 0;
+  padding-left: 0;
+
+  li {
+    // Needed for text-overflow-ellipsis.
+    overflow: hidden;
+  }
+
+  span {
+    @include text-overflow-ellipsis;
+    display: inline-block;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 20px;
+    max-width: 275px;
+    padding: 4px 8px;
+  }
+}
+</style>

--- a/apps/central/src/components/entity/upload/warnings.vue
+++ b/apps/central/src/components/entity/upload/warnings.vue
@@ -19,7 +19,7 @@ except according to the terms contained in the LICENSE file.
       <template #title>{{ $t('systemProperties') }}</template>
       <template #body>
         <p>{{ $tc('propertiesIgnored', systemProperties.length) }}</p>
-        <p><i18n-list :list="systemProperties"/></p>
+        <entity-upload-property-list :names="systemProperties"/>
       </template>
     </entity-upload-alert>
     <entity-upload-alert v-if="caseMismatch != null"
@@ -53,7 +53,7 @@ except according to the terms contained in the LICENSE file.
       <template #title>{{ $tc('invalidProperties', invalidProperties.length) }}</template>
       <template #body>
         <p>{{ $tc('propertiesIgnored', invalidProperties.length) }}</p>
-        <p><i18n-list :list="invalidProperties"/></p>
+        <entity-upload-property-list :names="invalidProperties"/>
       </template>
     </entity-upload-alert>
     <entity-upload-alert v-if="missingProperties != null" type="warning">
@@ -62,7 +62,7 @@ except according to the terms contained in the LICENSE file.
       </template>
       <template #body>
         <p>{{ $tc('missingProperties.description', missingProperties.length) }}</p>
-        <p><i18n-list :list="missingProperties"/></p>
+        <entity-upload-property-list :names="missingProperties"/>
       </template>
     </entity-upload-alert>
 
@@ -113,7 +113,7 @@ except according to the terms contained in the LICENSE file.
 
 <script setup>
 import EntityUploadAlert from './alert.vue';
-import I18nList from '../../i18n/list.vue';
+import EntityUploadPropertyList from './property-list.vue';
 import SentenceSeparator from '../../sentence-separator.vue';
 
 defineOptions({

--- a/apps/central/test/components/entity/upload/errors.spec.js
+++ b/apps/central/test/components/entity/upload/errors.spec.js
@@ -1,5 +1,5 @@
-import { nextTick } from 'vue';
-
+import EntityUploadAlert from '../../../../src/components/entity/upload/alert.vue';
+import EntityUploadPropertyList from '../../../../src/components/entity/upload/property-list.vue';
 import EntityUploadErrors from '../../../../src/components/entity/upload/errors.vue';
 
 import { mergeMountOptions, mount } from '../../../util/lifecycle';
@@ -42,17 +42,14 @@ describe('EntityUploadErrors', () => {
     });
   });
 
-  it('shows an error if there are duplicate column headers', async () => {
+  it('shows an error if there are duplicate column headers', () => {
     const component = mountComponent({
       props: { duplicateColumns: ['height', 'species'] }
     });
-    // Wait for I18nList to render.
-    await nextTick();
-
-    const p = component.get('.entity-upload-alert').findAll('p');
-    p.length.should.equal(3);
-    p[0].text().should.equal('Duplicate column headers');
-    p[2].text().should.equal('height, species');
+    const alert = component.getComponent(EntityUploadAlert);
+    alert.get('p').text().should.equal('Duplicate column headers');
+    const list = component.getComponent(EntityUploadPropertyList);
+    expect(list.props().names).to.eql(['height', 'species']);
   });
 
   it('shows a data error', () => {

--- a/apps/central/test/components/entity/upload/property-list.spec.js
+++ b/apps/central/test/components/entity/upload/property-list.spec.js
@@ -12,6 +12,6 @@ describe('EntityUploadPropertyList', () => {
     const li = component.findAll('li');
     const text = li.map(wrapper => wrapper.text());
     text.should.eql(['my_property', 'another_property']);
-    await li[0].get('span').should.have.textTooltip();
+    await li[0].should.have.textTooltip();
   });
 });

--- a/apps/central/test/components/entity/upload/property-list.spec.js
+++ b/apps/central/test/components/entity/upload/property-list.spec.js
@@ -1,0 +1,17 @@
+import EntityUploadPropertyList from '../../../../src/components/entity/upload/property-list.vue';
+
+import { mount } from '../../../util/lifecycle';
+
+const mountComponent = (options) => mount(EntityUploadPropertyList, options);
+
+describe('EntityUploadPropertyList', () => {
+  it('renders an item for each property', async () => {
+    const component = mountComponent({
+      props: { names: ['my_property', 'another_property'] }
+    });
+    const li = component.findAll('li');
+    const text = li.map(wrapper => wrapper.text());
+    text.should.eql(['my_property', 'another_property']);
+    await li[0].get('span').should.have.textTooltip();
+  });
+});

--- a/apps/central/test/components/entity/upload/warnings.spec.js
+++ b/apps/central/test/components/entity/upload/warnings.spec.js
@@ -1,6 +1,5 @@
-import { nextTick } from 'vue';
-
 import EntityUploadAlert from '../../../../src/components/entity/upload/alert.vue';
+import EntityUploadPropertyList from '../../../../src/components/entity/upload/property-list.vue';
 import EntityUploadWarnings from '../../../../src/components/entity/upload/warnings.vue';
 
 import { mergeMountOptions, mount } from '../../../util/lifecycle';
@@ -11,17 +10,14 @@ const mountComponent = (options) =>
   }));
 
 describe('EntityUploadWarnings', () => {
-  it('shows a warning for system properties', async () => {
+  it('shows a warning for system properties', () => {
     const component = mountComponent({
       props: { systemProperties: ['__id', '__foo'] }
     });
-    // Wait for I18nList to render.
-    await nextTick();
-
-    const p = component.getComponent(EntityUploadAlert).findAll('p');
-    p.length.should.equal(3);
-    p[0].text().should.startWith('System properties can’t be set');
-    p[2].text().should.equal('__id, __foo');
+    const warning = component.getComponent(EntityUploadAlert);
+    warning.get('p').text().should.startWith('System properties can’t be set');
+    const list = component.getComponent(EntityUploadPropertyList);
+    expect(list.props().names).to.eql(['__id', '__foo']);
   });
 
   it('shows a warning for columns that differ from properties on letter case', async () => {
@@ -52,30 +48,25 @@ describe('EntityUploadWarnings', () => {
     await table.get('td').should.have.textTooltip();
   });
 
-  it('shows a warning for columns that are invalid property names', async () => {
+  it('shows a warning for columns that are invalid property names', () => {
     const component = mountComponent({
       props: { invalidProperties: ['First name', 'phone#'] }
     });
-    // Wait for I18nList to render.
-    await nextTick();
-
-    const p = component.getComponent(EntityUploadAlert).findAll('p');
-    p.length.should.equal(3);
-    p[0].text().should.equal('These columns are not valid property names');
-    p[2].text().should.equal('First name, phone#');
+    const warning = component.getComponent(EntityUploadAlert);
+    const title = warning.get('p').text();
+    title.should.startWith('These columns are not valid property names');
+    const list = component.getComponent(EntityUploadPropertyList);
+    expect(list.props().names).to.eql(['First name', 'phone#']);
   });
 
-  it('shows a warning for missing properties', async () => {
+  it('shows a warning for missing properties', () => {
     const component = mountComponent({
       props: { missingProperties: ['foo', 'bar'] }
     });
-    // Wait for I18nList to render.
-    await nextTick();
-
-    const p = component.getComponent(EntityUploadAlert).findAll('p');
-    p.length.should.equal(3);
-    p[0].text().should.equal('Properties not found in file');
-    p[2].text().should.equal('foo, bar');
+    const warning = component.getComponent(EntityUploadAlert);
+    warning.get('p').text().should.equal('Properties not found in file');
+    const list = component.getComponent(EntityUploadPropertyList);
+    expect(list.props().names).to.eql(['foo', 'bar']);
   });
 
   describe('unknown (extra) properties', () => {


### PR DESCRIPTION
This PR makes progress on getodk/central#1904:

> In errors and warnings, show properties/columns as a list of space-separated pills/ovals, not a comma-separated text list

#### What has been done to verify that this works as intended?

New and updated tests. I also tried it out locally.