### PR TITLE
fix(web-forms#902): correct the paths to the locales directory

### DIFF
--- a/.changeset/common-crabs-lay.md
+++ b/.changeset/common-crabs-lay.md
@@ -1,0 +1,5 @@
+---
+"@getodk/web-forms": patch
+---
+
+Fixed a bug where translation of form buttons wasn't working.

--- a/packages/web-forms/e2e/test-cases/functional/translation.test.ts
+++ b/packages/web-forms/e2e/test-cases/functional/translation.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { FillFormPage } from '../../page-objects/pages/FillFormPage.js';
+
+test.describe('Translation', () => {
+  let formPage: FillFormPage;
+
+  test.beforeEach(async ({ page }) => {
+    formPage = await FillFormPage.loadForm(page, '01-itext-basic.xml');
+  });
+
+  test.use({ locale: 'es' });
+
+  test('displays simple translation form in Español', async () => {
+    // itext translations work
+    const label = formPage.page.getByText('1. Pregunta uno');
+    await label.scrollIntoViewIfNeeded();
+    await expect(label).toBeVisible();
+
+    // app translations work too
+    const sendButton = formPage.page.getByText('Enviar', { exact: true });
+    await sendButton.scrollIntoViewIfNeeded();
+    await expect(sendButton).toBeVisible();
+  });
+});

--- a/packages/web-forms/src/lib/locale/useLocale.ts
+++ b/packages/web-forms/src/lib/locale/useLocale.ts
@@ -20,8 +20,9 @@ const availableTranslations = import.meta.glob<{ default: TransifexTranslation }
 );
 
 const getAvailableTranslationsKey = (locale: string) => {
-  // must match the import path above
-  return `../../../locales/strings_${locale}.json`;
+  return Object.keys(availableTranslations).find((path) => {
+    return path.endsWith(`/strings_${locale}.json`);
+  });
 };
 
 /**
@@ -49,8 +50,13 @@ const loadMessages = async (locale: string): Promise<ICUMessage> => {
     return enMessages;
   }
 
+  const key = getAvailableTranslationsKey(locale);
+  if (!key) {
+    return enMessages;
+  }
+
   try {
-    const raw = await availableTranslations[getAvailableTranslationsKey(locale)]!();
+    const raw = await availableTranslations[key]!();
     return { ...enMessages, ...normalizeMessages(raw.default) };
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -200,7 +206,7 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
     }
 
     const messagesLocale = findBestLocale(candidates, (locale) => {
-      return Object.hasOwn(availableTranslations, getAvailableTranslationsKey(locale));
+      return !!getAvailableTranslationsKey(locale);
     });
     void loadMessages(messagesLocale).then((messages) => {
       if (latestRequestedLocale.locale === newContentLocale) {

--- a/packages/web-forms/src/lib/locale/useLocale.ts
+++ b/packages/web-forms/src/lib/locale/useLocale.ts
@@ -19,6 +19,11 @@ const availableTranslations = import.meta.glob<{ default: TransifexTranslation }
   '../../../locales/strings_*.json'
 );
 
+const getAvailableTranslationsKey = (locale: string) => {
+  // must match the import path above
+  return `../../../locales/strings_${locale}.json`;
+};
+
 /**
  * Transifex exports messages wrapped in an object (e.g., `{ string: "..." }`).
  * This flattens them into a consistent key-value pair.
@@ -45,7 +50,7 @@ const loadMessages = async (locale: string): Promise<ICUMessage> => {
   }
 
   try {
-    const raw = await availableTranslations[`/locales/strings_${locale}.json`]!();
+    const raw = await availableTranslations[getAvailableTranslationsKey(locale)]!();
     return { ...enMessages, ...normalizeMessages(raw.default) };
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -194,8 +199,8 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
       primevue.config.locale = { ...primevue.config.locale, ...primeLocale };
     }
 
-    const messagesLocale = findBestLocale(candidates, (lang) => {
-      return Object.hasOwn(availableTranslations, `/locales/strings_${lang}.json`);
+    const messagesLocale = findBestLocale(candidates, (locale) => {
+      return Object.hasOwn(availableTranslations, getAvailableTranslationsKey(locale));
     });
     void loadMessages(messagesLocale).then((messages) => {
       if (latestRequestedLocale.locale === newContentLocale) {

--- a/packages/web-forms/tests/components/form-layout/FormLanguageMenu.test.ts
+++ b/packages/web-forms/tests/components/form-layout/FormLanguageMenu.test.ts
@@ -36,8 +36,8 @@ describe('LanguageChanger', () => {
   it('changes the language', async () => {
     const { xform, component } = await mountComponent('01-itext-basic.xml');
 
-    expect(component.find('.p-select-label').text()).toEqual('English');
-    expect(xform.currentState.activeLanguage.language).toEqual('English');
+    expect(component.find('.p-select-label').text()).toEqual('English (en)');
+    expect(xform.currentState.activeLanguage.language).toEqual('English (en)');
 
     await component.trigger('click');
 
@@ -45,9 +45,9 @@ describe('LanguageChanger', () => {
 
     // @ts-expect-error - not undefined
     xform.setLanguage(component.emitted<FormLanguage[]>('update:activeLanguage')[0][0]);
-    expect(xform.currentState.activeLanguage.language).toEqual('Español');
+    expect(xform.currentState.activeLanguage.language).toEqual('Español (es)');
 
     await component.setProps({ activeLanguage: xform.currentState.activeLanguage });
-    expect(component.find('.p-select-label').text()).toEqual('Español');
+    expect(component.find('.p-select-label').text()).toEqual('Español (es)');
   });
 });

--- a/packages/web-forms/tests/fixtures/01-itext-basic.xml
+++ b/packages/web-forms/tests/fixtures/01-itext-basic.xml
@@ -9,12 +9,12 @@
     <h:title>Itext (basic)</h:title>
     <model>
       <itext>
-        <translation lang="English">
+        <translation lang="English (en)">
           <text id="q1:label">
             <value>1. Question one</value>
           </text>
         </translation>
-        <translation lang="Español">
+        <translation lang="Español (es)">
           <text id="q1:label">
             <value>1. Pregunta uno</value>
           </text>


### PR DESCRIPTION
Closes getodk/web-forms#902

This started failing when I made the change to build from src, not dist. Unfortunately this wasn't covered by tests so it didn't get picked up.

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Wrote an integration test
Manual testing

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
