### PR TITLE
Show viewAs only when useful and change text from "Viewing as" to "View as"

### DIFF
--- a/apps/central/src/components/entity/filters/view-as.vue
+++ b/apps/central/src/components/entity/filters/view-as.vue
@@ -1,5 +1,6 @@
 <template>
-  <label id="entity-filters-view-as" class="form-group" :class="{ disabled }">
+  <label v-if="showViewAs" id="entity-filters-view-as" class="form-group"
+    :class="{ disabled }">
     <span>{{ $t('viewAs') }}</span>
     <div class="display-value" aria-hidden="true">
       {{ displayValue }}
@@ -42,7 +43,10 @@ const props = defineProps({
     required: false
   }
 });
-const { fieldKeys } = useRequestData();
+const { dataset, fieldKeys } = useRequestData();
+
+const showViewAs = computed(() =>
+  dataset.dataExists && dataset.accessFilter != null);
 
 const displayValue = computed(() => {
   if (props.modelValue == null) return t('noUserSelected');
@@ -89,7 +93,7 @@ const onChange = (value) => {
 {
   "en": {
     "noUserSelected": "Me",
-    "viewAs": "Viewing As",
+    "viewAs": "View As",
   }
 }
 </i18n>

--- a/apps/central/test/components/entity/filters.spec.js
+++ b/apps/central/test/components/entity/filters.spec.js
@@ -405,7 +405,9 @@ describe('EntityFilters', () => {
 
   describe('view-as filter', () => {
     beforeEach(() => {
-      testData.extendedDatasets.createPast(1);
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: { type: 'ownerOnly' }
+      });
       testData.extendedFieldKeys.createPast(1);
     });
 

--- a/apps/central/test/components/entity/filters.spec.js
+++ b/apps/central/test/components/entity/filters.spec.js
@@ -366,7 +366,10 @@ describe('EntityFilters', () => {
   });
 
   it('does not update dataset.entities after filtering with view-as', () => {
-    testData.extendedDatasets.createPast(1, { entities: 2 });
+    testData.extendedDatasets.createPast(1, {
+      entities: 2,
+      accessFilter: { type: 'ownerOnly' }
+    });
     testData.extendedEntities.createPast(2);
     testData.extendedFieldKeys.createPast(1);
     return load('/projects/1/entity-lists/trees/entities', {

--- a/apps/central/test/components/entity/filters/view-as.spec.js
+++ b/apps/central/test/components/entity/filters/view-as.spec.js
@@ -11,12 +11,35 @@ const createFieldKeys = (count) => new Array(count).fill(undefined)
     .createPast(1, { displayName: `App User ${i}` })
     .last());
 
-const mountComponent = (fieldKeys, options) => mount(EntityFiltersViewAs, {
-  container: { requestData: testRequestData([useProject], { fieldKeys }) },
-  ...options
-});
+const mountComponent = (fieldKeys, options) => {
+  if (testData.extendedDatasets.size === 0)
+    testData.extendedDatasets.createPast(1, { accessFilter: { type: 'ownerOnly' } });
+  const dataset = testData.extendedDatasets.last();
+  return mount(EntityFiltersViewAs, {
+    container: {
+      requestData: testRequestData([useProject], { fieldKeys, dataset })
+    },
+    ...options
+  });
+};
 
 describe('EntityFiltersViewAs', () => {
+  describe('dataset access filter', () => {
+    it('renders the select if the dataset has an access filter', () => {
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: { type: 'ownerOnly' }
+      });
+      const component = mountComponent(createFieldKeys(1));
+      component.find('select').exists().should.be.true;
+    });
+
+    it('does not render the select if the dataset has no access filter', () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: null });
+      const component = mountComponent(createFieldKeys(1));
+      component.find('select').exists().should.be.false;
+    });
+  });
+
   it('passes the modelValue prop to the select', () => {
     const [fieldKey] = createFieldKeys(1);
     const component = mountComponent([fieldKey], {

--- a/apps/central/test/components/entity/list.spec.js
+++ b/apps/central/test/components/entity/list.spec.js
@@ -1045,6 +1045,24 @@ describe('EntityList', () => {
     });
   });
 
+  describe('"view as" filter', () => {
+    it('shows the filter if the dataset has an access filter', () => {
+      testData.extendedDatasets.createPast(1, {
+        accessFilter: { type: 'ownerOnly' }
+      });
+      return loadEntityList().afterResponses(component => {
+        component.find('#entity-filters-view-as').exists().should.be.true;
+      });
+    });
+
+    it('does not show the filter if the dataset has no access filter', () => {
+      testData.extendedDatasets.createPast(1, { accessFilter: null });
+      return loadEntityList().afterResponses(component => {
+        component.find('#entity-filters-view-as').exists().should.be.false;
+      });
+    });
+  });
+
   describe('search', () => {
     beforeEach(() => {
       testData.extendedDatasets.createPast(1, { entities: 2 });

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -2595,7 +2595,7 @@
         "string": "Me"
       },
       "viewAs": {
-        "string": "Viewing As"
+        "string": "View As"
       }
     },
     "EntityList": {


### PR DESCRIPTION
Request from @nicoleorlowski to change the text, also decided to only show the filter when it was going to be useful (e.g. when a dataset access filter is actually set).

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tests.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
