### PR TITLE
feat(web-forms#855): emit an event when language is set

### DIFF
--- a/.changeset/blue-parks-stick.md
+++ b/.changeset/blue-parks-stick.md
@@ -1,0 +1,6 @@
+---
+"@getodk/web-forms": minor
+"@getodk/forms": minor
+---
+
+Added component emit for language selection so app and component can stay in the same language

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -12,7 +12,7 @@ import { getDeviceId } from '../utils/device-id';
 import { hideSpinner } from '../utils/spinner';
 import { deleteLastSaved, getLastSaved, setLastSaved } from '../utils/last-saved';
 import { hasSubmitted, setSubmitted } from '../utils/once-store';
-import { i18n, setLocale } from '../i18n';
+import { setLocale } from '../i18n';
 
 defineOptions({
   name: 'WebFormRenderer'

--- a/apps/forms/src/components/web-form-renderer.vue
+++ b/apps/forms/src/components/web-form-renderer.vue
@@ -12,6 +12,8 @@ import { getDeviceId } from '../utils/device-id';
 import { hideSpinner } from '../utils/spinner';
 import { deleteLastSaved, getLastSaved, setLastSaved } from '../utils/last-saved';
 import { hasSubmitted, setSubmitted } from '../utils/once-store';
+import { i18n, setLocale } from '../i18n';
+
 defineOptions({
   name: 'WebFormRenderer'
 });
@@ -344,6 +346,7 @@ onMounted(async () => {
     :instance-defaults="defaultParameters"
     :last-saved-xml="lastSavedXml"
     @loaded="webFormLoaded"
+    @languageSelected="setLocale"
     @submit="handleSubmit"/>
 
   <Dialog modal :visible="!!visibleModal" :draggable="false" :closable="visibleModal?.hideable" @update:visible="visibleModal = null">

--- a/apps/forms/src/i18n.ts
+++ b/apps/forms/src/i18n.ts
@@ -75,6 +75,11 @@ addLocale('pt', 'Português');
 addLocale('zh', '汉语', '');
 addLocale('zh-Hant', '漢語', '');
 
+export const setLocale = (locale: string) => {
+  i18n.global.locale = locale;
+  document.documentElement.setAttribute('lang', locale);
+};
+
 const loadUsersLocale = () => {
   const locale = userLocale() ?? fallbackLocale;
   document.documentElement.setAttribute('lang', locale);

--- a/apps/forms/src/main.ts
+++ b/apps/forms/src/main.ts
@@ -7,7 +7,7 @@ import { webFormsPlugin } from '@getodk/web-forms';
 import Forms from './Forms.vue';
 
 import router from './router';
-import { i18n } from './i18n'
+import { i18n } from './i18n';
 import initSentry from './utils/sentry';
 
 import './assets/style.scss';

--- a/packages/web-forms/README.md
+++ b/packages/web-forms/README.md
@@ -385,6 +385,8 @@ The `<OdkWebForm>` component accepts the following props:
 The component emits the following events:
 
 - `loaded`: Emitted when the form is loaded and displayed to the user
+- `languageSelected`: Emitted when the form language is set, either when the form is loaded, or when the user selects an option from the language selector.
+  - Payload: ([language: string])
 - `submit`: Emitted when the user presses the "Send" button on a valid form
   - Payload: ([submissionPayload: MonolithicInstancePayload, callback: HostSubmissionResultCallback])
 - `submitChunked`: Emitted for chunked submissions when the form is valid

--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -111,6 +111,7 @@ const hostSubmissionResultCallbackFactory = (
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- evidently a type must be used for this to be assigned to a name (which we use!); as an interface, it won't satisfy the `Record` constraint of `defineEmits`.
 type OdkWebFormEmits = {
 	loaded: [],
+	languageSelected: [language: string],
 	submit: [submissionPayload: MonolithicInstancePayload, callback: HostSubmissionResultCallback];
 	submitChunked: [
 		submissionPayload: ChunkedInstancePayload,
@@ -223,9 +224,20 @@ const errorBannerDismissed = ref(false);
 const geolocationErrorMessage = ref<string | null>(null);
 const isFormEditMode = ref(false);
 provide(IS_FORM_EDIT_MODE, readonly(isFormEditMode));
-const { setLanguage, t } = useLocale(computed(() => state.value.root));
+const { setLanguage, getLanguage, t } = useLocale(computed(() => state.value.root));
 provide(TRANSLATE, t);
 const { navigateToFirstViolation, navigateToNode } = useNavigationTarget(() => state.value.root);
+
+if (isEmitSubscribed('onLanguageSelected')) {
+	const language = computed(() => getLanguage());
+	watch(
+		() => language.value,
+		(selected) => {
+			emit('languageSelected', selected);
+		},
+		{ immediate: true }
+	);
+}
 
 onErrorCaptured(err => {
 	runtimeError.value = FormInitializationError.from(err);

--- a/packages/web-forms/src/lib/locale/useLocale.ts
+++ b/packages/web-forms/src/lib/locale/useLocale.ts
@@ -244,7 +244,6 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
 
   onUnmounted(() => {
     latestRequestedLocale.locale = FALLBACK;
-    document.documentElement.lang = FALLBACK;
   });
 
   const t: Translate = (id, values) => currentIntl.value.formatMessage({ id }, values) as string;

--- a/packages/web-forms/src/lib/locale/useLocale.ts
+++ b/packages/web-forms/src/lib/locale/useLocale.ts
@@ -195,7 +195,6 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
 
   const applyLocale = (candidates: string[], formBaseLocale?: string) => {
     const newContentLocale = formBaseLocale ?? FALLBACK;
-    document.documentElement.lang = newContentLocale;
     latestRequestedLocale.locale = newContentLocale;
     const primeLocaleKey = findBestLocale(candidates, (lang) => {
       return Object.hasOwn(primeLocales, lang);
@@ -217,6 +216,10 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
         });
       }
     });
+  };
+
+  const getLanguage = () => {
+    return currentIntl.value.locale;
   };
 
   watch(
@@ -246,5 +249,5 @@ export const useLocale = (formRef: Ref<RootNode | null>) => {
 
   const t: Translate = (id, values) => currentIntl.value.formatMessage({ id }, values) as string;
 
-  return { setLanguage, t };
+  return { setLanguage, getLanguage, t };
 };

--- a/packages/web-forms/tests/lib/locale/useLocale.test.ts
+++ b/packages/web-forms/tests/lib/locale/useLocale.test.ts
@@ -10,9 +10,7 @@ import { defineComponent, ref, type Ref } from 'vue';
 import { globalMountOptions } from '../../helpers.ts';
 
 describe('useLocale', () => {
-  // Track wrappers to explicitly unmount them and prevent
-  // onUnmounted state pollution (document.documentElement.lang) across tests
-  let wrappers: Array<ReturnType<typeof mount>> = [];
+  const setLanguage = vi.fn();
 
   const makeLanguage = (language: string, localeCode: string, isDefault = false): FormLanguage => ({
     isDefault,
@@ -21,7 +19,7 @@ describe('useLocale', () => {
   });
 
   const makeFormRef = (languages: FormLanguage[]): Ref<RootNode | null> =>
-    ref({ languages, setLanguage: vi.fn() }) as unknown as Ref<RootNode | null>;
+    ref({ languages, setLanguage }) as unknown as Ref<RootNode | null>;
 
   const mountLocale = (formRef: Ref<RootNode | null>) => {
     let locale: ReturnType<typeof useLocale> | undefined;
@@ -35,22 +33,17 @@ describe('useLocale', () => {
     });
 
     const wrapper = mount(TestComponent, { global: globalMountOptions });
-    wrappers.push(wrapper);
 
     return { wrapper, getLocale: () => locale! };
   };
 
   beforeEach(() => {
     localStorage.removeItem(STORAGE_KEY);
-    document.documentElement.removeAttribute('lang');
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    localStorage.removeItem(STORAGE_KEY);
-
-    wrappers.forEach((w) => w.unmount());
-    wrappers = [];
+    vi.resetAllMocks();
   });
 
   describe('language priority order (saved > designer default > browser > first)', () => {
@@ -58,40 +51,46 @@ describe('useLocale', () => {
       localStorage.setItem(STORAGE_KEY, 'fr');
       vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['en']);
 
-      const formRef = makeFormRef([makeLanguage('English', 'en'), makeLanguage('French', 'fr')]);
+      const french = makeLanguage('French', 'fr');
+      const formRef = makeFormRef([makeLanguage('English', 'en'), french]);
       mountLocale(formRef);
-
-      expect(document.documentElement.lang).toBe('fr');
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(french);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('fr');
     });
 
     it('prefers designer default over browser language when no saved locale', () => {
       vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['en']);
 
-      const formRef = makeFormRef([
-        makeLanguage('English', 'en'),
-        makeLanguage('French', 'fr', true),
-      ]);
+      const english = makeLanguage('English', 'en');
+      const french = makeLanguage('French', 'fr', true);
+      const formRef = makeFormRef([english, french]);
       mountLocale(formRef);
-
-      expect(document.documentElement.lang).toBe('fr');
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(french);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('fr');
     });
 
     it('uses browser language when no saved locale and no designer default', () => {
       vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['jp']);
 
-      const formRef = makeFormRef([makeLanguage('English', 'en'), makeLanguage('Japanese', 'jp')]);
+      const japanese = makeLanguage('Japanese', 'jp');
+      const formRef = makeFormRef([makeLanguage('English', 'en'), japanese]);
       mountLocale(formRef);
-
-      expect(document.documentElement.lang).toBe('jp');
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(japanese);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('jp');
     });
 
     it('falls back to first available language when no saved locale, no designer default, and no browser match', () => {
       vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['de']);
 
-      const formRef = makeFormRef([makeLanguage('English', 'en'), makeLanguage('French', 'fr')]);
+      const english = makeLanguage('English', 'en');
+      const formRef = makeFormRef([english, makeLanguage('French', 'fr')]);
       mountLocale(formRef);
-
-      expect(document.documentElement.lang).toBe('en');
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(english);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('en');
     });
   });
 
@@ -99,35 +98,40 @@ describe('useLocale', () => {
     it('matches form language by base language when exact locale is not available', () => {
       vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['fr-CA']);
 
-      const formRef = makeFormRef([makeLanguage('English', 'en'), makeLanguage('French', 'fr')]);
+      const french = makeLanguage('French', 'fr');
+      const formRef = makeFormRef([makeLanguage('English', 'en'), french]);
       mountLocale(formRef);
-
-      expect(document.documentElement.lang).toBe('fr');
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(french);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('fr');
     });
 
     it('prefers exact locale match over base language match', () => {
       vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['fr-CA']);
 
-      const formRef = makeFormRef([
-        makeLanguage('French', 'fr'),
-        makeLanguage('French (Canada)', 'fr-CA'),
-      ]);
+      const canadian = makeLanguage('French (Canada)', 'fr-CA');
+      const formRef = makeFormRef([makeLanguage('French', 'fr'), canadian]);
       mountLocale(formRef);
-
-      expect(document.documentElement.lang).toBe('fr-CA');
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(canadian);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('fr-CA');
     });
   });
 
   describe('resolveLocale translation fallback', () => {
     it('loads base locale translations when exact locale has no translation file', async () => {
       document.documentElement.lang = 'fr';
-      const formRef = makeFormRef([makeLanguage('English (Fictional Region)', 'en-ZZ')]);
+      const fictional = makeLanguage('English (Fictional Region)', 'en-ZZ');
+      const formRef = makeFormRef([fictional]);
       const { getLocale } = mountLocale(formRef);
 
       await flushPromises();
 
       expect(getLocale().t('odk_web_forms.submit.label')).toBe('Send');
-      expect(document.documentElement.lang).toBe('en-ZZ');
+
+      expect(setLanguage).toHaveBeenCalledTimes(1);
+      expect(setLanguage).toHaveBeenCalledWith(fictional);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('en-ZZ');
     });
 
     it('falls back to English when no translation file exists for locale', async () => {


### PR DESCRIPTION
Closes getodk/web-forms#855
Closes getodk/web-forms#912

<!-- 
Thank you for contributing to ODK Central!

Before sending this PR, please read
https://github.com/getodk/central-frontend/blob/master/apps/central/docs/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Manual testing

#### Why is this the best possible solution? Were any other approaches considered?

It's the simplest way I could think of.

#### How does this change impact users? Describe intentional behavior changes from code updates. What are the regression risks?

It shouldn't do anything except it keeps both app and component in sync.

#### Does this change require updates to user documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.

No.
