### PR TITLE
fix(web-forms#898): blocks users resubmitting single submission forms

### DIFF
--- a/.changeset/dull-brooms-prove.md
+++ b/.changeset/dull-brooms-prove.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Fixed a bug where a single submission form could be resubmitted by keyboard navigation.

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -143,7 +143,7 @@ const handleResult = () => {
   // Success handler
   if (submissionResult.primaryInstanceResult.success && attachmentResultArr.every(r => r.success)) {
 
-    clearForm();
+    clearForm(props.form.once ? {} : { next: POST_SUBMIT__NEW_INSTANCE });
 
     if (isPublicLink.value) {
       visibleModal.value = { type: 'thankYouModal', hideable: false };
@@ -226,7 +226,7 @@ const submitData = async () => {
   handleResult();
 };
 
-const initializeSubmissionState = (data:SubmissionData, clearFormCallback:Function) => {
+const initializeSubmissionState = (data: SubmissionData) => {
   submissionData = data;
 
   submissionResult.primaryInstanceResult = {
@@ -239,17 +239,13 @@ const initializeSubmissionState = (data:SubmissionData, clearFormCallback:Functi
       success: false
     });
   });
-
-  clearForm = () => {
-    clearFormCallback({ next: POST_SUBMIT__NEW_INSTANCE });
-  };
 };
 
 const webFormLoaded = () => {
   hideSpinner();
 };
 
-const updateLastSaved = (hasLastSaved) => {
+const updateLastSaved = (hasLastSaved: boolean) => {
   if (!isEdit.value
     && !props.form.draft
     && submissionResult.primaryInstanceResult.success
@@ -279,7 +275,13 @@ const handleSubmit = async (
     // hence this branch should never execute.
     return;
   }
-  initializeSubmissionState(data as unknown as SubmissionData, clearFormCallback);
+  if (alreadySubmittedOnce()) {
+    // The user has already submitted a single submission form - should not get here.
+    return;
+  }
+  initializeSubmissionState(data as unknown as SubmissionData);
+  clearForm = clearFormCallback;
+
   await submitData();
   updateLastSaved(hasLastSaved);
 };
@@ -308,8 +310,12 @@ const editInstanceOptions = computed(() => {
   return null;
 });
 
+const alreadySubmittedOnce = () => {
+  return props.form.once && props.form.enketoOnceId && hasSubmitted(props.form.enketoOnceId);
+};
+
 onMounted(async () => {
-  if (props.form.once && props.form.enketoOnceId && hasSubmitted(props.form.enketoOnceId)) {
+  if (alreadySubmittedOnce()) {
     visibleModal.value = { type: 'thankYouModal', hideable: false };
     webFormLoaded(); // hide the spinner
     return;


### PR DESCRIPTION
Closes getodk/web-forms#898

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Testing

#### Why is this the best possible solution? Were any other approaches considered?

I also considered removing the form from the page altogether, but that felt disruptive when this was likely to be unintentional, and the feature isn't designed to be bullet proof.

Another option would be to introduce another constant like `POST_SUBMIT__NEW_INSTANCE`, for example, `POST_SUBMIT__DISABLE` which could disable the submit button in WF, and also potentially disable all the input fields. In this case I preferred to keep the changes on the app side.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
