### PR TITLE
Add transifex:pull to Central

### DIFF
--- a/apps/central/docs/CONTRIBUTING.md
+++ b/apps/central/docs/CONTRIBUTING.md
@@ -177,11 +177,7 @@ Also note about comments:
 - `restructure.js` will automatically generate comments for any message whose path ends with `.full`, because such messages are used for component interpolation.
 - Use JSON with comments, but do not use other features of JSON5, which our workflow might not support.
 
-Before each release, we download all translations from Transifex and save them in [`/apps/central/transifex/`](/apps/central/transifex/). Transifex allows translations to be downloaded "for use" or "to translate." We use "to translate," because untranslated strings are included as empty strings; "for use" fills in untranslated strings with the source strings, which we would then have to discard. On the website, Transifex allows the translations to be downloaded "to translate" for an individual locale, but not all locales at once. To download all locales at once, run the Transifex CLI in the root directory of the repository:
-
-```bash
-tx pull --mode translator --force
-```
+Before each release, we download all translations from Transifex and save them in [`/apps/central/transifex/`](/apps/central/transifex/). Transifex allows translations to be downloaded "for use" or "to translate." We use "to translate," because untranslated strings are included as empty strings; "for use" fills in untranslated strings with the source strings, which we would then have to discard. To download all locales "to translate", run `npm run transifex:pull`. Note that you will first need to install the Transifex CLI.
 
 Once they are downloaded, we convert the Structured JSON files to Vue I18n JSON by running `npm run transifex:destructure`.  This generates all locale files in `/apps/central/src/locales/` other than `en.json5`.
 

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -10,7 +10,8 @@
     "test": "./test/run.sh",
     "transifex:destructure": "node bin/transifex/destructure.js",
     "transifex:fix": "node bin/transifex/restructure.js > transifex/strings_en.json",
-    "transifex:lint": "./bin/transifex/lint.sh"
+    "transifex:lint": "./bin/transifex/lint.sh",
+    "transifex:pull": "cd ../.. && tx pull -r central.strings -f --mode translator"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",


### PR DESCRIPTION
This PR adds a new command to Central: `npm run transifex:pull`. This should make it easier to pull the latest translations for Central. It runs the `tx` CLI with the correct arguments and from the correct directory. Web Forms already has a `transifex:pull` command, so this PR is to add the command to Central as well.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly I just copied the command from Web Forms to Central. However, I did make one change. Web Forms specifies `-a` to `tx`, but we don't want that for Central. We only want to download translations for existing locales, not new ones. We generally don't add new locales until they're sufficiently translated. E.g., if someone requests a new language in Transifex, but doesn't actually translate it, we don't want to download that translation file during a Transifex pull; we would just have to delete it. Certain steps are required when a new locale is added to Central, which are documented in CONTRIBUTING.md.

#### What has been done to verify that this works as intended?

I tried running the new command, and it appeared to be successful. 🎉 I saw that the Transifex files were updated.