### PR TITLE
Do not upload entity CSV data for deleted property

### DIFF
--- a/apps/central/src/request-data/resources.js
+++ b/apps/central/src/request-data/resources.js
@@ -106,12 +106,6 @@ export default (container, createResource) => {
       // it here.
       if (!('accessFilter' in data)) Object.assign(data, { accessFilter: null });
 
-      if (data.properties != null) {
-        data.propertyMap = new Map();
-        for (const property of data.properties)
-          data.propertyMap.set(property.name, property);
-      }
-
       return data;
     };
     /* eslint-enable no-param-reassign */
@@ -125,6 +119,10 @@ export default (container, createResource) => {
       replaceData: (data) => {
         Object.assign(dataset.data, transformData(data));
       },
+      propertyMap: computeIfExists(() => dataset.properties.reduce(
+        (map, property) => map.set(property.name, property),
+        new Map()
+      )),
       hasGeometry: computeIfExists(() =>
         dataset.properties.some(({ name }) => name === 'geometry'))
     };

--- a/apps/central/test/components/entity/upload.spec.js
+++ b/apps/central/test/components/entity/upload.spec.js
@@ -1136,4 +1136,42 @@ describe('EntityUpload', () => {
           }));
     });
   });
+
+  it('does not upload data for a deleted property', () => {
+    mockLogin();
+    testData.extendedDatasets.createPast(1, {
+      properties: [{ name: 'height' }, { name: 'circumference' }]
+    });
+    return load('/projects/1/entity-lists/trees/properties')
+      .complete()
+      .request(async (app) => {
+        const tr = app.get('#dataset-properties tbody tr:nth-child(2)');
+        tr.get('td').text().should.equal('circumference');
+        await tr.get('.delete-button').trigger('click');
+        return app.get('.confirmation .btn-primary').trigger('click');
+      })
+      .respondWithSuccess()
+      .complete()
+      .route('/projects/1/entity-lists/trees')
+      .respondForComponent('DatasetEntities')
+      .complete()
+      .request(async (app) => {
+        await app.get('#dataset-entities-upload-button').trigger('click');
+        const modal = app.getComponent(EntityUpload);
+        const csv = createCSV('label,height,circumference\ndogwood,1,2');
+        await selectFile(modal, csv);
+        const warnings = modal.getComponent(EntityUploadWarnings).props();
+        warnings.extraProperties.should.eql(['circumference']);
+        return modal.get('.modal-actions .btn-primary').trigger('click');
+      })
+      .respondWithProblem()
+      .testRequests([{
+        method: 'POST',
+        url: '/v1/projects/1/datasets/trees/entities',
+        data: {
+          source: { name: 'my_data.csv', size: 38 },
+          entities: [{ label: 'dogwood', data: { height: '1' } }]
+        }
+      }]);
+  });
 });


### PR DESCRIPTION
This PR closes getodk/central#2200. I noticed that issue when looking at the `DatasetProperties` component while working on getodk/central#2189.

#### What has been done to verify that this works as intended?

I wrote a new test that fails without the code change.

#### Why is this the best possible solution? Were any other approaches considered?

Here's the problematic line that I noticed in `DatasetProperties`:

https://github.com/getodk/central-frontend/blob/f1e85b00d2d1db4c9a4e7f2f013126d2a0cdfe2b/apps/central/src/components/dataset/overview/dataset-properties.vue#L135

It's an issue because `EntityUpload` assumes that any change to `properties` happens via a call to `dataset.replaceData()`. That method was introduced in #1685 as a way to normalize `dataset.properties` whenever it changes. `EntityUpload` relies on `dataset.propertyMap`, which is recalculated whenever `dataset.replaceData()` is called:

https://github.com/getodk/central-frontend/blob/f1e85b00d2d1db4c9a4e7f2f013126d2a0cdfe2b/apps/central/src/request-data/resources.js#L109-L113

However, the line in `DatasetProperties` replaces `dataset.properties` without calling `dataset.replaceData()`.

I thought about changing the line in `DatasetProperties` to call `dataset.replaceData()`, but honestly that line likely predates even #1685. It's filtering the existing list of properties, not adding a new property that needs to be normalized, so it doesn't seem unreasonable to me for it to replace `dataset.properties` directly. It's common for code to modify `requestData` resources like that; it's less common to need to call a method like `dataset.replaceData()`.

Instead of using `dataset.replaceData()`, I changed how `dataset.propertyMap` is calculated. Instead of doing so imperatively in `dataset.replaceData()`, we can use a Vue computed ref. `dataset.properties` is reactive, so we can define a computed ref for `dataset.propertyMap` that should just work.