### PR TITLE
chore: skip npm audit in CI to improve timing

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -40,4 +40,4 @@ runs:
   - name: 'npm ci'
     shell: sh
     if: steps.cache-install.outputs.cache-hit != 'true'
-    run: npm ci
+    run: npm ci --no-audit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version-file: package.json
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --no-audit
     - run: npm run build
     - run: npm run lint
     - run: ./bin/check-bundle-size.js


### PR DESCRIPTION
<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->




#### What has been done to verify that this works as intended?

CI runs

#### Why is this the best possible solution? Were any other approaches considered?

The `npm ci` runs a security audit at the end, which has been slow since yesterday (maybe the npm audits endpoint is having issues):                                           
                                                                                                                                                                                                     
<img width="800" src="https://github.com/user-attachments/assets/06e4e9d3-06e8-49f9-8249-22d574288a00" />                                                                                          
                                                                                                                                                                                                     
This pushed the check-and-build job past its strict 5-minute timeout. With -`-no-audit`, the `npm ci` skips those extra registry requests and runs faster:                                                                 
                                                                                                                                                                                                     <img width="800" src="https://github.com/user-attachments/assets/5d984848-1da9-4843-b518-b82a40eb5ba0" />                                                                                          
                                                                                                                                                                                                     
The audit doesn't affect installation in any way, it's reporting only, and its exit code is ignored in `npm ci`. Audits still run for local `npm ci`, where we can see and act on the report output.   

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

NA

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
Na
