### PR TITLE
Remove skipAutoLogout route meta field

### DIFF
--- a/apps/central/src/routes.js
+++ b/apps/central/src/routes.js
@@ -79,10 +79,6 @@ The following meta fields are supported for bottom-level routes:
     However, NotFound requires neither: a user can navigate to NotFound whether
     they are logged in or anonymous.
 
-  - skipAutoLogout (default: false): If `true`, no alert will be displayed when
-    session is about to expire. Also user will be not be redirected to login
-    page when session has expired.
-
   requestData
   -----------
 
@@ -699,7 +695,6 @@ const routesByName = new Map();
     requireAnonymity: false,
     preserveData: [],
     fullWidth: false,
-    skipAutoLogout: false,
     ...meta,
     validateData: meta == null || meta.validateData == null
       ? []

--- a/apps/central/src/util/session.js
+++ b/apps/central/src/util/session.js
@@ -155,11 +155,10 @@ export const logOut = (container, setNext) => {
 // approach rather than using setTimeout() to schedule logout, because
 // setTimeout() does not seem to clock time while the computer is asleep.
 const logOutBeforeSessionExpires = (container) => {
-  const { i18n, requestData, alert, router } = container;
+  const { i18n, requestData, alert } = container;
   const { session } = requestData;
   let alerted;
   return () => {
-    if (router.currentRoute.value.meta.skipAutoLogout) return;
     if (!session.dataExists) return;
     const millisUntilExpires = Date.parse(session.expiresAt) - Date.now();
     const millisUntilLogout = millisUntilExpires - 60000;
@@ -183,7 +182,7 @@ const logOutBeforeSessionExpires = (container) => {
 const logOutAfterStorageChange = (container) => (event) => {
   // event.key == null if the user clears local storage in Chrome.
   if ((event.key == null || event.key === 'sessionExpires') &&
-    container.requestData.session.dataExists && !container.router.currentRoute.value.meta.skipAutoLogout) {
+    container.requestData.session.dataExists) {
     logOut(container, true).catch(noop);
   }
 };

--- a/apps/central/test/unit/session.spec.js
+++ b/apps/central/test/unit/session.spec.js
@@ -667,27 +667,6 @@ describe('util/session', () => {
           clock.tick(240000);
         });
     });
-
-    it('does not logout when skipAutoLogout is true', () => {
-      const clock = sinon.useFakeTimers();
-      testData.extendedUsers.createPast(1, { role: 'none' });
-      const container = createTestContainer({ router: mockRouter('/') });
-      container.router.currentRoute.value.meta.skipAutoLogout = true;
-      withSetup(useSessions, { container });
-      const { session } = setRequestData(container.requestData, {
-        session: testData.sessions.createNew({ expiresAt: '1970-01-01T00:05:00Z' })
-      });
-      return mockHttp(container)
-        .request(() => logIn(container, true))
-        .respondWithData(() => testData.extendedUsers.first())
-        .complete()
-        .testNoRequest(() => {
-          clock.tick(240000);
-        })
-        .afterResponse(() => {
-          session.dataExists.should.be.true;
-        });
-    });
   });
 
   describe('logout after session expiration', () => {
@@ -808,25 +787,6 @@ describe('util/session', () => {
           alert.state.should.be.false;
         });
     });
-
-    it('does not show alert if skipAutoLogout is true', () => {
-      const clock = sinon.useFakeTimers();
-      testData.extendedUsers.createPast(1, { role: 'none' });
-      const container = createTestContainer({ router: mockRouter('/') });
-      container.router.currentRoute.value.meta.skipAutoLogout = true;
-      withSetup(useSessions, { container });
-      const { requestData, alert } = container;
-      setRequestData(requestData, {
-        session: testData.sessions.createNew({ expiresAt: '1970-01-01T00:05:00Z' })
-      });
-      return mockHttp(container)
-        .request(() => logIn(container, true))
-        .respondWithData(() => testData.extendedUsers.first())
-        .afterResponse(() => {
-          clock.tick(120000);
-          alert.state.should.be.false;
-        });
-    });
   });
 
   describe('local storage changes', () => {
@@ -873,29 +833,6 @@ describe('util/session', () => {
         .respondWithSuccess()
         .afterResponse(() => {
           session.dataExists.should.be.false;
-        });
-    });
-
-    it('does not logs out if skipAutoLogout is true', () => {
-      testData.extendedUsers.createPast(1, { role: 'none' });
-      const container = createTestContainer({ router: mockRouter('/') });
-      container.router.currentRoute.value.meta.skipAutoLogout = true;
-      withSetup(useSessions, { container });
-      const { session } = setRequestData(container.requestData, {
-        session: testData.sessions.createNew()
-      });
-      return mockHttp(container)
-        .request(() => logIn(container, true))
-        .respondWithData(() => testData.extendedUsers.first())
-        .complete()
-        .testNoRequest(() => {
-          window.dispatchEvent(new StorageEvent('storage', {
-            key: null,
-            url: window.location.href
-          }));
-        })
-        .afterResponse(() => {
-          session.dataExists.should.be.true;
         });
     });
 


### PR DESCRIPTION
Closes getodk/central#2154.

#### What has been done to verify that this works as intended?

Tests continue to pass.

There was discussion on the issue that this mechanism is no longer needed.

#### Why is this the best possible solution? Were any other approaches considered?

I searched the codebase for `skipAutoLogout` and removed the associated code.

If we ever need this mechanism again in the future, we can always add it back and revert this PR.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

I think the risk of regression is probably low given (1) the minimal code changes and (2) the fact that `skipAutoLogout` is no longer used. However, given the importance of the code in src/util/session.js, I'm thinking I probably won't merge this PR until after regression testing is complete. In other words, this PR is intended for v2026.4, not v2026.3.