### PR TITLE
DatasetPropertyNew: show duplicate Problem inline

### DIFF
--- a/apps/central/src/components/dataset/property/new.vue
+++ b/apps/central/src/components/dataset/property/new.vue
@@ -18,8 +18,7 @@ except according to the terms contained in the LICENSE file.
         <p>{{ $t('introduction[0]') }}</p>
       </div>
       <form @submit.prevent="submit">
-        <property-input ref="input" v-model="name"
-          :properties="dataset.properties"/>
+        <property-input ref="input" v-model="name" :properties="propertyNames"/>
         <p>{{ $t('introduction[1]') }}</p>
         <div class="modal-actions">
           <button type="button" class="btn btn-link"
@@ -37,16 +36,15 @@ except according to the terms contained in the LICENSE file.
 </template>
 
 <script setup>
+import { computed, reactive, ref, watch } from 'vue';
 import { equals } from 'ramda';
-import { ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
 
 import Modal from '../../modal.vue';
 import PropertyInput from '../../property-input.vue';
 import Spinner from '../../spinner.vue';
 
 import useRequest from '../../../composables/request';
-import { apiPaths } from '../../../util/request';
+import { apiPaths, isProblem } from '../../../util/request';
 import { useRequestData } from '../../../request-data';
 import { noop } from '../../../util/util';
 
@@ -66,24 +64,30 @@ const emit = defineEmits(['hide', 'success']);
 
 const input = ref(null);
 const name = ref('');
+const duplicateNames = reactive([]);
+
+const propertyNames = computed(() =>
+  [...dataset.propertyMap.keys(), ...duplicateNames]);
 
 watch(() => props.state, (state) => {
   if (!state) name.value = '';
 });
 
-const { t } = useI18n();
 const submit = () => {
+  const data = { name: name.value };
   request({
     method: 'POST',
     url: apiPaths.datasetProperties(project.id, dataset.name),
-    data: { name: name.value },
-    problemToAlert: ({ code, details }) =>
-      (code === 409.3 && equals(details.fields, ['name', 'datasetId'])
-        ? t('problem.409_3')
-        : null)
+    data,
+    fulfillProblem: ({ code, details }) =>
+      (code === 409.3 && equals(details.fields, ['name', 'datasetId'])) ||
+      code === 409.24
   })
-    .then(() => {
-      emit('success');
+    .then(response => {
+      if (isProblem(response.data))
+        duplicateNames.push(data.name);
+      else
+        emit('success');
     })
     .catch(noop);
 };
@@ -99,11 +103,7 @@ const submit = () => {
     "introduction": [
       "To add an Entity property, choose a unique property name below.",
       "You can also add new properties by uploading a Form that references them, in which case the properties are created when the Form is published."
-    ],
-    "problem": {
-      // @transifexKey component.PropertyInput.duplicate.title
-      "409_3": "A property with this name already exists"
-    }
+    ]
   }
 }
 </i18n>

--- a/apps/central/test/components/dataset/property/new.spec.js
+++ b/apps/central/test/components/dataset/property/new.spec.js
@@ -2,6 +2,7 @@ import { nextTick } from 'vue';
 
 import DatasetPropertyNew from '../../../../src/components/dataset/property/new.vue';
 import DatasetProperties from '../../../../src/components/dataset/overview/dataset-properties.vue';
+import PropertyInput from '../../../../src/components/property-input.vue';
 
 import testData from '../../../data';
 import { load, mockHttp } from '../../../util/http';
@@ -108,24 +109,39 @@ describe('DatasetPropertyNew', () => {
     });
   });
 
-  it('shows a custom message for a duplicate property name', () =>
-    mockHttp()
-      .mount(DatasetPropertyNew, mountOptions())
-      .request(async (modal) => {
-        await modal.get('input').setValue('my_new_property');
-        return modal.get('form').trigger('submit');
-      })
-      .respondWithProblem({
+  describe('duplicate name Problem', () => {
+    [
+      {
         code: 409.3,
         message: 'A resource already exists with name,datasetId value(s) of my_new_property,1.',
         details: {
           fields: ['name', 'datasetId'],
           values: ['my_new_property', 1]
         }
-      })
-      .afterResponse(modal => {
-        modal.should.alert('danger', (message) => {
-          message.should.startWith('A property with this name already exists');
-        });
-      }));
+      },
+      {
+        code: 409.24,
+        message: "A resource already exists with name 'MY_NEW_PROPERTY' and you provided 'my_new_property' with different capitalization."
+      }
+    ].forEach(problem => {
+      it(`shows an inline error for a ${problem.code} Problem`, () =>
+        mockHttp()
+          .mount(DatasetPropertyNew, mountOptions())
+          .request(async (modal) => {
+            const input = modal.getComponent(PropertyInput);
+            input.props().properties.should.eql(['height']);
+            await input.get('input').setValue('my_new_property');
+            return modal.get('form').trigger('submit');
+          })
+          .respondWithProblem(problem)
+          .afterResponse(modal => {
+            const input = modal.getComponent(PropertyInput);
+            input.props().properties.should.eql(['height', 'my_new_property']);
+            const text = input.get('.property-input-error p').text();
+            text.should.equal('A property with this name already exists');
+
+            modal.should.not.redAlert();
+          }));
+    });
+  });
 });


### PR DESCRIPTION
This PR is a follow-up to #1876 (for getodk/central#2165). It is related to getodk/central#2173.

As of #1876, the `DatasetPropertyNew` modal will show an error inline if the user enters a property that is a case-insensitive duplicate of a property that is known to Frontend. However, if such a property is *unknown* to Frontend, having been created in a different tab or by a different user, Frontend will allow the request to go ahead, resulting in a Problem response from Backend, which Frontend will show in an ordinary alert at the top of the modal. This PR changes that so that if Frontend receives a Problem response about a duplicate property (either a 409.3 or a 409.24), it will indicate that in the same inline error. That way, the user will see the same error in the two cases: when the error is detected by Frontend and when it is detected by Backend.

#### What has been done to verify that this works as intended?

New/updated tests. I also tried it out locally.

#### Why is this the best possible solution? Were any other approaches considered?

If Backend returns a Problem response, Frontend could refresh the entity list once the modal is hidden in order to retrieve the latest list of entity properties. I'd be happy to do that in a follow-up PR, but it also feels like maybe too much / unnecessary.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

This shouldn't be a common case, so I don't feel like it's important for this PR to be merged to be released with v2026.3, which is about to start regression testing. Then again, I also don't feel like this PR is particularly risky. I'll discuss with @ktuite.