### PR TITLE
fix(web-forms#910): resolve potential race condition when redirecting

### DIFF
--- a/.changeset/cute-points-work.md
+++ b/.changeset/cute-points-work.md
@@ -1,0 +1,5 @@
+---
+"@getodk/forms": patch
+---
+
+Fixed a bug where a web form could be rendered without the necessary form data

--- a/apps/forms/src/components/preview.vue
+++ b/apps/forms/src/components/preview.vue
@@ -43,10 +43,10 @@ const fetchForm = async () => {
       // not logged in
       const relativeUrl = window.location.href.substring(window.location.origin.length);
       window.location.href = '/login?next=/wf' + relativeUrl;
-    } else {
-      // unknown error
-      errorState.value = true;
+      return;
     }
+    // unknown error
+    errorState.value = true;
     hideSpinner();
     loadingState.value = false;
   }

--- a/apps/forms/src/components/submission.vue
+++ b/apps/forms/src/components/submission.vue
@@ -135,7 +135,7 @@ const fetchFormConfig = async (): Promise<Form> => {
   throw new RequestError('Form not found', 404);
 };
 
-const fetchForm = async (): Promise<Form | undefined> => {
+const fetchForm = async (): Promise<Form> => {
   const formConfig = await fetchFormConfig();
 
   redirectEnketoUrls(formConfig);
@@ -158,11 +158,7 @@ const fetchForm = async (): Promise<Form | undefined> => {
       // editing in Enketo isn't supported
       throw new RequestError('Form not found', 404);
     }
-    if (offline.value) {
-      // TODO: Update once Web Forms has support for offline
-      window.location.replace(`/-/x/${formConfig.enketoId}${queryString(route.query)}`);
-      return;
-    }
+
     webFormsEnabled.value = false;
   }
   return formConfig;
@@ -197,7 +193,13 @@ const load = async () => {
   loadingState.value = true;
   errorCode.value = null;
   try {
-    form.value = await fetchForm();
+    const formConfig = await fetchForm();
+    if (offline.value) {
+      // TODO: Update once Web Forms has support for offline
+      window.location.replace(`/-/x/${formConfig.enketoId}${queryString(route.query)}`);
+      return;
+    }
+    form.value = formConfig;
     loadingState.value = false;
   } catch (e) {
     if (e instanceof RequestError) {
@@ -205,7 +207,9 @@ const load = async () => {
         // not logged in
         const relativeUrl = window.location.href.substring(window.location.origin.length);
         window.location.href = '/login?next=/wf' + relativeUrl;
-      } else if (e.statusCode >= 404 && e.statusCode < 405) {
+        return;
+      }
+      if (e.statusCode >= 404 && e.statusCode < 405) {
         // form not found
         errorCode.value = 404;
       } else {

--- a/apps/forms/src/components/submission.vue
+++ b/apps/forms/src/components/submission.vue
@@ -194,7 +194,7 @@ const load = async () => {
   errorCode.value = null;
   try {
     const formConfig = await fetchForm();
-    if (offline.value) {
+    if (!webFormsEnabled.value && offline.value) {
       // TODO: Update once Web Forms has support for offline
       window.location.replace(`/-/x/${formConfig.enketoId}${queryString(route.query)}`);
       return;


### PR DESCRIPTION
Closes getodk/web-forms#910

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Testing.

#### Why is this the best possible solution? Were any other approaches considered?

The redirect is async so would execute _after_ the synchronous code has run, including trying to render the form which may be null. By returning immediately we leave the loading state set to true so web-forms isn't rendered.

This probably wasn't a big deal because the redirect will still occur and the user probably won't even notice, but it's a waste of cycles and reports to sentry.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

None.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

None.