### PR TITLE
Remove unused displayNameLabel messages

### DIFF
--- a/apps/central/src/components/field-key/edit.vue
+++ b/apps/central/src/components/field-key/edit.vue
@@ -83,9 +83,7 @@ watch(() => props.state, (state) => {
   "en": {
     // This is the title at the top of a pop-up for editing an App User. {displayName} is the
     // the name of the App User
-    "title": "Edit App User “{displayName}”",
-    // Shown as label before the display name of the App User in the edit pop-up.
-    "displayNameLabel": "App User"
+    "title": "Edit App User “{displayName}”"
   }
 }
 </i18n>

--- a/apps/central/src/components/public-link/edit.vue
+++ b/apps/central/src/components/public-link/edit.vue
@@ -83,9 +83,7 @@ watch(() => props.state, (state) => {
   "en": {
     // This is the title at the top of a pop-up for editing a Public Access Link. {displayName} is
     // the display name of the Public Link
-    "title": "Edit Public Access Link “{displayName}”",
-    // Shown as label before the display name of the Public Access Link in the edit pop-up.
-    "displayNameLabel": "Public Link"
+    "title": "Edit Public Access Link “{displayName}”"
   }
 }
 </i18n>

--- a/apps/central/transifex/strings_en.json
+++ b/apps/central/transifex/strings_en.json
@@ -3055,10 +3055,6 @@
       "title": {
         "string": "Edit App User “{displayName}”",
         "developer_comment": "This is the title at the top of a pop-up for editing an App User. {displayName} is the the name of the App User"
-      },
-      "displayNameLabel": {
-        "string": "App User",
-        "developer_comment": "Shown as label before the display name of the App User in the edit pop-up."
       }
     },
     "FieldKeyList": {
@@ -5007,10 +5003,6 @@
       "title": {
         "string": "Edit Public Access Link “{displayName}”",
         "developer_comment": "This is the title at the top of a pop-up for editing a Public Access Link. {displayName} is the display name of the Public Link"
-      },
-      "displayNameLabel": {
-        "string": "Public Link",
-        "developer_comment": "Shown as label before the display name of the Public Access Link in the edit pop-up."
       }
     },
     "PublicLinkList": {


### PR DESCRIPTION
This PR closes getodk/central#1350. It removes two unused i18n messages. I noticed these while working on getodk/central#2165.

#### What has been done to verify that this works as intended?

I searched the codebase for the message key (`displayNameLabel`), but I didn't find any uses.

#### Why is this the best possible solution? Were any other approaches considered?

At some point, it'd be great to try to detect unused messages automatically. That's filed at getodk/central#829.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Should be no impact for users. It'll be one less thing for translators to translate.