### PR TITLE
Bump versions for v2026.3.0

### DIFF
--- a/.changeset/brave-lights-end.md
+++ b/.changeset/brave-lights-end.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Fixed a bug rendering outputs in single ordered list items

--- a/.changeset/bumpy-donuts-yell.md
+++ b/.changeset/bumpy-donuts-yell.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962

--- a/.changeset/busy-trees-open.md
+++ b/.changeset/busy-trees-open.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": minor
----
-
-Added the ability to enforce single submissions to public access links.

--- a/.changeset/chubby-books-stop.md
+++ b/.changeset/chubby-books-stop.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fix missing header background on repeats nested inside groups

--- a/.changeset/common-crabs-lay.md
+++ b/.changeset/common-crabs-lay.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixed a bug where translation of form buttons wasn't working.

--- a/.changeset/cool-beds-brake.md
+++ b/.changeset/cool-beds-brake.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-feat getodk/central#1875: Inline property creation for app user and PAL create modals

--- a/.changeset/curly-badgers-yawn.md
+++ b/.changeset/curly-badgers-yawn.md
@@ -1,7 +1,0 @@
----
-"@getodk/xpath": patch
-"@getodk/web-forms": patch
-"@getodk/xforms-engine": patch
----
-
-Fixed a bug where using commas for decimal places returned an invalid number.

--- a/.changeset/cute-points-work.md
+++ b/.changeset/cute-points-work.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Fixed a bug where a web form could be rendered without the necessary form data

--- a/.changeset/deep-taxis-trade.md
+++ b/.changeset/deep-taxis-trade.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Update translations (getodk/central#2137)

--- a/.changeset/dull-brooms-prove.md
+++ b/.changeset/dull-brooms-prove.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Fixed a bug where a single submission form could be resubmitted by keyboard navigation.

--- a/.changeset/easy-clubs-play.md
+++ b/.changeset/easy-clubs-play.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixed picker overlays and focus outlines when navigating to a question.

--- a/.changeset/every-hairs-unite.md
+++ b/.changeset/every-hairs-unite.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Handle error responses on homepage (getodk/central#1584, getodk/central#2070)

--- a/.changeset/fiery-kings-swim.md
+++ b/.changeset/fiery-kings-swim.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Reject forms with computation cycles at load

--- a/.changeset/four-buttons-run.md
+++ b/.changeset/four-buttons-run.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Remove trailing slashes from routes (getodk/central#1697)

--- a/.changeset/four-spiders-taste.md
+++ b/.changeset/four-spiders-taste.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": minor
-"@getodk/web-forms": minor
----
-
-Add pagination to Web Forms

--- a/.changeset/frank-hats-repair.md
+++ b/.changeset/frank-hats-repair.md
@@ -1,8 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Remove Custom Properties tab from project page (getodk/central#2075)
-The functionality is still there but properties are now managed through app users and public links.
-They can be created through the "Create New App User" and "Create New Public Link" modals, and viewed on the app user and link lists.
-

--- a/.changeset/frank-papers-trade.md
+++ b/.changeset/frank-papers-trade.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-feat getodk/central#1792: Add ViewAs <app user> filter to Entities

--- a/.changeset/free-ears-itch.md
+++ b/.changeset/free-ears-itch.md
@@ -1,5 +1,5 @@
 ---
-"@getodk/central-frontend": major
+"@getodk/central-frontend": minor
 ---
 
 Restore session when user initially navigates to "Not Found" page

--- a/.changeset/free-ears-itch.md
+++ b/.changeset/free-ears-itch.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Restore session when user initially navigates to "Not Found" page

--- a/.changeset/free-toes-refuse.md
+++ b/.changeset/free-toes-refuse.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Allow user to import Entity CSV with missing properties in header (getodk/central#1787)

--- a/.changeset/free-toes-retire.md
+++ b/.changeset/free-toes-retire.md
@@ -1,7 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-feat getodk/central#1871 and getodk/central#1874
-
-Allow App Users and Public Links to be filtered by actor properties and specific values of those properties. Single relations and equality only for now (e.g. show me app users where region = north).

--- a/.changeset/giant-papers-hear.md
+++ b/.changeset/giant-papers-hear.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Make routes case-sensitive

--- a/.changeset/hip-jokes-sink.md
+++ b/.changeset/hip-jokes-sink.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Added hooks to import and export translations with transifex

--- a/.changeset/honest-guests-love.md
+++ b/.changeset/honest-guests-love.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-When importing Entities from CSV, ignore columns that start with `__` (getodk/central#1785)

--- a/.changeset/huge-dryers-say.md
+++ b/.changeset/huge-dryers-say.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Prompt user to create Entity properties when CSV upload has unknown columns (getodk/central#1786)

--- a/.changeset/hungry-lions-wave.md
+++ b/.changeset/hungry-lions-wave.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Display lat/lon truncated to 5 decimals

--- a/.changeset/jolly-clocks-shop.md
+++ b/.changeset/jolly-clocks-shop.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Made the style of active select options more subtle than the selected style.

--- a/.changeset/kind-ravens-stay.md
+++ b/.changeset/kind-ravens-stay.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)

--- a/.changeset/light-maps-obey.md
+++ b/.changeset/light-maps-obey.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixed a bug where small dropdowns were rendered white additional whitespace at the bottom

--- a/.changeset/little-flowers-fetch.md
+++ b/.changeset/little-flowers-fetch.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": patch
----
-
-Remove the Close button from the success dialog.

--- a/.changeset/neat-insects-wear.md
+++ b/.changeset/neat-insects-wear.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Show file size in form attachment table (issue central#1895)

--- a/.changeset/perky-tools-pump.md
+++ b/.changeset/perky-tools-pump.md
@@ -1,5 +1,0 @@
----
-"@getodk/forms": minor
----
-
-Improved form loading times by fetching the project verbs from a more efficient server endpoint.

--- a/.changeset/plain-news-scream.md
+++ b/.changeset/plain-news-scream.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Reload page if asset fails to load after server upgrade (getodk/central#2073)

--- a/.changeset/plenty-ants-smell.md
+++ b/.changeset/plenty-ants-smell.md
@@ -1,7 +1,0 @@
----
-"@getodk/xforms-engine": minor
-"@getodk/web-forms": minor
-"@getodk/forms": minor
----
-
-Added feature to prefill form fields using URL parameters

--- a/.changeset/puny-wings-cry.md
+++ b/.changeset/puny-wings-cry.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Remove point, trace or shape from the map when its value is cleared by form logic.

--- a/.changeset/quiet-meteors-press.md
+++ b/.changeset/quiet-meteors-press.md
@@ -1,7 +1,0 @@
----
-"@getodk/web-forms": patch
-"@getodk/xpath": patch
-"@getodk/xforms-engine": patch
----
-
-Improved messages about form definition errors to make them easier to fix

--- a/.changeset/quiet-paths-serve.md
+++ b/.changeset/quiet-paths-serve.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": patch
----
-
-Remove attachment confirmation modal and automatically uploading all matching files

--- a/.changeset/sharp-pants-do.md
+++ b/.changeset/sharp-pants-do.md
@@ -1,7 +1,0 @@
----
-"@getodk/xforms-engine": patch
-"@getodk/web-forms": patch
-"@getodk/forms": patch
----
-
-Reduced bundle size for faster loading

--- a/.changeset/shy-pears-think.md
+++ b/.changeset/shy-pears-think.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Do not report session restore errors to Sentry (getodk/central#2072)

--- a/.changeset/silly-bars-wash.md
+++ b/.changeset/silly-bars-wash.md
@@ -1,8 +1,0 @@
----
-"@getodk/xforms-engine": minor
-"@getodk/web-forms": minor
-"@getodk/common": minor
-"@getodk/forms": minor
----
-
-Implemented last-saved virtual secondary instance feature

--- a/.changeset/six-cars-follow.md
+++ b/.changeset/six-cars-follow.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": minor
----
-
-Added support for `quick` appearance.

--- a/.changeset/six-moons-lie.md
+++ b/.changeset/six-moons-lie.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Prevent error if response for Entity List is received before Project (getodk/central#2189)

--- a/.changeset/small-doors-film.md
+++ b/.changeset/small-doors-film.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixed display bugs with top level form error message.

--- a/.changeset/small-sites-crash.md
+++ b/.changeset/small-sites-crash.md
@@ -1,7 +1,0 @@
----
-"@getodk/xpath": patch
-"@getodk/web-forms": patch
-"@getodk/xforms-engine": patch
----
-
-Removed rounding from area() and distance() xpath functions.

--- a/.changeset/strong-bats-shine.md
+++ b/.changeset/strong-bats-shine.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": minor
-"@getodk/web-forms": minor
----
-
-Block Next on pages with invalid questions

--- a/.changeset/tasty-yaks-flash.md
+++ b/.changeset/tasty-yaks-flash.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Update What's New modal for release

--- a/.changeset/tender-papers-grin.md
+++ b/.changeset/tender-papers-grin.md
@@ -1,6 +1,0 @@
----
-"@getodk/xforms-engine": minor
-"@getodk/web-forms": minor
----
-
-Scrolls to the right question on load, page changes, repeat changes, and validation errors.

--- a/.changeset/thin-parents-occur.md
+++ b/.changeset/thin-parents-occur.md
@@ -1,7 +1,0 @@
----
-"@getodk/xpath": patch
-"@getodk/web-forms": patch
-"@getodk/xforms-engine": patch
----
-
-Fixed a bug where the distance xpath function would error when passed empty input

--- a/.changeset/thirty-shrimps-move.md
+++ b/.changeset/thirty-shrimps-move.md
@@ -1,5 +1,0 @@
----
-"@getodk/xforms-engine": patch
----
-
-Stop recomputing form logic that cycles once it hits a change limit

--- a/.changeset/tidy-loops-dig.md
+++ b/.changeset/tidy-loops-dig.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Fixes the likert connector line alignment and unintended focus highlight.

--- a/.changeset/vast-cobras-lead.md
+++ b/.changeset/vast-cobras-lead.md
@@ -1,6 +1,0 @@
----
-"@getodk/web-forms": patch
-"@getodk/forms": patch
----
-
-Improved loading of form attachments to better handle dynamic updates to the filename.

--- a/.changeset/wacky-kids-sneeze.md
+++ b/.changeset/wacky-kids-sneeze.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-List duplicate column headers in Entity CSV file

--- a/.changeset/warm-zebras-knock.md
+++ b/.changeset/warm-zebras-knock.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Removed dependency on bootstrap plugins and jquery.

--- a/.changeset/whole-hoops-care.md
+++ b/.changeset/whole-hoops-care.md
@@ -1,5 +1,0 @@
----
-"@getodk/xpath": patch
----
-
-Made date formatting error handling consistent.

--- a/.changeset/wicked-bags-battle.md
+++ b/.changeset/wicked-bags-battle.md
@@ -1,5 +1,0 @@
----
-"@getodk/web-forms": patch
----
-
-Prevent horizontal layout shift when scrollbar appears in Forms

--- a/.changeset/wild-candles-sit.md
+++ b/.changeset/wild-candles-sit.md
@@ -1,5 +1,0 @@
----
-"@getodk/central-frontend": minor
----
-
-Truncate overflowing tooltips (getodk/central#2183)

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -19,21 +19,16 @@
 - 272a95e: List duplicate column headers in Entity CSV file
 - 398f558: Removed dependency on bootstrap plugins and jquery.
 - faa52cd: Truncate overflowing tooltips (getodk/central#2183)
-
-### Patch Changes
-
 - 28bd0d0: Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962
 - 87800e2: feat getodk/central#1875: Inline property creation for app user and PAL create modals
 - ab7272b: Remove Custom Properties tab from project page (getodk/central#2075)
-  The functionality is still there but properties are now managed through app users and public links.
-  They can be created through the "Create New App User" and "Create New Public Link" modals, and viewed on the app user and link lists.
-- 5acc384: feat getodk/central#1792: Add ViewAs <app user> filter to Entities
+  - The functionality is still there but properties are now managed through app users and public links.
+  - They can be created through the "Create New App User" and "Create New Public Link" modals, and viewed on the app user and link lists.
+- 5acc384: feat getodk/central#1792: Add ViewAs &lt;app user&gt; filter to Entities
 - b960928: feat getodk/central#1871 and getodk/central#1874
-
-  Allow App Users and Public Links to be filtered by actor properties and specific values of those properties. Single relations and equality only for now (e.g. show me app users where region = north).
-
+  - Allow App Users and Public Links to be filtered by actor properties and specific values of those properties. Single relations and equality only for now (e.g. show me app users where region = north).
 - 194cc9e: Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)
-- d8c66cd: Show file size in form attachment table (issue central#1895)
+- d8c66cd: Show file size in form attachment table (issue getodk/central#1895)
 - f6ac6db: Remove attachment confirmation modal and automatically uploading all matching files
 
 ## 2026.2.0

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @getodk/central-frontend
 
+## 2026.3.0
+
+### Minor Changes
+
+- e66343c: Update translations (getodk/central#2137)
+- 47ea79f: Handle error responses on homepage (getodk/central#1584, getodk/central#2070)
+- 8d57d76: Remove trailing slashes from routes (getodk/central#1697)
+- 4b148b1: Restore session when user initially navigates to "Not Found" page
+- 81cb08b: Allow user to import Entity CSV with missing properties in header (getodk/central#1787)
+- f1e85b0: Make routes case-sensitive
+- faa6675: When importing Entities from CSV, ignore columns that start with `__` (getodk/central#1785)
+- 96db2da: Prompt user to create Entity properties when CSV upload has unknown columns (getodk/central#1786)
+- 5a87c0e: Reload page if asset fails to load after server upgrade (getodk/central#2073)
+- 2a93ff7: Do not report session restore errors to Sentry (getodk/central#2072)
+- 8dac83f: Prevent error if response for Entity List is received before Project (getodk/central#2189)
+- 7f40e6f: Update What's New modal for release
+- 272a95e: List duplicate column headers in Entity CSV file
+- 398f558: Removed dependency on bootstrap plugins and jquery.
+- faa52cd: Truncate overflowing tooltips (getodk/central#2183)
+
+### Patch Changes
+
+- 28bd0d0: Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962
+- 87800e2: feat getodk/central#1875: Inline property creation for app user and PAL create modals
+- ab7272b: Remove Custom Properties tab from project page (getodk/central#2075)
+  The functionality is still there but properties are now managed through app users and public links.
+  They can be created through the "Create New App User" and "Create New Public Link" modals, and viewed on the app user and link lists.
+- 5acc384: feat getodk/central#1792: Add ViewAs <app user> filter to Entities
+- b960928: feat getodk/central#1871 and getodk/central#1874
+
+  Allow App Users and Public Links to be filtered by actor properties and specific values of those properties. Single relations and equality only for now (e.g. show me app users where region = north).
+
+- 194cc9e: Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)
+- d8c66cd: Show file size in form attachment table (issue central#1895)
+- f6ac6db: Remove attachment confirmation modal and automatically uploading all matching files
+
 ## 2026.2.0
 
 ### Minor Changes

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -28,13 +28,13 @@
 
 **Other improvements + bug fixes**
 
-- 194cc9e: Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)
+- 194cc9e: Features: Submission data and view xml on the Submission detail page (getodk/central#1707)
 - faa52cd: Truncate overflowing tooltips (getodk/central#2183)
 - 28bd0d0: Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962
 - 5a87c0e: Reload page if asset fails to load after server upgrade (getodk/central#2073)
 - 8dac83f: Prevent error if response for Entity List is received before Project (getodk/central#2189)
 - 47ea79f: Handle error responses on homepage (getodk/central#1584, getodk/central#2070)
-- 4b148b1: Restore session when user initially navigates to "Not Found" page
+- 4b148b1: Restore session when user initially navigates to "Not Found" page (getodk/central#1698)
 - f1e85b0: Make routes case-sensitive
 - 8d57d76: Remove trailing slashes from routes (getodk/central#1697)
 

--- a/apps/central/CHANGELOG.md
+++ b/apps/central/CHANGELOG.md
@@ -4,22 +4,15 @@
 
 ### Minor Changes
 
-- e66343c: Update translations (getodk/central#2137)
-- 47ea79f: Handle error responses on homepage (getodk/central#1584, getodk/central#2070)
-- 8d57d76: Remove trailing slashes from routes (getodk/central#1697)
-- 4b148b1: Restore session when user initially navigates to "Not Found" page
-- 81cb08b: Allow user to import Entity CSV with missing properties in header (getodk/central#1787)
-- f1e85b0: Make routes case-sensitive
-- faa6675: When importing Entities from CSV, ignore columns that start with `__` (getodk/central#1785)
+**Entity upload from CSV**
+
 - 96db2da: Prompt user to create Entity properties when CSV upload has unknown columns (getodk/central#1786)
-- 5a87c0e: Reload page if asset fails to load after server upgrade (getodk/central#2073)
-- 2a93ff7: Do not report session restore errors to Sentry (getodk/central#2072)
-- 8dac83f: Prevent error if response for Entity List is received before Project (getodk/central#2189)
-- 7f40e6f: Update What's New modal for release
+- 81cb08b: Allow user to import Entity CSV with missing properties in header (getodk/central#1787)
+- faa6675: When importing Entities from CSV, ignore columns that start with `__` (getodk/central#1785)
 - 272a95e: List duplicate column headers in Entity CSV file
-- 398f558: Removed dependency on bootstrap plugins and jquery.
-- faa52cd: Truncate overflowing tooltips (getodk/central#2183)
-- 28bd0d0: Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962
+
+**Entity filtering**
+
 - 87800e2: feat getodk/central#1875: Inline property creation for app user and PAL create modals
 - ab7272b: Remove Custom Properties tab from project page (getodk/central#2075)
   - The functionality is still there but properties are now managed through app users and public links.
@@ -27,9 +20,30 @@
 - 5acc384: feat getodk/central#1792: Add ViewAs &lt;app user&gt; filter to Entities
 - b960928: feat getodk/central#1871 and getodk/central#1874
   - Allow App Users and Public Links to be filtered by actor properties and specific values of those properties. Single relations and equality only for now (e.g. show me app users where region = north).
-- 194cc9e: Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)
-- d8c66cd: Show file size in form attachment table (issue getodk/central#1895)
+
+**Form Attachment upload**
+
 - f6ac6db: Remove attachment confirmation modal and automatically uploading all matching files
+- d8c66cd: Show file size in form attachment table (issue getodk/central#1895)
+
+**Other improvements + bug fixes**
+
+- 194cc9e: Features: Submission data and view xml on the Submission detail page [Central#1707](https://github.com/getodk/central/issues/1707)
+- faa52cd: Truncate overflowing tooltips (getodk/central#2183)
+- 28bd0d0: Fixes: added extra bottom margin for draft control so snackbar doesn't overlap it. getodk/central#1962
+- 5a87c0e: Reload page if asset fails to load after server upgrade (getodk/central#2073)
+- 8dac83f: Prevent error if response for Entity List is received before Project (getodk/central#2189)
+- 47ea79f: Handle error responses on homepage (getodk/central#1584, getodk/central#2070)
+- 4b148b1: Restore session when user initially navigates to "Not Found" page
+- f1e85b0: Make routes case-sensitive
+- 8d57d76: Remove trailing slashes from routes (getodk/central#1697)
+
+**Maintenance**
+
+- 7f40e6f: Update What's New modal for release
+- e66343c: Update translations (getodk/central#2137)
+- 398f558: Removed dependency on bootstrap plugins and jquery.
+- 2a93ff7: Do not report session restore errors to Sentry (getodk/central#2072)
 
 ## 2026.2.0
 

--- a/apps/central/package.json
+++ b/apps/central/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/central-frontend",
-  "version": "2026.2.0",
+  "version": "2026.3.0",
   "private": true,
   "scripts": {
     "eslint": "eslint --max-warnings 0 --cache --ext .js,.vue src/ test/ bin/ *.js",

--- a/apps/forms/CHANGELOG.md
+++ b/apps/forms/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @getodk/forms
 
+## 2026.3.0
+
+### Minor Changes
+
+- b4c54d2: Added the ability to enforce single submissions to public access links.
+- 49e5961: Improved form loading times by fetching the project verbs from a more efficient server endpoint.
+- 7bf7823: Added feature to prefill form fields using URL parameters
+- 654afd3: Implemented last-saved virtual secondary instance feature
+
+### Patch Changes
+
+- 8b1caf2: Fixed a bug where a web form could be rendered without the necessary form data
+- df4659c: Fixed a bug where a single submission form could be resubmitted by keyboard navigation.
+- 0dd2ba1: Added hooks to import and export translations with transifex
+- e8f02a0: Remove the Close button from the success dialog.
+- 92133fb: Reduced bundle size for faster loading
+- c0ff040: Improved loading of form attachments to better handle dynamic updates to the filename.
+
 ## 2026.2.2
 
 ### Patch Changes

--- a/apps/forms/package.json
+++ b/apps/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/forms",
-  "version": "2026.2.2",
+  "version": "2026.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
     },
     "apps/central": {
       "name": "@getodk/central-frontend",
-      "version": "2026.2.0",
+      "version": "2026.3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "axios": "^1.18.1",
@@ -486,7 +486,7 @@
     },
     "apps/forms": {
       "name": "@getodk/forms",
-      "version": "2026.2.2",
+      "version": "2026.3.0",
       "dependencies": {
         "idb-keyval": "^6.3.0",
         "primevue": "4.3.3",
@@ -22716,7 +22716,7 @@
     },
     "packages/common": {
       "name": "@getodk/common",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "jsdom": "^27.2.0"
       },
@@ -22727,7 +22727,7 @@
     },
     "packages/web-forms": {
       "name": "@getodk/web-forms",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/intl": "^4.1.14",
@@ -22743,7 +22743,7 @@
       "devDependencies": {
         "@faker-js/faker": "^10.5.0",
         "@fontsource/roboto": "^5.2.9",
-        "@getodk/xforms-engine": "1.0.3",
+        "@getodk/xforms-engine": "1.1.0",
         "@primeuix/themes": "1.0.3",
         "@types/image-blob-reduce": "^4",
         "@types/ramda": "^0.32.0",
@@ -22849,7 +22849,7 @@
     },
     "packages/xforms-engine": {
       "name": "@getodk/xforms-engine",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "bin-packer": "1.7.0",
@@ -22862,7 +22862,7 @@
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@getodk/tree-sitter-xpath": "^0.2.2",
-        "@getodk/xpath": "1.0.1",
+        "@getodk/xpath": "1.0.2",
         "@js-joda/core": "^5.7.0",
         "@types/papaparse": "^5.5.0",
         "babel-plugin-transform-jsbi-to-bigint": "^1.4.2",
@@ -22881,10 +22881,10 @@
     },
     "packages/xpath": {
       "name": "@getodk/xpath",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getodk/common": "1.0.0",
+        "@getodk/common": "1.1.0",
         "crypto-js": "^4.2.0"
       },
       "devDependencies": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @getodk/common
 
+## 1.1.0
+
+### Minor Changes
+
+- 654afd3: Implemented last-saved virtual secondary instance feature
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getodk/common",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "@getodk/common",
   "type": "module",
   "author": "getodk",

--- a/packages/web-forms/CHANGELOG.md
+++ b/packages/web-forms/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @getodk/web-forms
 
+## 1.1.0
+
+### Minor Changes
+
+- 25e142c: Add pagination to Web Forms
+- 7bf7823: Added feature to prefill form fields using URL parameters
+- 654afd3: Implemented last-saved virtual secondary instance feature
+- a291d38: Added support for `quick` appearance.
+- 76e0239: Block Next on pages with invalid questions
+- 8777bca: Scrolls to the right question on load, page changes, repeat changes, and validation errors.
+
+### Patch Changes
+
+- 3b4ef36: Fix missing header background on repeats nested inside groups
+- 1220b05: Fixed a bug where translation of form buttons wasn't working.
+- 689fa4e: Fixed a bug where using commas for decimal places returned an invalid number.
+- bacd037: Fixed picker overlays and focus outlines when navigating to a question.
+- f3e5673: Display lat/lon truncated to 5 decimals
+- f560dab: Made the style of active select options more subtle than the selected style.
+- d47006f: Fixed a bug where small dropdowns were rendered white additional whitespace at the bottom
+- ced497b: Remove point, trace or shape from the map when its value is cleared by form logic.
+- 5c10f08: Improved messages about form definition errors to make them easier to fix
+- 92133fb: Reduced bundle size for faster loading
+- d231758: Fixed display bugs with top level form error message.
+- 22757ca: Removed rounding from area() and distance() xpath functions.
+- c01c3a9: Fixed a bug where the distance xpath function would error when passed empty input
+- 8d80c1a: Fixes the likert connector line alignment and unintended focus highlight.
+- c0ff040: Improved loading of form attachments to better handle dynamic updates to the filename.
+- 24edc1d: Prevent horizontal layout shift when scrollbar appears in Forms
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/web-forms",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "description": "ODK Web Forms",
   "author": "getodk",
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@faker-js/faker": "^10.5.0",
     "@fontsource/roboto": "^5.2.9",
-    "@getodk/xforms-engine": "1.0.3",
+    "@getodk/xforms-engine": "1.1.0",
     "@primeuix/themes": "1.0.3",
     "@types/image-blob-reduce": "^4",
     "@types/ramda": "^0.32.0",

--- a/packages/xforms-engine/CHANGELOG.md
+++ b/packages/xforms-engine/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @getodk/xforms-engine
 
+## 1.1.0
+
+### Minor Changes
+
+- 25e142c: Add pagination to Web Forms
+- 7bf7823: Added feature to prefill form fields using URL parameters
+- 654afd3: Implemented last-saved virtual secondary instance feature
+- 76e0239: Block Next on pages with invalid questions
+- 8777bca: Scrolls to the right question on load, page changes, repeat changes, and validation errors.
+
+### Patch Changes
+
+- 5329340: Fixed a bug rendering outputs in single ordered list items
+- 689fa4e: Fixed a bug where using commas for decimal places returned an invalid number.
+- d4a5f92: Reject forms with computation cycles at load
+- 5c10f08: Improved messages about form definition errors to make them easier to fix
+- 92133fb: Reduced bundle size for faster loading
+- 22757ca: Removed rounding from area() and distance() xpath functions.
+- c01c3a9: Fixed a bug where the distance xpath function would error when passed empty input
+- c366ad9: Stop recomputing form logic that cycles once it hits a change limit
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/xforms-engine/package.json
+++ b/packages/xforms-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/xforms-engine",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "description": "XForms engine for ODK Web Forms",
   "type": "module",
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.5",
     "@getodk/tree-sitter-xpath": "^0.2.2",
-    "@getodk/xpath": "1.0.1",
+    "@getodk/xpath": "1.0.2",
     "@js-joda/core": "^5.7.0",
     "@types/papaparse": "^5.5.0",
     "babel-plugin-transform-jsbi-to-bigint": "^1.4.2",

--- a/packages/xpath/CHANGELOG.md
+++ b/packages/xpath/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @getodk/xpath
 
+## 1.0.2
+
+### Patch Changes
+
+- 689fa4e: Fixed a bug where using commas for decimal places returned an invalid number.
+- 5c10f08: Improved messages about form definition errors to make them easier to fix
+- 22757ca: Removed rounding from area() and distance() xpath functions.
+- c01c3a9: Fixed a bug where the distance xpath function would error when passed empty input
+- 49bfcb4: Made date formatting error handling consistent.
+- Updated dependencies [654afd3]
+  - @getodk/common@1.1.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/xpath/package.json
+++ b/packages/xpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getodk/xpath",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "Apache-2.0",
   "description": "XPath implementation for ODK Web Forms",
   "type": "module",
@@ -57,7 +57,7 @@
     "test:types:test": "tsc --project ./test/tsconfig.json --emitDeclarationOnly false --noEmit"
   },
   "dependencies": {
-    "@getodk/common": "1.0.0",
+    "@getodk/common": "1.1.0",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR bumps package versions and updates the changelog.

#### What has been done to verify that this works as intended?

Tests continue to pass.

#### Why is this the best possible solution? Were any other approaches considered?

Mostly I just followed these instructions in getodk/central#2222:

> Run `npm run version` in `central-frontend`, then `npm install`.

I also manually edited the Central changelog:

- I removed the distinction between minor changes and patch changes. It's all one release.
- Small changes to links and formatting
- 9f79eb97940dc402fde773ff1b7d3ac639d4725a may look like a bigger change, but I'm really just moving things around. I grouped related issues together, adding sections like we've done in previous release notes. I tried to roughly order issues according to likely user interest. In this commit, I didn't change the text or links of individual items. I just reordered items and added sections.