### PR TITLE
Add transifex commands to top-level package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "lint:fix": "npm run lint:fix --workspaces",
     "test": "npm run test --workspaces",
     "test:e2e": "e2e-tests/run-tests.sh",
+    "transifex:destructure": "npm run transifex:destructure --workspaces --if-present",
+    "transifex:fix": "npm run transifex:fix --workspaces --if-present",
+    "transifex:lint": "npm run transifex:lint --workspaces --if-present",
+    "transifex:pull": "npm run transifex:pull --workspaces --if-present",
     "version": "changeset version"
   },
   "volta": {


### PR DESCRIPTION
This is a follow-up PR to #1886. It implements the suggestion from https://github.com/getodk/central-frontend/pull/1886#pullrequestreview-5127421736:

> Let's also add `transifex:pull` in the top level package.json to do them all

In this PR, I've added all the shared `transifex` commands to package.json (not just `transifex:pull`):

- `transifex:pull`
- `transifex:destructure`
  - I could actually seeing this being used one day if we want to have the same person pull & destructure translations for both Central and Web Forms
- `transifex:lint`
  - Maybe this would be used someday? In CI? It doesn't hurt anyway.
- `transifex:fix`
  - Kind of hard to imagine the use case for this at the top level, but why not? Maybe it's nice in terms of consistency for as many `transifex` commands as possible to appear in the top-level package.json.
- **Not included:** `transifex:push`. This continues to be Web Forms-only.

#### What has been done to verify that this works as intended?

I tried all four commands, and I didn't see any unexpected errors.

I tried omitting `--if-present`, and there was an error. I think it's needed. :+1: