### PR TITLE
EntityUpload: hide table for CSV data until there is data

### DIFF
--- a/apps/central/src/components/entity/upload.vue
+++ b/apps/central/src/components/entity/upload.vue
@@ -31,18 +31,21 @@ except according to the terms contained in the LICENSE file.
             :count="serverPage.count" :size-options="pageSizeOptions"
             :spinner="serverEntities.awaitingResponse"/>
         </div>
-        <p class="entity-upload-section-title">{{ $t('newEntities') }}</p>
-        <div class="entity-upload-table-container panel panel-simple">
-          <div class="panel-heading">
-            <h1 class="panel-title">{{ $t('table.file') }}</h1>
-          </div>
-          <div class="panel-body">
-            <entity-upload-table :ref="setTable(1)" :entities="csvSlice"
-              :extra-properties="propertiesToCreate" :row-index="csvRow"
-              :page-size="csvPage.size" :highlighted="warningRows"/>
-            <pagination v-if="csvEntities != null" v-model:page="csvPage.page"
-              v-model:size="csvPage.size" :count="csvEntities.length"
-              :size-options="pageSizeOptions"/>
+
+        <div v-show="csvEntities != null">
+          <p class="entity-upload-section-title">{{ $t('newEntities') }}</p>
+          <div class="entity-upload-table-container panel panel-simple">
+            <div class="panel-heading">
+              <h1 class="panel-title">{{ $t('table.file') }}</h1>
+            </div>
+            <div class="panel-body">
+              <entity-upload-table :ref="setTable(1)" :entities="csvSlice"
+                :extra-properties="propertiesToCreate" :row-index="csvRow"
+                :page-size="csvPage.size" :highlighted="warningRows"/>
+              <pagination v-if="csvEntities != null" v-model:page="csvPage.page"
+                v-model:size="csvPage.size" :count="csvEntities.length"
+                :size-options="pageSizeOptions"/>
+            </div>
           </div>
         </div>
 

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { T } from 'ramda';
+import { T, pick } from 'ramda';
 
 import EntityFilters from '../../../src/components/entity/filters.vue';
 import EntityUpload from '../../../src/components/entity/upload.vue';
@@ -324,33 +324,61 @@ describe('EntityUpload', () => {
     });
   });
 
-  it('shows the data template link until there is CSV data', async () => {
+  it('renders correctly as the user moves through the flow', async () => {
     testData.extendedDatasets.createPast(1);
     const modal = await showModal();
+    const table = getTables(modal)[1];
     const fileSelect = modal.getComponent(EntityUploadFileSelect);
-    const hasAlerts = () => ({
-      errors: modal.findComponent(EntityUploadErrors).exists(),
-      warnings: modal.findComponent(EntityUploadWarnings).exists()
+    const getState = () => {
+      let tableVisible = true;
+      try {
+        table.should.be.visible();
+      } catch (_) {
+        tableVisible = false;
+      }
+
+      return {
+        errors: modal.findComponent(EntityUploadErrors).exists(),
+        warnings: modal.findComponent(EntityUploadWarnings).exists(),
+        table: tableVisible,
+        fileSelect: pick(['dataTemplate', 'errors'], fileSelect.props())
+      };
+    };
+
+    // Initial state
+    getState().should.eql({
+      errors: false,
+      warnings: false,
+      table: false,
+      fileSelect: { dataTemplate: true, errors: 0 }
     });
 
-    // The link is shown initially.
-    hasAlerts().should.eql({ errors: false, warnings: false });
-    fileSelect.props().should.include({ dataTemplate: true, errors: 0 });
-
-    // The link is shown if there is an error.
+    // Error case
     await selectFile(modal, createCSV('label,label\ndogwood,dogwood'));
-    hasAlerts().should.eql({ errors: true, warnings: false });
-    fileSelect.props().should.include({ dataTemplate: true, errors: 1 });
+    getState().should.eql({
+      errors: true,
+      warnings: false,
+      table: false,
+      fileSelect: { dataTemplate: true, errors: 1 }
+    });
 
-    // The link is not shown if there is only a warning.
+    // Warning only, no error
     await selectFile(modal, createCSV('label,__id\ndogwood,e'));
-    hasAlerts().should.eql({ errors: false, warnings: true });
-    fileSelect.props().should.include({ dataTemplate: false, errors: 0 });
+    getState().should.eql({
+      errors: false,
+      warnings: true,
+      table: true,
+      fileSelect: { dataTemplate: false, errors: 0 }
+    });
 
-    // The link is not shown if there are no errors or warnings.
+    // No errors or warnings
     await selectFile(modal, createCSV('label\ndogwood'));
-    hasAlerts().should.eql({ errors: false, warnings: false });
-    fileSelect.props().should.include({ dataTemplate: false, errors: 0 });
+    getState().should.eql({
+      errors: false,
+      warnings: false,
+      table: true,
+      fileSelect: { dataTemplate: false, errors: 0 }
+    });
   });
 
   it('resets errors and warnings after a new file is selected', async () => {


### PR DESCRIPTION
This PR addresses https://github.com/getodk/central/issues/1904#issuecomment-5520855236, specifically:

> It looks like the second table should be hidden until the upload file has been selected.

More precisely: the second table (the table for the CSV data) should be hidden until data has been parsed without error.

You can see this in action here:

https://github.com/user-attachments/assets/6a432d55-ef7f-458d-b638-fbe1f52917d2

#### What has been done to verify that this works as intended?

I tried it out locally. I also updated an existing test.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly it's just a matter of wrapping the second table in a `v-show`.

The margin between elements in the modal is simplified enough by now that nothing in that area needs to change. In general, I don't think styles need to change for this: everything looks OK to me visually.