### PR TITLE
Link to user docs, not API docs

### DIFF
--- a/apps/central/src/components/actor-properties/upsert.vue
+++ b/apps/central/src/components/actor-properties/upsert.vue
@@ -5,7 +5,7 @@
       <p>
         <i18n-t keypath="description.full">
           <template #assignEntities>
-            <doc-link to="central-api-accounts-and-users/#actor-properties">
+            <doc-link to="central-entities/#filter-by-property">
               {{ $t('description.assignEntities') }}
             </doc-link>
           </template>


### PR DESCRIPTION
While getting the user docs into rst I noticed that the informational link for actor properties goes to API docs rather than user docs. I think it's more useful to link to https://docs.getodk.org/central-entities/#filter-by-property

#### What has been done to verify that this works as intended?
Copied the link from loading the page.

#### Why is this the best possible solution? Were any other approaches considered?
I considered linking the word "Properties" instead but that would have to go different places for links and App Users. I think this is pragmatic.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

No risk, string change only.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.