### PR TITLE
fix(web-forms#914): improves form definition error messages

### DIFF
--- a/.changeset/quiet-meteors-press.md
+++ b/.changeset/quiet-meteors-press.md
@@ -1,0 +1,7 @@
+---
+"@getodk/web-forms": patch
+"@getodk/xpath": patch
+"@getodk/xforms-engine": patch
+---
+
+Improved messages about form definition errors to make them easier to fix

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -50,6 +50,7 @@ import {
 	watch,
 } from 'vue';
 import { FormInitializationError } from '@getodk/web-forms/lib/error/FormInitializationError';
+import { FormDesignError } from '@getodk/xpath';
 
 const webFormsVersion = __WEB_FORMS_VERSION__;
 type ObjectURL = `blob:${string}`;
@@ -229,6 +230,10 @@ const { navigateToFirstViolation, navigateToNode } = useNavigationTarget(() => s
 
 onErrorCaptured(err => {
 	runtimeError.value = FormInitializationError.from(err);
+	if (err instanceof FormDesignError) {
+		// don't let this error bubble to the console or sentry
+		return false;
+	}
 });
 
 watch(

--- a/packages/xpath/src/error/FormDesignError.ts
+++ b/packages/xpath/src/error/FormDesignError.ts
@@ -1,0 +1,1 @@
+export class FormDesignError extends Error {}

--- a/packages/xpath/src/error/TooFewArgumentsError.ts
+++ b/packages/xpath/src/error/TooFewArgumentsError.ts
@@ -1,0 +1,9 @@
+import { FormDesignError } from './FormDesignError';
+
+export class TooFewArgumentsError extends FormDesignError {
+  constructor(functionName: string, given: number, expected: number) {
+    super(
+      `Function "${functionName}" requires a minimum of ${expected} parameters but was called with ${given}`
+    );
+  }
+}

--- a/packages/xpath/src/error/TooManyArgumentsError.ts
+++ b/packages/xpath/src/error/TooManyArgumentsError.ts
@@ -1,0 +1,9 @@
+import { FormDesignError } from './FormDesignError';
+
+export class TooManyArgumentsError extends FormDesignError {
+  constructor(functionName: string, given: number, expected: number) {
+    super(
+      `Function "${functionName}" has a maximum of ${expected} parameters but was called with ${given}`
+    );
+  }
+}

--- a/packages/xpath/src/error/UnknownFunctionError.ts
+++ b/packages/xpath/src/error/UnknownFunctionError.ts
@@ -1,0 +1,7 @@
+import { FormDesignError } from './FormDesignError';
+
+export class UnknownFunctionError extends FormDesignError {
+  constructor(functionName: string) {
+    super(`Unknown function in form definition: "${functionName}"`);
+  }
+}

--- a/packages/xpath/src/evaluator/expression/FunctionCallExpressionEvaluator.ts
+++ b/packages/xpath/src/evaluator/expression/FunctionCallExpressionEvaluator.ts
@@ -5,6 +5,7 @@ import type { Evaluation } from '../../evaluations/Evaluation.ts';
 import type { FunctionCallNode } from '../../static/grammar/SyntaxNode.ts';
 import type { ExpressionEvaluator } from './ExpressionEvaluator.ts';
 import { createExpression } from './factory.ts';
+import { UnknownFunctionError } from '../../error/UnknownFunctionError.ts';
 
 interface FunctionCallName {
   readonly prefix: string | null;
@@ -58,7 +59,7 @@ export class FunctionCallExpressionEvaluator implements ExpressionEvaluator {
       const { prefix, localName } = name;
       const errorName = prefix == null ? localName : `${prefix}:${localName}`;
 
-      throw new Error(`Function '${errorName}' is not defined.`);
+      throw new UnknownFunctionError(errorName);
     }
 
     return functionImplementation.call(context.currentContext(), argumentExpressions);

--- a/packages/xpath/src/evaluator/functions/FunctionImplementation.ts
+++ b/packages/xpath/src/evaluator/functions/FunctionImplementation.ts
@@ -13,31 +13,8 @@ import type { EvaluationContext } from '../../context/EvaluationContext.ts';
 import type { Evaluation } from '../../evaluations/Evaluation.ts';
 import type { EvaluationType, PrimitiveEvaluationType } from '../../evaluations/EvaluationType.ts';
 import { LocationPathEvaluation } from '../../evaluations/LocationPathEvaluation.ts';
-
-export class UnknownFunctionError extends Error {
-  constructor(functionName: string) {
-    super(`Unknown function ${functionName}`);
-  }
-}
-
-export class InvalidArgumentError extends Error {
-  constructor(argumentIndex: number, parameter: Parameter | null) {
-    if (parameter == null) {
-      super(`Argument ${argumentIndex} not allowed`);
-    } else {
-      const { typeHint } = parameter;
-
-      const causeMessage =
-        typeHint == null
-          ? `Expected argument at index ${argumentIndex}`
-          : `Expected argument compatible with type ${typeHint} at index ${argumentIndex}`;
-
-      super(`Invalid argument at index: ${argumentIndex}`, {
-        cause: new Error(causeMessage),
-      });
-    }
-  }
-}
+import { TooFewArgumentsError } from '../../error/TooFewArgumentsError.ts';
+import { TooManyArgumentsError } from '../../error/TooManyArgumentsError.ts';
 
 export type ParameterArityType = 'optional' | 'required' | 'variadic';
 
@@ -46,11 +23,7 @@ export type ParameterTypeHint =
   // as lazy? This would allow call-site optimizations that would
   // be more challenging or fussy to implement in the individual
   // `FunctionImplementation`.
-  | 'any' // TODO: naming? Could be 'unknown' or 'result' or...?
-  | 'boolean'
-  | 'node'
-  | 'number'
-  | 'string';
+  'any' | 'boolean' | 'node' | 'number' | 'string';
 
 export interface Parameter {
   readonly arityType: ParameterArityType;
@@ -58,8 +31,6 @@ export interface Parameter {
 }
 
 // TODO: this is the parameter signature, what about return? (partly addressed by `TypedFunction`)
-// TODO: is it possible to enforce order? I.e.:
-// [...RequiredParameter, ...OptionalParameter, ...([] | [VariadicParameter])]
 export type FunctionSignature = readonly Parameter[];
 
 // prettier-ignore
@@ -101,7 +72,6 @@ export class FunctionImplementation {
     readonly signature: FunctionSignature,
     runtimeImplementation: FunctionCallable | FunctionImplementation
   ) {
-    // TODO: *validate signature order!*
     const arity = [...signature].reduce(
       (acc, parameter) => {
         const { arityType } = parameter;
@@ -154,27 +124,15 @@ export class FunctionImplementation {
   protected validateArguments<Arguments extends readonly EvaluableArgument[]>(
     args: Arguments
   ): asserts args is ValidArguments<Arguments, true> {
-    const { arity, signature } = this;
-    const { min, max } = arity;
+    const { min, max } = this.arity;
     const { length: argumentCount } = args;
 
     if (argumentCount < min) {
-      throw new InvalidArgumentError(min, null);
+      throw new TooFewArgumentsError(this.localName, argumentCount, min);
     }
 
     if (argumentCount > max) {
-      throw new InvalidArgumentError(max, null);
-    }
-
-    for (const [index, parameter] of signature.entries()) {
-      // TODO: `typeHint` checking...
-      if (parameter.arityType !== 'required') {
-        break;
-      }
-
-      if (args[index] == null) {
-        throw new InvalidArgumentError(index, parameter);
-      }
+      throw new TooManyArgumentsError(this.localName, argumentCount, max);
     }
   }
 }

--- a/packages/xpath/src/evaluator/functions/FunctionLibrary.ts
+++ b/packages/xpath/src/evaluator/functions/FunctionLibrary.ts
@@ -1,8 +1,8 @@
 import type { XPathNode } from '../../adapter/interface/XPathNode.ts';
+import { UnknownFunctionError } from '../../error/UnknownFunctionError.ts';
 import type { Evaluation } from '../../evaluations/Evaluation.ts';
 import { LocationPathEvaluation } from '../../evaluations/LocationPathEvaluation.ts';
 import type { EvaluableArgument, FunctionImplementation } from './FunctionImplementation.ts';
-import { UnknownFunctionError } from './FunctionImplementation.ts';
 
 // TODO: memoized boxed name types?
 type NamespaceURI = string | null;

--- a/packages/xpath/src/index.ts
+++ b/packages/xpath/src/index.ts
@@ -69,3 +69,5 @@ export type {
 } from './xforms/XFormsXPathEvaluator.ts';
 
 export type { XPathChoiceNode } from './adapter/interface/XPathChoiceNode.ts';
+
+export { FormDesignError } from './error/FormDesignError.ts';


### PR DESCRIPTION
Closes getodk/web-forms#914
Closes getodk/web-forms#863

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual and CI testing
It was difficult to verify that error messages weren't propagating to sentry, but I've stopped them being logged to console so I'm 99% sure this will work.

#### Why is this the best possible solution? Were any other approaches considered?

It would be cleaner to use try/catch but it could be thrown in many places and this works as a catch all.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

Hopefully just shows more useful error messages with less sentry spam.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.